### PR TITLE
Update and test default tracer APIs.

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -241,6 +241,7 @@ class Tracer:
             The currently active :class:`.Span`, or a placeholder span with an
             invalid :class:`.SpanContext`.
         """
+        return INVALID_SPAN
 
     @contextmanager  # type: ignore
     def start_span(self,
@@ -289,6 +290,7 @@ class Tracer:
         Yields:
             The newly-created span.
         """
+        yield INVALID_SPAN
 
     def create_span(self,
                     name: str,
@@ -324,6 +326,7 @@ class Tracer:
         Returns:
             The newly-created span.
         """
+        return INVALID_SPAN
 
     @contextmanager  # type: ignore
     def use_span(self, span: 'Span') -> typing.Iterator[None]:
@@ -338,6 +341,7 @@ class Tracer:
         Args:
             span: The span to start and make current.
         """
+        yield
 
 
 _TRACER: typing.Optional[Tracer] = None

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -241,6 +241,7 @@ class Tracer:
             The currently active :class:`.Span`, or a placeholder span with an
             invalid :class:`.SpanContext`.
         """
+        # pylint: disable=no-self-use
         return INVALID_SPAN
 
     @contextmanager  # type: ignore
@@ -290,6 +291,7 @@ class Tracer:
         Yields:
             The newly-created span.
         """
+        # pylint: disable=unused-argument,no-self-use
         yield INVALID_SPAN
 
     def create_span(self,
@@ -326,6 +328,7 @@ class Tracer:
         Returns:
             The newly-created span.
         """
+        # pylint: disable=unused-argument,no-self-use
         return INVALID_SPAN
 
     @contextmanager  # type: ignore
@@ -341,6 +344,7 @@ class Tracer:
         Args:
             span: The span to start and make current.
         """
+        # pylint: disable=unused-argument,no-self-use
         yield
 
 

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -1,0 +1,39 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from opentelemetry import trace
+
+
+class TestTracer(unittest.TestCase):
+    def setUp(self):
+        self.tracer = trace.Tracer()
+
+    def test_get_current_span(self):
+        span = self.tracer.get_current_span()
+        self.assertIsInstance(span, trace.Span)
+
+    def test_start_span(self):
+        with self.tracer.start_span("") as span:
+            self.assertIsInstance(span, trace.Span)
+
+    def test_create_span(self):
+        span = self.tracer.create_span("")
+        self.assertIsInstance(span, trace.Span)
+
+    def test_use_span(self):
+        span = trace.Span()
+        with self.tracer.use_span(span):
+            pass


### PR DESCRIPTION
I was running through adding the WSGI middleware integration and ran into errors when trying to use the default `tracer.start_span()` API.

The APIs were defined as stubs that didn't return anything even though the interface indicates the return type is required. In the case of the `contextmanager` decorated APIs, this resulted in an exception.