### PR TITLE
Introduce Context.suppress_instrumentation

### DIFF
--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
@@ -23,6 +23,7 @@ from urllib.parse import urlparse
 from requests.sessions import Session
 
 from opentelemetry import propagators
+from opentelemetry.context import Context
 from opentelemetry.trace import SpanKind
 
 
@@ -50,8 +51,8 @@ def enable(tracer):
 
     @functools.wraps(wrapped)
     def instrumented_request(self, method, url, *args, **kwargs):
-        # TODO: Check if we are in an exporter, cf. OpenCensus
-        # execution_context.is_exporter()
+        if Context.is_exporter:  # Check if we are in an exporter
+            return wrapped(self, method, url, *args, **kwargs)
 
         # See
         # https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md#http-client

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
@@ -51,7 +51,7 @@ def enable(tracer):
 
     @functools.wraps(wrapped)
     def instrumented_request(self, method, url, *args, **kwargs):
-        if Context.is_exporter:  # Check if we are in an exporter
+        if Context.suppress_instrumentation:
             return wrapped(self, method, url, *args, **kwargs)
 
         # See

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -21,6 +21,7 @@ from enum import Enum
 from opentelemetry.sdk import util
 
 from .. import Span, SpanProcessor
+from opentelemetry.context import Context
 
 logger = logging.getLogger(__name__)
 
@@ -72,11 +73,15 @@ class SimpleExportSpanProcessor(SpanProcessor):
         pass
 
     def on_end(self, span: Span) -> None:
+        is_exporter = Context.is_exporter
         try:
+            Context.is_exporter = True
             self.span_exporter.export((span,))
         # pylint: disable=broad-except
         except Exception as exc:
             logger.warning("Exception while exporting data: %s", exc)
+        finally:
+            Context.is_exporter = is_exporter
 
     def shutdown(self) -> None:
         self.span_exporter.shutdown()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -18,10 +18,10 @@ import threading
 import typing
 from enum import Enum
 
+from opentelemetry.context import Context
 from opentelemetry.sdk import util
 
 from .. import Span, SpanProcessor
-from opentelemetry.context import Context
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Added `Context.suppress_instrumentation` flag, which can be used for the following scenarios:
1. avoid instrumentation while running inside exporter.
2. suppress certain call path to avoid excessive/unwanted data.