### PR TITLE
Add type check to travis

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
   disallow_any_unimported = True
+  disallow_any_expr = True
   disallow_any_decorated = True
   disallow_any_explicit = True
   disallow_any_generics = True
@@ -7,7 +8,7 @@
   disallow_untyped_calls = True
   disallow_untyped_defs = True
   disallow_incomplete_defs = True
-  check-untyped-defs = True
+  check_untyped_defs = True
   disallow_untyped_decorators = True
   warn_unused_ignores = True
   warn_return_any = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,13 @@
+[mypy]
+  disallow_any_unimported = True
+  disallow_any_decorated = True
+  disallow_any_explicit = True
+  disallow_any_generics = True
+  disallow_subclassing_any = True
+  disallow_untyped_calls = True
+  disallow_untyped_defs = True
+  disallow_incomplete_defs = True
+  check-untyped-defs = True
+  disallow_untyped_decorators = True
+  warn_unused_ignores = True
+  warn_return_any = True

--- a/opentelemetry-api/opentelemetry/__init__.py
+++ b/opentelemetry-api/opentelemetry/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/opentelemetry-api/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/opentelemetry/trace/__init__.py
@@ -63,7 +63,7 @@ implicit or explicit context propagation consistently throughout.
 """
 
 from contextlib import contextmanager
-from typing import Iterator
+import typing
 
 
 class Tracer:
@@ -86,7 +86,7 @@ class Tracer:
 
 
     @contextmanager
-    def start_span(self, name: str, parent: 'Span') -> Iterator['Span']:
+    def start_span(self, name: str, parent: 'Span') -> typing.Iterator['Span']:
         """Context manager for span creation.
 
         Create a new child of the current span, or create a root span if no
@@ -155,7 +155,7 @@ class Tracer:
         """
 
     @contextmanager
-    def use_span(self, span: 'Span') -> Iterator[None]:
+    def use_span(self, span: 'Span') -> typing.Iterator[None]:
         """Context manager for controlling a span's lifetime.
 
         Start the given span and set it as the current span in this tracer's
@@ -229,5 +229,5 @@ class TraceOptions(int):
 
 
 # TODO
-class TraceState(dict):
+class TraceState(typing.Dict[str, str]):
     pass

--- a/opentelemetry-api/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/opentelemetry/trace/__init__.py
@@ -85,7 +85,7 @@ class Tracer:
         """
 
 
-    @contextmanager
+    @contextmanager  # type: ignore
     def start_span(self, name: str, parent: 'Span') -> typing.Iterator['Span']:
         """Context manager for span creation.
 
@@ -154,7 +154,7 @@ class Tracer:
             The newly-created span.
         """
 
-    @contextmanager
+    @contextmanager  # type: ignore
     def use_span(self, span: 'Span') -> typing.Iterator[None]:
         """Context manager for controlling a span's lifetime.
 

--- a/opentelemetry-api/setup.py
+++ b/opentelemetry-api/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
     include_package_data=True,
     long_description=open("README.rst").read(),
     install_requires=[
+        "typing; python_version<'3.5'",
     ],
     extras_require={},
     license="Apache-2.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
 skipsdist = True
-envlist = py37-lint
+envlist = py37-lint, py37-mypy
 
 [testenv]
 deps =
   py37-lint: pylint
+  py37-mypy: mypy
 
 commands =
-  py37-lint: pylint opentelemetry-api/opentelemetry/trace/
+  py37-lint: pylint opentelemetry-api/opentelemetry/
+  py37-mypy: mypy opentelemetry-api/opentelemetry/


### PR DESCRIPTION
Piling onto #30, this PR adds type checks via `mypy` to travis for the API package.

These are pretty strict defaults; I followed @Oberon00's approach in #24 and enabled every available option that wasn't already incompatible with our code. I had to omit `--disallow-any-expr` because of `contextmanager`, but there may still be a way around this.

See https://mypy.readthedocs.io/en/latest/config_file.html for details on these options.