### PR TITLE
Update versions and requirements to 0.2a0

### DIFF
--- a/examples/opentelemetry-example-app/setup.py
+++ b/examples/opentelemetry-example-app/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="opentelemetry-example-app",
-    version="0.1.dev0",
+    version="0.2a.0",
     author="OpenTelemetry Authors",
     author_email="cncf-opentelemetry-contributors@lists.cncf.io",
     classifiers=[
@@ -35,10 +35,10 @@ setuptools.setup(
     long_description=open("README.rst").read(),
     install_requires=[
         "typing; python_version<'3.5'",
-        "opentelemetry-api",
-        "opentelemetry-sdk",
-        "opentelemetry-ext-http-requests",
-        "opentelemetry-ext-wsgi",
+        "opentelemetry-api>=0.2a.0",
+        "opentelemetry-sdk>=0.2a.0",
+        "opentelemetry-ext-http-requests>=0.2a.0",
+        "opentelemetry-ext-wsgi>=0.2a.0",
         "flask",
         "requests",
     ],

--- a/examples/opentelemetry-example-app/setup.py
+++ b/examples/opentelemetry-example-app/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="opentelemetry-example-app",
-    version="0.2a.0",
+    version="0.2a0",
     author="OpenTelemetry Authors",
     author_email="cncf-opentelemetry-contributors@lists.cncf.io",
     classifiers=[
@@ -35,10 +35,10 @@ setuptools.setup(
     long_description=open("README.rst").read(),
     install_requires=[
         "typing; python_version<'3.5'",
-        "opentelemetry-api>=0.2a.0",
-        "opentelemetry-sdk>=0.2a.0",
-        "opentelemetry-ext-http-requests>=0.2a.0",
-        "opentelemetry-ext-wsgi>=0.2a.0",
+        "opentelemetry-api>=0.2a0",
+        "opentelemetry-sdk>=0.2a0",
+        "opentelemetry-ext-http-requests>=0.2a0",
+        "opentelemetry-ext-wsgi>=0.2a0",
         "flask",
         "requests",
     ],

--- a/ext/opentelemetry-ext-azure-monitor/setup.cfg
+++ b/ext/opentelemetry-ext-azure-monitor/setup.cfg
@@ -39,8 +39,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.2a.0
-    opentelemetry-sdk >= 0.2a.0
+    opentelemetry-api >= 0.2a0
+    opentelemetry-sdk >= 0.2a0
 
 [options.packages.find]
 where = src

--- a/ext/opentelemetry-ext-azure-monitor/setup.cfg
+++ b/ext/opentelemetry-ext-azure-monitor/setup.cfg
@@ -39,8 +39,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api
-    opentelemetry-sdk
+    opentelemetry-api >= 0.2a.0
+    opentelemetry-sdk >= 0.2a.0
 
 [options.packages.find]
 where = src

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/version.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.2a.0"

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/version.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2a.0"
+__version__ = "0.2a0"

--- a/ext/opentelemetry-ext-http-requests/setup.cfg
+++ b/ext/opentelemetry-ext-http-requests/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.2a.0
+    opentelemetry-api >= 0.2a0
     requests ~= 2.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-http-requests/setup.cfg
+++ b/ext/opentelemetry-ext-http-requests/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.1.dev0
+    opentelemetry-api >= 0.2a.0
     requests ~= 2.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.2a.0"

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2a.0"
+__version__ = "0.2a0"

--- a/ext/opentelemetry-ext-jaeger/setup.cfg
+++ b/ext/opentelemetry-ext-jaeger/setup.cfg
@@ -40,8 +40,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     thrift >= 0.10.0
-    opentelemetry-api
-    opentelemetry-sdk
+    opentelemetry-api >= 0.2a.0
+    opentelemetry-sdk >= 0.2a.0
 
 [options.packages.find]
 where = src

--- a/ext/opentelemetry-ext-jaeger/setup.cfg
+++ b/ext/opentelemetry-ext-jaeger/setup.cfg
@@ -40,8 +40,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     thrift >= 0.10.0
-    opentelemetry-api >= 0.2a.0
-    opentelemetry-sdk >= 0.2a.0
+    opentelemetry-api >= 0.2a0
+    opentelemetry-sdk >= 0.2a0
 
 [options.packages.find]
 where = src

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.2a.0"

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2a.0"
+__version__ = "0.2a0"

--- a/ext/opentelemetry-ext-opentracing-shim/setup.cfg
+++ b/ext/opentelemetry-ext-opentracing-shim/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
 packages=find_namespace:
 install_requires =
     opentracing
-    opentelemetry-api
+    opentelemetry-api >= 0.2a.0
 
 [options.packages.find]
 where = src

--- a/ext/opentelemetry-ext-opentracing-shim/setup.cfg
+++ b/ext/opentelemetry-ext-opentracing-shim/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
 packages=find_namespace:
 install_requires =
     opentracing
-    opentelemetry-api >= 0.2a.0
+    opentelemetry-api >= 0.2a0
 
 [options.packages.find]
 where = src

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.2a.0"

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2a.0"
+__version__ = "0.2a0"

--- a/ext/opentelemetry-ext-wsgi/setup.cfg
+++ b/ext/opentelemetry-ext-wsgi/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api
+    opentelemetry-api >= 0.2a.0
 
 [options.packages.find]
 where = src

--- a/ext/opentelemetry-ext-wsgi/setup.cfg
+++ b/ext/opentelemetry-ext-wsgi/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.2a.0
+    opentelemetry-api >= 0.2a0
 
 [options.packages.find]
 where = src

--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.2a.0"

--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2a.0"
+__version__ = "0.2a0"

--- a/opentelemetry-api/src/opentelemetry/util/version.py
+++ b/opentelemetry-api/src/opentelemetry/util/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.2a.0"

--- a/opentelemetry-api/src/opentelemetry/util/version.py
+++ b/opentelemetry-api/src/opentelemetry/util/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2a.0"
+__version__ = "0.2a0"

--- a/opentelemetry-sdk/setup.py
+++ b/opentelemetry-sdk/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     description="OpenTelemetry Python SDK",
     include_package_data=True,
     long_description=open("README.rst").read(),
-    install_requires=["opentelemetry-api==0.1.dev0"],
+    install_requires=["opentelemetry-api==0.2a.0"],
     extras_require={},
     license="Apache-2.0",
     package_dir={"": "src"},

--- a/opentelemetry-sdk/setup.py
+++ b/opentelemetry-sdk/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     description="OpenTelemetry Python SDK",
     include_package_data=True,
     long_description=open("README.rst").read(),
-    install_requires=["opentelemetry-api==0.2a.0"],
+    install_requires=["opentelemetry-api==0.2a0"],
     extras_require={},
     license="Apache-2.0",
     package_dir={"": "src"},

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.2a.0"

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2a.0"
+__version__ = "0.2a0"


### PR DESCRIPTION
Like #190, this PR sets the version number for all packages to `0.2a0`, and sets this as the minimum required version when one package depends on another.

We'll have to bump the version numbers on master and update the README once this is released.