### PR TITLE
Fix mypy errors

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -245,13 +245,9 @@ class Span:
         exc_type: typing.Optional[typing.Type[BaseException]],
         exc_val: typing.Optional[BaseException],
         exc_tb: typing.Optional[python_types.TracebackType],
-    ) -> typing.Optional[bool]:
-        """Ends context manager and calls `end` on the `Span`.
-
-        Returns False.
-        """
+    ) -> None:
+        """Ends context manager and calls `end` on the `Span`."""
         self.end()
-        return False
 
 
 class TraceOptions(int):

--- a/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
+++ b/opentelemetry-api/tests/distributedcontext/test_distributed_context.py
@@ -99,6 +99,14 @@ class TestDistributedContextManager(unittest.TestCase):
         self.assertIsNone(self.manager.get_current_context())
 
     def test_use_context(self):
-        expected = object()
+        expected = distributedcontext.DistributedContext(
+            (
+                distributedcontext.Entry(
+                    distributedcontext.EntryMetadata(0),
+                    distributedcontext.EntryKey("0"),
+                    distributedcontext.EntryValue(""),
+                ),
+            )
+        )
         with self.manager.use_context(expected) as output:
             self.assertIs(output, expected)

--- a/opentelemetry-api/tests/metrics/test_metrics.py
+++ b/opentelemetry-api/tests/metrics/test_metrics.py
@@ -24,7 +24,7 @@ class TestMeter(unittest.TestCase):
 
     def test_record_batch(self):
         counter = metrics.Counter()
-        self.meter.record_batch(("values"), ((counter, 1)))
+        self.meter.record_batch(("values"), ((counter, 1),))
 
     def test_create_metric(self):
         metric = self.meter.create_metric("", "", "", float, metrics.Counter)

--- a/opentelemetry-api/tests/test_loader.py
+++ b/opentelemetry-api/tests/test_loader.py
@@ -16,6 +16,7 @@ import os
 import sys
 import unittest
 from importlib import reload
+from typing import Any, Callable
 
 from opentelemetry import trace
 from opentelemetry.util import loader
@@ -59,7 +60,7 @@ class TestLoader(unittest.TestCase):
 
     # NOTE: We use do_* + *_<arg> methods because subtest wouldn't run setUp,
     # which we require here.
-    def do_test_preferred_impl(self, setter):
+    def do_test_preferred_impl(self, setter: Callable[[Any], Any]) -> None:
         setter(get_opentelemetry_implementation)
         tracer = trace.tracer()
         self.assertIs(tracer, DUMMY_TRACER)
@@ -81,7 +82,7 @@ class TestLoader(unittest.TestCase):
             )
         self.assertIn("already loaded", str(einfo.exception))
 
-    def do_test_get_envvar(self, envvar_suffix):
+    def do_test_get_envvar(self, envvar_suffix: str) -> None:
         global DUMMY_TRACER  # pylint:disable=global-statement
 
         # Test is not runnable with this!

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ python =
 
 [testenv]
 deps =
-  mypy,mypyinstalled: mypy~=0.711
+  mypy,mypyinstalled: mypy~=0.740
 
 setenv =
   mypy: MYPYPATH={toxinidir}/opentelemetry-api/src/


### PR DESCRIPTION
63f559ec seems to have broken mypy since we are returning a literal `False` in https://github.com/open-telemetry/opentelemetry-python/commit/63f559ec257da7868a58699cbac598f3c57bd889#diff-97345450e765fa40d32664356325e06cR248 while using `typing.Optional[bool]` as the type hint.

This causes the following mypy error:

```
opentelemetry-api/src/opentelemetry/trace/__init__.py:243: error: "bool" is invalid as return type for "__exit__" that always returns False
opentelemetry-api/src/opentelemetry/trace/__init__.py:243: note: Use "typing_extensions.Literal[False]" as the return type or change it to "None"
opentelemetry-api/src/opentelemetry/trace/__init__.py:243: note: If return type of "__exit__" implies that it may return True, the context manager may swallow exceptions
opentelemetry-api/src/opentelemetry/trace/__init__.py:243: error: "bool" is invalid as return type for "__exit__" that always returns False
opentelemetry-api/src/opentelemetry/trace/__init__.py:243: note: Use "typing_extensions.Literal[False]" as the return type or change it to "None"
opentelemetry-api/src/opentelemetry/trace/__init__.py:243: note: If return type of "__exit__" implies that it may return True, the context manager may swallow exceptions
```

~I don't know why the CI was green on that commit, but anyway it is failing now.~ As it turns out we don't pin the mypy version so apparently this started breaking with mypy `0.740`.

AFAICT this can be solved by changing the type hint to `typing_extensions.Literal[False]`, however reading the [docs](https://docs.python.org/3.7/reference/datamodel.html#object.__exit__) it seems the only return value which suppresses exceptions is `True`, therefore dropping the return statement altogether should have the same result as returning a literal `False` and would also allow us to set the type hint to `-> None` and fix mypy.