### PR TITLE
Type hint edits for #57

### DIFF
--- a/mypy-relaxed.ini
+++ b/mypy-relaxed.ini
@@ -3,7 +3,7 @@
 [mypy]
   disallow_any_unimported = True
 ; disallow_any_expr = True
-; disallow_any_decorated = True
+  disallow_any_decorated = True
 ; disallow_any_explicit = True
   disallow_any_generics = True
   disallow_subclassing_any = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
   disallow_any_unimported = True
   disallow_any_expr = True
-; disallow_any_decorated = True
+  disallow_any_decorated = True
 ; disallow_any_explicit = True
   disallow_any_generics = True
   disallow_subclassing_any = True

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -16,9 +16,11 @@ import typing
 
 from .base_context import BaseRuntimeContext
 
+
 __all__ = ['Context']
 
-Context: typing.Union[BaseRuntimeContext, None] = None
+
+Context: typing.Optional[BaseRuntimeContext]
 
 try:
     from .async_context import AsyncRuntimeContext

--- a/opentelemetry-api/src/opentelemetry/context/async_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/async_context.py
@@ -12,24 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextvars import ContextVar
 import typing
+from contextvars import ContextVar
 
-from .base_context import BaseRuntimeContext
+from . import base_context
 
 
-class AsyncRuntimeContext(BaseRuntimeContext):
-    class Slot(BaseRuntimeContext.Slot):
-        def __init__(self, name: str, default: typing.Any):
+class AsyncRuntimeContext(base_context.BaseRuntimeContext):
+    class Slot(base_context.BaseRuntimeContext.Slot):
+        def __init__(self, name: str, default: 'object'):
             # pylint: disable=super-init-not-called
             self.name = name
-            self.contextvar: typing.Any = ContextVar(name)
-            self.default = default if callable(default) else (lambda: default)
+            self.contextvar: 'ContextVar[object]' = ContextVar(name)
+            self.default: typing.Callable[..., object]
+            self.default = base_context.wrap_callable(default)
 
         def clear(self) -> None:
             self.contextvar.set(self.default())
 
-        def get(self) -> typing.Any:
+        def get(self) -> 'object':
             try:
                 return self.contextvar.get()
             except LookupError:
@@ -37,5 +38,5 @@ class AsyncRuntimeContext(BaseRuntimeContext):
                 self.set(value)
                 return value
 
-        def set(self, value: typing.Any) -> None:
+        def set(self, value: 'object') -> None:
             self.contextvar.set(value)


### PR DESCRIPTION
For #57.

@reyang I thought we could use generics here, but after another pass I don't think the context API should dictate the type of objects it stores. I replaced some `Any` annotations with `object`, but gave up on re-enabling `disallow_any_explicit` because of the get/setters in `ThreadLocalRuntimeContext`.

I'll comment in the main PR, but I don't think typing gives us any benefit here.