### PR TITLE
Build and host docs via github action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,6 @@ jobs:
     - name: Publish to gh-pages
       uses: JamesIves/github-pages-deploy-action@2.0.2
       env:
-        ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ACCESS_TOKEN: ${{ secrets.DocsPushToken }}
         BRANCH: gh-pages
         FOLDER: docs/_build/html/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,21 +16,8 @@ jobs:
         pip install tox
         tox -e docs
     - name: Publish to gh-pages
-      run: |
-        pwd
-        cp -R docs/_build/html/* docs/
-        rm -rf docs/build/
-        ls -lah docs/
-        git add -f docs/
-        echo 'GITHUB_EVENT_PATH'
-        echo $GITHUB_EVENT_PATH
-        cat $GITHUB_EVENT_PATH
-        echo 'GITHUB_ACTOR'
-        echo $GITHUB_ACTOR
-        echo 'GITHUB_EVENT_NAME'
-        git config --global user.email "libc@google.com"
-        git config --global user.name "Chris Kleinknecht"
-        git commit -m "Publish to GH pages"
-        echo "nop"
-        echo "git@github.com:${GITHUB_REPOSITORY}.git"
-        git push -f "git@github.com:${GITHUB_REPOSITORY}.git" HEAD:gh-pages
+      uses: JamesIves/github-pages-deploy-action@2.0.2
+      env:
+        ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: docs/_build/html/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Docs
+
+on:
+  pull_request: # change to 'push'
+    branches:
+    - master
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+    - name: Build docs
+      run: |
+        pip install tox
+        tox -e docs
+    - name: Publish to gh-pages
+      run: |
+        pwd
+        cp -R docs/_build/html/* docs/
+        rm -rf docs/build/
+        ls -lah docs/
+        git add -f docs/
+        echo 'GITHUB_EVENT_PATH'
+        echo $GITHUB_EVENT_PATH
+        cat $GITHUB_EVENT_PATH
+        echo 'GITHUB_ACTOR'
+        echo $GITHUB_ACTOR
+        echo 'GITHUB_EVENT_NAME'
+        git config --global user.email "libc@google.com"
+        git config --global user.name "Chris Kleinknecht"
+        git commit -m "Publish to GH pages"
+        echo "nop"
+        echo "git@github.com:${GITHUB_REPOSITORY}.git"
+        git push -f "git@github.com:${GITHUB_REPOSITORY}.git" HEAD:gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Docs
 
 on:
-  pull_request: # change to 'push'
+  push:
     branches:
     - master
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/setup-python@v1
     - name: Build docs
       run: |
-        pip install tox
+        pip install --upgrade tox
         tox -e docs
     - name: Publish to gh-pages
       uses: JamesIves/github-pages-deploy-action@2.0.2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,9 @@ extensions = [
     "sphinx.ext.viewcode",
     # Link to other sphinx docs
     "sphinx.ext.intersphinx",
+    # Add a .nojekyll file to the generated HTML docs
+    # https://help.github.com/en/articles/files-that-start-with-an-underscore-are-missing
+    "sphinx.ext.githubpages",
 ]
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}

--- a/tox.ini
+++ b/tox.ini
@@ -96,3 +96,6 @@ changedir = docs
 
 commands =
   sphinx-build -W --keep-going -b html -T . _build/html
+  ; stop jekyll from running on gh-pages
+  ; https://help.github.com/en/articles/files-that-start-with-an-underscore-are-missing
+  touch _build/html/.nojekyll

--- a/tox.ini
+++ b/tox.ini
@@ -96,6 +96,3 @@ changedir = docs
 
 commands =
   sphinx-build -W --keep-going -b html -T . _build/html
-  ; stop jekyll from running on gh-pages
-  ; https://help.github.com/en/articles/files-that-start-with-an-underscore-are-missing
-  touch _build/html/.nojekyll


### PR DESCRIPTION
Docs are live! See https://open-telemetry.github.io/opentelemetry-python/index.html.

Fixes #9.

This PR adds a [github action](https://github.com/open-telemetry/opentelemetry-python/actions) that builds the docs and copies them to the [`gh-pages`](https://github.com/open-telemetry/opentelemetry-python/tree/gh-pages) branch on each push to `master`.

We do the same thing in OpenCensus, but via travis. OC's docs are here: https://census-instrumentation.github.io/opencensus-python/.

Note that this uses the third-party action [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action/tree/2.0.2) (see [`entrypoint.sh`](https://github.com/JamesIves/github-pages-deploy-action/blob/c3d5102651ac519d324ac463752e6894d8e54ca6/entrypoint.sh) for details). I had to create a new personal access token for this action, the built-in `GITHUB_TOKEN` token [doesn't work](https://github.com/JamesIves/github-pages-deploy-action/issues/5).

Some things we could still improve:
- Host multiple versions of the docs, a la https://readthedocs.org
- Default to displaying docs for the last-released version of the library instead of the version on master
- Don't rebuild docs unless source files have changed
- Automate running `sphinx-apidoc` to update sources