### PR TITLE
Add flake8 and isort lint checks

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+from_first=True

--- a/opentelemetry-api/src/opentelemetry/loader.py
+++ b/opentelemetry-api/src/opentelemetry/loader.py
@@ -61,7 +61,7 @@ skipped if :data:`sys.flags` has ``ignore_environment`` set (which usually
 means that the Python interpreter was invoked with the ``-E`` or ``-I`` flag).
 """
 
-from typing import Type, TypeVar, Optional, Callable
+from typing import Callable, Optional, Type, TypeVar
 import importlib
 import os
 import sys
@@ -78,9 +78,10 @@ _UntrustedImplFactory = Callable[[Type[_T]], Optional[object]]
 # annotate setters, were it not for https://github.com/python/mypy/issues/7092
 # Once that bug is resolved, setters should use this instead of duplicating the
 # code.
-#ImplementationFactory = Callable[[Type[_T]], Optional[_T]]
+# ImplementationFactory = Callable[[Type[_T]], Optional[_T]]
 
 _DEFAULT_FACTORY: Optional[_UntrustedImplFactory[object]] = None
+
 
 def _try_load_impl_from_modname(
         implementation_modname: str, api_type: Type[_T]) -> Optional[_T]:
@@ -91,6 +92,7 @@ def _try_load_impl_from_modname(
         return None
 
     return _try_load_impl_from_mod(implementation_mod, api_type)
+
 
 def _try_load_impl_from_mod(
         implementation_mod: object, api_type: Type[_T]) -> Optional[_T]:
@@ -108,6 +110,7 @@ def _try_load_impl_from_mod(
         return None
 
     return _try_load_impl_from_callback(implementation_fn, api_type)
+
 
 def _try_load_impl_from_callback(
         implementation_fn: _UntrustedImplFactory[_T],
@@ -149,11 +152,10 @@ def _try_load_configured_impl(
         return _try_load_impl_from_callback(_DEFAULT_FACTORY, api_type)
     return None
 
+
 # Public to other opentelemetry-api modules
-def _load_impl(
-        api_type: Type[_T],
-        factory: Optional[Callable[[Type[_T]], Optional[_T]]]
-    ) -> _T:
+def _load_impl(api_type: Type[_T],
+               factory: Optional[Callable[[Type[_T]], Optional[_T]]]) -> _T:
     """Tries to load a configured implementation, if unsuccessful, returns a
     fast no-op implemenation that is always available.
     """
@@ -163,9 +165,10 @@ def _load_impl(
         return api_type()
     return result
 
+
 def set_preferred_default_implementation(
         implementation_factory: _UntrustedImplFactory[_T]) -> None:
     """Sets a factory function that may be called for any implementation
     object. See the :ref:`module docs <loader-factory>` for more details."""
-    global _DEFAULT_FACTORY #pylint:disable=global-statement
+    global _DEFAULT_FACTORY  # pylint:disable=global-statement
     _DEFAULT_FACTORY = implementation_factory

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -64,6 +64,7 @@ implicit or explicit context propagation consistently throughout.
 
 from contextlib import contextmanager
 import typing
+
 from opentelemetry import loader
 
 

--- a/opentelemetry-api/tests/__init__.py
+++ b/opentelemetry-api/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/opentelemetry-api/tests/test_loader.py
+++ b/opentelemetry-api/tests/test_loader.py
@@ -1,0 +1,95 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from importlib import reload
+import sys
+import unittest
+import os
+
+from opentelemetry import loader
+from opentelemetry import trace
+
+DUMMY_TRACER = None
+
+class DummyTracer(trace.Tracer):
+    pass
+
+def get_opentelemetry_implementation(type_):
+    global DUMMY_TRACER #pylint:disable=global-statement
+    assert type_ is trace.Tracer
+    DUMMY_TRACER = DummyTracer()
+    return DUMMY_TRACER
+
+#pylint:disable=redefined-outer-name,protected-access,unidiomatic-typecheck
+
+class TestLoader(unittest.TestCase):
+
+    def setUp(self):
+        reload(loader)
+        reload(trace)
+
+        # Need to reload self, otherwise DummyTracer will have the wrong base
+        # class after reloading `trace`.
+        reload(sys.modules[__name__])
+
+
+    def test_get_default(self):
+        tracer = trace.tracer()
+        self.assertIs(type(tracer), trace.Tracer)
+
+    def test_preferred_impl(self):
+        trace.set_preferred_tracer_implementation(
+            get_opentelemetry_implementation)
+        tracer = trace.tracer()
+        self.assertIs(tracer, DUMMY_TRACER)
+
+    # NOTE: We use do_* + *_<arg> methods because subtest wouldn't run setUp,
+    # which we require here.
+    def do_test_preferred_impl(self, setter):
+        setter(get_opentelemetry_implementation)
+        tracer = trace.tracer()
+        self.assertIs(tracer, DUMMY_TRACER)
+    def test_preferred_impl_with_tracer(self):
+        self.do_test_preferred_impl(trace.set_preferred_tracer_implementation)
+    def test_preferred_impl_with_default(self):
+        self.do_test_preferred_impl(
+            loader.set_preferred_default_implementation)
+
+    def test_try_set_again(self):
+        self.assertTrue(trace.tracer())
+        # Try setting after the tracer has already been created:
+        with self.assertRaises(RuntimeError) as einfo:
+            trace.set_preferred_tracer_implementation(
+                get_opentelemetry_implementation)
+        self.assertIn('already loaded', str(einfo.exception))
+
+    def do_test_get_envvar(self, envvar_suffix):
+        global DUMMY_TRACER #pylint:disable=global-statement
+
+        # Test is not runnable with this!
+        self.assertFalse(sys.flags.ignore_environment)
+
+        envname = 'OPENTELEMETRY_PYTHON_IMPLEMENTATION_' + envvar_suffix
+        os.environ[envname] = __name__
+        try:
+            tracer = trace.tracer()
+            self.assertIs(tracer, DUMMY_TRACER)
+        finally:
+            DUMMY_TRACER = None
+            del os.environ[envname]
+        self.assertIs(type(tracer), DummyTracer)
+    def test_get_envvar_tracer(self):
+        return self.do_test_get_envvar('TRACER')
+    def test_get_envvar_default(self):
+        return self.do_test_get_envvar('DEFAULT')

--- a/opentelemetry-api/tests/test_loader.py
+++ b/opentelemetry-api/tests/test_loader.py
@@ -13,25 +13,28 @@
 # limitations under the License.
 
 from importlib import reload
+import os
 import sys
 import unittest
-import os
 
 from opentelemetry import loader
 from opentelemetry import trace
 
 DUMMY_TRACER = None
 
+
 class DummyTracer(trace.Tracer):
     pass
 
+
 def get_opentelemetry_implementation(type_):
-    global DUMMY_TRACER #pylint:disable=global-statement
+    global DUMMY_TRACER  # pylint:disable=global-statement
     assert type_ is trace.Tracer
     DUMMY_TRACER = DummyTracer()
     return DUMMY_TRACER
 
-#pylint:disable=redefined-outer-name,protected-access,unidiomatic-typecheck
+
+# pylint:disable=redefined-outer-name,protected-access,unidiomatic-typecheck
 
 class TestLoader(unittest.TestCase):
 
@@ -42,7 +45,6 @@ class TestLoader(unittest.TestCase):
         # Need to reload self, otherwise DummyTracer will have the wrong base
         # class after reloading `trace`.
         reload(sys.modules[__name__])
-
 
     def test_get_default(self):
         tracer = trace.tracer()
@@ -60,8 +62,10 @@ class TestLoader(unittest.TestCase):
         setter(get_opentelemetry_implementation)
         tracer = trace.tracer()
         self.assertIs(tracer, DUMMY_TRACER)
+
     def test_preferred_impl_with_tracer(self):
         self.do_test_preferred_impl(trace.set_preferred_tracer_implementation)
+
     def test_preferred_impl_with_default(self):
         self.do_test_preferred_impl(
             loader.set_preferred_default_implementation)
@@ -75,7 +79,7 @@ class TestLoader(unittest.TestCase):
         self.assertIn('already loaded', str(einfo.exception))
 
     def do_test_get_envvar(self, envvar_suffix):
-        global DUMMY_TRACER #pylint:disable=global-statement
+        global DUMMY_TRACER  # pylint:disable=global-statement
 
         # Test is not runnable with this!
         self.assertFalse(sys.flags.ignore_environment)
@@ -89,7 +93,9 @@ class TestLoader(unittest.TestCase):
             DUMMY_TRACER = None
             del os.environ[envname]
         self.assertIs(type(tracer), DummyTracer)
+
     def test_get_envvar_tracer(self):
         return self.do_test_get_envvar('TRACER')
+
     def test_get_envvar_default(self):
         return self.do_test_get_envvar('DEFAULT')

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py37-{lint,mypy,test}, docs
+envlist = py{34,35,36,37}-test, lint, py37-mypy, docs
 
 [travis]
 python =
@@ -8,7 +8,6 @@ python =
 
 [testenv]
 deps =
-  lint: pylint~=2.3.1
   mypy: mypy~=0.711
 
 setenv =
@@ -18,16 +17,25 @@ setenv =
 changedir =
   test: opentelemetry-api/tests
 
-
 commands =
-; Prefer putting everything in one pylint command to profit from duplication
-; warnings.
-  py37-lint: pylint opentelemetry-api/src/opentelemetry/ opentelemetry-api/tests/
   py37-mypy: mypy opentelemetry-api/src/opentelemetry/
 ; For test code, we don't want to use the full mypy strictness, so we use its
 ; default flags instead.
   py37-mypy: mypy opentelemetry-api/tests/ --config-file=
   test: python -m unittest discover
+
+[testenv:lint]
+deps =
+  pylint~=2.3.1
+  flake8~=3.7.8
+  isort~=4.3.21
+
+commands =
+; Prefer putting everything in one pylint command to profit from duplication
+; warnings.
+  pylint opentelemetry-api/src/opentelemetry/ opentelemetry-api/tests/
+  flake8 opentelemetry-api/src/opentelemetry/ opentelemetry-api/tests/
+  isort --check-only --recursive opentelemetry-api/src
 
 [testenv:docs]
 deps =
@@ -35,6 +43,7 @@ deps =
   sphinx-rtd-theme~=0.4.3
   sphinx-autodoc-typehints~=1.6.0
 
+changedir = docs
+
 commands =
   sphinx-build -W --keep-going -b html -T . _build/html
-changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py{34,35,36,37}-test, lint, py37-mypy, docs
 
 [travis]
 python =
-  3.7: py37, docs
+  3.7: py37, lint, docs
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -26,9 +26,9 @@ commands =
 
 [testenv:lint]
 deps =
-  pylint~=2.3.1
-  flake8~=3.7.8
-  isort~=4.3.21
+  pylint~=2.3
+  flake8~=3.7
+  isort~=4.3
 
 commands =
 ; Prefer putting everything in one pylint command to profit from duplication
@@ -39,9 +39,9 @@ commands =
 
 [testenv:docs]
 deps =
-  sphinx~=2.1.2
-  sphinx-rtd-theme~=0.4.3
-  sphinx-autodoc-typehints~=1.6.0
+  sphinx~=2.1
+  sphinx-rtd-theme~=0.4
+  sphinx-autodoc-typehints~=1.6
 
 changedir = docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py37-{lint,mypy}, docs
+envlist = py37-{lint,mypy,test}, docs
 
 [travis]
 python =
@@ -11,10 +11,23 @@ deps =
   lint: pylint~=2.3.1
   mypy: mypy~=0.711
 
+setenv =
+  PYTHONPATH={toxinidir}/opentelemetry-api/src/
+  mypy: MYPYPATH={env:PYTHONPATH}
+
+changedir =
+  test: opentelemetry-api/tests
+
 
 commands =
-  py37-lint: pylint opentelemetry-api/src/opentelemetry/
+; Prefer putting everything in one pylint command to profit from duplication
+; warnings.
+  py37-lint: pylint opentelemetry-api/src/opentelemetry/ opentelemetry-api/tests/
   py37-mypy: mypy opentelemetry-api/src/opentelemetry/
+; For test code, we don't want to use the full mypy strictness, so we use its
+; default flags instead.
+  py37-mypy: mypy opentelemetry-api/tests/ --config-file=
+  test: python -m unittest discover
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
From https://github.com/open-telemetry/opentelemetry-python/pull/42#discussion_r302254223, builds on #42. Compare to @Oberon00's `unit-tests` branch for a sane diff: https://github.com/Oberon00/opentelemetry-python/compare/unit-tests...c24t:more-pedantic-lint

This PR makes lint a bit stricter by adding `flake8` and `isort` checks.