### PR TITLE
Fixing contributing.md links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,7 @@ The Python special interest group (SIG) meets regularly. See the OpenTelemetry
 [community](https://github.com/open-telemetry/community#python-sdk) repo for
 information on this and other language SIGs.
 
-See the [public meeting
-notes](https://docs.google.com/document/d/1CIMGoIOZ-c3-igzbd6_Pnxx1SjAkjwqoYSUWxPY8XIs/edit)
+See the [public meeting notes](https://docs.google.com/document/d/1CIMGoIOZ-c3-igzbd6_Pnxx1SjAkjwqoYSUWxPY8XIs/edit)
 for a summary description of past meetings. To request edit access join the
 meeting or get in touch on Gitter.
 
@@ -23,12 +22,12 @@ The standard Python unittest module is used to author unit tests.
 ## Design Choices
 
 As with other OpenTelemetry clients, opentelemetry-python follows the 
-(opentelemetry-specification)[https://github.com/open-telemetry/opentelemetry-specification].
+[opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification).
 
-It's especially valuable to read through the (library guidelines)[https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/library-guidelines.md].
+It's especially valuable to read through the [library guidelines](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/library-guidelines.md).
 
 
 ## Styleguide
 
 * docstrings should adhere to the Google styleguide as specified
-  with the (napolean extension)[http://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy] extension in (Sphinx)[http://www.sphinx-doc.org/en/master/index.html].
+  with the [napolean extension](http://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy) extension in [Sphinx](http://www.sphinx-doc.org/en/master/index.html).

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ The Python [OpenTelemetry](https://opentelemetry.io/) client.
 
 ## Contributing
 
-See (CONTRIBUTING.md)[CONTRIBUTING.md]
+See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
contributing.md did not have the proper syntax for markdown
links.