### PR TITLE
Add DefaultSpan in the API.

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -175,10 +175,23 @@ class SpanContext:
         """
 
 
+class DefaultSpan(Span):
+    """The default Span that is used when no Span implementation is available.
+
+    All operations are no-op except context propagation.
+    """
+    def __init__(self, context):
+        self._context = context
+
+    def get_context(self):
+        return self._context
+
+
 INVALID_SPAN_ID = 0
 INVALID_TRACE_ID = 0
 INVALID_SPAN_CONTEXT = SpanContext(INVALID_TRACE_ID, INVALID_SPAN_ID,
                                    DEFAULT_TRACEOPTIONS, DEFAULT_TRACESTATE)
+INVALID_SPAN = DefaultSpan(INVALID_SPAN_CONTEXT)
 
 
 class Tracer:

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -180,10 +180,10 @@ class DefaultSpan(Span):
 
     All operations are no-op except context propagation.
     """
-    def __init__(self, context):
+    def __init__(self, context: 'SpanContext') -> None:
         self._context = context
 
-    def get_context(self):
+    def get_context(self) -> 'SpanContext':
         return self._context
 
 

--- a/opentelemetry-api/tests/trace/__init__.py
+++ b/opentelemetry-api/tests/trace/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/opentelemetry-api/tests/trace/test_defaultspan.py
+++ b/opentelemetry-api/tests/trace/test_defaultspan.py
@@ -1,0 +1,31 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from opentelemetry import trace
+
+
+class TestDefaultSpan(unittest.TestCase):
+    def test_ctor(self):
+        context = trace.SpanContext(1, 1,
+                                    trace.DEFAULT_TRACEOPTIONS,
+                                    trace.DEFAULT_TRACESTATE)
+        span = trace.DefaultSpan(context)
+        self.assertEqual(context, span.get_context())
+
+    def test_invalid_span(self):
+        self.assertIsNotNone(trace.INVALID_SPAN)
+        self.assertIsNotNone(trace.INVALID_SPAN.get_context())
+        self.assertFalse(trace.INVALID_SPAN.get_context().is_valid())


### PR DESCRIPTION
This PR adds `DefaultSpan`, which simply carries a specified `SpanContext`.

This is done to: 1) Define an actual `INVALID_SPAN` and to 2) Later add support for context-propagation for our `DefaultTracer` (to be added).

(`DefaultTracer` in Java is expected to be the no-op implementation that simply does context-propagation. Something to consider here, too, is whether we want to have this functionality in the actual base `Span` / `Tracer` classes ;) )