### PR TITLE
fix bug in BoundedList for python 3.4 and add tests

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/util.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util.py
@@ -62,7 +62,7 @@ class BoundedList(Sequence):
 
     def __iter__(self):
         with self._lock:
-            return iter(self._dq.copy())
+            return iter(deque(self._dq))
 
     def append(self, item):
         with self._lock:
@@ -89,7 +89,7 @@ class BoundedList(Sequence):
 
 
 class BoundedDict(MutableMapping):
-    """A dict with a fixed max capacity."""
+    """An ordered dict with a fixed max capacity."""
 
     def __init__(self, maxlen):
         if not isinstance(maxlen, int):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util.py
@@ -42,7 +42,11 @@ def ns_to_iso_str(nanoseconds):
 
 
 class BoundedList(Sequence):
-    """An append only list with a fixed max size."""
+    """An append only list with a fixed max size.
+
+    Calls to `append` and `extend` will drop the oldest elements if there is
+    not enough room.
+    """
 
     def __init__(self, maxlen):
         self.dropped = 0
@@ -89,7 +93,11 @@ class BoundedList(Sequence):
 
 
 class BoundedDict(MutableMapping):
-    """An ordered dict with a fixed max capacity."""
+    """An ordered dict with a fixed max capacity.
+
+    Oldest elements are dropped when the dict is full and a new element is
+    added.
+    """
 
     def __init__(self, maxlen):
         if not isinstance(maxlen, int):

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -30,13 +30,13 @@ class TestBoundedList(unittest.TestCase):
         blist.append(13)
 
         with self.assertRaises(IndexError):
-            blist[2]
+            _ = blist[2]
 
         with self.assertRaises(IndexError):
-            blist[4]
+            _ = blist[4]
 
         with self.assertRaises(IndexError):
-            blist[-3]
+            _ = blist[-3]
 
     def test_from_seq(self):
         list_len = len(TestBoundedList.base)
@@ -207,4 +207,4 @@ class TestBoundedDict(unittest.TestCase):
         self.assertEqual(len(bdict), dic_len - 1)
 
         with self.assertRaises(KeyError):
-            bdict["new-name"]
+            _ = bdict["new-name"]

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -1,0 +1,162 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import unittest
+
+from opentelemetry.sdk.util import BoundedDict, BoundedList
+
+
+class TestBoundedList(unittest.TestCase):
+    base = [52, 36, 53, 29, 54, 99, 56, 48, 22, 35, 21, 65, 10, 95, 42, 60]
+
+    def test_negative_maxlen(self):
+        with self.assertRaises(ValueError):
+            BoundedList(-1)
+
+    def test_from_seq(self):
+        list_len = len(TestBoundedList.base)
+        blist = BoundedList.from_seq(list_len, TestBoundedList.base)
+
+        self.assertEqual(len(blist), list_len)
+
+        for idx in range(list_len):
+            self.assertEqual(blist[idx], TestBoundedList.base[idx])
+
+        # sequence too big
+        with self.assertRaises(ValueError):
+            BoundedList.from_seq(list_len / 2, TestBoundedList.base)
+
+    def test_append_no_drop(self):
+        # create empty list
+        list_len = len(TestBoundedList.base)
+        blist = BoundedList(list_len)
+        self.assertEqual(len(blist), 0)
+
+        # fill list
+        for idx in TestBoundedList.base:
+            blist.append(idx)
+
+        self.assertEqual(len(blist), list_len)
+        self.assertEqual(blist.dropped, 0)
+
+        for idx in range(list_len):
+            self.assertEqual(blist[idx], TestBoundedList.base[idx])
+
+        # test __iter__ in BoundedList
+        idx = 0
+        for val in blist:
+            self.assertEqual(val, TestBoundedList.base[idx])
+            idx += 1
+
+    def test_append_drop(self):
+        list_len = len(TestBoundedList.base)
+        # create full BoundedList
+        blist = BoundedList.from_seq(list_len, TestBoundedList.base)
+
+        # try to append more items
+        for idx in range(8):
+            # should drop the element without raising exceptions
+            blist.append(idx)
+
+        self.assertEqual(len(blist), list_len)
+        self.assertEqual(blist.dropped, 8)
+
+    def test_extend_no_drop(self):
+        # create empty list
+        list_len = len(TestBoundedList.base)
+        blist = BoundedList(list_len)
+        self.assertEqual(len(blist), 0)
+
+        # fill list
+        blist.extend(TestBoundedList.base)
+
+        self.assertEqual(len(blist), list_len)
+        self.assertEqual(blist.dropped, 0)
+
+        for idx in range(list_len):
+            self.assertEqual(blist[idx], TestBoundedList.base[idx])
+
+        # test __iter__ in BoundedList
+        idx = 0
+        for val in blist:
+            self.assertEqual(val, TestBoundedList.base[idx])
+            idx += 1
+
+    def test_extend_drop(self):
+        list_len = len(TestBoundedList.base)
+        # create full BoundedList
+        blist = BoundedList.from_seq(list_len, TestBoundedList.base)
+        other_list = [13, 37, 51, 91]
+
+        # try to extend with more elements
+        blist.extend(other_list)
+
+        self.assertEqual(len(blist), list_len)
+        self.assertEqual(blist.dropped, len(other_list))
+
+
+class TestBoundedDict(unittest.TestCase):
+    base = collections.OrderedDict(
+        [
+            ("name", "Firulais"),
+            ("age", 7),
+            ("weight", 13),
+            ("vaccinated", True),
+        ]
+    )
+
+    def test_negative_maxlen(self):
+        with self.assertRaises(ValueError):
+            BoundedDict(-1)
+
+    def test_from_map(self):
+        dic_len = len(TestBoundedDict.base)
+        bdict = BoundedDict.from_map(dic_len, TestBoundedDict.base)
+
+        self.assertEqual(len(bdict), dic_len)
+
+        for key in TestBoundedDict.base:
+            self.assertEqual(bdict[key], TestBoundedDict.base[key])
+
+        # map too big
+        with self.assertRaises(ValueError):
+            BoundedDict.from_map(dic_len / 2, TestBoundedDict.base)
+
+    def test_bounded_dict(self):
+        # create empty dict
+        dic_len = len(TestBoundedDict.base)
+        bdict = BoundedDict(dic_len)
+        self.assertEqual(len(bdict), 0)
+
+        # fill list
+        for key in TestBoundedDict.base:
+            bdict[key] = TestBoundedDict.base[key]
+
+        self.assertEqual(len(bdict), dic_len)
+        self.assertEqual(bdict.dropped, 0)
+
+        for key in TestBoundedDict.base:
+            self.assertEqual(bdict[key], TestBoundedDict.base[key])
+
+        # test __iter__ in BoundedList
+        for key in bdict:
+            self.assertEqual(bdict[key], TestBoundedDict.base[key])
+
+        # try to append more elements
+        for key in TestBoundedDict.base:
+            bdict["new-key" + key] = TestBoundedDict.base[key]
+
+        self.assertEqual(len(bdict), dic_len)
+        self.assertEqual(bdict.dropped, dic_len)

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -22,6 +22,11 @@ class TestBoundedList(unittest.TestCase):
     base = [52, 36, 53, 29, 54, 99, 56, 48, 22, 35, 21, 65, 10, 95, 42, 60]
 
     def test_raises(self):
+        """Test corner cases
+
+        - negative list size
+        - access out of range indexes
+        """
         with self.assertRaises(ValueError):
             BoundedList(-1)
 
@@ -39,8 +44,8 @@ class TestBoundedList(unittest.TestCase):
             _ = blist[-3]
 
     def test_from_seq(self):
-        list_len = len(TestBoundedList.base)
-        base_copy = list(TestBoundedList.base)
+        list_len = len(self.base)
+        base_copy = list(self.base)
         blist = BoundedList.from_seq(list_len, base_copy)
 
         self.assertEqual(len(blist), list_len)
@@ -50,79 +55,77 @@ class TestBoundedList(unittest.TestCase):
             base_copy[idx] = idx * base_copy[idx]
 
         for idx in range(list_len):
-            self.assertEqual(blist[idx], TestBoundedList.base[idx])
+            self.assertEqual(blist[idx], self.base[idx])
 
         # test that iter yields the correct number of elements
         self.assertEqual(len(tuple(blist)), list_len)
 
         # sequence too big
         with self.assertRaises(ValueError):
-            BoundedList.from_seq(list_len / 2, TestBoundedList.base)
+            BoundedList.from_seq(list_len / 2, self.base)
 
     def test_append_no_drop(self):
+        """Append max capacity elements to the list without dropping elements."""
         # create empty list
-        list_len = len(TestBoundedList.base)
+        list_len = len(self.base)
         blist = BoundedList(list_len)
         self.assertEqual(len(blist), 0)
 
         # fill list
-        for item in TestBoundedList.base:
+        for item in self.base:
             blist.append(item)
 
         self.assertEqual(len(blist), list_len)
         self.assertEqual(blist.dropped, 0)
 
         for idx in range(list_len):
-            self.assertEqual(blist[idx], TestBoundedList.base[idx])
+            self.assertEqual(blist[idx], self.base[idx])
 
         # test __iter__ in BoundedList
-        idx = 0
-        for val in blist:
-            self.assertEqual(val, TestBoundedList.base[idx])
-            idx += 1
+        for idx, val in enumerate(blist):
+            self.assertEqual(val, self.base[idx])
 
     def test_append_drop(self):
-        list_len = len(TestBoundedList.base)
+        """Append more than max capacity elements and test that oldest ones are dropped."""
+        list_len = len(self.base)
         # create full BoundedList
-        blist = BoundedList.from_seq(list_len, TestBoundedList.base)
+        blist = BoundedList.from_seq(list_len, self.base)
 
         # try to append more items
-        for idx in range(list_len):
+        for val in self.base:
             # should drop the element without raising exceptions
-            blist.append(2 * TestBoundedList.base[idx])
+            blist.append(2 * val)
 
         self.assertEqual(len(blist), list_len)
         self.assertEqual(blist.dropped, list_len)
 
         # test that new elements are in the list
         for idx in range(list_len):
-            self.assertEqual(blist[idx], 2 * TestBoundedList.base[idx])
+            self.assertEqual(blist[idx], 2 * self.base[idx])
 
     def test_extend_no_drop(self):
         # create empty list
-        list_len = len(TestBoundedList.base)
+        list_len = len(self.base)
         blist = BoundedList(list_len)
         self.assertEqual(len(blist), 0)
 
         # fill list
-        blist.extend(TestBoundedList.base)
+        blist.extend(self.base)
 
         self.assertEqual(len(blist), list_len)
         self.assertEqual(blist.dropped, 0)
 
         for idx in range(list_len):
-            self.assertEqual(blist[idx], TestBoundedList.base[idx])
+            self.assertEqual(blist[idx], self.base[idx])
 
         # test __iter__ in BoundedList
-        idx = 0
-        for val in blist:
-            self.assertEqual(val, TestBoundedList.base[idx])
-            idx += 1
+        for idx, val in enumerate(blist):
+            self.assertEqual(val, self.base[idx])
 
     def test_extend_drop(self):
-        list_len = len(TestBoundedList.base)
+        list_len = len(self.base)
         # create full BoundedList
-        blist = BoundedList.from_seq(list_len, TestBoundedList.base)
+        blist = BoundedList.from_seq(list_len, self.base)
         other_list = [13, 37, 51, 91]
 
         # try to extend with more elements
@@ -147,8 +150,8 @@ class TestBoundedDict(unittest.TestCase):
             BoundedDict(-1)
 
     def test_from_map(self):
-        dic_len = len(TestBoundedDict.base)
-        base_copy = collections.OrderedDict(TestBoundedDict.base)
+        dic_len = len(self.base)
+        base_copy = collections.OrderedDict(self.base)
         bdict = BoundedDict.from_map(dic_len, base_copy)
 
         self.assertEqual(len(bdict), dic_len)
@@ -157,50 +160,50 @@ class TestBoundedDict(unittest.TestCase):
         base_copy["name"] = "Bruno"
         base_copy["age"] = 3
 
-        for key in TestBoundedDict.base:
-            self.assertEqual(bdict[key], TestBoundedDict.base[key])
+        for key in self.base:
+            self.assertEqual(bdict[key], self.base[key])
 
         # test that iter yields the correct number of elements
         self.assertEqual(len(tuple(bdict)), dic_len)
 
         # map too big
         with self.assertRaises(ValueError):
-            BoundedDict.from_map(dic_len / 2, TestBoundedDict.base)
+            BoundedDict.from_map(dic_len / 2, self.base)
 
     def test_bounded_dict(self):
         # create empty dict
-        dic_len = len(TestBoundedDict.base)
+        dic_len = len(self.base)
         bdict = BoundedDict(dic_len)
         self.assertEqual(len(bdict), 0)
 
         # fill dict
-        for key in TestBoundedDict.base:
-            bdict[key] = TestBoundedDict.base[key]
+        for key in self.base:
+            bdict[key] = self.base[key]
 
         self.assertEqual(len(bdict), dic_len)
         self.assertEqual(bdict.dropped, 0)
 
-        for key in TestBoundedDict.base:
-            self.assertEqual(bdict[key], TestBoundedDict.base[key])
+        for key in self.base:
+            self.assertEqual(bdict[key], self.base[key])
 
         # test __iter__ in BoundedDict
         for key in bdict:
-            self.assertEqual(bdict[key], TestBoundedDict.base[key])
+            self.assertEqual(bdict[key], self.base[key])
 
         # updating an existing element should not drop
         bdict["name"] = "Bruno"
         self.assertEqual(bdict.dropped, 0)
 
         # try to append more elements
-        for key in TestBoundedDict.base:
-            bdict["new-" + key] = TestBoundedDict.base[key]
+        for key in self.base:
+            bdict["new-" + key] = self.base[key]
 
         self.assertEqual(len(bdict), dic_len)
         self.assertEqual(bdict.dropped, dic_len)
 
         # test that elements in the dict are the new ones
-        for key in TestBoundedDict.base:
-            self.assertEqual(bdict["new-" + key], TestBoundedDict.base[key])
+        for key in self.base:
+            self.assertEqual(bdict["new-" + key], self.base[key])
 
         # delete an element
         del bdict["new-name"]


### PR DESCRIPTION
While implementing the jaeger exporter I found that it's not possible to iterate over the links of a Span in python3.4 because the `BoundedList` uses `deque.copy()` that was introduced in python3.5. 
This PR fixes that and adds few tests to avoid similar problems in the future.