### PR TITLE
wsgi: Fix port 80 always appended in http.host.

### DIFF
--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
@@ -48,10 +48,12 @@ class OpenTelemetryMiddleware:
         if not host:
             host = environ["SERVER_NAME"]
             port = environ["SERVER_PORT"]
+            scheme = environ["wsgi.url_scheme"]
             if (
-                port != "80"
-                and environ["wsgi.url_scheme"] == "http"
-                or port != "443"
+                scheme == "http"
+                and port != "80"
+                or scheme == "https"
+                and port != "443"
             ):
                 host += ":" + port
 

--- a/ext/opentelemetry-ext-wsgi/tests/test_wsgi_middleware.py
+++ b/ext/opentelemetry-ext-wsgi/tests/test_wsgi_middleware.py
@@ -203,9 +203,7 @@ class TestWsgiAttributes(unittest.TestCase):
         self.assertIn("http.url", attrs)
         self.assertEqual(attrs["http.url"], expected_url)
         self.assertIn("http.host", attrs)
-        self.assertEqual(
-            attrs["http.host"], urlparse(attrs["http.url"]).netloc
-        )
+        self.assertEqual(attrs["http.host"], urlparse(expected_url).netloc)
 
     def test_request_attributes_with_partial_raw_uri(self):
         self.environ["RAW_URI"] = "/#top"
@@ -230,6 +228,18 @@ class TestWsgiAttributes(unittest.TestCase):
 
         self.environ["SERVER_PORT"] = "80"
         self.validate_url("https://127.0.0.1:80/")
+
+    def test_http_uri_port(self):
+        del self.environ["HTTP_HOST"]
+        self.environ["SERVER_PORT"] = "80"
+        self.environ["wsgi.url_scheme"] = "http"
+        self.validate_url("http://127.0.0.1/")
+
+        self.environ["SERVER_PORT"] = "8080"
+        self.validate_url("http://127.0.0.1:8080/")
+
+        self.environ["SERVER_PORT"] = "443"
+        self.validate_url("http://127.0.0.1:443/")
 
     def test_request_attributes_with_nonstandard_port_and_no_host(self):
         del self.environ["HTTP_HOST"]


### PR DESCRIPTION
Bug found by @a-feld (https://github.com/open-telemetry/opentelemetry-python/pull/148#discussion_r327685988). I somehow thought that this must be possible with only checking the scheme once, but it seems not https://www.wolframalpha.com/input/?i=%28S+%26+X%29+%7C+%28%21S+%26+Y%29