### PR TITLE
Use start_as_current_span by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ tracer = trace.tracer()
 tracer.add_span_processor(
     SimpleExportSpanProcessor(ConsoleSpanExporter())
 )
-with tracer.start_span('foo'):
-    with tracer.start_span('bar'):
-        with tracer.start_span('baz'):
+with tracer.start_as_current_span('foo'):
+    with tracer.start_as_current_span('bar'):
+        with tracer.start_as_current_span('baz'):
             print(Context)
 ```
 

--- a/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
+++ b/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
@@ -67,7 +67,7 @@ app = flask.Flask(__name__)
 def hello():
     # emit a trace that measures how long the
     # sleep takes
-    with trace.tracer().start_span("example-request"):
+    with trace.tracer().start_as_current_span("example-request"):
         requests.get("http://www.example.com")
     return "hello"
 

--- a/examples/trace/server.py
+++ b/examples/trace/server.py
@@ -45,7 +45,7 @@ app.wsgi_app = OpenTelemetryMiddleware(app.wsgi_app)
 
 @app.route("/")
 def hello():
-    with trace.tracer().start_span("parent"):
+    with trace.tracer().start_as_current_span("parent"):
         requests.get("https://www.wikipedia.org/wiki/Rabbit")
     return "hello"
 

--- a/ext/opentelemetry-ext-azure-monitor/examples/server.py
+++ b/ext/opentelemetry-ext-azure-monitor/examples/server.py
@@ -34,7 +34,7 @@ app.wsgi_app = OpenTelemetryMiddleware(app.wsgi_app)
 
 @app.route("/")
 def hello():
-    with trace.tracer().start_span("parent"):
+    with trace.tracer().start_as_current_span("parent"):
         requests.get("https://www.wikipedia.org/wiki/Rabbit")
     return "hello"
 

--- a/ext/opentelemetry-ext-azure-monitor/examples/trace.py
+++ b/ext/opentelemetry-ext-azure-monitor/examples/trace.py
@@ -23,5 +23,5 @@ tracer.add_span_processor(
     SimpleExportSpanProcessor(AzureMonitorSpanExporter())
 )
 
-with tracer.start_span("hello") as span:
+with tracer.start_as_current_span("hello") as span:
     print("Hello, World!")

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
@@ -65,7 +65,7 @@ def enable(tracer):
                 path = "<URL parses to None>"
             path = parsed_url.path
 
-        with tracer.start_span(path, kind=SpanKind.CLIENT) as span:
+        with tracer.start_as_current_span(path, kind=SpanKind.CLIENT) as span:
             span.set_attribute("component", "http")
             span.set_attribute("http.method", method.upper())
             span.set_attribute("http.url", url)

--- a/ext/opentelemetry-ext-http-requests/tests/test_requests_integration.py
+++ b/ext/opentelemetry-ext-http-requests/tests/test_requests_integration.py
@@ -40,12 +40,12 @@ class TestRequestsIntegration(unittest.TestCase):
         self.span.set_attribute = setspanattr
         self.start_span_patcher = mock.patch.object(
             self.tracer,
-            "start_span",
+            "start_as_current_span",
             autospec=True,
             spec_set=True,
             return_value=self.span_context_manager,
         )
-        self.start_span = self.start_span_patcher.start()
+        self.start_as_current_span = self.start_span_patcher.start()
 
         mocked_response = requests.models.Response()
         mocked_response.status_code = 200
@@ -70,7 +70,7 @@ class TestRequestsIntegration(unittest.TestCase):
         url = "https://www.example.org/foo/bar?x=y#top"
         requests.get(url=url)
         self.assertEqual(1, len(self.send.call_args_list))
-        self.tracer.start_span.assert_called_with(
+        self.tracer.start_as_current_span.assert_called_with(
             "/foo/bar", kind=trace.SpanKind.CLIENT
         )
         self.span_context_manager.__enter__.assert_called_with()
@@ -97,10 +97,10 @@ class TestRequestsIntegration(unittest.TestCase):
         with self.assertRaises(exception_type):
             requests.post(url=url)
         self.assertTrue(
-            self.tracer.start_span.call_args[0][0].startswith(
+            self.tracer.start_as_current_span.call_args[0][0].startswith(
                 "<Unparsable URL"
             ),
-            msg=self.tracer.start_span.call_args,
+            msg=self.tracer.start_as_current_span.call_args,
         )
         self.span_context_manager.__enter__.assert_called_with()
         exitspan = self.span_context_manager.__exit__

--- a/ext/opentelemetry-ext-jaeger/README.rst
+++ b/ext/opentelemetry-ext-jaeger/README.rst
@@ -51,7 +51,7 @@ gRPC is still not supported by this implementation.
     # add to the tracer
     tracer.add_span_processor(span_processor)
 
-    with tracer.start_span('foo'):
+    with tracer.start_as_current_span('foo'):
         print('Hello world!')
 
     # shutdown the span processor

--- a/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
+++ b/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
@@ -29,16 +29,16 @@ span_processor = BatchExportSpanProcessor(jaeger_exporter)
 tracer.add_span_processor(span_processor)
 
 # create some spans for testing
-with tracer.start_span("foo") as foo:
+with tracer.start_as_current_span("foo") as foo:
     time.sleep(0.1)
     foo.set_attribute("my_atribbute", True)
     foo.add_event("event in foo", {"name": "foo1"})
-    with tracer.start_span("bar") as bar:
+    with tracer.start_as_current_span("bar") as bar:
         time.sleep(0.2)
         bar.set_attribute("speed", 100.0)
         bar.add_link(foo.get_context())
 
-        with tracer.start_span("baz") as baz:
+        with tracer.start_as_current_span("baz") as baz:
             time.sleep(0.3)
             baz.set_attribute("name", "mauricio")
 

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -29,6 +29,10 @@ class TestTracer(unittest.TestCase):
         with self.tracer.start_span("") as span:
             self.assertIsInstance(span, trace.Span)
 
+    def test_start_as_current_span(self):
+        with self.tracer.start_as_current_span("") as span:
+            self.assertIsInstance(span, trace.Span)
+
     def test_create_span(self):
         span = self.tracer.create_span("")
         self.assertIsInstance(span, trace.Span)

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -48,6 +48,27 @@ class TestSimpleExportSpanProcessor(unittest.TestCase):
         span_processor = export.SimpleExportSpanProcessor(my_exporter)
         tracer.add_span_processor(span_processor)
 
+        with tracer.start_as_current_span("foo"):
+            with tracer.start_as_current_span("bar"):
+                with tracer.start_as_current_span("xxx"):
+                    pass
+
+        self.assertListEqual(["xxx", "bar", "foo"], spans_names_list)
+
+    def test_simple_span_processor_no_context(self):
+        """Check that we process spans that are never made active.
+
+        SpanProcessors should act on a span's start and end events whether or
+        not it is ever the active span.
+        """
+        tracer = trace.Tracer()
+
+        spans_names_list = []
+
+        my_exporter = MySpanExporter(destination=spans_names_list)
+        span_processor = export.SimpleExportSpanProcessor(my_exporter)
+        tracer.add_span_processor(span_processor)
+
         with tracer.start_span("foo"):
             with tracer.start_span("bar"):
                 with tracer.start_span("xxx"):

--- a/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
+++ b/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
@@ -31,9 +31,9 @@ class TestInMemorySpanExporter(unittest.TestCase):
         span_processor = export.SimpleExportSpanProcessor(memory_exporter)
         tracer.add_span_processor(span_processor)
 
-        with tracer.start_span("foo"):
-            with tracer.start_span("bar"):
-                with tracer.start_span("xxx"):
+        with tracer.start_as_current_span("foo"):
+            with tracer.start_as_current_span("bar"):
+                with tracer.start_as_current_span("xxx"):
                     pass
 
         span_list = memory_exporter.get_finished_spans()
@@ -47,9 +47,9 @@ class TestInMemorySpanExporter(unittest.TestCase):
         span_processor = export.SimpleExportSpanProcessor(memory_exporter)
         tracer.add_span_processor(span_processor)
 
-        with tracer.start_span("foo"):
-            with tracer.start_span("bar"):
-                with tracer.start_span("xxx"):
+        with tracer.start_as_current_span("foo"):
+            with tracer.start_as_current_span("bar"):
+                with tracer.start_as_current_span("xxx"):
                     pass
 
         memory_exporter.clear()
@@ -63,9 +63,9 @@ class TestInMemorySpanExporter(unittest.TestCase):
         span_processor = export.SimpleExportSpanProcessor(memory_exporter)
         tracer.add_span_processor(span_processor)
 
-        with tracer.start_span("foo"):
-            with tracer.start_span("bar"):
-                with tracer.start_span("xxx"):
+        with tracer.start_as_current_span("foo"):
+            with tracer.start_as_current_span("bar"):
+                with tracer.start_as_current_span("xxx"):
                     pass
 
         span_list = memory_exporter.get_finished_spans()
@@ -74,9 +74,9 @@ class TestInMemorySpanExporter(unittest.TestCase):
         memory_exporter.shutdown()
 
         # after shutdown no new spans are accepted
-        with tracer.start_span("foo"):
-            with tracer.start_span("bar"):
-                with tracer.start_span("xxx"):
+        with tracer.start_as_current_span("foo"):
+            with tracer.start_as_current_span("bar"):
+                with tracer.start_as_current_span("xxx"):
                     pass
 
         span_list = memory_exporter.get_finished_spans()


### PR DESCRIPTION
This is a follow up to #198, which renamed `start_span` to `start_as_current_span`.

There were several examples and tests with calls to `start_span` that look like they should have been updated, including the example in the main README.



