### PR TITLE
Version number normalization test

### DIFF
--- a/ext/opentelemetry-ext-azure-monitor/tests/test_package.py
+++ b/ext/opentelemetry-ext-azure-monitor/tests/test_package.py
@@ -1,0 +1,28 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pkg_resources
+
+from opentelemetry.ext.azure_monitor import version
+
+
+class TestVersion(unittest.TestCase):
+    def test_version(self):
+        """Check that the version number is normalized."""
+        self.assertEqual(
+            version.__version__,
+            str(pkg_resources.parse_version(version.__version__)),
+        )

--- a/ext/opentelemetry-ext-http-requests/tests/test_package.py
+++ b/ext/opentelemetry-ext-http-requests/tests/test_package.py
@@ -1,0 +1,28 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pkg_resources
+
+from opentelemetry.ext.http_requests import version
+
+
+class TestVersion(unittest.TestCase):
+    def test_version(self):
+        """Check that the version number is normalized."""
+        self.assertEqual(
+            version.__version__,
+            str(pkg_resources.parse_version(version.__version__)),
+        )

--- a/ext/opentelemetry-ext-jaeger/tests/test_package.py
+++ b/ext/opentelemetry-ext-jaeger/tests/test_package.py
@@ -1,0 +1,28 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pkg_resources
+
+from opentelemetry.ext.jaeger import version
+
+
+class TestVersion(unittest.TestCase):
+    def test_version(self):
+        """Check that the version number is normalized."""
+        self.assertEqual(
+            version.__version__,
+            str(pkg_resources.parse_version(version.__version__)),
+        )

--- a/ext/opentelemetry-ext-opentracing-shim/tests/test_package.py
+++ b/ext/opentelemetry-ext-opentracing-shim/tests/test_package.py
@@ -1,0 +1,28 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pkg_resources
+
+from opentelemetry.ext.opentracing_shim import version
+
+
+class TestVersion(unittest.TestCase):
+    def test_version(self):
+        """Check that the version number is normalized."""
+        self.assertEqual(
+            version.__version__,
+            str(pkg_resources.parse_version(version.__version__)),
+        )

--- a/ext/opentelemetry-ext-wsgi/test_package.py
+++ b/ext/opentelemetry-ext-wsgi/test_package.py
@@ -1,0 +1,28 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pkg_resources
+
+from opentelemetry.ext.wsgi import version
+
+
+class TestVersion(unittest.TestCase):
+    def test_version(self):
+        """Check that the version number is normalized."""
+        self.assertEqual(
+            version.__version__,
+            str(pkg_resources.parse_version(version.__version__)),
+        )

--- a/opentelemetry-api/tests/test_package.py
+++ b/opentelemetry-api/tests/test_package.py
@@ -1,0 +1,28 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pkg_resources
+
+from opentelemetry.util import version
+
+
+class TestVersion(unittest.TestCase):
+    def test_version(self):
+        """Check that the version number is normalized."""
+        self.assertEqual(
+            version.__version__,
+            str(pkg_resources.parse_version(version.__version__)),
+        )

--- a/opentelemetry-sdk/tests/test_package.py
+++ b/opentelemetry-sdk/tests/test_package.py
@@ -1,0 +1,28 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pkg_resources
+
+from opentelemetry.sdk import version
+
+
+class TestVersion(unittest.TestCase):
+    def test_version(self):
+        """Check that the version number is normalized."""
+        self.assertEqual(
+            version.__version__,
+            str(pkg_resources.parse_version(version.__version__)),
+        )


### PR DESCRIPTION
From @Oberon00's comment: https://github.com/open-telemetry/opentelemetry-python/pull/250#discussion_r339971776.

@Oberon00 do you think it's worth including tests like this?

This PR adds a test for each package to check that the version number is normalized, similar to the [check in the Dynatrace OneAgent SDK](https://github.com/Dynatrace/OneAgent-SDK-for-Python/blob/a59b28cc9cdb7f818dee9304903d91df69eb31f0/setup.py#L71-L74). It checks that the verison is importable in each package, and matches the normalized version according to `pkg_resources`.

We're unlikely to make this particular mistake again, but it can't hurt to test it.