### PR TITLE
Unit tests

### DIFF
--- a/opentelemetry-api/tests/__init__.py
+++ b/opentelemetry-api/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/opentelemetry-api/tests/test_loader.py
+++ b/opentelemetry-api/tests/test_loader.py
@@ -1,0 +1,95 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from importlib import reload
+import sys
+import unittest
+import os
+
+from opentelemetry import loader
+from opentelemetry import trace
+
+DUMMY_TRACER = None
+
+class DummyTracer(trace.Tracer):
+    pass
+
+def get_opentelemetry_implementation(type_):
+    global DUMMY_TRACER #pylint:disable=global-statement
+    assert type_ is trace.Tracer
+    DUMMY_TRACER = DummyTracer()
+    return DUMMY_TRACER
+
+#pylint:disable=redefined-outer-name,protected-access,unidiomatic-typecheck
+
+class TestLoader(unittest.TestCase):
+
+    def setUp(self):
+        reload(loader)
+        reload(trace)
+
+        # Need to reload self, otherwise DummyTracer will have the wrong base
+        # class after reloading `trace`.
+        reload(sys.modules[__name__])
+
+
+    def test_get_default(self):
+        tracer = trace.tracer()
+        self.assertIs(type(tracer), trace.Tracer)
+
+    def test_preferred_impl(self):
+        trace.set_preferred_tracer_implementation(
+            get_opentelemetry_implementation)
+        tracer = trace.tracer()
+        self.assertIs(tracer, DUMMY_TRACER)
+
+    # NOTE: We use do_* + *_<arg> methods because subtest wouldn't run setUp,
+    # which we require here.
+    def do_test_preferred_impl(self, setter):
+        setter(get_opentelemetry_implementation)
+        tracer = trace.tracer()
+        self.assertIs(tracer, DUMMY_TRACER)
+    def test_preferred_impl_with_tracer(self):
+        self.do_test_preferred_impl(trace.set_preferred_tracer_implementation)
+    def test_preferred_impl_with_default(self):
+        self.do_test_preferred_impl(
+            loader.set_preferred_default_implementation)
+
+    def test_try_set_again(self):
+        self.assertTrue(trace.tracer())
+        # Try setting after the tracer has already been created:
+        with self.assertRaises(RuntimeError) as einfo:
+            trace.set_preferred_tracer_implementation(
+                get_opentelemetry_implementation)
+        self.assertIn('already loaded', str(einfo.exception))
+
+    def do_test_get_envvar(self, envvar_suffix):
+        global DUMMY_TRACER #pylint:disable=global-statement
+
+        # Test is not runnable with this!
+        self.assertFalse(sys.flags.ignore_environment)
+
+        envname = 'OPENTELEMETRY_PYTHON_IMPLEMENTATION_' + envvar_suffix
+        os.environ[envname] = __name__
+        try:
+            tracer = trace.tracer()
+            self.assertIs(tracer, DUMMY_TRACER)
+        finally:
+            DUMMY_TRACER = None
+            del os.environ[envname]
+        self.assertIs(type(tracer), DummyTracer)
+    def test_get_envvar_tracer(self):
+        return self.do_test_get_envvar('TRACER')
+    def test_get_envvar_default(self):
+        return self.do_test_get_envvar('DEFAULT')

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py37-{lint,mypy}, docs
+envlist = py37-{lint,mypy,test}, docs
 
 [travis]
 python =
@@ -11,10 +11,23 @@ deps =
   lint: pylint~=2.3.1
   mypy: mypy~=0.711
 
+setenv =
+  PYTHONPATH={toxinidir}/opentelemetry-api/src/
+  mypy: MYPYPATH={env:PYTHONPATH}
+
+changedir =
+  test: opentelemetry-api/tests
+
 
 commands =
-  py37-lint: pylint opentelemetry-api/src/opentelemetry/
+; Prefer putting everything in one pylint command to profit from duplication
+; warnings.
+  py37-lint: pylint opentelemetry-api/src/opentelemetry/ opentelemetry-api/tests/
   py37-mypy: mypy opentelemetry-api/src/opentelemetry/
+; For test code, we don't want to use the full mypy strictness, so we use its
+; default flags instead.
+  py37-mypy: mypy opentelemetry-api/tests/ --config-file=
+  test: python -m unittest discover
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
Based on #29.

Adds unit tests using the `unittest` standard library module, executes them in tox and runs pylint and a basic `mypy` configuration on the test code.