### PR TITLE
Adding warning to log/log_event calls

### DIFF
--- a/ext/opentelemetry-ext-opentracing-shim/setup.cfg
+++ b/ext/opentelemetry-ext-opentracing-shim/setup.cfg
@@ -39,6 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
+    Deprecated >= 1.2.6
     opentracing
     opentelemetry-api
 

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
@@ -15,6 +15,7 @@
 import logging
 
 import opentracing
+from deprecated import deprecated
 
 from opentelemetry.ext.opentracing_shim import util
 
@@ -77,6 +78,14 @@ class SpanShim(opentracing.Span):
         self._otel_span.add_event(event_name, event_timestamp, key_values)
         return self
 
+    @deprecated(reason="This method is deprecated in favor of log_kv")
+    def log(self, **kwargs):
+        super().log(**kwargs)
+
+    @deprecated(reason="This method is deprecated in favor of log_kv")
+    def log_event(self, event, payload=None):
+        super().log_event(event, payload=payload)
+
     def set_baggage_item(self, key, value):
         logger.warning(
             "Calling unimplemented method set_baggage_item() on class %s",
@@ -90,10 +99,6 @@ class SpanShim(opentracing.Span):
             self.__class__.__name__,
         )
         # TODO: Implement.
-
-    # TODO: Verify calls to deprecated methods `log_event()` and `log()` on
-    # base class work properly (it's probably fine because both methods call
-    # `log_kv()`).
 
 
 class ScopeShim(opentracing.Scope):

--- a/ext/opentelemetry-ext-opentracing-shim/tests/test_shim.py
+++ b/ext/opentelemetry-ext-opentracing-shim/tests/test_shim.py
@@ -406,6 +406,28 @@ class TestShim(unittest.TestCase):
             # biggest possible loss of precision.
             self.assertAlmostEqual(result, now, places=6)
 
+    def test_log(self):
+        """Test the `log` method on `Span` objects."""
+
+        with self.shim.start_span("TestSpan") as span:
+            with self.assertWarns(DeprecationWarning):
+                span.log(event="foo", payload="bar")
+
+        self.assertEqual(span.unwrap().events[0].attributes["event"], "foo")
+        self.assertEqual(span.unwrap().events[0].attributes["payload"], "bar")
+        self.assertIsNotNone(span.unwrap().events[0].timestamp)
+
+    def test_log_event(self):
+        """Test the `log_event` method on `Span` objects."""
+
+        with self.shim.start_span("TestSpan") as span:
+            with self.assertWarns(DeprecationWarning):
+                span.log_event("foo", "bar")
+
+        self.assertEqual(span.unwrap().events[0].attributes["event"], "foo")
+        self.assertEqual(span.unwrap().events[0].attributes["payload"], "bar")
+        self.assertIsNotNone(span.unwrap().events[0].timestamp)
+
     def test_span_context(self):
         """Test construction of `SpanContextShim` objects."""
 

--- a/ext/opentelemetry-ext-opentracing-shim/tests/test_shim.py
+++ b/ext/opentelemetry-ext-opentracing-shim/tests/test_shim.py
@@ -407,7 +407,7 @@ class TestShim(unittest.TestCase):
             self.assertAlmostEqual(result, now, places=6)
 
     def test_log(self):
-        """Test the `log` method on `Span` objects."""
+        """Test the deprecated `log` method on `Span` objects."""
 
         with self.shim.start_span("TestSpan") as span:
             with self.assertWarns(DeprecationWarning):
@@ -418,7 +418,7 @@ class TestShim(unittest.TestCase):
         self.assertIsNotNone(span.unwrap().events[0].timestamp)
 
     def test_log_event(self):
-        """Test the `log_event` method on `Span` objects."""
+        """Test the deprecated `log_event` method on `Span` objects."""
 
         with self.shim.start_span("TestSpan") as span:
             with self.assertWarns(DeprecationWarning):


### PR DESCRIPTION
Tested that calling log/log_event worked without implementing them. The implementation is strictly to log a warning when those deprecated methods are called.

Signed-off-by: Alex Boten <aboten@lightstep.com>