### PR TITLE
Integrate tracer with context

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@
 
 The Python [OpenTelemetry](https://opentelemetry.io/) client.
 
+## Installation
+
+## Usage
+```python
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import Tracer
+
+trace.set_preferred_tracer_implementation(lambda T: Tracer())
+tracer = trace.tracer()
+with tracer.start_span('foo'):
+    print(Context)
+    with tracer.start_span('bar'):
+        print(Context)
+        with tracer.start_span('baz'):
+            print(Context)
+        print(Context)
+    print(Context)
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/opentelemetry-api/src/opentelemetry/context/base_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/base_context.py
@@ -98,10 +98,10 @@ class BaseRuntimeContext:
         slot.set(value)
 
     def __getitem__(self, name: str) -> 'object':
-        return getattr(self, name)
+        return self.__getitem__(name)
 
     def __setitem__(self, name: str, value: 'object') -> None:
-        setattr(self, name, value)
+        self.__setattr__(name, value)
 
     def with_current_context(
             self,

--- a/opentelemetry-api/src/opentelemetry/context/base_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/base_context.py
@@ -64,11 +64,9 @@ class BaseRuntimeContext:
         :returns: The registered slot.
         """
         with cls._lock:
-            if name in cls._slots:
-                raise ValueError('slot {} already registered'.format(name))
-            slot = cls.Slot(name, default)
-            cls._slots[name] = slot
-            return slot
+            if name not in cls._slots:
+                cls._slots[name] = cls.Slot(name, default)
+            return cls._slots[name]
 
     def apply(self, snapshot: typing.Dict[str, 'object']) -> None:
         """Set the current context from a given snapshot dictionary"""

--- a/opentelemetry-api/src/opentelemetry/context/base_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/base_context.py
@@ -97,6 +97,12 @@ class BaseRuntimeContext:
         slot = self._slots[name]
         slot.set(value)
 
+    def __getitem__(self, name: str) -> 'object':
+        return getattr(self, name)
+
+    def __setitem__(self, name: str, value: 'object') -> None:
+        setattr(self, name, value)
+
     def with_current_context(
             self,
             func: typing.Callable[..., 'object'],

--- a/opentelemetry-api/src/opentelemetry/context/base_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/base_context.py
@@ -98,7 +98,7 @@ class BaseRuntimeContext:
         slot.set(value)
 
     def __getitem__(self, name: str) -> 'object':
-        return self.__getitem__(name)
+        return self.__getattr__(name)
 
     def __setitem__(self, name: str, value: 'object') -> None:
         self.__setattr__(name, value)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from unittest import mock
-import contextvars
 import unittest
 
 from opentelemetry import trace as trace_api
@@ -30,8 +29,7 @@ class TestTracer(unittest.TestCase):
 class TestSpanCreation(unittest.TestCase):
 
     def test_start_span_implicit(self):
-        context = contextvars.ContextVar('test_start_span_implicit')
-        tracer = trace.Tracer(context)
+        tracer = trace.Tracer('test_start_span_implicit')
 
         self.assertIsNone(tracer.get_current_span())
 
@@ -69,8 +67,7 @@ class TestSpanCreation(unittest.TestCase):
         self.assertIsNotNone(root.end_time)
 
     def test_start_span_explicit(self):
-        context = contextvars.ContextVar('test_start_span_explicit')
-        tracer = trace.Tracer(context)
+        tracer = trace.Tracer('test_start_span_explicit')
 
         other_parent = trace_api.SpanContext(
             trace_id=0x000000000000000000000000deadbeef,


### PR DESCRIPTION
1. Leverage `opentelemetry.context` from tracer.
2. Update the main README file.

Part of the effort for #22.