### PR TITLE
sdk/trace: add SpanProcessor

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -145,6 +145,68 @@ Event = namedtuple("Event", ("name", "attributes"))
 Link = namedtuple("Link", ("context", "attributes"))
 
 
+class SpanProcessor:
+    """Interface which allows hooks for SDK's `Span`s start and end method
+    invocations.
+
+    Span processors can be registered directly using
+    :func:`~Tracer:add_span_processor` and they are invoked in the same order
+    as they were registered.
+    """
+
+    def on_start(self, span: "Span") -> None:
+        """Called when a :class:`Span` is started.
+
+        This method is called synchronously on the thread that starts the
+        span, therefore it should not block or throw an exception.
+
+        Args:
+            span: The :class:`Span` that just started.
+        """
+
+    def on_end(self, span: "Span") -> None:
+        """Called when a :class:`Span` is ended.
+
+        This method is called synchronously on the thread that ends the
+        span, therefore it should not block or throw an exception.
+
+        Args:
+            span: The :class:`Span` that just ended.
+        """
+
+    def shutdown(self) -> None:
+        """Called when a :class:`Tracer` is shutdown."""
+
+
+class MultiSpanProcessor(SpanProcessor):
+    """Implementation of :class:`SpanProcessor` that forwards all received
+    events to a list of `SpanProcessor`.
+    """
+
+    def __init__(self):
+        # use a tuple to avoid race conditions when adding a new span and
+        # iterating through it on "on_start" and "on_end".
+        self._span_processors = ()
+        self._lock = threading.Lock()
+
+    def add_span_processor(self, span_processor: SpanProcessor):
+        """Adds a SpanProcessor to the list handled by this instance."""
+        with self._lock:
+            self._span_processors = self._span_processors + (span_processor,)
+
+    def on_start(self, span: "Span") -> None:
+        for sp in self._span_processors:
+            sp.on_start(span)
+
+    def on_end(self, span: "Span") -> None:
+        for sp in self._span_processors:
+            sp.on_end(span)
+
+    def shutdown(self) -> None:
+        for sp in self._span_processors:
+            sp.shutdown()
+
+
 class Span(trace_api.Span):
     """See `opentelemetry.trace.Span`.
 
@@ -161,6 +223,8 @@ class Span(trace_api.Span):
         attributes: The span's attributes to be exported
         events: Timestamped events to be exported
         links: Links to other spans to be exported
+        span_processor: `SpanProcessor` to invoke when starting and ending
+            this `Span`.
     """
 
     # Initialize these lazily assuming most spans won't have them.
@@ -179,6 +243,7 @@ class Span(trace_api.Span):
         attributes: types.Attributes = None,  # TODO
         events: typing.Sequence[Event] = None,  # TODO
         links: typing.Sequence[Link] = None,  # TODO
+        span_processor: SpanProcessor = SpanProcessor(),
     ) -> None:
 
         self.name = name
@@ -190,6 +255,7 @@ class Span(trace_api.Span):
         self.attributes = attributes
         self.events = events
         self.links = links
+        self.span_processor = span_processor
 
         if attributes is None:
             self.attributes = Span.empty_attributes
@@ -247,10 +313,12 @@ class Span(trace_api.Span):
     def start(self):
         if self.start_time is None:
             self.start_time = util.time_ns()
+            self.span_processor.on_start(self)
 
     def end(self):
         if self.end_time is None:
             self.end_time = util.time_ns()
+            self.span_processor.on_end(self)
 
     def update_name(self, name: str) -> None:
         self.name = name
@@ -286,6 +354,7 @@ class Tracer(trace_api.Tracer):
         if name:
             slot_name = "{}.current_span".format(name)
         self._current_span_slot = Context.register_slot(slot_name)
+        self._active_span_processor = MultiSpanProcessor()
 
     def get_current_span(self):
         """See `opentelemetry.trace.Tracer.get_current_span`."""
@@ -325,7 +394,12 @@ class Tracer(trace_api.Tracer):
                 parent_context.trace_options,
                 parent_context.trace_state,
             )
-        return Span(name=name, context=context, parent=parent)
+        return Span(
+            name=name,
+            context=context,
+            parent=parent,
+            span_processor=self._active_span_processor,
+        )
 
     @contextmanager
     def use_span(self, span: "Span") -> typing.Iterator["Span"]:
@@ -338,6 +412,16 @@ class Tracer(trace_api.Tracer):
         finally:
             self._current_span_slot.set(span_snapshot)
             span.end()
+
+    def add_span_processor(self, span_processor: SpanProcessor) -> None:
+        """Registers a new :class:`SpanProcessor` for this `Tracer`.
+
+        The span processors are invoked in the same order they are registered.
+        """
+
+        # no lock here because MultiSpanProcessor.add_span_processor is
+        # thread safe
+        self._active_span_processor.add_span_processor(span_processor)
 
 
 tracer = Tracer()


### PR DESCRIPTION
`SpanProcessor` is an interface that allows to register hooks for Span `start` and `end` invocations.

It is not already part of the spec but there is ongoing work on this: https://github.com/open-telemetry/opentelemetry-specification/pull/205

This PR introduces the SpanProcessor interface in the SDK, also a MultiSpanProcessor implementation based on the java one to allow more than one processor to be registered. 

Built-in span processors are not considered here and will be added in another PR soon.

According to the specs the span processors should only be invoked when `IsRecordingEvents` is true, however that flag is still missing: https://github.com/open-telemetry/opentelemetry-python/issues/100

The following is a small example of how span processor can be used:

```
...
from opentelemetry.sdk import trace

# implement `SpanProcessor` interface
class MySpanProcessor(trace.SpanProcessor):
    def on_start(self, span: "trace.Span") -> None:
        print("span started...")

    def on_end(self, span: "trace.Span") -> None:
        print("span ended...")

# create tracer instance (real users will use trace.tracer() from the api package)
tracer = trace.Tracer()

# add span processor to the tracer
tracer.add_span_processor(MySpanProcessor())

# create some spans just to test
with tracer.start_span("foo"):
    with tracer.start_span("bar"):
        with tracer.start_span("baz"):
            pass
...
```


This is ongoing work for https://github.com/open-telemetry/opentelemetry-python/issues/60.