### PR TITLE
Fix running tox on Windows.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ changedir =
   test-ext-wsgi: ext/opentelemetry-ext-wsgi/tests
 
 commands_pre =
-  pip install -U pip setuptools wheel
+  python -m pip install -U pip setuptools wheel
   test: pip install -e {toxinidir}/opentelemetry-api
   test-sdk: pip install -e {toxinidir}/opentelemetry-sdk
   ext: pip install -e {toxinidir}/opentelemetry-api


### PR DESCRIPTION
Previously, this would result in an error:

```
Installing collected packages: pip, setuptools, wheel
  Found existing installation: pip 19.1.1
    Uninstalling pip-19.1.1:
      Successfully uninstalled pip-19.1.1
ERROR: Could not install packages due to an EnvironmentError: [WinError 5] Access is denied: 'C:\\Users\\USERNAME\\AppData\\Local\\Temp\\pip-uninstall-ex4vlsgo\\pip.exe'
Consider using the `--user` option or check the permissions.

ERROR: InvocationError for command 'C:\workspaces\misc\opentelemetry-python\.tox\py36-test-sdk\Scripts\pip.EXE' install -U pip setuptools wheel (exited with code 1)
```