### PR TITLE
Add tox and travis, run pylint on builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+dist: xenial
+
+language: python
+
+python:
+  - '3.7'
+
+install:
+  - pip install tox-travis
+
+script:
+  - tox
+
+branches:
+  only:
+    - master

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+skipsdist=True
+envlist = py37-lint
+
+[testenv]
+install_command = python -m pip install {opts} {packages}
+
+deps =
+  py37-lint: pylint
+
+commands =
+  py37-lint: pylint opentelemetry-api/opentelemetry/

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-skipsdist=True
+skipsdist = True
 envlist = py37-lint
 
 [testenv]
-install_command = python -m pip install {opts} {packages}
-
 deps =
   py37-lint: pylint
 
 commands =
-  py37-lint: pylint opentelemetry-api/opentelemetry/
+  py37-lint: pylint opentelemetry-api/opentelemetry/trace/


### PR DESCRIPTION
A bare-bones fix for #6. This should run pylint on travis on each build.

There's still a lot more to do to make travis useful, but this is a start. See @lzchen's [travis config in opencensus](https://github.com/census-instrumentation/opencensus-python/pull/658) for generating the docs, running the tests, etc.