### PR TITLE
Add initial DistributedContext implementation.

### DIFF
--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -87,13 +87,14 @@ class DistributedContext:
     def get_entry_value(
             self,
             key: EntryKey
-    ) -> typing.Optional[Entry]:
+    ) -> typing.Optional[EntryValue]:
         """Returns the entry associated with a key or None
 
         Args:
             key: the key with which to perform a lookup
         """
-        return self._container.get(key)
+        if key in self._container:
+            return self._container[key].value
 
 
 class DistributedContextManager:

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -95,6 +95,7 @@ class DistributedContext:
         """
         if key in self._container:
             return self._container[key].value
+        return None
 
 
 class DistributedContextManager:

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from contextlib import contextmanager
-import abc
 import typing
 
 PRINTABLE = set(chr(num) for num in range(32, 127))
@@ -75,20 +74,23 @@ class Entry:
         self.value = value
 
 
-class DistributedContext(abc.ABC):
+class DistributedContext(dict):
     """A container for distributed context entries"""
 
-    @abc.abstractmethod
     def get_entries(self) -> typing.Iterable[Entry]:
         """Returns an immutable iterator to entries."""
+        return self.values()
 
-    @abc.abstractmethod
-    def get_entry_value(self, key: EntryKey) -> typing.Optional[EntryValue]:
+    def get_entry_value(
+            self,
+            key: EntryKey
+    ) -> typing.Optional[EntryValue]:
         """Returns the entry associated with a key or None
 
         Args:
             key: the key with which to perform a lookup
         """
+        return self.get(key)
 
 
 class DistributedContextManager:

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -49,7 +49,7 @@ class EntryKey(str):
 
     @staticmethod
     def create(value: str) -> "EntryKey":
-        if len(value) > 255 or any(c not in PRINTABLE for c in value):
+        if not 0 < len(value) <= 255 or any(c not in PRINTABLE for c in value):
             raise ValueError("Invalid EntryKey", value)
 
         return typing.cast(EntryKey, value)

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -17,26 +17,39 @@ import string
 import typing
 
 
-class EntryMetadata:
+PRINTABLE = set(string.printable)
+
+
+class EntryMetadata(dict):
     NO_PROPAGATION = 0
     UNLIMITED_PROPAGATION = -1
 
     def __init__(self, entry_ttl: int) -> None:
         self.entry_ttl = entry_ttl
 
+    def __getattr__(self, key: str) -> "object":
+        return self[key]
 
-class EntryKey(str):
-    def __new__(cls, value):
-        if len(value) > 255 or any(c not in string.printable for c in value):
+    def __setattr__(self, key: str, value: "object") -> None:
+        self[key] = value
+
+
+class EntryKey:
+    @staticmethod
+    def create(value):
+        if len(value) > 255 or any(c not in PRINTABLE for c in value):
             raise ValueError("Invalid EntryKey", value)
-        return str.__new__(cls, value)
+
+        return typing.cast(EntryKey, value)
 
 
-class EntryValue(str):
-    def __new__(cls, value):
-        if any(c not in string.printable for c in value):
+class EntryValue:
+    @staticmethod
+    def create(value):
+        if any(c not in PRINTABLE for c in value):
             raise ValueError("Invalid EntryValue", value)
-        return str.__new__(cls, value)
+
+        return typing.cast(EntryValue, value)
 
 
 class Entry:

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -49,6 +49,7 @@ class EntryKey(str):
 
     @staticmethod
     def create(value: str) -> "EntryKey":
+        # pylint: disable=len-as-condition
         if not 0 < len(value) <= 255 or any(c not in PRINTABLE for c in value):
             raise ValueError("Invalid EntryKey", value)
 

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import abc
 from contextlib import contextmanager
+import abc
 import string
 import typing
-
 
 PRINTABLE = set(string.printable)
 
@@ -67,7 +66,10 @@ class EntryValue(str):
 
 class Entry:
     def __init__(
-        self, metadata: EntryMetadata, key: EntryKey, value: EntryValue
+            self,
+            metadata: EntryMetadata,
+            key: EntryKey,
+            value: EntryValue,
     ) -> None:
         self.metadata = metadata
         self.key = key
@@ -80,7 +82,6 @@ class DistributedContext(abc.ABC):
     @abc.abstractmethod
     def get_entries(self) -> typing.Iterable[Entry]:
         """Returns an immutable iterator to entries."""
-        pass
 
     @abc.abstractmethod
     def get_entry_value(self, key: EntryKey) -> typing.Optional[EntryValue]:
@@ -89,7 +90,6 @@ class DistributedContext(abc.ABC):
         Args:
             key: the key with which to perform a lookup
         """
-        pass
 
 
 class DistributedContextManager:
@@ -99,11 +99,11 @@ class DistributedContextManager:
         Returns:
             A DistributedContext instance representing the current context.
         """
-        pass
 
     @contextmanager
     def use_context(
-        self, context: DistributedContext
+            self,
+            context: DistributedContext,
     ) -> typing.Iterator[DistributedContext]:
         """Context manager for controlling a DistributedContext lifetime.
 
@@ -115,4 +115,5 @@ class DistributedContextManager:
         Args:
             context: A DistributedContext instance to make current.
         """
+        # pylint: disable=no-self-use
         yield context

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -14,10 +14,9 @@
 
 from contextlib import contextmanager
 import abc
-import string
 import typing
 
-PRINTABLE = set(string.printable)
+PRINTABLE = set(chr(num) for num in range(32, 127))
 
 
 class EntryMetadata:

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -15,7 +15,7 @@
 from contextlib import contextmanager
 import typing
 
-PRINTABLE = set(chr(num) for num in range(32, 127))
+PRINTABLE = frozenset(chr(num) for num in range(32, 127))
 
 
 class EntryMetadata:

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -27,7 +27,7 @@ class EntryMetadata:
 
 class EntryKey(str):
     def __new__(cls, value):
-        if any(c not in string.printable for c in value) or len(value) > 255:
+        if len(value) > 255 or any(c not in string.printable for c in value):
             raise ValueError("Invalid EntryKey", value)
         return str.__new__(cls, value)
 

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -21,7 +21,7 @@ import typing
 PRINTABLE = set(string.printable)
 
 
-class EntryMetadata(dict):
+class EntryMetadata:
     """A class representing metadata of a DistributedContext entry
 
     Args:
@@ -34,13 +34,7 @@ class EntryMetadata(dict):
     UNLIMITED_PROPAGATION = -1
 
     def __init__(self, entry_ttl: int) -> None:
-        super().__init__(entry_ttl=entry_ttl)
-
-    def __getattr__(self, key: str) -> "object":
-        return self[key]
-
-    def __setattr__(self, key: str, value: "object") -> None:
-        self[key] = value
+        self.entry_ttl = entry_ttl
 
 
 class EntryKey(str):

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -43,8 +43,11 @@ class EntryMetadata(dict):
         self[key] = value
 
 
-class EntryKey:
+class EntryKey(str):
     """A class representing a key for a DistributedContext entry"""
+
+    def __new__(cls, value: str):
+        return cls.create(value)
 
     @staticmethod
     def create(value: str) -> "EntryKey":
@@ -54,8 +57,11 @@ class EntryKey:
         return typing.cast(EntryKey, value)
 
 
-class EntryValue:
+class EntryValue(str):
     """A class representing the value of a DistributedContext entry"""
+
+    def __new__(cls, value: str):
+        return cls.create(value)
 
     @staticmethod
     def create(value: str) -> "EntryValue":

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -74,23 +74,26 @@ class Entry:
         self.value = value
 
 
-class DistributedContext(dict):
+class DistributedContext:
     """A container for distributed context entries"""
+
+    def __init__(self, entries: typing.Iterable[Entry]) -> None:
+        self._container = {entry.key: entry for entry in entries}
 
     def get_entries(self) -> typing.Iterable[Entry]:
         """Returns an immutable iterator to entries."""
-        return self.values()
+        return self._container.values()
 
     def get_entry_value(
             self,
             key: EntryKey
-    ) -> typing.Optional[EntryValue]:
+    ) -> typing.Optional[Entry]:
         """Returns the entry associated with a key or None
 
         Args:
             key: the key with which to perform a lookup
         """
-        return self.get(key)
+        return self._container.get(key)
 
 
 class DistributedContextManager:

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -13,9 +13,16 @@
 # limitations under the License.
 
 from contextlib import contextmanager
+import itertools
+import string
 import typing
 
-PRINTABLE = frozenset(chr(num) for num in range(32, 127))
+PRINTABLE = frozenset(itertools.chain(
+    string.ascii_letters,
+    string.digits,
+    string.punctuation,
+    " ",
+))
 
 
 class EntryMetadata:

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -39,7 +39,7 @@ class EntryMetadata:
 class EntryKey(str):
     """A class representing a key for a DistributedContext entry"""
 
-    def __new__(cls, value: str):
+    def __new__(cls, value: str) -> "EntryKey":
         return cls.create(value)
 
     @staticmethod
@@ -53,7 +53,7 @@ class EntryKey(str):
 class EntryValue(str):
     """A class representing the value of a DistributedContext entry"""
 
-    def __new__(cls, value: str):
+    def __new__(cls, value: str) -> "EntryValue":
         return cls.create(value)
 
     @staticmethod
@@ -100,7 +100,7 @@ class DistributedContextManager:
             A DistributedContext instance representing the current context.
         """
 
-    @contextmanager
+    @contextmanager  # type: ignore
     def use_context(
             self,
             context: DistributedContext,

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/__init__.py
@@ -34,7 +34,7 @@ class EntryMetadata(dict):
     UNLIMITED_PROPAGATION = -1
 
     def __init__(self, entry_ttl: int) -> None:
-        self.entry_ttl = entry_ttl
+        super().__init__(entry_ttl=entry_ttl)
 
     def __getattr__(self, key: str) -> "object":
         return self[key]

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/propagation/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .binaryformat import BinaryFormat
+from .httptextformat import HTTPTextFormat
+
+__all__ = ["BinaryFormat", "HTTPTextFormat"]

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/propagation/binaryformat.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/propagation/binaryformat.py
@@ -1,0 +1,61 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import typing
+
+from opentelemetry.distributedcontext import DistributedContext
+
+
+class BinaryFormat(abc.ABC):
+    """API for serialization of span context into binary formats.
+
+    This class provides an interface that enables converting span contexts
+    to and from a binary format.
+    """
+
+    @staticmethod
+    @abc.abstractmethod
+    def to_bytes(context: DistributedContext) -> bytes:
+        """Creates a byte representation of a DistributedContext.
+
+        to_bytes should read values from a DistributedContext and return a data
+        format to represent it, in bytes.
+
+        Args:
+            context: the DistributedContext to serialize
+
+        Returns:
+            A bytes representation of the DistributedContext.
+
+        """
+
+    @staticmethod
+    @abc.abstractmethod
+    def from_bytes(
+            byte_representation: bytes) -> typing.Optional[DistributedContext]:
+        """Return a DistributedContext that was represented by bytes.
+
+        from_bytes should return back a DistributedContext that was constructed
+        from the data serialized in the byte_representation passed. If it is
+        not possible to read in a proper DistributedContext, return None.
+
+        Args:
+            byte_representation: the bytes to deserialize
+
+        Returns:
+            A bytes representation of the DistributedContext if it is valid.
+            Otherwise return None.
+
+        """

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/propagation/httptextformat.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/propagation/httptextformat.py
@@ -38,8 +38,6 @@ class HTTPTextFormat(abc.ABC):
 
         PROPAGATOR = HTTPTextFormat()
 
-
-
         def get_header_from_flask_request(request, key):
             return request.headers.get_all(key)
 

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/propagation/httptextformat.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/propagation/httptextformat.py
@@ -1,0 +1,109 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import typing
+
+from opentelemetry.distributedcontext import DistributedContext
+
+Setter = typing.Callable[[object, str, str], None]
+Getter = typing.Callable[[object, str], typing.List[str]]
+
+
+class HTTPTextFormat(abc.ABC):
+    """API for propagation of span context via headers.
+
+    This class provides an interface that enables extracting and injecting
+    span context into headers of HTTP requests. HTTP frameworks and clients
+    can integrate with HTTPTextFormat by providing the object containing the
+    headers, and a getter and setter function for the extraction and
+    injection of values, respectively.
+
+    Example::
+
+        import flask
+        import requests
+        from opentelemetry.context.propagation import HTTPTextFormat
+
+        PROPAGATOR = HTTPTextFormat()
+
+
+
+        def get_header_from_flask_request(request, key):
+            return request.headers.get_all(key)
+
+        def set_header_into_requests_request(request: requests.Request,
+                                             key: str, value: str):
+            request.headers[key] = value
+
+        def example_route():
+            distributed_context = PROPAGATOR.extract(
+                get_header_from_flask_request,
+                flask.request
+            )
+            request_to_downstream = requests.Request(
+                "GET", "http://httpbin.org/get"
+            )
+            PROPAGATOR.inject(
+                distributed_context,
+                set_header_into_requests_request,
+                request_to_downstream
+            )
+            session = requests.Session()
+            session.send(request_to_downstream.prepare())
+
+
+    .. _Propagation API Specification:
+       https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-propagators.md
+    """
+    @abc.abstractmethod
+    def extract(self, get_from_carrier: Getter,
+                carrier: object) -> DistributedContext:
+        """Create a DistributedContext from values in the carrier.
+
+        The extract function should retrieve values from the carrier
+        object using get_from_carrier, and use values to populate a
+        DistributedContext value and return it.
+
+        Args:
+            get_from_carrier: a function that can retrieve zero
+                or more values from the carrier. In the case that
+                the value does not exist, return an empty list.
+            carrier: and object which contains values that are
+                used to construct a DistributedContext. This object
+                must be paired with an appropriate get_from_carrier
+                which understands how to extract a value from it.
+        Returns:
+            A DistributedContext with configuration found in the carrier.
+
+        """
+    @abc.abstractmethod
+    def inject(self, context: DistributedContext, set_in_carrier: Setter,
+               carrier: object) -> None:
+        """Inject values from a DistributedContext into a carrier.
+
+        inject enables the propagation of values into HTTP clients or
+        other objects which perform an HTTP request. Implementations
+        should use the set_in_carrier method to set values on the
+        carrier.
+
+        Args:
+            context: The DistributedContext to read values from.
+            set_in_carrier: A setter function that can set values
+                on the carrier.
+            carrier: An object that a place to define HTTP headers.
+                Should be paired with set_in_carrier, which should
+                know how to set header values on the carrier.
+
+        """

--- a/opentelemetry-api/tests/distributedcontext/__init__.py
+++ b/opentelemetry-api/tests/distributedcontext/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
+++ b/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
@@ -1,0 +1,76 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from opentelemetry import distributedcontext
+
+
+class TestEntryMetadata(unittest.TestCase):
+    def test_entry_ttl_no_propagation(self):
+        metadata = distributedcontext.EntryMetadata(
+            distributedcontext.EntryMetadata.NO_PROPAGATION,
+        )
+        self.assertEqual(metadata.entry_ttl, 0)
+
+    def test_entry_ttl_unlimited_propagation(self):
+        metadata = distributedcontext.EntryMetadata(
+            distributedcontext.EntryMetadata.UNLIMITED_PROPAGATION,
+        )
+        self.assertEqual(metadata.entry_ttl, -1)
+
+
+class TestEntryKey(unittest.TestCase):
+    def test_create_too_long(self):
+        with self.assertRaises(ValueError):
+            distributedcontext.EntryKey.create("a" * 256)
+
+    def test_create_invalid_character(self):
+        with self.assertRaises(ValueError):
+            distributedcontext.EntryKey.create("\x00")
+
+    def test_create_valid(self):
+        key = distributedcontext.EntryKey.create("ok")
+        self.assertEqual(key, "ok")
+
+    def test_key_new(self):
+        key = distributedcontext.EntryKey("ok")
+        self.assertEqual(key, "ok")
+
+
+class TestEntryValue(unittest.TestCase):
+    def test_create_invalid_character(self):
+        with self.assertRaises(ValueError):
+            distributedcontext.EntryValue.create("\x00")
+
+    def test_create_valid(self):
+        key = distributedcontext.EntryValue.create("ok")
+        self.assertEqual(key, "ok")
+
+    def test_key_new(self):
+        key = distributedcontext.EntryValue("ok")
+        self.assertEqual(key, "ok")
+
+
+class TestDistributedContextManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = distributedcontext.DistributedContextManager()
+
+    def test_get_current_context(self):
+        self.assertIsNone(self.manager.get_current_context())
+
+    def test_use_context(self):
+        o = object()
+        with self.manager.use_context(o) as output:
+            self.assertIs(output, o)

--- a/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
+++ b/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
@@ -83,7 +83,7 @@ class TestDistributedContext(unittest.TestCase):
         value = self.context.get_entry_value(
             self.entry.key,
         )
-        self.assertIs(value, self.entry)
+        self.assertIs(value, self.entry.value)
 
     def test_get_entry_value_missing(self):
         key = distributedcontext.EntryKey("missing")

--- a/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
+++ b/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
@@ -71,6 +71,6 @@ class TestDistributedContextManager(unittest.TestCase):
         self.assertIsNone(self.manager.get_current_context())
 
     def test_use_context(self):
-        o = object()
-        with self.manager.use_context(o) as output:
-            self.assertIs(output, o)
+        expected = object()
+        with self.manager.use_context(expected) as output:
+            self.assertIs(output, expected)

--- a/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
+++ b/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
@@ -63,6 +63,33 @@ class TestEntryValue(unittest.TestCase):
         self.assertEqual(key, "ok")
 
 
+class TestDistributedContext(unittest.TestCase):
+    def setUp(self):
+        entry = self.entry = distributedcontext.Entry(
+            distributedcontext.EntryMetadata(
+                distributedcontext.EntryMetadata.NO_PROPAGATION,
+            ),
+            distributedcontext.EntryKey("key"),
+            distributedcontext.EntryValue("value"),
+        )
+        context = self.context = distributedcontext.DistributedContext()
+        context[entry.key] = entry
+
+    def test_get_entries(self):
+        self.assertIn(self.entry, self.context.get_entries())
+
+    def test_get_entry_value_present(self):
+        value = self.context.get_entry_value(
+            self.entry.key,
+        )
+        self.assertIs(value, self.entry)
+
+    def test_get_entry_value_missing(self):
+        key = distributedcontext.EntryKey("missing")
+        value = self.context.get_entry_value(key)
+        self.assertIsNone(value)
+
+
 class TestDistributedContextManager(unittest.TestCase):
     def setUp(self):
         self.manager = distributedcontext.DistributedContextManager()

--- a/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
+++ b/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
@@ -32,6 +32,10 @@ class TestEntryMetadata(unittest.TestCase):
 
 
 class TestEntryKey(unittest.TestCase):
+    def test_create_empty(self):
+        with self.assertRaises(ValueError):
+            distributedcontext.EntryKey.create("")
+
     def test_create_too_long(self):
         with self.assertRaises(ValueError):
             distributedcontext.EntryKey.create("a" * 256)

--- a/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
+++ b/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
@@ -72,8 +72,9 @@ class TestDistributedContext(unittest.TestCase):
             distributedcontext.EntryKey("key"),
             distributedcontext.EntryValue("value"),
         )
-        context = self.context = distributedcontext.DistributedContext()
-        context[entry.key] = entry
+        self.context = distributedcontext.DistributedContext((
+            entry,
+        ))
 
     def test_get_entries(self):
         self.assertIn(self.entry, self.context.get_entries())

--- a/opentelemetry-sdk/src/opentelemetry/sdk/distributedcontext/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/distributedcontext/__init__.py
@@ -19,25 +19,6 @@ from opentelemetry import distributedcontext as dctx_api
 from opentelemetry.context import Context
 
 
-class DistributedContext(dict, dctx_api.DistributedContext):
-    """A container for distributed context entries"""
-
-    def get_entries(self) -> typing.Iterable[dctx_api.Entry]:
-        """Returns an immutable iterator to entries."""
-        return self.values()
-
-    def get_entry_value(
-            self,
-            key: dctx_api.EntryKey
-    ) -> typing.Optional[dctx_api.EntryValue]:
-        """Returns the entry associated with a key or None
-
-        Args:
-            key: the key with which to perform a lookup
-        """
-        return self.get(key)
-
-
 class DistributedContextManager(dctx_api.DistributedContextManager):
     """See `opentelemetry.distributedcontext.DistributedContextManager`
 
@@ -53,7 +34,9 @@ class DistributedContextManager(dctx_api.DistributedContextManager):
 
         self._current_context = Context.register_slot(slot_name)
 
-    def get_current_context(self) -> typing.Optional[DistributedContext]:
+    def get_current_context(
+            self,
+    ) -> typing.Optional[dctx_api.DistributedContext]:
         """Gets the current DistributedContext.
 
         Returns:
@@ -64,8 +47,8 @@ class DistributedContextManager(dctx_api.DistributedContextManager):
     @contextmanager
     def use_context(
             self,
-            context: DistributedContext,
-    ) -> typing.Iterator[DistributedContext]:
+            context: dctx_api.DistributedContext,
+    ) -> typing.Iterator[dctx_api.DistributedContext]:
         """Context manager for controlling a DistributedContext lifetime.
 
         Set the context as the active DistributedContext.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/distributedcontext/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/distributedcontext/__init__.py
@@ -13,56 +13,70 @@
 # limitations under the License.
 
 from contextlib import contextmanager
-import contextvars
 import typing
 
+from opentelemetry.context import Context
 from opentelemetry import distributedcontext as dctx_api
-
-_CURRENT_DISTRIBUTEDCONTEXT_CV = contextvars.ContextVar(
-    'distributed_context',
-    default=None,
-)
-
-
-class EntryMetadata(dctx_api.EntryMetadata):
-    pass
-
-
-class EntryKey(dctx_api.EntryKey):
-    pass
-
-
-class EntryValue(dctx_api.EntryValue):
-    pass
-
-
-class Entry(dctx_api.Entry):
-    pass
 
 
 class DistributedContext(dict, dctx_api.DistributedContext):
-    def get_entries(self) -> typing.Iterable[Entry]:
+    """A container for distributed context entries"""
+
+    def get_entries(self) -> typing.Iterable[dctx_api.Entry]:
+        """Returns an immutable iterator to entries."""
         return self.values()
 
-    def get_entry_value(self, key: EntryKey) -> typing.Optional[EntryValue]:
+    def get_entry_value(
+        self, key: dctx_api.EntryKey
+    ) -> typing.Optional[dctx_api.EntryValue]:
+        """Returns the entry associated with a key or None
+
+        Args:
+            key: the key with which to perform a lookup
+        """
         return self.get(key)
 
 
 class DistributedContextManager(dctx_api.DistributedContextManager):
-    def __init__(self,
-                 cv: 'contextvars.ContextVar' = _CURRENT_DISTRIBUTEDCONTEXT_CV,
-                 ) -> None:
-        self._cv = cv
+    """See `opentelemetry.distributedcontext.DistributedContextManager`
+
+    Args:
+        name: The name of the context manager
+    """
+
+    def __init__(self, name: str = "") -> None:
+        if name:
+            slot_name = "DistributedContext.{}".format(name)
+        else:
+            slot_name = "DistributedContext"
+
+        self._current_context = Context.register_slot(slot_name)
 
     def get_current_context(self) -> typing.Optional[DistributedContext]:
-        return self._cv.get(default=None)
+        """Gets the current DistributedContext.
+
+        Returns:
+            A DistributedContext instance representing the current context.
+        """
+        return self._current_context.get()
 
     @contextmanager
     def use_context(
         self, context: DistributedContext
     ) -> typing.Iterator[DistributedContext]:
-        token = self._cv.set(context)
+        """Context manager for controlling a DistributedContext lifetime.
+
+        Set the context as the active DistributedContext.
+
+        On exiting, the context manager will restore the parent
+        DistributedContext.
+
+        Args:
+            context: A DistributedContext instance to make current.
+        """
+        snapshot = self._current_context.get()
+        self._current_context.set(context)
         try:
             yield context
         finally:
-            self._cv.reset(token)
+            self._current_context.set(snapshot)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/distributedcontext/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/distributedcontext/__init__.py
@@ -15,8 +15,8 @@
 from contextlib import contextmanager
 import typing
 
-from opentelemetry.context import Context
 from opentelemetry import distributedcontext as dctx_api
+from opentelemetry.context import Context
 
 
 class DistributedContext(dict, dctx_api.DistributedContext):
@@ -27,7 +27,8 @@ class DistributedContext(dict, dctx_api.DistributedContext):
         return self.values()
 
     def get_entry_value(
-        self, key: dctx_api.EntryKey
+            self,
+            key: dctx_api.EntryKey
     ) -> typing.Optional[dctx_api.EntryValue]:
         """Returns the entry associated with a key or None
 
@@ -62,7 +63,8 @@ class DistributedContextManager(dctx_api.DistributedContextManager):
 
     @contextmanager
     def use_context(
-        self, context: DistributedContext
+            self,
+            context: DistributedContext,
     ) -> typing.Iterator[DistributedContext]:
         """Context manager for controlling a DistributedContext lifetime.
 

--- a/opentelemetry-sdk/tests/distributedcontext/__init__.py
+++ b/opentelemetry-sdk/tests/distributedcontext/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/opentelemetry-sdk/tests/distributedcontext/test_distributed_context.py
+++ b/opentelemetry-sdk/tests/distributedcontext/test_distributed_context.py
@@ -27,7 +27,7 @@ class TestDistributedContextManager(unittest.TestCase):
         self.assertIsNone(self.manager.get_current_context())
 
         # Start initial context
-        dctx = dctx_api.DistributedContext()
+        dctx = dctx_api.DistributedContext(())
         with self.manager.use_context(dctx) as current:
             self.assertIs(current, dctx)
             self.assertIs(
@@ -36,7 +36,7 @@ class TestDistributedContextManager(unittest.TestCase):
             )
 
             # Context is overridden
-            nested_dctx = dctx_api.DistributedContext()
+            nested_dctx = dctx_api.DistributedContext(())
             with self.manager.use_context(nested_dctx) as current:
                 self.assertIs(current, nested_dctx)
                 self.assertIs(

--- a/opentelemetry-sdk/tests/distributedcontext/test_distributed_context.py
+++ b/opentelemetry-sdk/tests/distributedcontext/test_distributed_context.py
@@ -1,0 +1,83 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+
+from opentelemetry.distributedcontext import (
+    Entry,
+    EntryMetadata,
+    EntryKey,
+    EntryValue,
+)
+
+from opentelemetry.sdk import distributedcontext
+
+
+class TestDistributedContext(unittest.TestCase):
+    def setUp(self):
+        entry = self.entry = Entry(
+            EntryMetadata(EntryMetadata.NO_PROPAGATION),
+            EntryKey("key"),
+            EntryValue("value"),
+        )
+        context = self.context = distributedcontext.DistributedContext()
+        context[entry.key] = entry
+
+    def test_get_entries(self):
+        self.assertIn(self.entry, self.context.get_entries())
+
+    def test_get_entry_value_present(self):
+        value = self.context.get_entry_value(
+            self.entry.key,
+        )
+        self.assertIs(value, self.entry)
+
+    def test_get_entry_value_missing(self):
+        key = EntryKey("missing")
+        value = self.context.get_entry_value(key)
+        self.assertIsNone(value)
+
+
+class TestDistributedContextManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = distributedcontext.DistributedContextManager()
+
+    def test_use_context(self):
+        # Context is None initially
+        self.assertIsNone(self.manager.get_current_context())
+
+        # Start initial context
+        dctx = distributedcontext.DistributedContext()
+        with self.manager.use_context(dctx) as current:
+            self.assertIs(current, dctx)
+            self.assertIs(
+                self.manager.get_current_context(),
+                dctx,
+            )
+
+            # Context is overridden
+            nested_dctx = distributedcontext.DistributedContext()
+            with self.manager.use_context(nested_dctx) as current:
+                self.assertIs(current, nested_dctx)
+                self.assertIs(
+                    self.manager.get_current_context(),
+                    nested_dctx,
+                )
+
+            # Context is restored
+            self.assertIs(
+                self.manager.get_current_context(),
+                dctx,
+            )

--- a/opentelemetry-sdk/tests/distributedcontext/test_distributed_context.py
+++ b/opentelemetry-sdk/tests/distributedcontext/test_distributed_context.py
@@ -14,40 +14,8 @@
 
 import unittest
 
-
-from opentelemetry.distributedcontext import (
-    Entry,
-    EntryMetadata,
-    EntryKey,
-    EntryValue,
-)
-
+from opentelemetry import distributedcontext as dctx_api
 from opentelemetry.sdk import distributedcontext
-
-
-class TestDistributedContext(unittest.TestCase):
-    def setUp(self):
-        entry = self.entry = Entry(
-            EntryMetadata(EntryMetadata.NO_PROPAGATION),
-            EntryKey("key"),
-            EntryValue("value"),
-        )
-        context = self.context = distributedcontext.DistributedContext()
-        context[entry.key] = entry
-
-    def test_get_entries(self):
-        self.assertIn(self.entry, self.context.get_entries())
-
-    def test_get_entry_value_present(self):
-        value = self.context.get_entry_value(
-            self.entry.key,
-        )
-        self.assertIs(value, self.entry)
-
-    def test_get_entry_value_missing(self):
-        key = EntryKey("missing")
-        value = self.context.get_entry_value(key)
-        self.assertIsNone(value)
 
 
 class TestDistributedContextManager(unittest.TestCase):
@@ -59,7 +27,7 @@ class TestDistributedContextManager(unittest.TestCase):
         self.assertIsNone(self.manager.get_current_context())
 
         # Start initial context
-        dctx = distributedcontext.DistributedContext()
+        dctx = dctx_api.DistributedContext()
         with self.manager.use_context(dctx) as current:
             self.assertIs(current, dctx)
             self.assertIs(
@@ -68,7 +36,7 @@ class TestDistributedContextManager(unittest.TestCase):
             )
 
             # Context is overridden
-            nested_dctx = distributedcontext.DistributedContext()
+            nested_dctx = dctx_api.DistributedContext()
             with self.manager.use_context(nested_dctx) as current:
                 self.assertIs(current, nested_dctx)
                 self.assertIs(


### PR DESCRIPTION
This PR fixes issue #91 by attempting to implement the [distributed context api](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-distributedcontext.md) specification.

The work is based somewhat on the [opentelemetry-ruby](https://github.com/open-telemetry/opentelemetry-ruby/tree/master/api/lib/opentelemetry/distributed_context) implementation.

This PR hasn't yet implemented the propagator APIs for DistributedContext. The intent is that when this PR is ready for review a stub will have been implemented for propagators in distributed context.