### PR TITLE
sdk: create_span() and start_span() with trace_id and span_id

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -300,21 +300,26 @@ class Tracer(trace_api.Tracer):
         return self._current_span_slot.get()
 
     @contextmanager
-    def start_span(self,
+    def start_span(self,  # pylint: disable=arguments-differ
                    name: str,
-                   parent: trace_api.ParentSpan = trace_api.Tracer.CURRENT_SPAN
+                   parent: trace_api.ParentSpan =
+                   trace_api.Tracer.CURRENT_SPAN,
+                   span_id: typing.Optional[int] = None
                    ) -> typing.Iterator['Span']:
         """See `opentelemetry.trace.Tracer.start_span`."""
-        with self.use_span(self.create_span(name, parent)) as span:
+        with self.use_span(self.create_span(name, parent,
+                                            span_id=span_id)) as span:
             yield span
 
-    def create_span(self,
+    def create_span(self,  # pylint: disable=arguments-differ
                     name: str,
                     parent: trace_api.ParentSpan =
-                    trace_api.Tracer.CURRENT_SPAN
+                    trace_api.Tracer.CURRENT_SPAN,
+                    span_id: typing.Optional[int] = None
                     ) -> 'Span':
         """See `opentelemetry.trace.Tracer.create_span`."""
-        span_id = generate_span_id()
+        if span_id is None:
+            span_id = generate_span_id()
         if parent is Tracer.CURRENT_SPAN:
             parent = self.get_current_span()
         if parent is None:


### PR DESCRIPTION
sdk: create_span() and start_span() with span_id

OTEP-7 ("Remove support to report out-of-band telemetry from the API") states that the API does not support specifying the span_id in create_span() or start_span(). Also, following OTEP-2 ("Remove SpanData"), we cannot use the SpanData to specify the span_id.

However, the need to specify the span_id remains for some applications. Following the suggestion from OTEP-7, I am adding this feature in the SDK only.

This patch adds the named argument span_id in create_span() and start_span() to optionally specify the id of the span to be created. When unset, the previous behavior remains and the SDK allocates a
span_id automatically.

Callers should give the name of the argument and not rely on the current argument order because more arguments could be passed in the future. OTEP-2 lists possible additional optional arguments:
- start timestamp
- span ID
- resource

Example of call:
```
    with tracer.start_span('foo', span_id=my_span_id):
        print(Context)
```

OTEP-7: https://github.com/open-telemetry/oteps/pull/26
OTEP-2: https://github.com/open-telemetry/oteps/blob/master/text/0002-remove-spandata.md
