### PR TITLE
Span: add attribute, event, link setter to the API

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -123,7 +123,7 @@ class Span:
         """
 
     def add_link(self: 'Span',
-                 context: 'SpanContext',
+                 link_target_context: 'SpanContext',
                  attributes: 'types.Attributes' = None,
                  ) -> None:
         """Adds a Link to another span.

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -109,7 +109,7 @@ class Span:
                       ) -> None:
         """Sets an Attribute.
 
-        Sets a single `Attribute` with the key and value passed as arguments.
+        Sets a single Attribute with the key and value passed as arguments.
         """
 
     def add_event(self: 'Span',
@@ -128,7 +128,7 @@ class Span:
                  ) -> None:
         """Adds a Link to another span.
 
-        Adds a single `Link` to the span via the `SpanContext` passed as
+        Adds a single Link to the span via the `SpanContext` passed as
         argument.
         """
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -124,12 +124,13 @@ class Span:
 
     def add_link(self: 'Span',
                  link_target_context: 'SpanContext',
-                 attributes: 'types.Attributes' = None,
+                 context: 'SpanContext',
+                 attributes: types.Attributes = None,
                  ) -> None:
         """Adds a Link to another span.
 
-        Adds a single Link from this Span to another Span identified by the `SpanContext` passed as
-        argument.
+        Adds a single Link from this Span to another Span identified by the
+        `SpanContext` passed as argument.
         """
 
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -128,7 +128,8 @@ class Span:
                  ) -> None:
         """Adds a Link to another span.
 
-        Adds a single Link to the Span via the SpanContext passed as argument.
+        Adds a single `Link` to the span via the `SpanContext` passed as
+        argument.
         """
 
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -65,6 +65,7 @@ from contextlib import contextmanager
 import typing
 
 from opentelemetry import loader
+from opentelemetry import types
 
 # TODO: quarantine
 ParentSpan = typing.Optional[typing.Union['Span', 'SpanContext']]
@@ -100,6 +101,34 @@ class Span:
 
         Returns:
             A :class:`.SpanContext` with a copy of this span's immutable state.
+        """
+
+    def set_attribute(self: 'Span',
+                      key: str,
+                      value: 'types.AttributeValue'
+                      ) -> None:
+        """Sets an Attribute.
+
+        Sets a single Attribute with the key and value passed as arguments.
+        """
+
+    def add_event(self: 'Span',
+                  name: str,
+                  attributes: 'types.Attributes',
+                  ) -> None:
+        """Adds an Event.
+
+        Adds a single Event with the name and, optionally, attributes passed
+        as arguments.
+        """
+
+    def add_link(self: 'Span',
+                 context: 'SpanContext',
+                 attributes: 'types.Attributes',
+                 ) -> None:
+        """Adds a Link to another Span.
+
+        Adds a single Link to the Span via the SpanContext passed as argument.
         """
 
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -109,7 +109,7 @@ class Span:
                       ) -> None:
         """Sets an Attribute.
 
-        Sets a single Attribute with the key and value passed as arguments.
+        Sets a single `Attribute` with the key and value passed as arguments.
         """
 
     def add_event(self: 'Span',

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -126,7 +126,7 @@ class Span:
                  context: 'SpanContext',
                  attributes: 'types.Attributes',
                  ) -> None:
-        """Adds a Link to another Span.
+        """Adds a Link to another span.
 
         Adds a single Link to the Span via the SpanContext passed as argument.
         """

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -105,7 +105,7 @@ class Span:
 
     def set_attribute(self: 'Span',
                       key: str,
-                      value: 'types.AttributeValue'
+                      value: 'types.AttributeValue',
                       ) -> None:
         """Sets an Attribute.
 
@@ -114,7 +114,7 @@ class Span:
 
     def add_event(self: 'Span',
                   name: str,
-                  attributes: 'types.Attributes',
+                  attributes: 'types.Attributes' = None,
                   ) -> None:
         """Adds an Event.
 
@@ -124,7 +124,7 @@ class Span:
 
     def add_link(self: 'Span',
                  context: 'SpanContext',
-                 attributes: 'types.Attributes',
+                 attributes: 'types.Attributes' = None,
                  ) -> None:
         """Adds a Link to another span.
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -114,7 +114,7 @@ class Span:
 
     def add_event(self: 'Span',
                   name: str,
-                  attributes: 'types.Attributes' = None,
+                  attributes: types.Attributes = None,
                   ) -> None:
         """Adds an Event.
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -124,7 +124,6 @@ class Span:
 
     def add_link(self: 'Span',
                  link_target_context: 'SpanContext',
-                 context: 'SpanContext',
                  attributes: types.Attributes = None,
                  ) -> None:
         """Adds a Link to another span.

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -128,7 +128,7 @@ class Span:
                  ) -> None:
         """Adds a Link to another span.
 
-        Adds a single Link to the span via the `SpanContext` passed as
+        Adds a single Link from this Span to another Span identified by the `SpanContext` passed as
         argument.
         """
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -105,7 +105,7 @@ class Span:
 
     def set_attribute(self: 'Span',
                       key: str,
-                      value: 'types.AttributeValue',
+                      value: types.AttributeValue,
                       ) -> None:
         """Sets an Attribute.
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -238,18 +238,22 @@ class Span(trace_api.Span):
 
     def add_event(self: 'Span',
                   name: str,
-                  attributes: 'types.Attributes',
+                  attributes: 'types.Attributes' = None,
                   ) -> None:
         if self.events is Span.empty_events:
             self.events = BoundedList(MAX_NUM_EVENTS)
+        if attributes is None:
+            attributes = Span.empty_attributes
         self.events.append(Event(name, attributes))
 
     def add_link(self: 'Span',
                  context: 'trace_api.SpanContext',
-                 attributes: 'types.Attributes',
+                 attributes: 'types.Attributes' = None,
                  ) -> None:
         if self.links is Span.empty_links:
             self.links = BoundedList(MAX_NUM_LINKS)
+        if attributes is None:
+            attributes = Span.empty_attributes
         self.links.append(Link(context, attributes))
 
     def start(self):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -230,7 +230,7 @@ class Span(trace_api.Span):
 
     def set_attribute(self: 'Span',
                       key: str,
-                      value: 'types.AttributeValue'
+                      value: types.AttributeValue,
                       ) -> None:
         if self.attributes is Span.empty_attributes:
             self.attributes = BoundedDict(MAX_NUM_ATTRIBUTES)
@@ -238,7 +238,7 @@ class Span(trace_api.Span):
 
     def add_event(self: 'Span',
                   name: str,
-                  attributes: 'types.Attributes' = None,
+                  attributes: types.Attributes = None,
                   ) -> None:
         if self.events is Span.empty_events:
             self.events = BoundedList(MAX_NUM_EVENTS)
@@ -247,14 +247,14 @@ class Span(trace_api.Span):
         self.events.append(Event(name, attributes))
 
     def add_link(self: 'Span',
-                 context: 'trace_api.SpanContext',
-                 attributes: 'types.Attributes' = None,
+                 link_target_context: 'trace_api.SpanContext',
+                 attributes: types.Attributes = None,
                  ) -> None:
         if self.links is Span.empty_links:
             self.links = BoundedList(MAX_NUM_LINKS)
         if attributes is None:
             attributes = Span.empty_attributes
-        self.links.append(Link(context, attributes))
+        self.links.append(Link(link_target_context, attributes))
 
     def start(self):
         if self.start_time is None:


### PR DESCRIPTION
Basic tests that exercise the API are added as well. However it does not
actually test that the attributes, events and links are written properly
because there is no getter. Those tests can be added later when the
attributes are actually used.

The spec mentions additional APIs for lazy initialization (AddLazyEvent,
AddLazyLink). Those are not added in this patch because OT-Python does
not expose the Event type (currently defined in the SDK only).

---

https://github.com/open-telemetry/opentelemetry-python/issues/75 (attribute)
https://github.com/open-telemetry/opentelemetry-python/issues/76 (event)
https://github.com/open-telemetry/opentelemetry-python/issues/77 (link)
