### PR TITLE
ext/jaeger: fix bad variable type

### DIFF
--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -122,6 +122,9 @@ class JaegerSpanExporter(SpanExporter):
     def shutdown(self):
         pass
 
+def _nsec_to_usec_round(nsec):
+    """Round nanoseconds to microseconds"""
+    return (nsec + 500) // 10 ** 3
 
 def _translate_to_jaeger(spans: Span):
     """Translate the spans to Jaeger format.
@@ -137,8 +140,8 @@ def _translate_to_jaeger(spans: Span):
         trace_id = ctx.trace_id
         span_id = ctx.span_id
 
-        start_time_us = span.start_time // 10 ** 3
-        duration_us = (span.end_time - span.start_time) // 10 ** 3
+        start_time_us = _nsec_to_usec_round(span.start_time)
+        duration_us = _nsec_to_usec_round(span.end_time - span.start_time)
 
         parent_id = 0
         if isinstance(span.parent, trace_api.Span):
@@ -227,7 +230,7 @@ def _extract_logs_from_span(span):
             )
         )
 
-        event_timestamp_us = event.timestamp // 10 ** 3
+        event_timestamp_us = _nsec_to_usec_round(event.timestamp)
         logs.append(
             jaeger.Log(timestamp=int(event_timestamp_us), fields=fields)
         )

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -137,8 +137,8 @@ def _translate_to_jaeger(spans: Span):
         trace_id = ctx.trace_id
         span_id = ctx.span_id
 
-        start_time_us = span.start_time // 1e3
-        duration_us = (span.end_time - span.start_time) // 1e3
+        start_time_us = span.start_time // 10 ** 3
+        duration_us = (span.end_time - span.start_time) // 10 ** 3
 
         parent_id = 0
         if isinstance(span.parent, trace_api.Span):
@@ -227,7 +227,7 @@ def _extract_logs_from_span(span):
             )
         )
 
-        event_timestamp_us = event.timestamp // 1e3
+        event_timestamp_us = event.timestamp // 10 ** 3
         logs.append(
             jaeger.Log(timestamp=int(event_timestamp_us), fields=fields)
         )

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -122,9 +122,11 @@ class JaegerSpanExporter(SpanExporter):
     def shutdown(self):
         pass
 
+
 def _nsec_to_usec_round(nsec):
     """Round nanoseconds to microseconds"""
     return (nsec + 500) // 10 ** 3
+
 
 def _translate_to_jaeger(spans: Span):
     """Translate the spans to Jaeger format.

--- a/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
+++ b/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
@@ -98,6 +98,14 @@ class TestJaegerSpanExporter(unittest.TestCase):
         self.assertNotEqual(exporter.collector, collector)
         self.assertTrue(exporter.collector.auth is None)
 
+    def test_nsec_to_usec_round(self):
+        # pylint: disable=protected-access
+        nsec_to_usec_round = jaeger_exporter._nsec_to_usec_round
+
+        self.assertEqual(nsec_to_usec_round(5000), 5)
+        self.assertEqual(nsec_to_usec_round(5499), 5)
+        self.assertEqual(nsec_to_usec_round(5500), 6)
+
     # pylint: disable=too-many-locals
     def test_translate_to_jaeger(self):
         # pylint: disable=invalid-name


### PR DESCRIPTION
The type of startTime and duration were float types, it caused an exception
in the thrift package because they are declared as i64 integers in thrift.
It wasn't detected because there were not tests covering it, also for
some reason I have been using an old version on my computer all this time.

This commit fixes it by ensuring the datatypes are int (changing 1eX notation
by 10 ** X notation), it also intruce new tests to guarantee that a similar
problem is detected the next time.
