### PR TITLE
Change sphinx default role to "any"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,9 @@ author = 'OpenTelemetry Authors'
 
 # -- General configuration ---------------------------------------------------
 
+# Easy automatic cross-references for `code in backticks`
+default_role = 'any'
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -178,7 +178,7 @@ class Span:
         Each span represents a single operation. The span's start time is the
         wall time at which the operation started.
 
-        Only the first call to ``start`` should modify the span, and
+        Only the first call to `start` should modify the span, and
         implementations are free to ignore or raise on further calls.
         """
 
@@ -187,7 +187,7 @@ class Span:
 
         The span's end time is the wall time at which the operation finished.
 
-        Only the first call to ``end`` should modify the span, and
+        Only the first call to `end` should modify the span, and
         implementations are free to ignore or raise on further calls.
         """
 


### PR DESCRIPTION
This PR changes the sphinx default role so that comments in single-backticks render as literal text and link(!) to the appropriate section of the docs if sphinx can find one.

This recommendation comes from the [sphinx docs](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-any):

> This role is a good candidate for setting default_role. If you do, you can write cross-references without a lot of markup overhead. 

One downside is that sphinx can't find a target for some text it'll emit a warning:

```
docstring of opentelemetry.trace:9: WARNING: 'any' reference target not found: BlankSpan
```

but we can get around this by using double-backticks to specify the `:code:` role, which is what we were doing before this change anyway.