### PR TITLE
Span creation in tracer SDK

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,3 @@
 [settings]
 force_single_line=True
 from_first=True
-from_first=True

--- a/.pylintrc
+++ b/.pylintrc
@@ -64,7 +64,8 @@ disable=missing-docstring,
       fixme, # Warns about FIXME, TODO, etc. comments.
       too-few-public-methods, # Might be good to re-enable this later.
       too-many-instance-attributes,
-      too-many-arguments
+      too-many-arguments,
+      ungrouped-imports # Leave this up to isort
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/opentelemetry-api/setup.py
+++ b/opentelemetry-api/setup.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+
 import setuptools
 
 BASE_DIR = os.path.dirname(__file__)

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -66,6 +66,8 @@ import typing
 
 from opentelemetry import loader
 
+ParentSpan = typing.Optional[typing.Union['Span', 'SpanContext']]
+
 
 class Span:
     """A span represents a single operation within a trace."""
@@ -215,8 +217,6 @@ INVALID_TRACE_ID = 0x00000000000000000000000000000000
 INVALID_SPAN_CONTEXT = SpanContext(INVALID_TRACE_ID, INVALID_SPAN_ID,
                                    DEFAULT_TRACEOPTIONS, DEFAULT_TRACESTATE)
 INVALID_SPAN = DefaultSpan(INVALID_SPAN_CONTEXT)
-
-ParentSpan = typing.Optional[typing.Union['Span', 'SpanContext']]
 
 
 class Tracer:

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -66,6 +66,7 @@ import typing
 
 from opentelemetry import loader
 
+# TODO: quarantine
 ParentSpan = typing.Optional[typing.Union['Span', 'SpanContext']]
 
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -200,6 +200,8 @@ INVALID_SPAN_CONTEXT = SpanContext(INVALID_TRACE_ID, INVALID_SPAN_ID,
                                    DEFAULT_TRACEOPTIONS, DEFAULT_TRACESTATE)
 INVALID_SPAN = DefaultSpan(INVALID_SPAN_CONTEXT)
 
+ParentSpan = typing.Optional[typing.Union['Span', 'SpanContext']]
+
 
 class Tracer:
     """Handles span creation and in-process context propagation.
@@ -226,7 +228,7 @@ class Tracer:
     @contextmanager  # type: ignore
     def start_span(self,
                    name: str,
-                   parent: typing.Union['Span', 'SpanContext'] = CURRENT_SPAN
+                   parent: ParentSpan = CURRENT_SPAN
                    ) -> typing.Iterator['Span']:
         """Context manager for span creation.
 
@@ -273,7 +275,7 @@ class Tracer:
 
     def create_span(self,
                     name: str,
-                    parent: typing.Union['Span', 'SpanContext'] = CURRENT_SPAN
+                    parent: ParentSpan = CURRENT_SPAN
                     ) -> 'Span':
         """Creates a span.
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -157,8 +157,13 @@ class SpanContext:
     def __init__(self,
                  trace_id: int,
                  span_id: int,
-                 options: 'TraceOptions',
-                 state: 'TraceState') -> None:
+                 options: 'TraceOptions' = None,
+                 state: 'TraceState' = None
+                 ) -> None:
+        if options is None:
+            options = DEFAULT_TRACEOPTIONS
+        if state is None:
+            state = DEFAULT_TRACESTATE
         self.trace_id = trace_id
         self.span_id = span_id
         self.options = options
@@ -173,6 +178,8 @@ class SpanContext:
         Returns:
             True if the `SpanContext` is valid, false otherwise.
         """
+        return (self.trace_id != INVALID_TRACE_ID and
+                self.span_id != INVALID_SPAN_ID)
 
 
 class DefaultSpan(Span):
@@ -187,8 +194,8 @@ class DefaultSpan(Span):
         return self._context
 
 
-INVALID_SPAN_ID = 0
-INVALID_TRACE_ID = 0
+INVALID_SPAN_ID = 0x0000000000000000
+INVALID_TRACE_ID = 0x00000000000000000000000000000000
 INVALID_SPAN_CONTEXT = SpanContext(INVALID_TRACE_ID, INVALID_SPAN_ID,
                                    DEFAULT_TRACEOPTIONS, DEFAULT_TRACESTATE)
 INVALID_SPAN = DefaultSpan(INVALID_SPAN_CONTEXT)

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -141,6 +141,14 @@ class TraceState(typing.Dict[str, str]):
 DEFAULT_TRACESTATE = TraceState.get_default()
 
 
+def format_trace_id(trace_id: int) -> str:
+    return '0x{:032x}'.format(trace_id)
+
+
+def format_span_id(span_id: int) -> str:
+    return '0x{:016x}'.format(span_id)
+
+
 class SpanContext:
     """The state of a Span to propagate between processes.
 
@@ -157,17 +165,25 @@ class SpanContext:
     def __init__(self,
                  trace_id: int,
                  span_id: int,
-                 options: 'TraceOptions' = None,
-                 state: 'TraceState' = None
+                 traceoptions: 'TraceOptions' = None,
+                 tracestate: 'TraceState' = None
                  ) -> None:
-        if options is None:
-            options = DEFAULT_TRACEOPTIONS
-        if state is None:
-            state = DEFAULT_TRACESTATE
+        if traceoptions is None:
+            traceoptions = DEFAULT_TRACEOPTIONS
+        if tracestate is None:
+            tracestate = DEFAULT_TRACESTATE
         self.trace_id = trace_id
         self.span_id = span_id
-        self.options = options
-        self.state = state
+        self.traceoptions = traceoptions
+        self.tracestate = tracestate
+
+    def __repr__(self):
+        return ("{}(trace_id={}, span_id={})"
+                .format(
+                    type(self).__name__,
+                    format_trace_id(self.trace_id),
+                    format_span_id(self.span_id)
+                ))
 
     def is_valid(self) -> bool:
         """Get whether this `SpanContext` is valid.

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -177,7 +177,7 @@ class SpanContext:
         self.traceoptions = traceoptions
         self.tracestate = tracestate
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return ("{}(trace_id={}, span_id={})"
                 .format(
                     type(self).__name__,

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -122,7 +122,7 @@ class TraceOptions(int):
         return cls(cls.DEFAULT)
 
 
-DEFAULT_TRACEOPTIONS = TraceOptions.get_default()
+DEFAULT_TRACE_OPTIONS = TraceOptions.get_default()
 
 
 class TraceState(typing.Dict[str, str]):
@@ -141,7 +141,7 @@ class TraceState(typing.Dict[str, str]):
         return cls()
 
 
-DEFAULT_TRACESTATE = TraceState.get_default()
+DEFAULT_TRACE_STATE = TraceState.get_default()
 
 
 def format_trace_id(trace_id: int) -> str:
@@ -168,17 +168,17 @@ class SpanContext:
     def __init__(self,
                  trace_id: int,
                  span_id: int,
-                 traceoptions: 'TraceOptions' = None,
-                 tracestate: 'TraceState' = None
+                 trace_options: 'TraceOptions' = None,
+                 trace_state: 'TraceState' = None
                  ) -> None:
-        if traceoptions is None:
-            traceoptions = DEFAULT_TRACEOPTIONS
-        if tracestate is None:
-            tracestate = DEFAULT_TRACESTATE
+        if trace_options is None:
+            trace_options = DEFAULT_TRACE_OPTIONS
+        if trace_state is None:
+            trace_state = DEFAULT_TRACE_STATE
         self.trace_id = trace_id
         self.span_id = span_id
-        self.traceoptions = traceoptions
-        self.tracestate = tracestate
+        self.trace_options = trace_options
+        self.trace_state = trace_state
 
     def __repr__(self) -> str:
         return ("{}(trace_id={}, span_id={})"
@@ -216,7 +216,7 @@ class DefaultSpan(Span):
 INVALID_SPAN_ID = 0x0000000000000000
 INVALID_TRACE_ID = 0x00000000000000000000000000000000
 INVALID_SPAN_CONTEXT = SpanContext(INVALID_TRACE_ID, INVALID_SPAN_ID,
-                                   DEFAULT_TRACEOPTIONS, DEFAULT_TRACESTATE)
+                                   DEFAULT_TRACE_OPTIONS, DEFAULT_TRACE_STATE)
 INVALID_SPAN = DefaultSpan(INVALID_SPAN_CONTEXT)
 
 

--- a/opentelemetry-api/src/opentelemetry/types.py
+++ b/opentelemetry-api/src/opentelemetry/types.py
@@ -1,0 +1,19 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import typing
+
+AttributeValue = typing.Union[str, bool, float]
+Attributes = typing.Dict[str, AttributeValue]

--- a/opentelemetry-api/tests/trace/test_defaultspan.py
+++ b/opentelemetry-api/tests/trace/test_defaultspan.py
@@ -20,8 +20,8 @@ from opentelemetry import trace
 class TestDefaultSpan(unittest.TestCase):
     def test_ctor(self):
         context = trace.SpanContext(1, 1,
-                                    trace.DEFAULT_TRACEOPTIONS,
-                                    trace.DEFAULT_TRACESTATE)
+                                    trace.DEFAULT_TRACE_OPTIONS,
+                                    trace.DEFAULT_TRACE_STATE)
         span = trace.DefaultSpan(context)
         self.assertEqual(context, span.get_context())
 

--- a/opentelemetry-sdk/setup.py
+++ b/opentelemetry-sdk/setup.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+
 import setuptools
 
 BASE_DIR = os.path.dirname(__file__)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -330,8 +330,8 @@ class Tracer(trace_api.Tracer):
             context = trace_api.SpanContext(
                 parent_context.trace_id,
                 span_id,
-                parent_context.traceoptions,
-                parent_context.tracestate)
+                parent_context.trace_options,
+                parent_context.trace_state)
         return Span(name=name, context=context, parent=parent)
 
     @contextmanager

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -34,11 +34,15 @@ except ImportError:
     from collections import MutableMapping
     from collections import Sequence
 
+
+_CURRENT_SPAN_CV = contextvars.ContextVar('current_span', default=None)
+
 MAX_NUM_ATTRIBUTES = 32
 MAX_NUM_EVENTS = 128
 MAX_NUM_LINKS = 32
 
 AttributeValue = typing.Union[str, bool, float]
+Attributes = typing.Dict[str, AttributeValue]
 
 
 class BoundedList(Sequence):
@@ -183,9 +187,9 @@ class Span(trace_api.Span):
                  sampler=None,  # TODO
                  trace_config=None,  # TODO
                  resource=None,  # TODO
-                 attributes=None,  # TODO
-                 events=None,  # TODO
-                 links=None,  # TODO
+                 attributes: Attributes = None,  # TODO
+                 events: typing.Sequence[Event] = None,  # TODO
+                 links: typing.Sequence[Link] = None,  # TODO
                  ) -> None:
 
         self.name = name
@@ -258,9 +262,6 @@ class Span(trace_api.Span):
     def end(self):
         if self.end_time is None:
             self.end_time = util.time_ns()
-
-
-_CURRENT_SPAN_CV = contextvars.ContextVar('current_span', default=None)
 
 
 def generate_span_id():

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -163,7 +163,7 @@ class Span(trace_api.Span):
                  name: str,
                  context: 'trace_api.SpanContext',
                  # TODO: span processor
-                 parent: typing.Union['Span', 'trace_api.SpanContext'] = None,
+                 parent: trace_api.ParentSpan = None,
                  root: bool = False,
                  sampler=None,  # TODO
                  trace_config=None,  # TraceConfig TODO
@@ -283,8 +283,7 @@ class Tracer(trace_api.Tracer):
     @contextmanager
     def start_span(self,
                    name: str,
-                   parent: typing.Union['Span', 'trace_api.SpanContext'] =
-                   CURRENT_SPAN
+                   parent: trace_api.ParentSpan = CURRENT_SPAN
                    ) -> typing.Iterator['Span']:
         """See `opentelemetry.trace.Tracer.start_span`."""
         with self.use_span(self.create_span(name, parent)) as span:
@@ -292,8 +291,7 @@ class Tracer(trace_api.Tracer):
 
     def create_span(self,
                     name: str,
-                    parent: typing.Union['Span', 'trace_api.SpanContext'] =
-                    CURRENT_SPAN
+                    parent: trace_api.ParentSpan = CURRENT_SPAN
                     ) -> 'Span':
         """See `opentelemetry.trace.Tracer.create_span`."""
         span_id = generate_span_id()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -250,7 +250,7 @@ def generate_span_id():
     Returns:
         A random 64-bit int for use as a span ID
     """
-    return '{:016x}'.format(random.getrandbits(64))
+    return random.getrandbits(64)
 
 
 def generate_trace_id():
@@ -259,7 +259,7 @@ def generate_trace_id():
     Returns:
         A random 128-bit int for use as a trace ID
     """
-    return '{:032x}'.format(random.getrandbits(128))
+    return random.getrandbits(128)
 
 
 class Tracer(trace_api.Tracer):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -157,8 +157,7 @@ Link = namedtuple('Link', ('context', 'attributes'))
 class Span(trace_api.Span):
     """See `opentelemetry.trace.Span`.
 
-    Users should generally create `Span`s via the `Tracer` instead of this
-    constructor.
+    Users should create `Span`s via the `Tracer` instead of this constructor.
 
     Args:
         name: The name of the operation this span represents

--- a/opentelemetry-sdk/tests/resources/test_init.py
+++ b/opentelemetry-sdk/tests/resources/test_init.py
@@ -1,4 +1,5 @@
 import unittest
+
 from opentelemetry.sdk import resources
 
 

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -55,10 +55,10 @@ class TestSpanCreation(unittest.TestCase):
                 self.assertEqual(root_context.trace_id, child_context.trace_id)
                 self.assertNotEqual(root_context.span_id,
                                     child_context.span_id)
-                self.assertEqual(root_context.tracestate,
-                                 child_context.tracestate)
-                self.assertEqual(root_context.traceoptions,
-                                 child_context.traceoptions)
+                self.assertEqual(root_context.trace_state,
+                                 child_context.trace_state)
+                self.assertEqual(root_context.trace_options,
+                                 child_context.trace_options)
 
             # After exiting the child's scope the parent should become the
             # current span again.
@@ -103,10 +103,10 @@ class TestSpanCreation(unittest.TestCase):
                 self.assertEqual(other_parent.trace_id, child_context.trace_id)
                 self.assertNotEqual(other_parent.span_id,
                                     child_context.span_id)
-                self.assertEqual(other_parent.tracestate,
-                                 child_context.tracestate)
-                self.assertEqual(other_parent.traceoptions,
-                                 child_context.traceoptions)
+                self.assertEqual(other_parent.trace_state,
+                                 child_context.trace_state)
+                self.assertEqual(other_parent.trace_options,
+                                 child_context.trace_options)
 
             # After exiting the child's scope the last span on the stack should
             # become current, not the child's parent.

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -29,5 +29,5 @@ class TestTracer(unittest.TestCase):
 class TestSpan(unittest.TestCase):
 
     def test_basic_span(self):
-        span = trace.Span('name', mock.Mock(spec=trace.SpanContext))
+        span = trace.Span('name', mock.Mock(spec=trace_api.SpanContext))
         self.assertEqual(span.name, 'name')

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from unittest import mock
+import contextvars
 import unittest
 
 from opentelemetry import trace as trace_api
@@ -24,6 +25,94 @@ class TestTracer(unittest.TestCase):
     def test_extends_api(self):
         tracer = trace.Tracer()
         self.assertIsInstance(tracer, trace_api.Tracer)
+
+
+class TestSpanCreation(unittest.TestCase):
+
+    def test_start_span_implicit(self):
+        context = contextvars.ContextVar('test_start_span_implicit')
+        tracer = trace.Tracer(context)
+
+        self.assertIsNone(tracer.get_current_span())
+
+        with tracer.start_span('root') as root:
+            self.assertIs(tracer.get_current_span(), root)
+
+            self.assertIsNotNone(root.start_time)
+            self.assertIsNone(root.end_time)
+
+            with tracer.start_span('child') as child:
+                self.assertIs(tracer.get_current_span(), child)
+                self.assertIs(child.parent, root)
+
+                self.assertIsNotNone(child.start_time)
+                self.assertIsNone(child.end_time)
+
+                # The new child span should inherit the parent's context but
+                # get a new span ID.
+                root_context = root.get_context()
+                child_context = child.get_context()
+                self.assertEqual(root_context.trace_id, child_context.trace_id)
+                self.assertNotEqual(root_context.span_id,
+                                    child_context.span_id)
+                self.assertEqual(root_context.tracestate,
+                                 child_context.tracestate)
+                self.assertEqual(root_context.traceoptions,
+                                 child_context.traceoptions)
+
+            # After exiting the child's scope the parent should become the
+            # current span again.
+            self.assertIs(tracer.get_current_span(), root)
+            self.assertIsNotNone(child.end_time)
+
+        self.assertIsNone(tracer.get_current_span())
+        self.assertIsNotNone(root.end_time)
+
+    def test_start_span_explicit(self):
+        context = contextvars.ContextVar('test_start_span_explicit')
+        tracer = trace.Tracer(context)
+
+        other_parent = trace_api.SpanContext(
+            trace_id=0x000000000000000000000000deadbeef,
+            span_id=0x00000000deadbef0
+        )
+
+        self.assertIsNone(tracer.get_current_span())
+
+        # Test with the implicit root span
+        with tracer.start_span('root') as root:
+            self.assertIs(tracer.get_current_span(), root)
+
+            self.assertIsNotNone(root.start_time)
+            self.assertIsNone(root.end_time)
+
+            with tracer.start_span('stepchild', other_parent) as child:
+                # The child should become the current span as usual, but its
+                # parent should be the one passed in, not the
+                # previously-current span.
+                self.assertIs(tracer.get_current_span(), child)
+                self.assertNotEqual(child.parent, root)
+                self.assertIs(child.parent, other_parent)
+
+                self.assertIsNotNone(child.start_time)
+                self.assertIsNone(child.end_time)
+
+                # The child should inherit its context fromr the explicit
+                # parent, not the previously-current span.
+                child_context = child.get_context()
+                self.assertEqual(other_parent.trace_id, child_context.trace_id)
+                self.assertNotEqual(other_parent.span_id,
+                                    child_context.span_id)
+                self.assertEqual(other_parent.tracestate,
+                                 child_context.tracestate)
+                self.assertEqual(other_parent.traceoptions,
+                                 child_context.traceoptions)
+
+            # After exiting the child's scope the last span on the stack should
+            # become current, not the child's parent.
+            self.assertNotEqual(tracer.get_current_span(), other_parent)
+            self.assertIs(tracer.get_current_span(), root)
+            self.assertIsNotNone(child.end_time)
 
 
 class TestSpan(unittest.TestCase):


### PR DESCRIPTION
This PR adds span creation methods to the `Tracer` SDK. See `test_start_span_implicit` and `test_start_span_explicit` for examples of how this should work.

This uses a module-level context variable for now, I'll replace it with our own context API in a separate PR. It also sets a global module-level `tracer` which doesn't square with the existing loader logic, also to be replaced in a follow-up PR.