### PR TITLE
Fix time conversion bug

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/util.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util.py
@@ -26,5 +26,5 @@ except AttributeError:
 
 def ns_to_iso_str(nanoseconds):
     """Get an ISO 8601 string from time_ns value."""
-    ts = datetime.datetime.fromtimestamp(nanoseconds / 1e9)
+    ts = datetime.datetime.utcfromtimestamp(nanoseconds / 1e9)
     return ts.strftime("%Y-%m-%dT%H:%M:%S.%fZ")


### PR DESCRIPTION
`datetime.datetime.fromtimestamp(...)` is using local time, changed to `datetime.datetime.utcfromtimestamp(...)`.