### PR TITLE
Move util.time_ns to API.

### DIFF
--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -1,0 +1,12 @@
+import time
+
+# Since we want API users to be able to provide timestamps,
+# this needs to be in the API.
+
+try:
+    time_ns = time.time_ns
+# Python versions < 3.7
+except AttributeError:
+
+    def time_ns() -> int:
+        return int(time.time() * 1e9)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -22,6 +22,7 @@ from contextlib import contextmanager
 from opentelemetry import trace as trace_api
 from opentelemetry.context import Context
 from opentelemetry.sdk import util
+from opentelemetry.util import time_ns
 from opentelemetry.sdk.util import BoundedDict, BoundedList
 from opentelemetry.util import types
 
@@ -205,7 +206,7 @@ class Span(trace_api.Span):
     ) -> None:
         if attributes is None:
             attributes = Span.empty_attributes
-        self.add_lazy_event(trace_api.Event(name, util.time_ns(), attributes))
+        self.add_lazy_event(trace_api.Event(name, time_ns(), attributes))
 
     def add_lazy_event(self, event: trace_api.Event) -> None:
         with self._lock:
@@ -249,7 +250,7 @@ class Span(trace_api.Span):
             has_started = self.start_time is not None
             if not has_started:
                 self.start_time = (
-                    start_time if start_time is not None else util.time_ns()
+                    start_time if start_time is not None else time_ns()
                 )
         if has_started:
             logger.warning("Calling start() on a started span.")
@@ -265,7 +266,7 @@ class Span(trace_api.Span):
             has_ended = self.end_time is not None
             if not has_ended:
                 self.end_time = (
-                    end_time if end_time is not None else util.time_ns()
+                    end_time if end_time is not None else time_ns()
                 )
         if has_ended:
             logger.warning("Calling end() on an ended span.")

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -22,9 +22,8 @@ from contextlib import contextmanager
 from opentelemetry import trace as trace_api
 from opentelemetry.context import Context
 from opentelemetry.sdk import util
-from opentelemetry.util import time_ns
 from opentelemetry.sdk.util import BoundedDict, BoundedList
-from opentelemetry.util import types
+from opentelemetry.util import time_ns, types
 
 logger = logging.getLogger(__name__)
 
@@ -265,9 +264,7 @@ class Span(trace_api.Span):
                 raise RuntimeError("Calling end() on a not started span.")
             has_ended = self.end_time is not None
             if not has_ended:
-                self.end_time = (
-                    end_time if end_time is not None else time_ns()
-                )
+                self.end_time = end_time if end_time is not None else time_ns()
         if has_ended:
             logger.warning("Calling end() on an ended span.")
             return

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -19,7 +19,7 @@ import typing
 from enum import Enum
 
 from opentelemetry.context import Context
-from opentelemetry.sdk import util
+from opentelemetry.util import time_ns
 
 from .. import Span, SpanProcessor
 
@@ -163,9 +163,9 @@ class BatchExportSpanProcessor(SpanProcessor):
                         break
 
             # substract the duration of this export call to the next timeout
-            start = util.time_ns()
+            start = time_ns()
             self.export()
-            end = util.time_ns()
+            end = time_ns()
             duration = (end - start) / 1e9
             timeout = self.schedule_delay_millis / 1e3 - duration
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util.py
@@ -25,6 +25,7 @@ except ImportError:
     from collections import MutableMapping
     from collections import Sequence
 
+
 def ns_to_iso_str(nanoseconds):
     """Get an ISO 8601 string from time_ns value."""
     ts = datetime.datetime.utcfromtimestamp(nanoseconds / 1e9)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util.py
@@ -14,7 +14,6 @@
 
 import datetime
 import threading
-import time
 from collections import OrderedDict, deque
 
 try:
@@ -25,15 +24,6 @@ except ImportError:
     # pylint: disable=no-name-in-module,ungrouped-imports
     from collections import MutableMapping
     from collections import Sequence
-
-try:
-    time_ns = time.time_ns
-# Python versions < 3.7
-except AttributeError:
-
-    def time_ns():
-        return int(time.time() * 1e9)
-
 
 def ns_to_iso_str(nanoseconds):
     """Get an ISO 8601 string from time_ns value."""

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -19,6 +19,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.sdk import trace
 from opentelemetry.util import time_ns
 
+
 class TestTracer(unittest.TestCase):
     def test_extends_api(self):
         tracer = trace.Tracer()

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -16,8 +16,8 @@ import unittest
 from unittest import mock
 
 from opentelemetry import trace as trace_api
-from opentelemetry.sdk import trace, util
-
+from opentelemetry.sdk import trace
+from opentelemetry.util import time_ns
 
 class TestTracer(unittest.TestCase):
     def test_extends_api(self):
@@ -174,7 +174,7 @@ class TestSpan(unittest.TestCase):
             # events
             root.add_event("event0")
             root.add_event("event1", {"name": "birthday"})
-            now = util.time_ns()
+            now = time_ns()
             root.add_lazy_event(
                 trace_api.Event("event2", now, {"name": "hello"})
             )


### PR DESCRIPTION
Since we now have timestamp parameters in the API, we should also have a function that obtains matching arguments there.