### PR TITLE
Add default invalid SpanContext

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -123,16 +123,11 @@ DEFAULT_TRACEOPTIONS = TraceOptions.get_default()
 
 
 class TraceState(typing.Dict[str, str]):
-    """A list of key-value pairs that carries system-specific config.
+    """A list of key-value pairs representing vendor-specific trace info.
 
-    Keys are strings of up to 256 characters containing only lowercase letters
-    ``a-z``, digits ``0-9``, underscores ``_``, dashes ``-``, asterisks ``*``,
-    and forward slashes ``/``.
-
-    Values are strings of up to 256 printable ASCII RFC0020 characters (i.e.,
-    the range ``0x20`` to ``0x7E``) except comma ``,`` and equals sign ``=``.
-
-    See the `W3C Trace Context - Tracestate`_ spec for details.
+    Keys and values are strings of up to 256 printable US-ASCII characters.
+    Implementations should conform to the the `W3C Trace Context - Tracestate`_
+    spec, which describes additional restrictions on valid field values.
 
     .. _W3C Trace Context - Tracestate:
         https://www.w3.org/TR/trace-context/#tracestate-field

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -106,9 +106,10 @@ class TraceOptions(int):
     The only supported option is the "recorded" flag (``0x01``). If set, this
     flag indicates that the trace may have been recorded upstream.
 
-    See the `W3C Trace Context`_ spec for details.
+    See the `W3C Trace Context - Traceparent`_ spec for details.
 
-    .. _W3C Trace Context: https://www.w3.org/TR/trace-context/#trace-flags
+    .. _W3C Trace Context - Traceparent:
+        https://www.w3.org/TR/trace-context/#trace-flags
     """
     DEFAULT = 0x00
     RECORDED = 0x01
@@ -130,6 +131,11 @@ class TraceState(typing.Dict[str, str]):
 
     Values are strings of up to 256 printable ASCII RFC0020 characters (i.e.,
     the range ``0x20`` to ``0x7E``) except comma ``,`` and equals sign ``=``.
+
+    See the `W3C Trace Context - Tracestate`_ spec for details.
+
+    .. _W3C Trace Context - Tracestate:
+        https://www.w3.org/TR/trace-context/#tracestate-field
     """
 
     @classmethod

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -254,10 +254,31 @@ class TraceOptions(int):
     DEFAULT = 0x00
     RECORDED = 0x01
 
+    @classmethod
+    def get_default(cls) -> 'TraceOptions':
+        return cls(cls.DEFAULT)
 
-# TODO
+
+DEFAULT_TRACEOPTIONS = TraceOptions.get_default()
+
+
 class TraceState(typing.Dict[str, str]):
-    pass
+    """A list of key-value pairs that carries system-specific config.
+
+    Keys are strings of up to 256 characters containing only lowercase letters
+    ``a-z``, digits ``0-9``, underscores ``_``, dashes ``-``, asterisks ``*``,
+    and forward slashes ``/``.
+
+    Values are strings of up to 256 printable ASCII RFC0020 characters (i.e.,
+    the range ``0x20`` to ``0x7E``) except comma ``,`` and equals sign ``=``.
+    """
+
+    @classmethod
+    def get_default(cls) -> 'TraceState':
+        return cls()
+
+
+DEFAULT_TRACESTATE = TraceState.get_default()
 
 
 _TRACER: typing.Optional[Tracer] = None

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -241,9 +241,18 @@ class Tracer:
         """
 
 
-# TODO
 class TraceOptions(int):
-    pass
+    """A bitmask that represents options specific to the trace.
+
+    The only supported option is the "recorded" flag (``0x01``). If set, this
+    flag indicates that the trace may have been recorded upstream.
+
+    See the `W3C Trace Context`_ spec for details.
+
+    .. _W3C Trace Context: https://www.w3.org/TR/trace-context/#trace-flags
+    """
+    DEFAULT = 0x00
+    RECORDED = 0x01
 
 
 # TODO

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -66,6 +66,7 @@ from contextlib import contextmanager
 import typing
 from opentelemetry import loader
 
+
 class Span:
     """A span represents a single operation within a trace."""
 
@@ -118,6 +119,7 @@ class SpanContext:
                  options: 'TraceOptions',
                  state: 'TraceState') -> None:
         pass
+
 
 class Tracer:
     """Handles span creation and in-process context propagation.
@@ -253,25 +255,27 @@ _TRACER: typing.Optional[Tracer] = None
 _TRACER_FACTORY: typing.Optional[
     typing.Callable[[typing.Type[Tracer]], typing.Optional[Tracer]]] = None
 
+
 def tracer() -> Tracer:
     """Gets the current global :class:`~.Tracer` object.
-    If there isn't one set yet, a default will be loaded."""
 
-    global _TRACER, _TRACER_FACTORY #pylint:disable=global-statement
+    If there isn't one set yet, a default will be loaded.
+    """
+    global _TRACER, _TRACER_FACTORY  # pylint:disable=global-statement
 
     if _TRACER is None:
-        #pylint:disable=protected-access
+        # pylint:disable=protected-access
         _TRACER = loader._load_impl(Tracer, _TRACER_FACTORY)
         del _TRACER_FACTORY
 
     return _TRACER
 
+
 def set_preferred_tracer_implementation(
         factory: typing.Callable[
             [typing.Type[Tracer]], typing.Optional[Tracer]]
         ) -> None:
-    """Sets a factory function which may be used to create the tracer
-    implementation.
+    """Set the factory to be used to create the tracer.
 
     See :mod:`opentelemetry.loader` for details.
 
@@ -280,8 +284,7 @@ def set_preferred_tracer_implementation(
     Args:
         factory: Callback that should create a new :class:`Tracer` instance.
     """
-
-    global _TRACER_FACTORY #pylint:disable=global-statement
+    global _TRACER_FACTORY  # pylint:disable=global-statement
 
     if _TRACER:
         raise RuntimeError("Tracer already loaded.")

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -166,8 +166,8 @@ class SpanContext:
     def is_valid(self) -> bool:
         """Get whether this `SpanContext` is valid.
 
-        A `SpanContext` is said to be invalid if its trace ID and span ID are
-        both invalid (i.e. ``0``).
+        A `SpanContext` is said to be invalid if its trace ID or span ID is
+        invalid (i.e. ``0``).
 
         Returns:
             True if the `SpanContext` is valid, false otherwise.


### PR DESCRIPTION
This PR adds a global invalid `SpanContext` and fleshes out `TraceState` and `TraceOptions`. Since we need this package to provide this `SpanContext` by default, this means getting some implementation in our API.

I opted for simplicity instead of trying to match the structure and behavior of the java client exactly here. Note that there's no class for trace/span IDs, no precondition checks, etc. The change is only a few lines, but those lines are ripe for argument.

Compare to the java [`SpanContext`](https://github.com/open-telemetry/opentelemetry-java/blob/8e368d2f4ad8da3c78d61d1348f14d58a225f9ec/api/src/main/java/io/opentelemetry/trace/SpanContext.java) and see the related classes.
