### PR TITLE
SDK Tracer treats invalid span parent like null (fixes #233)

### DIFF
--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -54,14 +54,16 @@ class TestSpanCreation(unittest.TestCase):
     def test_create_span_invalid_spancontext(self):
         """If an invalid span context is passed as the parent, the created
         span should use a new span id.
+
+        Invalid span contexts should also not be added as a parent. This
+        eliminates redundant error handling logic in exporters.
         """
         tracer = trace.Tracer("test_create_span_invalid_spancontext")
         new_span = tracer.create_span(
             "root", parent=trace_api.INVALID_SPAN_CONTEXT
         )
-        self.assertNotEqual(
-            new_span.context.span_id, trace_api.INVALID_SPAN_ID
-        )
+        self.assertTrue(new_span.context.is_valid())
+        self.assertIsNone(new_span.parent)
 
     def test_start_span_implicit(self):
         tracer = trace.Tracer("test_start_span_implicit")

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -51,6 +51,18 @@ class TestTracerSampling(unittest.TestCase):
 
 
 class TestSpanCreation(unittest.TestCase):
+    def test_create_span_invalid_spancontext(self):
+        """If an invalid span context is passed as the parent, the created
+        span should use a new span id.
+        """
+        tracer = trace.Tracer("test_create_span_invalid_spancontext")
+        new_span = tracer.create_span(
+            "root", parent=trace_api.INVALID_SPAN_CONTEXT
+        )
+        self.assertNotEqual(
+            new_span.context.span_id, trace_api.INVALID_SPAN_ID
+        )
+
     def test_start_span_implicit(self):
         tracer = trace.Tracer("test_start_span_implicit")
 


### PR DESCRIPTION
Fixes #233. The SDK tracer will now create spans with invalid parents
as brand new spans, similar to not having a parent at all.

Adding this behavior to the Tracer ensures that integrations do not have
to handle invalid span contexts in their own code, and ensures that behavior
is consistent with w3c tracecontext (which specifies invalid results should
be handled by creating new spans).