### PR TITLE
Add issue templates from OC

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe your environment** Describe any aspect of your environment relevant to the problem, including your Python version, [platform](https://docs.python.org/3/library/platform.html), version numbers of installed dependencies, information about your cloud hosting provider, etc. If you're reporting a problem with a specific version of a library in this repo, please check whether the problem has been fixed on master.
+
+**Steps to reproduce**
+Describe exactly how to reproduce the error. Include a code sample if applicable.
+
+**What is the expected behavior?**
+What did you expect to see?
+
+**What is the actual behavior?**
+What did you see instead?
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+labels: feature-request
+---
+
+Before opening a feature request against this repo, consider whether the feature should/could be implemented in the [other OpenCensus client libraries](https://github.com/census-instrumentation). If so, please [open an issue on opencensus-specs](https://github.com/census-instrumentation/opencensus-specs/issues/new) first.
+
+**Is your feature request related to a problem?**
+If so, provide a concise description of the problem.
+
+**Describe the solution you'd like**
+What do you want to happen instead? What is the expected behavior?
+
+**Describe alternatives you've considered**
+Which alternative solutions or features have you considered?
+
+**Additional context**
+Add any other context about the feature request here.


### PR DESCRIPTION
This PR adds the issue templates from https://github.com/census-instrumentation/opencensus-python/pull/634. Not that there's much reason for someone to use the bug report template yet...