### PR TITLE
Add Link and Event classes

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -88,6 +88,29 @@ class Link:
         return self._attributes
 
 
+class Event:
+    """A text annotation with a set of attributes."""
+
+    def __init__(
+        self, name: str, timestamp: int, attributes: types.Attributes = None
+    ) -> None:
+        self._name = name
+        self._attributes = attributes
+        self._timestamp = timestamp
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def attributes(self) -> types.Attributes:
+        return self._attributes
+
+    @property
+    def timestamp(self) -> int:
+        return self._timestamp
+
+
 class Span:
     """A span represents a single operation within a trace."""
 
@@ -129,10 +152,16 @@ class Span:
     def add_event(
         self, name: str, attributes: types.Attributes = None
     ) -> None:
-        """Adds an Event.
+        """Adds an `Event`.
 
-        Adds a single Event with the name and, optionally, attributes passed
+        Adds a single `Event` with the name and, optionally, attributes passed
         as arguments.
+        """
+
+    def add_lazy_event(self, event: Event) -> None:
+        """Adds an `Event`.
+
+        Adds an `Event` that has previously been created.
         """
 
     def add_link(

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -102,16 +102,14 @@ class Span:
             A :class:`.SpanContext` with a copy of this span's immutable state.
         """
 
-    def set_attribute(
-        self: "Span", key: str, value: types.AttributeValue
-    ) -> None:
+    def set_attribute(self, key: str, value: types.AttributeValue) -> None:
         """Sets an Attribute.
 
         Sets a single Attribute with the key and value passed as arguments.
         """
 
     def add_event(
-        self: "Span", name: str, attributes: types.Attributes = None
+        self, name: str, attributes: types.Attributes = None
     ) -> None:
         """Adds an Event.
 
@@ -120,7 +118,7 @@ class Span:
         """
 
     def add_link(
-        self: "Span",
+        self,
         link_target_context: "SpanContext",
         attributes: types.Attributes = None,
     ) -> None:

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -70,6 +70,24 @@ from opentelemetry import loader, types
 ParentSpan = typing.Optional[typing.Union["Span", "SpanContext"]]
 
 
+class Link:
+    """A link to a `Span`."""
+
+    def __init__(
+        self, context: "SpanContext", attributes: types.Attributes = None
+    ) -> None:
+        self._context = context
+        self._attributes = attributes
+
+    @property
+    def context(self) -> "SpanContext":
+        return self._context
+
+    @property
+    def attributes(self) -> types.Attributes:
+        return self._attributes
+
+
 class Span:
     """A span represents a single operation within a trace."""
 
@@ -122,10 +140,16 @@ class Span:
         link_target_context: "SpanContext",
         attributes: types.Attributes = None,
     ) -> None:
-        """Adds a Link to another span.
+        """Adds a `Link` to another span.
 
-        Adds a single Link from this Span to another Span identified by the
+        Adds a single `Link` from this Span to another Span identified by the
         `SpanContext` passed as argument.
+        """
+
+    def add_lazy_link(self, link: "Link") -> None:
+        """Adds a `Link` to another span.
+
+        Adds a `Link` that has previously been created.
         """
 
     def update_name(self, name: str) -> None:

--- a/opentelemetry-api/src/opentelemetry/types.py
+++ b/opentelemetry-api/src/opentelemetry/types.py
@@ -16,4 +16,4 @@
 import typing
 
 AttributeValue = typing.Union[str, bool, float]
-Attributes = typing.Dict[str, AttributeValue]
+Attributes = typing.Optional[typing.Dict[str, AttributeValue]]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -233,7 +233,7 @@ class Span(trace_api.Span):
     empty_links = BoundedList(MAX_NUM_LINKS)
 
     def __init__(
-        self: "Span",
+        self,
         name: str,
         context: "trace_api.SpanContext",
         parent: trace_api.ParentSpan = None,
@@ -283,15 +283,13 @@ class Span(trace_api.Span):
     def get_context(self):
         return self.context
 
-    def set_attribute(
-        self: "Span", key: str, value: types.AttributeValue
-    ) -> None:
+    def set_attribute(self, key: str, value: types.AttributeValue) -> None:
         if self.attributes is Span.empty_attributes:
             self.attributes = BoundedDict(MAX_NUM_ATTRIBUTES)
         self.attributes[key] = value
 
     def add_event(
-        self: "Span", name: str, attributes: types.Attributes = None
+        self, name: str, attributes: types.Attributes = None
     ) -> None:
         if self.events is Span.empty_events:
             self.events = BoundedList(MAX_NUM_EVENTS)
@@ -300,7 +298,7 @@ class Span(trace_api.Span):
         self.events.append(Event(name, attributes))
 
     def add_link(
-        self: "Span",
+        self,
         link_target_context: "trace_api.SpanContext",
         attributes: types.Attributes = None,
     ) -> None:

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -130,6 +130,7 @@ class TestSpanCreation(unittest.TestCase):
         self.assertIsNone(tracer.get_current_span())
 
         with tracer.start_span("root") as root:
+            # attributes
             root.set_attribute("component", "http")
             root.set_attribute("http.method", "GET")
             root.set_attribute(
@@ -144,18 +145,6 @@ class TestSpanCreation(unittest.TestCase):
             root.set_attribute("attr-key", "attr-value1")
             root.set_attribute("attr-key", "attr-value2")
 
-            root.add_event("event0")
-            root.add_event("event1", {"name": "birthday"})
-
-            root.add_link(other_context1)
-            root.add_link(other_context2, {"name": "neighbor"})
-
-            root.update_name("toor")
-            self.assertEqual(root.name, "toor")
-
-            # The public API does not expose getters.
-            # Checks by accessing the span members directly
-
             self.assertEqual(len(root.attributes), 7)
             self.assertEqual(root.attributes["component"], "http")
             self.assertEqual(root.attributes["http.method"], "GET")
@@ -168,6 +157,10 @@ class TestSpanCreation(unittest.TestCase):
             self.assertEqual(root.attributes["misc.pi"], 3.14)
             self.assertEqual(root.attributes["attr-key"], "attr-value2")
 
+            # events
+            root.add_event("event0")
+            root.add_event("event1", {"name": "birthday"})
+
             self.assertEqual(len(root.events), 2)
             self.assertEqual(
                 root.events[0], trace.Event(name="event0", attributes={})
@@ -176,6 +169,10 @@ class TestSpanCreation(unittest.TestCase):
                 root.events[1],
                 trace.Event(name="event1", attributes={"name": "birthday"}),
             )
+
+            # links
+            root.add_link(other_context1)
+            root.add_link(other_context2, {"name": "neighbor"})
 
             self.assertEqual(len(root.links), 2)
             self.assertEqual(
@@ -193,6 +190,9 @@ class TestSpanCreation(unittest.TestCase):
             )
             self.assertEqual(root.links[1].attributes, {"name": "neighbor"})
 
+            # name
+            root.update_name("toor")
+            self.assertEqual(root.name, "toor")
 
 class TestSpan(unittest.TestCase):
     def test_basic_span(self):

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -17,6 +17,7 @@ import unittest
 
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk import trace
+from opentelemetry.sdk import util
 
 
 class TestTracer(unittest.TestCase):
@@ -164,15 +165,22 @@ class TestSpanCreation(unittest.TestCase):
             # events
             root.add_event("event0")
             root.add_event("event1", {"name": "birthday"})
+            now = util.time_ns()
+            root.add_lazy_event(
+                trace_api.Event("event2", now, {"name": "hello"})
+            )
 
-            self.assertEqual(len(root.events), 2)
-            self.assertEqual(
-                root.events[0], trace.Event(name="event0", attributes={})
-            )
-            self.assertEqual(
-                root.events[1],
-                trace.Event(name="event1", attributes={"name": "birthday"}),
-            )
+            self.assertEqual(len(root.events), 3)
+
+            self.assertEqual(root.events[0].name, "event0")
+            self.assertEqual(root.events[0].attributes, {})
+
+            self.assertEqual(root.events[1].name, "event1")
+            self.assertEqual(root.events[1].attributes, {"name": "birthday"})
+
+            self.assertEqual(root.events[2].name, "event2")
+            self.assertEqual(root.events[2].attributes, {"name": "hello"})
+            self.assertEqual(root.events[2].timestamp, now)
 
             # links
             root.add_link(other_context1)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -126,6 +126,10 @@ class TestSpanCreation(unittest.TestCase):
             trace_id=trace.generate_trace_id(),
             span_id=trace.generate_span_id(),
         )
+        other_context3 = trace_api.SpanContext(
+            trace_id=trace.generate_trace_id(),
+            span_id=trace.generate_span_id(),
+        )
 
         self.assertIsNone(tracer.get_current_span())
 
@@ -173,8 +177,11 @@ class TestSpanCreation(unittest.TestCase):
             # links
             root.add_link(other_context1)
             root.add_link(other_context2, {"name": "neighbor"})
+            root.add_lazy_link(
+                trace_api.Link(other_context3, {"component": "http"})
+            )
 
-            self.assertEqual(len(root.links), 2)
+            self.assertEqual(len(root.links), 3)
             self.assertEqual(
                 root.links[0].context.trace_id, other_context1.trace_id
             )
@@ -189,10 +196,15 @@ class TestSpanCreation(unittest.TestCase):
                 root.links[1].context.span_id, other_context2.span_id
             )
             self.assertEqual(root.links[1].attributes, {"name": "neighbor"})
+            self.assertEqual(
+                root.links[2].context.span_id, other_context3.span_id
+            )
+            self.assertEqual(root.links[2].attributes, {"component": "http"})
 
             # name
             root.update_name("toor")
             self.assertEqual(root.name, "toor")
+
 
 class TestSpan(unittest.TestCase):
     def test_basic_span(self):


### PR DESCRIPTION
This PR creates classes for `Link` and `Event`,  also implements the `add_lazy_{event,link}` methods.

Having a proper class would make it easier to extend in the future. Those classes are implemented directly in the API as they are general enough and different implementations could reuse them.

Solves https://github.com/open-telemetry/opentelemetry-python/issues/76
Solves https://github.com/open-telemetry/opentelemetry-python/issues/77