### PR TITLE
sdk/trace/exporters: add batch span processor exporter

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -142,7 +142,7 @@ class BatchExportSpanProcessor(SpanProcessor):
 
         if len(self.queue) >= self.max_queue_size // 2:
             with self.condition:
-                    self.condition.notify()
+                self.condition.notify()
 
     def worker(self):
         timeout = self.schedule_delay_millis / 1e3

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -14,8 +14,8 @@
 
 import time
 import unittest
-
 from unittest import mock
+
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk import trace
 from opentelemetry.sdk.trace import export
@@ -56,16 +56,17 @@ class TestSimpleExportSpanProcessor(unittest.TestCase):
         self.assertListEqual(["xxx", "bar", "foo"], spans_names_list)
 
 
-class TestBatchExportSpanProcessor(unittest.TestCase):
-    def _create_start_and_end_span(self, name, span_processor):
-        span = trace.Span(
-            name,
-            mock.Mock(spec=trace_api.SpanContext),
-            span_processor=span_processor
-        )
-        span.start()
-        span.end()
+def _create_start_and_end_span(name, span_processor):
+    span = trace.Span(
+        name,
+        mock.Mock(spec=trace_api.SpanContext),
+        span_processor=span_processor,
+    )
+    span.start()
+    span.end()
 
+
+class TestBatchExportSpanProcessor(unittest.TestCase):
     def test_batch_span_processor(self):
         spans_names_list = []
 
@@ -75,7 +76,7 @@ class TestBatchExportSpanProcessor(unittest.TestCase):
         span_names = ["xxx", "bar", "foo"]
 
         for name in span_names:
-            self._create_start_and_end_span(name, span_processor)
+            _create_start_and_end_span(name, span_processor)
 
         span_processor.shutdown()
         self.assertListEqual(span_names, spans_names_list)
@@ -91,8 +92,8 @@ class TestBatchExportSpanProcessor(unittest.TestCase):
             my_exporter, max_queue_size=512, max_export_batch_size=128
         )
 
-        for idx in range(512):
-            self._create_start_and_end_span("foo", span_processor)
+        for _ in range(512):
+            _create_start_and_end_span("foo", span_processor)
 
         span_processor.shutdown()
         self.assertEqual(len(spans_names_list), 512)
@@ -105,12 +106,15 @@ class TestBatchExportSpanProcessor(unittest.TestCase):
             destination=spans_names_list, max_export_batch_size=128
         )
         span_processor = export.BatchExportSpanProcessor(
-            my_exporter, max_queue_size=256, max_export_batch_size=64, schedule_delay_millis=100
+            my_exporter,
+            max_queue_size=256,
+            max_export_batch_size=64,
+            schedule_delay_millis=100,
         )
 
-        for iteration in range(4):
-            for idx in range(256):
-                self._create_start_and_end_span("foo", span_processor)
+        for _ in range(4):
+            for _ in range(256):
+                _create_start_and_end_span("foo", span_processor)
 
             time.sleep(0.05)  # give some time for the exporter to upload spans
 
@@ -127,7 +131,7 @@ class TestBatchExportSpanProcessor(unittest.TestCase):
         )
 
         # create single span
-        self._create_start_and_end_span("foo", span_processor)
+        _create_start_and_end_span("foo", span_processor)
 
         time.sleep(0.05 + 0.02)
         # span should be already exported

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -113,7 +113,7 @@ class TestBatchExportSpanProcessor(unittest.TestCase):
         with tracer.start_span("foo1"):
             pass
 
-        time.sleep(0.05)
+        time.sleep(0.05 + 0.02)
         # span should be already exported
         self.assertEqual(len(spans_names_list), 1)
 


### PR DESCRIPTION
The exporters specification states that two built-in span processors should be
implemented, the simple processor span and the batch processor span.

This commit implements the later, it is mainly based on the opentelemetry/java
one.

The algorithm implements the following logic:
- a condition variable is used to notify the worker thread in case the queue
is half full, so that exporting can start before the queue gets full and spans
are dropped.
- export is called each schedule_delay_millis if there is a least one new span
to export.
- when the processor is shutdown all remaining spans are exported.