### PR TITLE
Make Sphinx check for undefined references & .gitignore _build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ htmlcov
 
 # VSCode
 .vscode
+
+# Sphinx
+_build/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,13 @@ extensions = [
     'sphinx.ext.intersphinx',
 ]
 
+intersphinx_mapping = {'python': ('https://docs.python.org/3/', None)}
+
+# http://www.sphinx-doc.org/en/master/config.html#confval-nitpicky
+# Sphinx will warn about all references where the target cannot be found.
+nitpicky = True
+nitpick_ignore = []
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
The `intersphinx_mapping` is required to avoid warnings about things like `typing.Iterator`, I think it's neat anyway to have these linked.