### PR TITLE
Add B3 exporter to alpha release table

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ release.
 | Tracing SDK                 | Alpha   | September 30 2019 |
 | Metrics API                 | Alpha   | September 30 2019 |
 | Metrics SDK                 | Alpha   | September 30 2019 |
+| B3 Trace Exporter           | Alpha   | September 30 2019 |
 | Jaeger Trace Exporter       | Alpha   | Unknown           |
 | Prometheus Metrics Exporter | Alpha   | Unknown           |
 | Context Propagation         | Alpha   | September 30 2019 |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ release.
 | Tracing SDK                 | Alpha   | September 30 2019 |
 | Metrics API                 | Alpha   | September 30 2019 |
 | Metrics SDK                 | Alpha   | September 30 2019 |
-| B3 Trace Exporter           | Alpha   | September 30 2019 |
+| Zipkin Trace Exporter       | Alpha   | September 30 2019 |
 | Jaeger Trace Exporter       | Alpha   | Unknown           |
 | Prometheus Metrics Exporter | Alpha   | Unknown           |
 | Context Propagation         | Alpha   | September 30 2019 |


### PR DESCRIPTION
Quick update for https://github.com/open-telemetry/opentelemetry-python/issues/162#issuecomment-534737421.