### PR TITLE
ext/wsgi: use current span when extracting fails

### DIFF
--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
@@ -108,6 +108,9 @@ class OpenTelemetryMiddleware:
         tracer = trace.tracer()
         path_info = environ["PATH_INFO"] or "/"
         parent_span = propagators.extract(_get_header_from_environ, environ)
+        # if extracing fails then use current span as parent
+        if parent_span is trace.INVALID_SPAN_CONTEXT:
+            parent_span = tracer.CURRENT_SPAN
 
         span = tracer.create_span(
             path_info, parent_span, kind=trace.SpanKind.SERVER

--- a/ext/opentelemetry-ext-wsgi/tests/test_wsgi_middleware.py
+++ b/ext/opentelemetry-ext-wsgi/tests/test_wsgi_middleware.py
@@ -75,10 +75,10 @@ def error_wsgi(environ, start_response):
 
 class TestWsgiApplication(unittest.TestCase):
     def setUp(self):
-        tracer = trace_api.tracer()
+        self.tracer = trace_api.tracer()
         self.span = mock.create_autospec(trace_api.Span, spec_set=True)
         self.create_span_patcher = mock.patch.object(
-            tracer,
+            self.tracer,
             "create_span",
             autospec=True,
             spec_set=True,
@@ -131,7 +131,7 @@ class TestWsgiApplication(unittest.TestCase):
 
         # Verify that start_span has been called
         self.create_span.assert_called_with(
-            "/", trace_api.INVALID_SPAN_CONTEXT, kind=trace_api.SpanKind.SERVER
+            "/", self.tracer.CURRENT_SPAN, kind=trace_api.SpanKind.SERVER
         )
         self.span.start.assert_called_with()
 


### PR DESCRIPTION
If propagator.extract() returns INVALID_SPAN it means that the http headers
do not contain valid trace information, in this case use the current span as
parent.

Before this change INVALID_SPAN was being passed to create_span then all the
traces were generated with trace_id = 0x0.
