### PR TITLE
Fix test failures involving contextvars.

### DIFF
--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -112,8 +112,7 @@ class TestSpanCreation(unittest.TestCase):
             self.assertIsNotNone(child.end_time)
 
     def test_span_members(self):
-        context = contextvars.ContextVar('test_span_members')
-        tracer = trace.Tracer(context)
+        tracer = trace.Tracer()
 
         other_context1 = trace_api.SpanContext(
             trace_id=trace.generate_trace_id(),

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -112,7 +112,7 @@ class TestSpanCreation(unittest.TestCase):
             self.assertIsNotNone(child.end_time)
 
     def test_span_members(self):
-        tracer = trace.Tracer()
+        tracer = trace.Tracer('test_span_members')
 
         other_context1 = trace_api.SpanContext(
             trace_id=trace.generate_trace_id(),


### PR DESCRIPTION
I'm not exactly sure how this happened but it looks like #86 introduced a failure on master.  The failure is due to the sdk test using `contextvars` to attempt to initialize the tracer.

This PR removes the use of `contextvars` in the offending test.