### PR TITLE
Update changelogs for 0.2a0 release

### DIFF
--- a/ext/opentelemetry-ext-azure-monitor/CHANGELOG.md
+++ b/ext/opentelemetry-ext-azure-monitor/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
-## 0.1a.0
+## 0.2a0
+
+Released 2019-10-29
+
+- Updates for core library changes
+
+## 0.1a0
+
 Released 2019-09-30
 
 - Initial release

--- a/ext/opentelemetry-ext-http-requests/CHANGELOG.md
+++ b/ext/opentelemetry-ext-http-requests/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
-## 0.1a.0
+## 0.2a0
+
+Released 2019-10-29
+
+- Updates for core library changes
+
+## 0.1a0
+
 Released 2019-09-30
 
 - Initial release

--- a/ext/opentelemetry-ext-jaeger/CHANGELOG.md
+++ b/ext/opentelemetry-ext-jaeger/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+## 0.2a.0
+
+Released 2019-10-29
+
+- Initial release

--- a/ext/opentelemetry-ext-opentracing-shim/CHANGELOG.md
+++ b/ext/opentelemetry-ext-opentracing-shim/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+## 0.2a.0
+
+Released 2019-10-29
+
+- Initial release

--- a/ext/opentelemetry-ext-wsgi/CHANGELOG.md
+++ b/ext/opentelemetry-ext-wsgi/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
-## 0.1a.0
+## 0.2a0
+
+Released 2019-10-29
+
+- Updates for core library changes
+
+## 0.1a0
+
 Released 2019-09-30
 
 - Initial release

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -1,9 +1,22 @@
 # Changelog
 
 ## Unreleased
-- Initial release
 
-## 0.1a.0
+## 0.2a0
+
+Released 2019-10-29
+
+- W3C TraceContext fixes and compliance tests
+  ([#228](https://github.com/open-telemetry/opentelemetry-python/pull/228))
+- Multiple metrics API changes
+- Multiple tracing API changes
+- Multiple context API changes
+- Sampler API
+  ([#225](https://github.com/open-telemetry/opentelemetry-python/pull/225))
+- Multiple bugfixes and improvements
+
+## 0.1a0
+
 Released 2019-09-30
 
 - Initial release

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 ## Unreleased
 
-## 0.1a.0
+## 0.2a0
+
+Released 2019-10-29
+
+- W3C TraceContext fixes and compliance tests
+  ([#228](https://github.com/open-telemetry/opentelemetry-python/pull/228))
+- Multiple metrics SDK changes
+- Multiple tracing SDK changes
+- Sampler SDK
+  ([#225](https://github.com/open-telemetry/opentelemetry-python/pull/225))
+- Multiple bugfixes and improvements
+
+## 0.1a0
+
 Released 2019-09-30
 
 - Initial release


### PR DESCRIPTION
Follow-up to #251. See also #250, though ideally we'd have merged this PR before that one.

We have to choose whether to update the changelogs before or after release. One benefit of changing them on master before the release is that we can split off the release branch after updating them, but before updating the version number. After the split the release branch should get the next release version (here `0.2a0`) and the master branch should get the next dev version (here `0.3.dev0`).

This matches the OpenCensus release strategy with one important exception: here all `ext` packages get the same version, even if they haven't been updated since the last release. This is why the new `ext-jaeger` and `ext-opencensus-shim` packages start at version `0.2a0`.