### PR TITLE
Add initial tracer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # opentelemetry-python
+
+
+Join the chat at Python SIG gitter: [![Join the chat at Python SIG gitter](https://badges.gitter.im/open-telemetry/opentelemetry-python.svg)](https://gitter.im/open-telemetry/opentelemetry-python?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/opentelemetry/api/trace/__init__.py
+++ b/opentelemetry/api/trace/__init__.py
@@ -30,7 +30,8 @@ context. By default, new spans are "attached" to the context in that they are
 created as children of the currently active span, and the newly-created span
 becomes the new active span::
 
-    from opentelemetry.sdk.trace import tracer
+    # TODO (#15): which module holds the global tracer?
+    from opentelemetry.api.trace import tracer
 
     # Create a new root span, set it as the current span in context
     with tracer.start_span("parent"):
@@ -43,7 +44,7 @@ becomes the new active span::
 When creating a span that's "detached" from the context the active span doesn't
 change, and the caller is responsible for managing the span's lifetime::
 
-    from opentelemetry.sdk.trace import tracer
+    from opentelemetry.api.trace import tracer
 
     # Explicit parent span assignment
     span = tracer.create_span("child", parent=parent) as child:

--- a/opentelemetry/api/trace/__init__.py
+++ b/opentelemetry/api/trace/__init__.py
@@ -151,7 +151,10 @@ class Span(object):
         raise NotImplementedError
 
     def get_context(self) -> SpanContext:
-        """Get an immutable snapshot of this span.
+        """Get the span's SpanContext.
+
+        Get an immutable, serializable identifier for this span that can be
+        used to create new child spans.
 
         Returns:
             A :class:`.SpanContext` with a copy of this span's immutable state.

--- a/opentelemetry/api/trace/__init__.py
+++ b/opentelemetry/api/trace/__init__.py
@@ -75,7 +75,7 @@ class Tracer(object):
     """
 
     def get_current_span(self) -> Span:
-        """Get the currently active span from the context.
+        """Gets the currently active span from the context.
 
         If there is no current span, return a placeholder span with an invalid
         context.
@@ -178,7 +178,7 @@ class Span(object):
     """A span represents a single operation within a trace."""
 
     def start(self) -> None:
-        """Set the current time as the span's start time.
+        """Sets the current time as the span's start time.
 
         Each span represents a single operation. The span's start time is the
         wall time at which the operation started.
@@ -189,7 +189,7 @@ class Span(object):
         raise NotImplementedError
 
     def end(self) -> None:
-        """Set the current time as the span's end time.
+        """Sets the current time as the span's end time.
 
         The span's end time is the wall time at which the operation finished.
 
@@ -199,7 +199,7 @@ class Span(object):
         raise NotImplementedError
 
     def get_context(self) -> SpanContext:
-        """Get the span's SpanContext.
+        """Gets the span's SpanContext.
 
         Get an immutable, serializable identifier for this span that can be
         used to create new child spans.

--- a/opentelemetry/api/trace/__init__.py
+++ b/opentelemetry/api/trace/__init__.py
@@ -100,10 +100,10 @@ class Tracer(object):
 
         Args:
             name: The name of the span to be created.
-            parent: The new span's parent.
+            parent: This span's parent.
 
-        Raises:
-            ValueError: if ``name`` is null.
+        Yields:
+            The newly-created span.
         """
         raise NotImplementedError
 

--- a/opentelemetry/api/trace/__init__.py
+++ b/opentelemetry/api/trace/__init__.py
@@ -100,7 +100,7 @@ class Tracer(object):
 
         Args:
             name: The name of the span to be created.
-            parent: This span's parent.
+            parent: The new span's parent.
 
         Raises:
             ValueError: if ``name`` is null.

--- a/opentelemetry/api/trace/__init__.py
+++ b/opentelemetry/api/trace/__init__.py
@@ -171,8 +171,8 @@ class SpanContext(object):
     Args:
         trace_id: The ID of the trace that this span belongs to.
         span_id: This span's ID.
-        options: Global trace options to propagate.
-        state: Global tracing-system-specific info to propagate.
+        options: Trace options to propagate.
+        state: Tracing-system-specific info to propagate.
     """
 
     def __init__(self,

--- a/opentelemetry/api/trace/__init__.py
+++ b/opentelemetry/api/trace/__init__.py
@@ -100,9 +100,9 @@ class Tracer(object):
 
         Example::
 
-            with tracer.span("one") as parent:
+            with tracer.start_span("one") as parent:
                 parent.add_event("parent's event")
-                with tracer.span("two") as child:
+                with tracer.start_span("two") as child:
                     child.add_event("child's event")
                     tracer.get_current_span()  # returns child
                 tracer.get_current_span()      # returns parent

--- a/opentelemetry/api/trace/__init__.py
+++ b/opentelemetry/api/trace/__init__.py
@@ -1,0 +1,190 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The OpenTelemetry tracing API describes the classes used to generate
+distributed traces.
+
+The :class:`.Tracer` class controls access to the execution context, and
+manages span creation. Each operation in a trace is represented by a
+:class:`.Span`, which records the start, end time, and metadata associated with
+the operation.
+
+This module provides abstract (i.e. unimplemented) classes required for
+tracing, and a concrete no-op ``BlankSpan`` that allows applications to use the
+API package alone without a supporting implementation.
+
+The tracer supports implicit and explicit context propagation. By default spans
+are created as children of the currently active span, and the newly-created
+span becomes the new active span::
+
+    from opentelemetry.sdk.trace import tracer
+
+    # Create a new root span, set it as the current span in context
+    with tracer.span("parent"):
+        # Attach a new child and update the current span
+        with tracer.span("child"):
+            do_work():
+        # Close child span, set parent as current
+    # Close parent span, set default span as current
+
+Under explicit context propagation there is no concept of an active span, and
+the caller is responsible for managing the span's lifetime::
+
+    from opentelemetry.sdk.trace import tracer
+    from your.integration import deserialize_span
+
+    parent = deserialize_span(serialized_span)
+    # Explicit parent span assignment
+    with tracer.span("child", parent=parent) as child:
+        do_work(span=child)
+
+Applications should generally use a single global tracer, and use either
+implicit or explicit context propagation consistently throughout.
+
+.. versionadded:: 0.1.0
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+from contextlib import contextmanager
+
+
+class Tracer(object):
+    """Handles span creation and in-process context propagation.
+
+    This class provides methods for manipulating the context, creating spans,
+    and controlling spans' lifecycles.
+    """
+
+    def get_current_span(self) -> Span:
+        """Get the currently active span from the context.
+
+        Returns:
+            The currently active :class:`.Span`.
+        """
+        raise NotImplementedError
+
+    @contextmanager
+    def span(self, name: str, parent: Span=None) -> Iterator[None]:
+        """Context manager for span creation.
+
+        Create a new child of the current span, or create a root span if no
+        current span exists. Start the span and set it as the current span in
+        this tracer's context.
+
+        On exiting the context manager stop the span and set its parent as the
+        current span.
+
+        Example::
+
+            with tracer.span("one") as parent:
+                parent.add_event("parent's event")
+                with tracer.span("two") as child:
+                    child.add_event("child's event")
+                    tracer.get_current_span()  # returns child
+                tracer.get_current_span()      # returns parent
+            tracer.get_current_span()          # returns the previously active span
+
+        Args:
+            name: The name of the span to be created.
+            parent: This span's parent.
+
+        Raises:
+            ValueError: if ``name`` is null.
+        """
+        raise NotImplementedError
+
+    def create_span(self, name: str, parent: Span=None) -> Span:
+        """Create a new span as a child of the currently active span.
+
+        If called with ``parent`` this method won't affect the tracer's
+        context.
+
+        See ``span`` for a context manager that controls the span's lifetime.
+
+        Args:
+            name: The name of the span to be created.
+            parent: This span's parent.
+
+        Raises:
+            ValueError: if ``name`` is null.
+        """
+        raise NotImplementedError
+
+
+class Span(object):
+    """A span represents a single operation within a trace.
+    """
+
+    def start(self) -> None:
+        """Set the current time as the span's start time.
+
+        Each span represents a single operation. The span's start time is the
+        wall time at which the operation started.
+
+        Only the first call to ``start`` should modify the span, and
+        implementations are free to ignore or raise on further calls.
+        """
+        raise NotImplementedError
+
+    def end(self) -> None:
+        """Set the current time as the span's end time.
+
+        The span's end time is the wall time at which the operation finished.
+
+        Only the first call to ``end`` should modify the span, and
+        implementations are free to ignore or raise on further calls.
+        """
+        raise NotImplementedError
+
+    def get_context(self) -> SpanContext:
+        """Get an immutable snapshot of this span.
+
+        Returns:
+            A :class:`.SpanContext` with a copy of this span's immutable state.
+        """
+        raise NotImplementedError
+
+
+class SpanContext(object):
+    """The state of a Span to propagate between processes.
+
+    This class includes the immutable attributes of a :class:`.Span` that must
+    be propagated to a span's children and across process boundaries.
+
+    Args:
+        trace_id: The ID of the trace that this span belongs to.
+        span_id: This span's ID.
+        options: Global trace options to propagate.
+        state: Global tracing-system-specific info to propagate.
+    """
+
+    def __init__(self,
+                 trace_id: str,
+                 span_id: str,
+                 options: TraceOptions,
+                 state: TraceState) -> SpanContext:
+        pass
+
+
+# TODO
+class TraceOptions(int):
+    pass
+
+
+# TODO
+class TraceState(dict):
+    pass

--- a/opentelemetry/api/trace/__init__.py
+++ b/opentelemetry/api/trace/__init__.py
@@ -85,7 +85,7 @@ class Tracer(object):
             The currently active :class:`.Span`, or a placeholder span with an
             invalid :class:`.SpanContext`.
         """
-        raise NotImplementedError
+        pass
 
 
     @contextmanager
@@ -129,7 +129,7 @@ class Tracer(object):
         Yields:
             The newly-created span.
         """
-        raise NotImplementedError
+        pass
 
     def create_span(self, name: str, parent: Span) -> Span:
         """Creates a new child span of the given parent.
@@ -157,7 +157,7 @@ class Tracer(object):
         Returns:
             The newly-created span.
         """
-        raise NotImplementedError
+        pass
 
     @contextmanager
     def use_span(self, span: Span) -> Iterator[None]:
@@ -172,7 +172,7 @@ class Tracer(object):
         Args:
             span: The span to start and make current.
         """
-        raise NotImplementedError
+        pass
 
 
 class Span(object):
@@ -187,7 +187,7 @@ class Span(object):
         Only the first call to ``start`` should modify the span, and
         implementations are free to ignore or raise on further calls.
         """
-        raise NotImplementedError
+        pass
 
     def end(self) -> None:
         """Sets the current time as the span's end time.
@@ -197,7 +197,7 @@ class Span(object):
         Only the first call to ``end`` should modify the span, and
         implementations are free to ignore or raise on further calls.
         """
-        raise NotImplementedError
+        pass
 
     def get_context(self) -> SpanContext:
         """Gets the span's SpanContext.
@@ -208,7 +208,7 @@ class Span(object):
         Returns:
             A :class:`.SpanContext` with a copy of this span's immutable state.
         """
-        raise NotImplementedError
+        pass
 
 
 class SpanContext(object):

--- a/opentelemetry/api/trace/__init__.py
+++ b/opentelemetry/api/trace/__init__.py
@@ -58,8 +58,8 @@ implicit or explicit context propagation consistently throughout.
 
 from __future__ import annotations
 
-from typing import Iterator
 from contextlib import contextmanager
+from typing import Iterator
 
 
 class Tracer(object):

--- a/opentelemetry/api/trace/__init__.py
+++ b/opentelemetry/api/trace/__init__.py
@@ -78,7 +78,7 @@ class Tracer(object):
         raise NotImplementedError
 
     @contextmanager
-    def span(self, name: str, parent: Span=None) -> Iterator[None]:
+    def span(self, name: str, parent: Span=None) -> Iterator[Span]:
         """Context manager for span creation.
 
         Create a new child of the current span, or create a root span if no


### PR DESCRIPTION
This PR adds the tracing API package and proposes some conventions for the package structure, documentation, and style of the project. As it is now, the API only describes the required classes for using the tracer to record spans. Propagation formats, resources, and the context API are all out of scope for this PR.

The API here borrows from:
- The current [opentelemetry-java API](https://github.com/open-telemetry/opentelemetry-java/tree/master/api) (generate the javadocs and see `.../docs/io/opentelemetry/trace/Tracer.html`)
- The WIP [OpenTelemetry tracing spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/tracing-api.md)
- The [OpenTracing spec](https://opentracing.io/specification/)
- The [OpenCensus tracing spec](https://github.com/census-instrumentation/opencensus-specs/tree/master/trace)
- The existing [opencensus-python tracing implementation](https://github.com/census-instrumentation/opencensus-python/tree/master/opencensus/trace)

The OT java API is our current best source of truth. Ideally we can use this PR to prove the java API and push the discussion here up to the spec.