### PR TITLE
Documenting a design decision about focus on capabilities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,19 @@ As with other OpenTelemetry clients, opentelemetry-python follows the
 
 It's especially valuable to read through the (library guidelines)[https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/library-guidelines.md].
 
+### Focus on Capabilities, Not Structure Compliance
+
+OpenTelemetry is an evolving specification, one where the desires and
+use cases are clear, but the method to satisfy those uses cases are not.
+
+As such, Contributions should provide functionality and behavior that 
+conforms to the specification, but the interface and structure is flexible.
+
+It is preferable to have contributions follow the idioms of the language 
+rather than conform to specific API names or argument patterns in the spec.
+
+For a deeper discussion, see: https://github.com/open-telemetry/opentelemetry-specification/issues/165
+
 
 ## Styleguide
 


### PR DESCRIPTION
I think as a project, we've decided to focus on capabilities rather than strict naming adherence. I think it'd be great if we could document that.

I figure the link to the PR is partially temporary, and we can repoint at the section in the specification that outlines this once the appropriate PR is merged into opentelemetry-specification.