### PR TITLE
Describe isort's multi_line_output setting

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,14 @@
 [settings]
-multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=79
+
+; 3 stands for Vertical Hanging Indent, e.g.
+; from third_party import (
+;     lib1,
+;     lib2,
+;     lib3,
+; )
+; docs: https://github.com/timothycrosley/isort#multi-line-output-modes
+multi_line_output=3


### PR DESCRIPTION
Hello,

These changes follow up #95.

The `multi_line_output` was already set to `3` in the [Add initial black formatting](https://github.com/open-telemetry/opentelemetry-python/pull/104) PR, so after rebasing to `master` this commit contains only comment that describes a magic number from the `isort` configuration file.

Related discussions:
 - https://github.com/open-telemetry/opentelemetry-python/pull/95#discussion_r315942697
 - https://github.com/open-telemetry/opentelemetry-python/pull/95#issuecomment-523566519