### PR TITLE
Implement Azure Monitor Exporter

### DIFF
--- a/ext/opentelemetry-ext-azure-monitor/README.rst
+++ b/ext/opentelemetry-ext-azure-monitor/README.rst
@@ -3,6 +3,13 @@ OpenTelemetry Azure Monitor Exporters
 
 This library provides integration with Microsoft Azure Monitor.
 
+Installation
+------------
+
+::
+
+    pip install opentelemetry-ext-azure-monitor
+
 References
 ----------
 

--- a/ext/opentelemetry-ext-azure-monitor/examples/client.py
+++ b/ext/opentelemetry-ext-azure-monitor/examples/client.py
@@ -1,0 +1,30 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import requests
+
+from opentelemetry import trace
+from opentelemetry.ext import http_requests
+from opentelemetry.ext.azure_monitor import AzureMonitorSpanExporter
+from opentelemetry.sdk.trace import Tracer
+from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+
+trace.set_preferred_tracer_implementation(lambda T: Tracer())
+tracer = trace.tracer()
+http_requests.enable(tracer)
+span_processor = BatchExportSpanProcessor(AzureMonitorSpanExporter())
+tracer.add_span_processor(span_processor)
+
+response = requests.get(url="http://127.0.0.1:5000/")
+span_processor.shutdown()

--- a/ext/opentelemetry-ext-azure-monitor/examples/server.py
+++ b/ext/opentelemetry-ext-azure-monitor/examples/server.py
@@ -1,0 +1,43 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import flask
+import requests
+
+from opentelemetry import trace
+from opentelemetry.ext import http_requests
+from opentelemetry.ext.azure_monitor import AzureMonitorSpanExporter
+from opentelemetry.ext.wsgi import OpenTelemetryMiddleware
+from opentelemetry.sdk.trace import Tracer
+from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+
+trace.set_preferred_tracer_implementation(lambda T: Tracer())
+
+http_requests.enable(trace.tracer())
+span_processor = BatchExportSpanProcessor(AzureMonitorSpanExporter())
+trace.tracer().add_span_processor(span_processor)
+
+app = flask.Flask(__name__)
+app.wsgi_app = OpenTelemetryMiddleware(app.wsgi_app)
+
+@app.route("/")
+def hello():
+    with trace.tracer().start_span("parent"):
+        requests.get("https://www.wikipedia.org/wiki/Rabbit")
+    return "hello"
+
+
+if __name__ == "__main__":
+    app.run(debug=True)
+    span_processor.shutdown()

--- a/ext/opentelemetry-ext-azure-monitor/examples/server.py
+++ b/ext/opentelemetry-ext-azure-monitor/examples/server.py
@@ -31,6 +31,7 @@ trace.tracer().add_span_processor(span_processor)
 app = flask.Flask(__name__)
 app.wsgi_app = OpenTelemetryMiddleware(app.wsgi_app)
 
+
 @app.route("/")
 def hello():
     with trace.tracer().start_span("parent"):

--- a/ext/opentelemetry-ext-azure-monitor/examples/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/examples/trace.py
@@ -1,7 +1,11 @@
+import logging
+
 from opentelemetry import trace
 from opentelemetry.ext.azure_monitor import AzureMonitorSpanExporter
 from opentelemetry.sdk.trace import Tracer
 from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
+
+logging.basicConfig(level=logging.INFO)
 
 trace.set_preferred_tracer_implementation(lambda T: Tracer())
 tracer = trace.tracer()

--- a/ext/opentelemetry-ext-azure-monitor/examples/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/examples/trace.py
@@ -1,3 +1,17 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
 from opentelemetry import trace

--- a/ext/opentelemetry-ext-azure-monitor/examples/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/examples/trace.py
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 from opentelemetry import trace
 from opentelemetry.ext.azure_monitor import AzureMonitorSpanExporter
 from opentelemetry.sdk.trace import Tracer
 from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
-
-logging.basicConfig(level=logging.INFO)
 
 trace.set_preferred_tracer_implementation(lambda T: Tracer())
 tracer = trace.tracer()

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
@@ -27,8 +27,9 @@ class BaseObject(dict):
                 if item[0] not in tmp:
                     tmp[item[0]] = item[1]
             if (
-                current._default == current
-            ):  # noqa pylint: disable=protected-access
+                current._default  # noqa pylint: disable=protected-access
+                == current
+            ):
                 break
             current = current._default  # noqa pylint: disable=protected-access
         return repr(tmp)

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
@@ -21,13 +21,16 @@ class BaseObject(dict):
 
     def __repr__(self):
         tmp = {}
+        current = self
         while True:
-            for item in self.items():
+            for item in current.items():
                 if item[0] not in tmp:
                     tmp[item[0]] = item[1]
-            if self._default == self:
+            if (
+                current._default == current
+            ):  # noqa pylint: disable=protected-access
                 break
-            self = self._default
+            current = current._default  # noqa pylint: disable=protected-access
         return repr(tmp)
 
     def __setattr__(self, name, value):
@@ -51,7 +54,7 @@ class BaseObject(dict):
         return self._default[key]
 
 
-BaseObject._default = BaseObject()
+BaseObject._default = BaseObject()  # noqa pylint: disable=protected-access
 
 
 class Data(BaseObject):
@@ -59,8 +62,8 @@ class Data(BaseObject):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.baseData = self.baseData
-        self.baseType = self.baseType
+        self.baseData = self.baseData  # noqa pylint: disable=invalid-name
+        self.baseType = self.baseType  # noqa pylint: disable=invalid-name
 
 
 class DataPoint(BaseObject):
@@ -168,7 +171,7 @@ class RemoteDependency(BaseObject):
         super().__init__(*args, **kwargs)
         self.ver = self.ver
         self.name = self.name
-        self.resultCode = self.resultCode
+        self.resultCode = self.resultCode  # noqa pylint: disable=invalid-name
         self.duration = self.duration
 
 
@@ -189,7 +192,9 @@ class Request(BaseObject):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.ver = self.ver
-        self.id = self.id
+        self.id = self.id  # noqa pylint: disable=invalid-name
         self.duration = self.duration
-        self.responseCode = self.responseCode
+        self.responseCode = (
+            self.responseCode
+        )  # noqa pylint: disable=invalid-name
         self.success = self.success

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
@@ -67,8 +67,8 @@ class Data(BaseObject):
 
 class DataPoint(BaseObject):
     _default = BaseObject(
-        ns='',
-        name='',
+        ns="",
+        name="",
         kind=None,
         value=0.0,
         count=None,
@@ -86,8 +86,8 @@ class DataPoint(BaseObject):
 class Envelope(BaseObject):
     _default = BaseObject(
         ver=1,
-        name='',
-        time='',
+        name="",
+        time="",
         sampleRate=None,
         seq=None,
         iKey=None,
@@ -105,7 +105,7 @@ class Envelope(BaseObject):
 class Event(BaseObject):
     _default = BaseObject(
         ver=2,
-        name='',
+        name="",
         properties=None,
         measurements=None,
     )
@@ -135,7 +135,7 @@ class ExceptionData(BaseObject):
 class Message(BaseObject):
     _default = BaseObject(
         ver=2,
-        message='',
+        message="",
         severityLevel=None,
         properties=None,
         measurements=None,
@@ -163,10 +163,10 @@ class MetricData(BaseObject):
 class RemoteDependency(BaseObject):
     _default = BaseObject(
         ver=2,
-        name='',
-        id='',
-        resultCode='',
-        duration='',
+        name="",
+        id="",
+        resultCode="",
+        duration="",
         success=True,
         data=None,
         type=None,
@@ -186,9 +186,9 @@ class RemoteDependency(BaseObject):
 class Request(BaseObject):
     _default = BaseObject(
         ver=2,
-        id='',
-        duration='',
-        responseCode='',
+        id="",
+        duration="",
+        responseCode="",
         success=True,
         source=None,
         name=None,

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
@@ -37,10 +37,11 @@ class BaseObject(dict):
         try:
             return self[name]
         except KeyError:
-            raise AttributeError("'{}' object has no attribute {}".format(
-                type(self).__name__,
-                name,
-            ))
+            raise AttributeError(
+                "'{}' object has no attribute {}".format(
+                    type(self).__name__, name
+                )
+            )
 
     def __getitem__(self, key):
         if self._default is self:
@@ -54,10 +55,7 @@ BaseObject._default = BaseObject()
 
 
 class Data(BaseObject):
-    _default = BaseObject(
-        baseData=None,
-        baseType=None,
-    )
+    _default = BaseObject(baseData=None, baseType=None)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -103,12 +101,7 @@ class Envelope(BaseObject):
 
 
 class Event(BaseObject):
-    _default = BaseObject(
-        ver=2,
-        name="",
-        properties=None,
-        measurements=None,
-    )
+    _default = BaseObject(ver=2, name="", properties=None, measurements=None)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -148,11 +141,7 @@ class Message(BaseObject):
 
 
 class MetricData(BaseObject):
-    _default = BaseObject(
-        ver=2,
-        metrics=[],
-        properties=None,
-    )
+    _default = BaseObject(ver=2, metrics=[], properties=None)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
@@ -194,5 +194,7 @@ class Request(BaseObject):
         self.ver = self.ver
         self.id = self.id  # noqa pylint: disable=invalid-name
         self.duration = self.duration
-        self.responseCode = self.responseCode  # noqa pylint: disable=invalid-name
+        self.responseCode = (
+            self.responseCode  # noqa pylint: disable=invalid-name
+        )  # noqa pylint: disable=invalid-name
         self.success = self.success

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
@@ -194,7 +194,5 @@ class Request(BaseObject):
         self.ver = self.ver
         self.id = self.id  # noqa pylint: disable=invalid-name
         self.duration = self.duration
-        self.responseCode = (
-            self.responseCode
-        )  # noqa pylint: disable=invalid-name
+        self.responseCode = self.responseCode  # noqa pylint: disable=invalid-name
         self.success = self.success

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
@@ -194,7 +194,7 @@ class Request(BaseObject):
         self.ver = self.ver
         self.id = self.id  # noqa pylint: disable=invalid-name
         self.duration = self.duration
-        self.responseCode = (
-            self.responseCode  # noqa pylint: disable=invalid-name
-        )  # noqa pylint: disable=invalid-name
+        self.responseCode = (  # noqa pylint: disable=invalid-name
+            self.responseCode
+        )
         self.success = self.success

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/protocol.py
@@ -1,0 +1,206 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class BaseObject(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for key in kwargs:
+            self[key] = kwargs[key]
+
+    def __repr__(self):
+        tmp = {}
+        while True:
+            for item in self.items():
+                if item[0] not in tmp:
+                    tmp[item[0]] = item[1]
+            if self._default == self:
+                break
+            self = self._default
+        return repr(tmp)
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError("'{}' object has no attribute {}".format(
+                type(self).__name__,
+                name,
+            ))
+
+    def __getitem__(self, key):
+        if self._default is self:
+            return super().__getitem__(key)
+        if key in self:
+            return super().__getitem__(key)
+        return self._default[key]
+
+
+BaseObject._default = BaseObject()
+
+
+class Data(BaseObject):
+    _default = BaseObject(
+        baseData=None,
+        baseType=None,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.baseData = self.baseData
+        self.baseType = self.baseType
+
+
+class DataPoint(BaseObject):
+    _default = BaseObject(
+        ns='',
+        name='',
+        kind=None,
+        value=0.0,
+        count=None,
+        min=None,
+        max=None,
+        stdDev=None,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = self.name
+        self.value = self.value
+
+
+class Envelope(BaseObject):
+    _default = BaseObject(
+        ver=1,
+        name='',
+        time='',
+        sampleRate=None,
+        seq=None,
+        iKey=None,
+        flags=None,
+        tags=None,
+        data=None,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = self.name
+        self.time = self.time
+
+
+class Event(BaseObject):
+    _default = BaseObject(
+        ver=2,
+        name='',
+        properties=None,
+        measurements=None,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ver = self.ver
+        self.name = self.name
+
+
+class ExceptionData(BaseObject):
+    _default = BaseObject(
+        ver=2,
+        exceptions=[],
+        severityLevel=None,
+        problemId=None,
+        properties=None,
+        measurements=None,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ver = self.ver
+        self.exceptions = self.exceptions
+
+
+class Message(BaseObject):
+    _default = BaseObject(
+        ver=2,
+        message='',
+        severityLevel=None,
+        properties=None,
+        measurements=None,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ver = self.ver
+        self.message = self.message
+
+
+class MetricData(BaseObject):
+    _default = BaseObject(
+        ver=2,
+        metrics=[],
+        properties=None,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ver = self.ver
+        self.metrics = self.metrics
+
+
+class RemoteDependency(BaseObject):
+    _default = BaseObject(
+        ver=2,
+        name='',
+        id='',
+        resultCode='',
+        duration='',
+        success=True,
+        data=None,
+        type=None,
+        target=None,
+        properties=None,
+        measurements=None,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ver = self.ver
+        self.name = self.name
+        self.resultCode = self.resultCode
+        self.duration = self.duration
+
+
+class Request(BaseObject):
+    _default = BaseObject(
+        ver=2,
+        id='',
+        duration='',
+        responseCode='',
+        success=True,
+        source=None,
+        name=None,
+        url=None,
+        properties=None,
+        measurements=None,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ver = self.ver
+        self.id = self.id
+        self.duration = self.duration
+        self.responseCode = self.responseCode
+        self.success = self.success

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from opentelemetry import trace as trace_api
 from opentelemetry.ext.azure_monitor import protocol
 from opentelemetry.ext.azure_monitor import util
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.sdk.util import ns_to_iso_str
+from opentelemetry.trace import SpanKind
 from urllib.parse import urlparse
 
 
@@ -53,7 +53,7 @@ class AzureMonitorSpanExporter(SpanExporter):
                 span.context.trace_id,
                 span.parent.span_id,
             )
-        if span.kind in (trace_api.SpanKind.SERVER, trace_api.SpanKind.CONSUMER):
+        if span.kind in (SpanKind.CONSUMER, SpanKind.SERVER):
             envelope.name = "Microsoft.ApplicationInsights.Request"
             data = protocol.Request(
                 id="|{:032x}.{:016x}.".format(span.context.trace_id, span.context.span_id),
@@ -91,7 +91,7 @@ class AzureMonitorSpanExporter(SpanExporter):
                 baseData=data,
                 baseType="RemoteDependencyData",
             )
-            if span.kind in (trace_api.SpanKind.CLIENT, trace_api.SpanKind.PRODUCER):
+            if span.kind in (SpanKind.CLIENT, SpanKind.PRODUCER):
                 data.type = "HTTP"  # TODO
                 if "http.url" in span.attributes:
                     url = span.attributes["http.url"]

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
@@ -14,14 +14,14 @@
 
 import json
 import logging
+from urllib.parse import urlparse
+
 import requests
 
-from opentelemetry.ext.azure_monitor import protocol
-from opentelemetry.ext.azure_monitor import util
+from opentelemetry.ext.azure_monitor import protocol, util
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.sdk.util import ns_to_iso_str
 from opentelemetry.trace import SpanKind
-from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
@@ -99,7 +99,7 @@ class AzureMonitorSpanExporter(SpanExporter):
             envelope.tags[
                 "ai.operation.parentId"
             ] = "|{:032x}.{:016x}.".format(
-                span.context.trace_id, span.parent.span_id
+                span.context.trace_id, span.context.span_id
             )
         if span.kind in (SpanKind.CONSUMER, SpanKind.SERVER):
             envelope.name = "Microsoft.ApplicationInsights.Request"

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
@@ -86,7 +86,7 @@ class AzureMonitorSpanExporter(SpanExporter):
             days, hours, minutes, seconds, microseconds
         )
 
-    def span_to_envelope(self, span):
+    def span_to_envelope(self, span):  # noqa pylint: disable=too-many-branches
         envelope = protocol.Envelope(
             iKey=self.options.instrumentation_key,
             tags=dict(util.azure_monitor_context),
@@ -95,10 +95,10 @@ class AzureMonitorSpanExporter(SpanExporter):
         envelope.tags["ai.operation.id"] = "{:032x}".format(
             span.context.trace_id
         )
-        if span.parent:
-            parent = span.parent
-            if isinstance(parent, Span):
-                parent = parent.context
+        parent = span.parent
+        if isinstance(parent, Span):
+            parent = parent.context
+        if parent:
             envelope.tags[
                 "ai.operation.parentId"
             ] = "|{:032x}.{:016x}.".format(parent.trace_id, parent.span_id)

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
@@ -32,8 +32,7 @@ class AzureMonitorSpanExporter(SpanExporter):
             print(self.span_to_envelope(span))
         return SpanExportResult.SUCCESS
 
-    @staticmethod
-    def ns_to_duration(nanoseconds):
+    def ns_to_duration(self, nanoseconds):
         n = (nanoseconds + 500000) // 1000000  # duration in milliseconds
         n, ms = divmod(n, 1000)
         n, s = divmod(n, 60)

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
@@ -93,20 +93,25 @@ class AzureMonitorSpanExporter(SpanExporter):
             span.context.trace_id
         )
         if span.parent:
-            envelope.tags["ai.operation.parentId"] = "|{:032x}.{:016x}.".format(
-                span.context.trace_id,
-                span.parent.span_id,
+            envelope.tags[
+                "ai.operation.parentId"
+            ] = "|{:032x}.{:016x}.".format(
+                span.context.trace_id, span.parent.span_id
             )
         if span.kind in (SpanKind.CONSUMER, SpanKind.SERVER):
             envelope.name = "Microsoft.ApplicationInsights.Request"
             data = protocol.Request(
-                id="|{:032x}.{:016x}.".format(span.context.trace_id, span.context.span_id),
+                id="|{:032x}.{:016x}.".format(
+                    span.context.trace_id, span.context.span_id
+                ),
                 duration=self.ns_to_duration(span.end_time - span.start_time),
                 responseCode="0",
                 success=False,
                 properties={},
             )
-            envelope.data = protocol.Data(baseData=data, baseType="RequestData")
+            envelope.data = protocol.Data(
+                baseData=data, baseType="RequestData"
+            )
             if "http.method" in span.attributes:
                 data.name = span.attributes["http.method"]
             if "http.route" in span.attributes:
@@ -119,13 +124,11 @@ class AzureMonitorSpanExporter(SpanExporter):
                 data.responseCode = str(status_code)
                 data.success = status_code >= 200 and status_code <= 399
         else:
-            envelope.name = \
-                "Microsoft.ApplicationInsights.RemoteDependency"
+            envelope.name = "Microsoft.ApplicationInsights.RemoteDependency"
             data = protocol.RemoteDependency(
                 name=span.name,
                 id="|{:032x}.{:016x}.".format(
-                    span.context.trace_id,
-                    span.context.span_id,
+                    span.context.trace_id, span.context.span_id
                 ),
                 resultCode="0",  # TODO
                 duration=self.ns_to_duration(span.end_time - span.start_time),
@@ -133,8 +136,7 @@ class AzureMonitorSpanExporter(SpanExporter):
                 properties={},
             )
             envelope.data = protocol.Data(
-                baseData=data,
-                baseType="RemoteDependencyData",
+                baseData=data, baseType="RemoteDependencyData"
             )
             if span.kind in (SpanKind.CLIENT, SpanKind.PRODUCER):
                 data.type = "HTTP"  # TODO

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
@@ -152,7 +152,22 @@ class AzureMonitorSpanExporter(SpanExporter):
                     data.resultCode = str(span.attributes["http.status_code"])
             else:  # SpanKind.INTERNAL
                 data.type = "InProc"
-        # TODO: links, tracestate, tags
         for key in span.attributes:
             data.properties[key] = span.attributes[key]
+        if span.links:
+            links = []
+            for link in span.links:
+                links.append(
+                    {
+                        "operation_Id": "{:032x}".format(
+                            link.context.trace_id
+                        ),
+                        "id": "|{:032x}.{:016x}.".format(
+                            link.context.trace_id, link.context.span_id
+                        ),
+                    }
+                )
+            data.properties["_MS.links"] = json.dumps(links)
+            print(data.properties["_MS.links"])
+        # TODO: tracestate, tags
         return envelope

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
@@ -21,7 +21,7 @@ import requests
 from opentelemetry.ext.azure_monitor import protocol, util
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.sdk.util import ns_to_iso_str
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import Span, SpanKind
 
 logger = logging.getLogger(__name__)
 
@@ -96,10 +96,13 @@ class AzureMonitorSpanExporter(SpanExporter):
             span.context.trace_id
         )
         if span.parent:
+            parent = span.parent
+            if isinstance(parent, Span):
+                parent = parent.context
             envelope.tags[
                 "ai.operation.parentId"
             ] = "|{:032x}.{:016x}.".format(
-                span.context.trace_id, span.context.span_id
+                parent.trace_id, parent.span_id
             )
         if span.kind in (SpanKind.CONSUMER, SpanKind.SERVER):
             envelope.name = "Microsoft.ApplicationInsights.Request"

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
@@ -12,14 +12,99 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from opentelemetry import trace as trace_api
+from opentelemetry.ext.azure_monitor import protocol
+from opentelemetry.ext.azure_monitor import util
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.sdk.util import ns_to_iso_str
+from urllib.parse import urlparse
 
 
 class AzureMonitorSpanExporter(SpanExporter):
-    def __init__(self):
-        pass
+    def __init__(self, **options):
+        self.options = util.Options(**options)
+        if not self.options.instrumentation_key:
+            raise ValueError("The instrumentation_key is not provided.")
 
     def export(self, spans):
         for span in spans:
             print(span)  # TODO: add actual implementation here
+            print(self.span_to_envelope(span))
         return SpanExportResult.SUCCESS
+
+    @staticmethod
+    def ns_to_duration(nanoseconds):
+        n = (nanoseconds + 500000) // 1000000  # duration in milliseconds
+        n, ms = divmod(n, 1000)
+        n, s = divmod(n, 60)
+        n, m = divmod(n, 60)
+        d, h = divmod(n, 24)
+        return "{:d}.{:02d}:{:02d}:{:02d}.{:03d}".format(d, h, m, s, ms)
+
+    def span_to_envelope(self, span):
+        envelope = protocol.Envelope(
+            iKey=self.options.instrumentation_key,
+            tags=dict(util.azure_monitor_context),
+            time=ns_to_iso_str(span.start_time),
+        )
+        envelope.tags["ai.operation.id"] = "{:032x}".format(span.context.trace_id)
+        if span.parent:
+            envelope.tags["ai.operation.parentId"] = "|{:032x}.{:016x}.".format(
+                span.context.trace_id,
+                span.parent.span_id,
+            )
+        if span.kind in (trace_api.SpanKind.SERVER, trace_api.SpanKind.CONSUMER):
+            envelope.name = "Microsoft.ApplicationInsights.Request"
+            data = protocol.Request(
+                id="|{:032x}.{:016x}.".format(span.context.trace_id, span.context.span_id),
+                duration=self.ns_to_duration(span.end_time - span.start_time),
+                responseCode="0",
+                success=False,
+                properties={},
+            )
+            envelope.data = protocol.Data(baseData=data, baseType="RequestData")
+            if "http.method" in span.attributes:
+                data.name = span.attributes["http.method"]
+            if "http.route" in span.attributes:
+                data.name = data.name + " " + span.attributes["http.route"]
+                envelope.tags["ai.operation.name"] = data.name
+            if "http.url" in span.attributes:
+                data.url = span.attributes["http.url"]
+            if "http.status_code" in span.attributes:
+                status_code = span.attributes["http.status_code"]
+                data.responseCode = str(status_code)
+                data.success = (
+                    status_code >= 200 and status_code <= 399
+                )
+        else:
+            envelope.name = \
+                "Microsoft.ApplicationInsights.RemoteDependency"
+            data = protocol.RemoteDependency(
+                name=span.name,  # TODO
+                id="|{:032x}.{:016x}.".format(span.context.trace_id, span.context.span_id),
+                resultCode="0",  # TODO
+                duration=self.ns_to_duration(span.end_time - span.start_time),
+                success=True,  # TODO
+                properties={},
+            )
+            envelope.data = protocol.Data(
+                baseData=data,
+                baseType="RemoteDependencyData",
+            )
+            if span.kind in (trace_api.SpanKind.CLIENT, trace_api.SpanKind.PRODUCER):
+                data.type = "HTTP"  # TODO
+                if "http.url" in span.attributes:
+                    url = span.attributes["http.url"]
+                    # TODO: error handling, probably put scheme as well
+                    data.name = urlparse(url).netloc
+                if "http.status_code" in span.attributes:
+                    data.resultCode = str(span.attributes["http.status_code"])
+            else: # SpanKind.INTERNAL
+                data.type = "InProc"
+        # TODO: links, tracestate, tags
+        for key in span.attributes:
+            # This removes redundant data from ApplicationInsights
+            if key.startswith("http."):
+                continue
+            data.properties[key] = span.attributes[key]
+        return envelope

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
@@ -57,7 +57,7 @@ class AzureMonitorSpanExporter(SpanExporter):
             logger.warning("Error while reading response body %s.", ex)
         else:
             try:
-                data = json.loads(text)
+                data = json.loads(text)  # noqa pylint: disable=unused-variable
             except Exception:  # noqa pylint: disable=broad-except
                 pass
 

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/trace.py
@@ -101,9 +101,7 @@ class AzureMonitorSpanExporter(SpanExporter):
                 parent = parent.context
             envelope.tags[
                 "ai.operation.parentId"
-            ] = "|{:032x}.{:016x}.".format(
-                parent.trace_id, parent.span_id
-            )
+            ] = "|{:032x}.{:016x}.".format(parent.trace_id, parent.span_id)
         if span.kind in (SpanKind.CONSUMER, SpanKind.SERVER):
             envelope.name = "Microsoft.ApplicationInsights.Request"
             data = protocol.Request(

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/util.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/util.py
@@ -22,13 +22,13 @@ from opentelemetry.ext.azure_monitor.version import __version__ as ext_version
 from opentelemetry.sdk.version import __version__ as opentelemetry_version
 
 azure_monitor_context = {
-    'ai.cloud.role': os.path.basename(sys.argv[0]) or 'Python Application',
-    'ai.cloud.roleInstance': platform.node(),
-    'ai.device.id': platform.node(),
-    'ai.device.locale': locale.getdefaultlocale()[0],
-    'ai.device.osVersion': platform.version(),
-    'ai.device.type': 'Other',
-    'ai.internal.sdkVersion': 'py{}:ot{}:ext{}'.format(
+    "ai.cloud.role": os.path.basename(sys.argv[0]) or "Python Application",
+    "ai.cloud.roleInstance": platform.node(),
+    "ai.device.id": platform.node(),
+    "ai.device.locale": locale.getdefaultlocale()[0],
+    "ai.device.osVersion": platform.version(),
+    "ai.device.type": "Other",
+    "ai.internal.sdkVersion": "py{}:ot{}:ext{}".format(
         platform.python_version(),
         opentelemetry_version,
         ext_version,
@@ -38,7 +38,7 @@ azure_monitor_context = {
 
 class Options(BaseObject):
     _default = BaseObject(
-        endpoint='https://dc.services.visualstudio.com/v2/track',
-        instrumentation_key=os.getenv('APPINSIGHTS_INSTRUMENTATIONKEY', None),
+        endpoint="https://dc.services.visualstudio.com/v2/track",
+        instrumentation_key=os.getenv("APPINSIGHTS_INSTRUMENTATIONKEY", None),
         timeout=10.0,  # networking timeout in seconds
     )

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/util.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/util.py
@@ -29,9 +29,7 @@ azure_monitor_context = {
     "ai.device.osVersion": platform.version(),
     "ai.device.type": "Other",
     "ai.internal.sdkVersion": "py{}:ot{}:ext{}".format(
-        platform.python_version(),
-        opentelemetry_version,
-        ext_version,
+        platform.python_version(), opentelemetry_version, ext_version
     ),
 }
 

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/util.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/util.py
@@ -1,0 +1,44 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import locale
+import os
+import platform
+import sys
+
+from opentelemetry.ext.azure_monitor.protocol import BaseObject
+from opentelemetry.ext.azure_monitor.version import __version__ as ext_version
+from opentelemetry.sdk.version import __version__ as opentelemetry_version
+
+azure_monitor_context = {
+    'ai.cloud.role': os.path.basename(sys.argv[0]) or 'Python Application',
+    'ai.cloud.roleInstance': platform.node(),
+    'ai.device.id': platform.node(),
+    'ai.device.locale': locale.getdefaultlocale()[0],
+    'ai.device.osVersion': platform.version(),
+    'ai.device.type': 'Other',
+    'ai.internal.sdkVersion': 'py{}:ot{}:ext{}'.format(
+        platform.python_version(),
+        opentelemetry_version,
+        ext_version,
+    ),
+}
+
+
+class Options(BaseObject):
+    _default = BaseObject(
+        endpoint='https://dc.services.visualstudio.com/v2/track',
+        instrumentation_key=os.getenv('APPINSIGHTS_INSTRUMENTATIONKEY', None),
+        timeout=10.0,  # networking timeout in seconds
+    )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -22,6 +22,7 @@ from opentelemetry.context import Context
 from opentelemetry.sdk import util
 
 from .. import Span, SpanProcessor
+from opentelemetry.context import Context
 
 logger = logging.getLogger(__name__)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -22,7 +22,6 @@ from opentelemetry.context import Context
 from opentelemetry.sdk import util
 
 from .. import Span, SpanProcessor
-from opentelemetry.context import Context
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Currently the exporter works with `SimpleExportSpanProcessor`, it should work with `batch export span processor` once #153 gets merged.

Most of the code were copied from OpenCensus https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-azure, with some style adjustments.