### PR TITLE
Add SpanKind option at span creation (closes #103).

### DIFF
--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
@@ -22,6 +22,8 @@ from urllib.parse import urlparse
 
 from requests.sessions import Session
 
+from opentelemetry.trace import SpanKind
+
 
 # NOTE: Currently we force passing a tracer. But in turn, this forces the user
 # to configure a SDK before enabling this integration. In turn, this means that
@@ -61,11 +63,8 @@ def enable(tracer):
                 path = "<URL parses to None>"
             path = parsed_url.path
 
-        with tracer.start_span(path) as span:
+        with tracer.start_span(path, kind=SpanKind.CLIENT) as span:
             span.set_attribute("component", "http")
-            # TODO: The OTel spec says "SpanKind" MUST be "Client" but that
-            #  seems to be a leftover, as Spans have no explicit field for
-            #  kind.
             span.set_attribute("http.method", method.upper())
             span.set_attribute("http.url", url)
 

--- a/ext/opentelemetry-ext-http-requests/tests/test_requests_integration.py
+++ b/ext/opentelemetry-ext-http-requests/tests/test_requests_integration.py
@@ -56,7 +56,9 @@ class TestRequestsIntegration(unittest.TestCase):
         url = "https://www.example.org/foo/bar?x=y#top"
         requests.get(url=url)
         self.assertEqual(1, len(self.send.call_args_list))
-        self.tracer.start_span.assert_called_with("/foo/bar")
+        self.tracer.start_span.assert_called_with(
+            "/foo/bar", kind=trace.SpanKind.CLIENT
+        )
         self.span_context_manager.__enter__.assert_called_with()
         self.span_context_manager.__exit__.assert_called_with(None, None, None)
         self.assertEqual(

--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
@@ -88,7 +88,7 @@ class OpenTelemetryMiddleware:
         tracer = trace.tracer()
         path_info = environ["PATH_INFO"] or "/"
 
-        with tracer.start_span(path_info) as span:
+        with tracer.start_span(path_info, kind=trace.SpanKind.SERVER) as span:
             self._add_request_attributes(span, environ)
             start_response = self._create_start_response(span, start_response)
 

--- a/ext/opentelemetry-ext-wsgi/tests/test_wsgi_middleware.py
+++ b/ext/opentelemetry-ext-wsgi/tests/test_wsgi_middleware.py
@@ -125,7 +125,9 @@ class TestWsgiApplication(unittest.TestCase):
             self.assertIsNone(self.exc_info)
 
         # Verify that start_span has been called
-        self.start_span.assert_called_once_with("/")
+        self.start_span.assert_called_once_with(
+            "/", kind=trace_api.SpanKind.SERVER
+        )
 
     def test_basic_wsgi_call(self):
         app = OpenTelemetryMiddleware(simple_wsgi)

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -125,7 +125,7 @@ class SpanKind(enum.Enum):
     #: Indicates that the span describes an operation that handles a remote request.
     SERVER = 1
 
-    #: Indicates that the span describes an request to some remote service.
+    #: Indicates that the span describes a request to some remote service.
     CLIENT = 2
 
     #: Indicates that the span describes a producer sending a message to a

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -241,6 +241,7 @@ class Span(trace_api.Span):
         attributes: types.Attributes = None,  # TODO
         events: typing.Sequence[trace_api.Event] = None,  # TODO
         links: typing.Sequence[trace_api.Link] = None,  # TODO
+        kind: trace_api.SpanKind = trace_api.SpanKind.INTERNAL,
         span_processor: SpanProcessor = SpanProcessor(),
     ) -> None:
 
@@ -253,6 +254,8 @@ class Span(trace_api.Span):
         self.attributes = attributes
         self.events = events
         self.links = links
+        self.kind = kind
+
         self.span_processor = span_processor
         self._lock = threading.Lock()
 
@@ -404,15 +407,17 @@ class Tracer(trace_api.Tracer):
         self,
         name: str,
         parent: trace_api.ParentSpan = trace_api.Tracer.CURRENT_SPAN,
+        kind: trace_api.SpanKind = trace_api.SpanKind.INTERNAL,
     ) -> typing.Iterator["Span"]:
         """See `opentelemetry.trace.Tracer.start_span`."""
-        with self.use_span(self.create_span(name, parent)) as span:
+        with self.use_span(self.create_span(name, parent, kind)) as span:
             yield span
 
     def create_span(
         self,
         name: str,
         parent: trace_api.ParentSpan = trace_api.Tracer.CURRENT_SPAN,
+        kind: trace_api.SpanKind = trace_api.SpanKind.INTERNAL,
     ) -> "Span":
         """See `opentelemetry.trace.Tracer.create_span`."""
         span_id = generate_span_id()
@@ -438,6 +443,7 @@ class Tracer(trace_api.Tracer):
             context=context,
             parent=parent,
             span_processor=self._active_span_processor,
+            kind=kind,
         )
 
     @contextmanager

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -36,10 +36,14 @@ class TestSpanCreation(unittest.TestCase):
 
             self.assertIsNotNone(root.start_time)
             self.assertIsNone(root.end_time)
+            self.assertEqual(root.kind, trace_api.SpanKind.INTERNAL)
 
-            with tracer.start_span("child") as child:
+            with tracer.start_span(
+                "child", kind=trace_api.SpanKind.CLIENT
+            ) as child:
                 self.assertIs(tracer.get_current_span(), child)
                 self.assertIs(child.parent, root)
+                self.assertEqual(root.kind, trace_api.SpanKind.INTERNAL)
 
                 self.assertIsNotNone(child.start_time)
                 self.assertIsNone(child.end_time)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -43,7 +43,7 @@ class TestSpanCreation(unittest.TestCase):
             ) as child:
                 self.assertIs(tracer.get_current_span(), child)
                 self.assertIs(child.parent, root)
-                self.assertEqual(root.kind, trace_api.SpanKind.INTERNAL)
+                self.assertEqual(child.kind, trace_api.SpanKind.CLIENT)
 
                 self.assertIsNotNone(child.start_time)
                 self.assertIsNone(child.end_time)


### PR DESCRIPTION
Even though the Spec PR isn't merged and there's some discussion going on, I think this will be more useful than not being able to distinguish HTTP client & server at all.