### PR TITLE
Fixes for black 19.10b0

### DIFF
--- a/ext/opentelemetry-ext-wsgi/tests/test_wsgi_middleware.py
+++ b/ext/opentelemetry-ext-wsgi/tests/test_wsgi_middleware.py
@@ -210,7 +210,7 @@ class TestWsgiAttributes(unittest.TestCase):
         self.validate_url("http://127.0.0.1/#top")
 
     def test_request_attributes_with_partial_raw_uri_and_nonstandard_port(
-        self
+        self,
     ):
         self.environ["RAW_URI"] = "/?"
         del self.environ["HTTP_HOST"]

--- a/opentelemetry-api/src/opentelemetry/distributedcontext/propagation/binaryformat.py
+++ b/opentelemetry-api/src/opentelemetry/distributedcontext/propagation/binaryformat.py
@@ -44,7 +44,7 @@ class BinaryFormat(abc.ABC):
     @staticmethod
     @abc.abstractmethod
     def from_bytes(
-        byte_representation: bytes
+        byte_representation: bytes,
     ) -> typing.Optional[DistributedContext]:
         """Return a DistributedContext that was represented by bytes.
 

--- a/opentelemetry-api/src/opentelemetry/propagators/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/__init__.py
@@ -78,7 +78,7 @@ def get_global_httptextformat() -> httptextformat.HTTPTextFormat:
 
 
 def set_global_httptextformat(
-    http_text_format: httptextformat.HTTPTextFormat
+    http_text_format: httptextformat.HTTPTextFormat,
 ) -> None:
     global _HTTP_TEXT_FORMAT  # pylint:disable=global-statement
     _HTTP_TEXT_FORMAT = http_text_format

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -589,7 +589,7 @@ def tracer() -> Tracer:
 
 
 def set_preferred_tracer_implementation(
-    factory: ImplementationFactory
+    factory: ImplementationFactory,
 ) -> None:
     """Set the factory to be used to create the tracer.
 

--- a/opentelemetry-api/src/opentelemetry/util/loader.py
+++ b/opentelemetry-api/src/opentelemetry/util/loader.py
@@ -173,7 +173,7 @@ def _load_impl(
 
 
 def set_preferred_default_implementation(
-    implementation_factory: _UntrustedImplFactory[_T]
+    implementation_factory: _UntrustedImplFactory[_T],
 ) -> None:
     """Sets a factory function that may be called for any implementation
     object. See the :ref:`module docs <loader-factory>` for more details."""


### PR DESCRIPTION
A change between black versions [`19.3b0`](https://github.com/psf/black/releases/tag/19.3b0) and [`19.10b0`](https://github.com/psf/black/releases/tag/19.10b0) broke lint on master. This fixes it by re-running black on affected files.

Occasional PRs like these may be the price we pay for not pinning our build tools, but it may be worth it to keep them up to date.