### PR TITLE
Switch type hints to strings for 3.4

### DIFF
--- a/opentelemetry-api/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/opentelemetry/trace/__init__.py
@@ -62,8 +62,6 @@ implicit or explicit context propagation consistently throughout.
 .. versionadded:: 0.1.0
 """
 
-from __future__ import annotations
-
 from contextlib import contextmanager
 from typing import Iterator
 
@@ -75,7 +73,7 @@ class Tracer(object):
     and controlling spans' lifecycles.
     """
 
-    def get_current_span(self) -> Span:
+    def get_current_span(self) -> 'Span':
         """Gets the currently active span from the context.
 
         If there is no current span, return a placeholder span with an invalid
@@ -89,7 +87,7 @@ class Tracer(object):
 
 
     @contextmanager
-    def start_span(self, name: str, parent: Span) -> Iterator[Span]:
+    def start_span(self, name: str, parent: 'Span') -> Iterator['Span']:
         """Context manager for span creation.
 
         Create a new child of the current span, or create a root span if no
@@ -131,7 +129,7 @@ class Tracer(object):
         """
         pass
 
-    def create_span(self, name: str, parent: Span) -> Span:
+    def create_span(self, name: str, parent: 'Span') -> 'Span':
         """Creates a new child span of the given parent.
 
         Creating the span does not start it, and should not affect the tracer's
@@ -160,7 +158,7 @@ class Tracer(object):
         pass
 
     @contextmanager
-    def use_span(self, span: Span) -> Iterator[None]:
+    def use_span(self, span: 'Span') -> Iterator[None]:
         """Context manager for controlling a span's lifetime.
 
         Start the given span and set it as the current span in this tracer's
@@ -199,7 +197,7 @@ class Span(object):
         """
         pass
 
-    def get_context(self) -> SpanContext:
+    def get_context(self) -> 'SpanContext':
         """Gets the span's SpanContext.
 
         Get an immutable, serializable identifier for this span that can be
@@ -227,8 +225,8 @@ class SpanContext(object):
     def __init__(self,
                  trace_id: str,
                  span_id: str,
-                 options: TraceOptions,
-                 state: TraceState) -> None:
+                 options: 'TraceOptions',
+                 state: 'TraceState') -> None:
         pass
 
 


### PR DESCRIPTION
One possible fix for #25.

Since type annotations are evaluated at import time, annotations that refer to classes later in the same module will fail. This is fixed in 3.8, and available as a future import in 3.7. If we want to support python versions older than 3.7 our type annotations need to be strings that evaluate to the right type when the module is finished loading.