### PR TITLE
Add contextmanager for Context

### DIFF
--- a/opentelemetry-api/src/opentelemetry/context/base_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/base_context.py
@@ -100,7 +100,7 @@ class BaseRuntimeContext:
     def __setitem__(self, name: str, value: "object") -> None:
         self.__setattr__(name, value)
 
-    @contextmanager
+    @contextmanager  # type: ignore
     def __call__(self, **kwargs) -> typing.Iterator[None]:
         snapshot = {key: self[key] for key in kwargs}
         for key in kwargs:

--- a/opentelemetry-api/src/opentelemetry/context/base_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/base_context.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import contextmanager
 import threading
 import typing
 
@@ -98,6 +99,15 @@ class BaseRuntimeContext:
 
     def __setitem__(self, name: str, value: "object") -> None:
         self.__setattr__(name, value)
+
+    @contextmanager
+    def __call__(self, **kwargs):
+        snapshot = {key: self[key] for key in kwargs}
+        for key in kwargs:
+            self[key] = kwargs[key]
+        yield
+        for key in kwargs:
+            self[key] = snapshot[key]
 
     def with_current_context(
         self, func: typing.Callable[..., "object"]

--- a/opentelemetry-api/src/opentelemetry/context/base_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/base_context.py
@@ -101,9 +101,7 @@ class BaseRuntimeContext:
         self.__setattr__(name, value)
 
     @contextmanager  # type: ignore
-    def use(
-        self, **kwargs: typing.Dict[str, object]
-    ) -> typing.Iterator[None]:
+    def use(self, **kwargs: typing.Dict[str, object]) -> typing.Iterator[None]:
         snapshot = {key: self[key] for key in kwargs}
         for key in kwargs:
             self[key] = kwargs[key]

--- a/opentelemetry-api/src/opentelemetry/context/base_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/base_context.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import contextmanager
 import threading
 import typing
+from contextlib import contextmanager
 
 
 def wrap_callable(target: "object") -> typing.Callable[[], object]:
@@ -101,7 +101,7 @@ class BaseRuntimeContext:
         self.__setattr__(name, value)
 
     @contextmanager
-    def __call__(self, **kwargs) -> None:
+    def __call__(self, **kwargs) -> typing.Iterator[None]:
         snapshot = {key: self[key] for key in kwargs}
         for key in kwargs:
             self[key] = kwargs[key]

--- a/opentelemetry-api/src/opentelemetry/context/base_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/base_context.py
@@ -101,7 +101,9 @@ class BaseRuntimeContext:
         self.__setattr__(name, value)
 
     @contextmanager  # type: ignore
-    def __call__(self, **kwargs) -> typing.Iterator[None]:
+    def __call__(
+        self, **kwargs: typing.Dict[str, "object"]
+    ) -> typing.Iterator[None]:
         snapshot = {key: self[key] for key in kwargs}
         for key in kwargs:
             self[key] = kwargs[key]

--- a/opentelemetry-api/src/opentelemetry/context/base_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/base_context.py
@@ -101,8 +101,8 @@ class BaseRuntimeContext:
         self.__setattr__(name, value)
 
     @contextmanager  # type: ignore
-    def __call__(
-        self, **kwargs: typing.Dict[str, "object"]
+    def use(
+        self, **kwargs: typing.Dict[str, object]
     ) -> typing.Iterator[None]:
         snapshot = {key: self[key] for key in kwargs}
         for key in kwargs:

--- a/opentelemetry-api/src/opentelemetry/context/base_context.py
+++ b/opentelemetry-api/src/opentelemetry/context/base_context.py
@@ -101,7 +101,7 @@ class BaseRuntimeContext:
         self.__setattr__(name, value)
 
     @contextmanager
-    def __call__(self, **kwargs):
+    def __call__(self, **kwargs) -> None:
         snapshot = {key: self[key] for key in kwargs}
         for key in kwargs:
             self[key] = kwargs[key]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -184,8 +184,11 @@ class BatchExportSpanProcessor(SpanProcessor):
             idx += 1
         with Context(suppress_instrumentation=True):
             try:
-                # Ignore type b/c the Optional[None]+slicing is too "clever" for mypy
-                self.span_exporter.export(self.spans_list[:idx])  # type: ignore
+                # Ignore type b/c the Optional[None]+slicing is too "clever"
+                # for mypy
+                self.span_exporter.export(
+                    self.spans_list[:idx]
+                )  # type: ignore
             # pylint: disable=broad-except
             except Exception:
                 logger.exception("Exception while exporting data.")

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -73,7 +73,7 @@ class SimpleExportSpanProcessor(SpanProcessor):
         pass
 
     def on_end(self, span: Span) -> None:
-        with Context(suppress_instrumentation=True):
+        with Context.use(suppress_instrumentation=True):
             try:
                 self.span_exporter.export((span,))
             # pylint: disable=broad-except
@@ -182,7 +182,7 @@ class BatchExportSpanProcessor(SpanProcessor):
         while idx < self.max_export_batch_size and self.queue:
             self.spans_list[idx] = self.queue.pop()
             idx += 1
-        with Context(suppress_instrumentation=True):
+        with Context.use(suppress_instrumentation=True):
             try:
                 # Ignore type b/c the Optional[None]+slicing is too "clever"
                 # for mypy


### PR DESCRIPTION
Resolves #183.

Now it is much simpler to restore context:
```python
from opentelemetry.context import Context

Context.a = 'a'
print(Context)
Context.b = 'b'
print(Context)
with Context.use(a='foo', b='bar'):
    print(Context)
    with Context.use(a='baz', c='baz'):
        print(Context)
print(Context)
```

You will get:
```
AsyncRuntimeContext({'a': 'a'})
AsyncRuntimeContext({'a': 'a', 'b': 'b'})
AsyncRuntimeContext({'a': 'foo', 'b': 'bar'})
AsyncRuntimeContext({'a': 'baz', 'b': 'bar', 'c': 'baz'})
AsyncRuntimeContext({'a': 'a', 'b': 'b', 'c': None})
```