### PR TITLE
span: add is_recording_events

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -192,7 +192,7 @@ class Span:
         """
 
     def is_recording_events(self) -> bool:
-        """Returns the flag whether this span will be recorded.
+        """Returns whether this span will be recorded.
 
         Returns true if this Span is active and recording information like
         events with the AddEvent operation and attributes using SetAttributes.

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -195,7 +195,7 @@ class Span:
         """Returns whether this span will be recorded.
 
         Returns true if this Span is active and recording information like
-        events with the AddEvent operation and attributes using SetAttributes.
+        events with the add_event operation and attributes using set_attribute.
         """
 
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -191,6 +191,13 @@ class Span:
         on the implementation.
         """
 
+    def is_recording_events(self) -> bool:
+        """Returns the flag whether this span will be recorded.
+
+        Returns true if this Span is active and recording information like
+        events with the AddEvent operation and attributes using SetAttributes.
+        """
+
 
 class TraceOptions(int):
     """A bitmask that represents options specific to the trace.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -284,6 +284,8 @@ class Span(trace_api.Span):
 
     def set_attribute(self, key: str, value: types.AttributeValue) -> None:
         with self._lock:
+            if not self.is_recording_events():
+                return
             has_ended = self.end_time is not None
             if not has_ended:
                 if self.attributes is Span.empty_attributes:
@@ -302,6 +304,8 @@ class Span(trace_api.Span):
 
     def add_lazy_event(self, event: trace_api.Event) -> None:
         with self._lock:
+            if not self.is_recording_events():
+                return
             has_ended = self.end_time is not None
             if not has_ended:
                 if self.events is Span.empty_events:
@@ -322,6 +326,8 @@ class Span(trace_api.Span):
 
     def add_lazy_link(self, link: "trace_api.Link") -> None:
         with self._lock:
+            if not self.is_recording_events():
+                return
             has_ended = self.end_time is not None
             if not has_ended:
                 if self.links is Span.empty_links:
@@ -333,6 +339,8 @@ class Span(trace_api.Span):
 
     def start(self):
         with self._lock:
+            if not self.is_recording_events():
+                return
             has_started = self.start_time is not None
             if not has_started:
                 self.start_time = util.time_ns()
@@ -343,6 +351,8 @@ class Span(trace_api.Span):
 
     def end(self):
         with self._lock:
+            if not self.is_recording_events():
+                return
             if self.start_time is None:
                 raise RuntimeError("Calling end() on a not started span.")
             has_ended = self.end_time is not None
@@ -361,6 +371,9 @@ class Span(trace_api.Span):
             logger.warning("Calling update_name() on an ended span.")
             return
         self.name = name
+
+    def is_recording_events(self) -> bool:
+        return True
 
 
 def generate_span_id():


### PR DESCRIPTION
Add missing is_recording_events() function to span in API and SDK.

The important point of this commit is to implement the check in functions like
add_event, set_attribute and so son.  Currently is_recording_events always
returns true.

Solves: https://github.com/open-telemetry/opentelemetry-python/issues/100