### PR TITLE
Set pylint's line length to 79 chars

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -245,7 +245,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=79
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/opentelemetry-api/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/opentelemetry/trace/__init__.py
@@ -104,7 +104,7 @@ class Tracer:
                     child.add_event("child's event")
                     tracer.get_current_span()  # returns child
                 tracer.get_current_span()      # returns parent
-            tracer.get_current_span()          # returns the previously active span
+            tracer.get_current_span()          # returns previously active span
 
         This is a convenience method for creating spans attached to the
         tracer's context. Applications that need more control over the span


### PR DESCRIPTION
This limits lines to 79 characters, [as Guido intended](https://www.python.org/dev/peps/pep-0008/#maximum-line-length). Hopefully everybody sees this as an uncontroversial and good idea.

Motivated by https://github.com/open-telemetry/opentelemetry-python/pull/29#discussion_r297399860.