### PR TITLE
Removing add_link and add_lazy_link from api/sdk

### DIFF
--- a/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
+++ b/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
@@ -1,6 +1,6 @@
 import time
 
-from opentelemetry import trace, trace_api
+from opentelemetry import trace
 from opentelemetry.ext import jaeger
 from opentelemetry.sdk.trace import Tracer
 from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
@@ -34,7 +34,7 @@ with tracer.start_as_current_span("foo") as foo:
     foo.set_attribute("my_atribbute", True)
     foo.add_event("event in foo", {"name": "foo1"})
     with tracer.start_as_current_span(
-        "bar", links=[trace_api.Link(foo.get_context())]
+        "bar", links=[trace.Link(foo.get_context())]
     ) as bar:
         time.sleep(0.2)
         bar.set_attribute("speed", 100.0)

--- a/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
+++ b/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
@@ -1,6 +1,6 @@
 import time
 
-from opentelemetry import trace
+from opentelemetry import trace, trace_api
 from opentelemetry.ext import jaeger
 from opentelemetry.sdk.trace import Tracer
 from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
@@ -33,10 +33,11 @@ with tracer.start_as_current_span("foo") as foo:
     time.sleep(0.1)
     foo.set_attribute("my_atribbute", True)
     foo.add_event("event in foo", {"name": "foo1"})
-    with tracer.start_as_current_span("bar") as bar:
+    with tracer.start_as_current_span(
+        "bar", links=[trace_api.Link(foo.get_context())]
+    ) as bar:
         time.sleep(0.2)
         bar.set_attribute("speed", 100.0)
-        bar.add_link(foo.get_context())
 
         with tracer.start_as_current_span("baz") as baz:
             time.sleep(0.3)

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
@@ -228,7 +228,7 @@ class TracerShim(opentracing.Tracer):
         # use a `None` parent, which triggers the creation of a new trace.
         parent = child_of.unwrap() if child_of else None
 
-        links = None
+        links = ()
         if references:
             links = []
             for ref in references:

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
@@ -15,7 +15,6 @@
 import logging
 
 import opentracing
-
 from deprecated import deprecated
 
 import opentelemetry.trace as trace_api

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
@@ -233,9 +233,8 @@ class TracerShim(opentracing.Tracer):
         # use a `None` parent, which triggers the creation of a new trace.
         parent = child_of.unwrap() if child_of else None
 
-        links = ()
+        links = []
         if references:
-            links = []
             for ref in references:
                 links.append(trace_api.Link(ref.referenced_context.unwrap()))
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -76,15 +76,15 @@ ParentSpan = typing.Optional[typing.Union["Span", "SpanContext"]]
 class Link:
     """A link to a `Span`."""
 
-    empty_attributes = {}  # type: typing.Dict[str, types.AttributeValue]
-
     def __init__(
         self, context: "SpanContext", attributes: types.Attributes = None
     ) -> None:
         self._context = context
         self._attributes = attributes
         if attributes is None:
-            self._attributes = Link.empty_attributes
+            self._attributes = (
+                {}
+            )  # type: typing.Dict[str, types.AttributeValue]
 
     @property
     def context(self) -> "SpanContext":

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -76,7 +76,7 @@ ParentSpan = typing.Optional[typing.Union["Span", "SpanContext"]]
 class Link:
     """A link to a `Span`."""
 
-    empty_attributes = {} # type: typing.Dict[str, typing.Union[str, bool, float]]
+    empty_attributes = {}  # type: typing.Dict[str, types.AttributeValue]
 
     def __init__(
         self, context: "SpanContext", attributes: types.Attributes = None

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -81,9 +81,7 @@ class Link:
     ) -> None:
         self._context = context
         if attributes is None:
-            self._attributes = (
-                {}
-            )  # type: typing.Dict[str, types.AttributeValue]
+            self._attributes = {}  # type: types.Attributes
         else:
             self._attributes = attributes
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -80,11 +80,12 @@ class Link:
         self, context: "SpanContext", attributes: types.Attributes = None
     ) -> None:
         self._context = context
-        self._attributes = attributes
         if attributes is None:
             self._attributes = (
                 {}
             )  # type: typing.Dict[str, types.AttributeValue]
+        else:
+            self._attributes = attributes
 
     @property
     def context(self) -> "SpanContext":

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -402,6 +402,7 @@ class Tracer:
         name: str,
         parent: ParentSpan = CURRENT_SPAN,
         kind: SpanKind = SpanKind.INTERNAL,
+        attributes: typing.Optional[types.Attributes] = None,
         links: typing.Sequence[Link] = (),
     ) -> "Span":
         """Starts a span.
@@ -431,6 +432,7 @@ class Tracer:
             parent: The span's parent. Defaults to the current span.
             kind: The span's kind (relationship to parent). Note that is
                 meaningful even if there is no parent.
+            attributes: The span's attributes.
             links: Links span to other spans
 
         Returns:
@@ -445,6 +447,7 @@ class Tracer:
         name: str,
         parent: ParentSpan = CURRENT_SPAN,
         kind: SpanKind = SpanKind.INTERNAL,
+        attributes: typing.Optional[types.Attributes] = None,
         links: typing.Sequence[Link] = (),
     ) -> typing.Iterator["Span"]:
         """Context manager for creating a new span and set it
@@ -481,6 +484,7 @@ class Tracer:
             parent: The span's parent. Defaults to the current span.
             kind: The span's kind (relationship to parent). Note that is
                 meaningful even if there is no parent.
+            attributes: The span's attributes.
             links: Links span to other spans
 
         Yields:
@@ -495,6 +499,7 @@ class Tracer:
         name: str,
         parent: ParentSpan = CURRENT_SPAN,
         kind: SpanKind = SpanKind.INTERNAL,
+        attributes: typing.Optional[types.Attributes] = None,
         links: typing.Sequence[Link] = (),
     ) -> "Span":
         """Creates a span.
@@ -525,6 +530,7 @@ class Tracer:
             parent: The span's parent. Defaults to the current span.
             kind: The span's kind (relationship to parent). Note that is
                 meaningful even if there is no parent.
+            attributes: The span's attributes.
             links: Links span to other spans
 
         Returns:

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -431,7 +431,7 @@ class Tracer:
             parent: The span's parent. Defaults to the current span.
             kind: The span's kind (relationship to parent). Note that is
                 meaningful even if there is no parent.
-            links: The span's links, to be used in sampling decisions
+            links: Links span to other spans
 
         Returns:
             The newly-created span.
@@ -481,7 +481,7 @@ class Tracer:
             parent: The span's parent. Defaults to the current span.
             kind: The span's kind (relationship to parent). Note that is
                 meaningful even if there is no parent.
-            links: The span's links, to be used in sampling decisions
+            links: Links span to other spans
 
         Yields:
             The newly-created span.
@@ -525,7 +525,7 @@ class Tracer:
             parent: The span's parent. Defaults to the current span.
             kind: The span's kind (relationship to parent). Note that is
                 meaningful even if there is no parent.
-            links: The span's links, to be used in sampling decisions
+            links: Links span to other spans
 
         Returns:
             The newly-created span.

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -75,12 +75,15 @@ ParentSpan = typing.Optional[typing.Union["Span", "SpanContext"]]
 
 class Link:
     """A link to a `Span`."""
+    empty_attributes: typing.Dict[str, types.AttributeValue] = dict()
 
     def __init__(
         self, context: "SpanContext", attributes: types.Attributes = None
     ) -> None:
         self._context = context
         self._attributes = attributes
+        if attributes is None:
+            self._attributes = Link.empty_attributes
 
     @property
     def context(self) -> "SpanContext":
@@ -196,23 +199,6 @@ class Span:
         """Adds an `Event`.
 
         Adds an `Event` that has previously been created.
-        """
-
-    def add_link(
-        self,
-        link_target_context: "SpanContext",
-        attributes: types.Attributes = None,
-    ) -> None:
-        """Adds a `Link` to another span.
-
-        Adds a single `Link` from this Span to another Span identified by the
-        `SpanContext` passed as argument.
-        """
-
-    def add_lazy_link(self, link: "Link") -> None:
-        """Adds a `Link` to another span.
-
-        Adds a `Link` that has previously been created.
         """
 
     def update_name(self, name: str) -> None:
@@ -416,6 +402,7 @@ class Tracer:
         name: str,
         parent: ParentSpan = CURRENT_SPAN,
         kind: SpanKind = SpanKind.INTERNAL,
+        links: typing.Sequence[Link] = (),
     ) -> "Span":
         """Starts a span.
 
@@ -457,6 +444,7 @@ class Tracer:
         name: str,
         parent: ParentSpan = CURRENT_SPAN,
         kind: SpanKind = SpanKind.INTERNAL,
+        links: typing.Sequence[Link] = (),
     ) -> typing.Iterator["Span"]:
         """Context manager for creating a new span and set it
         as the current span in this tracer's context.
@@ -505,6 +493,7 @@ class Tracer:
         name: str,
         parent: ParentSpan = CURRENT_SPAN,
         kind: SpanKind = SpanKind.INTERNAL,
+        links: typing.Sequence[Link] = (),
     ) -> "Span":
         """Creates a span.
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -75,7 +75,7 @@ ParentSpan = typing.Optional[typing.Union["Span", "SpanContext"]]
 
 class Link:
     """A link to a `Span`."""
-    empty_attributes: typing.Dict[str, types.AttributeValue] = dict()
+    empty_attributes = {}
 
     def __init__(
         self, context: "SpanContext", attributes: types.Attributes = None

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -431,6 +431,7 @@ class Tracer:
             parent: The span's parent. Defaults to the current span.
             kind: The span's kind (relationship to parent). Note that is
                 meaningful even if there is no parent.
+            links: The span's links, to be used in sampling decisions
 
         Returns:
             The newly-created span.
@@ -480,6 +481,7 @@ class Tracer:
             parent: The span's parent. Defaults to the current span.
             kind: The span's kind (relationship to parent). Note that is
                 meaningful even if there is no parent.
+            links: The span's links, to be used in sampling decisions
 
         Yields:
             The newly-created span.
@@ -523,6 +525,7 @@ class Tracer:
             parent: The span's parent. Defaults to the current span.
             kind: The span's kind (relationship to parent). Note that is
                 meaningful even if there is no parent.
+            links: The span's links, to be used in sampling decisions
 
         Returns:
             The newly-created span.

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -75,7 +75,8 @@ ParentSpan = typing.Optional[typing.Union["Span", "SpanContext"]]
 
 class Link:
     """A link to a `Span`."""
-    empty_attributes = {}
+
+    empty_attributes = {} # type: typing.Dict[str, typing.Union[str, bool, float]]
 
     def __init__(
         self, context: "SpanContext", attributes: types.Attributes = None

--- a/opentelemetry-api/src/opentelemetry/trace/sampling.py
+++ b/opentelemetry-api/src/opentelemetry/trace/sampling.py
@@ -17,7 +17,7 @@ from typing import Dict, Mapping, Optional, Sequence
 
 # pylint: disable=unused-import
 from opentelemetry.trace import Link, SpanContext
-from opentelemetry.util.types import AttributeValue
+from opentelemetry.util.types import Attributes, AttributeValue
 
 
 class Decision:
@@ -53,6 +53,7 @@ class Sampler(abc.ABC):
         trace_id: int,
         span_id: int,
         name: str,
+        attributes: Optional[Attributes] = None,
         links: Sequence["Link"] = (),
     ) -> "Decision":
         pass
@@ -70,6 +71,7 @@ class StaticSampler(Sampler):
         trace_id: int,
         span_id: int,
         name: str,
+        attributes: Optional[Attributes] = None,
         links: Sequence["Link"] = (),
     ) -> "Decision":
         return self._decision
@@ -107,6 +109,7 @@ class ProbabilitySampler(Sampler):
         trace_id: int,
         span_id: int,
         name: str,
+        attributes: Optional[Attributes] = None,  # TODO
         links: Sequence["Link"] = (),
     ) -> "Decision":
         if parent_context is not None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -130,7 +130,7 @@ class Span(trace_api.Span):
         resource: None = None,  # TODO
         attributes: types.Attributes = None,  # TODO
         events: Sequence[trace_api.Event] = None,  # TODO
-        links: Sequence[trace_api.Link] = None,
+        links: Sequence[trace_api.Link] = (),
         kind: trace_api.SpanKind = trace_api.SpanKind.INTERNAL,
         span_processor: SpanProcessor = SpanProcessor(),
     ) -> None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -400,16 +400,17 @@ class Tracer(trace_api.Tracer):
 
         if sampling_decision.sampled:
             if attributes is None:
-                attributes = sampling_decision.attributes
+                span_attributes = sampling_decision.attributes
             else:
                 # apply sampling decision attributes after initial attributes
-                attributes = {**attributes, **sampling_decision.attributes}
+                span_attributes = attributes.copy()
+                span_attributes.update(sampling_decision.attributes)
             return Span(
                 name=name,
                 context=context,
                 parent=parent,
                 sampler=self.sampler,
-                attributes=attributes,
+                attributes=span_attributes,
                 span_processor=self._active_span_processor,
                 kind=kind,
                 links=links,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -387,11 +387,7 @@ class Tracer(trace_api.Tracer):
         # The sampler may also add attributes to the newly-created span, e.g.
         # to include information about the sampling decision.
         sampling_decision = self.sampler.should_sample(
-            parent_context,
-            context.trace_id,
-            context.span_id,
-            name,
-            {},  # TODO: links
+            parent_context, context.trace_id, context.span_id, name, links,
         )
 
         if sampling_decision.sampled:

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -361,11 +361,6 @@ class TestSpan(unittest.TestCase):
         """"Events, attributes are not allowed after span is ended"""
         tracer = trace.Tracer("test_ended_span")
 
-        other_context1 = trace_api.SpanContext(
-            trace_id=trace.generate_trace_id(),
-            span_id=trace.generate_span_id(),
-        )
-
         with tracer.start_as_current_span("root") as root:
             # everything should be empty at the beginning
             self.assertEqual(len(root.attributes), 0)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -248,6 +248,46 @@ class TestSpan(unittest.TestCase):
             self.assertEqual(root.attributes["misc.pi"], 3.14)
             self.assertEqual(root.attributes["attr-key"], "attr-value2")
 
+        attributes = {
+            "attr-key": "val",
+            "attr-key2": "val2",
+            "attr-in-both": "span-attr",
+        }
+        with self.tracer.start_as_current_span(
+            "root2", attributes=attributes
+        ) as root:
+            self.assertEqual(len(root.attributes), 3)
+            self.assertEqual(root.attributes["attr-key"], "val")
+            self.assertEqual(root.attributes["attr-key2"], "val2")
+            self.assertEqual(root.attributes["attr-in-both"], "span-attr")
+
+        decision_attributes = {
+            "sampler-attr": "sample-val",
+            "attr-in-both": "decision-attr",
+        }
+        self.tracer.sampler = sampling.StaticSampler(
+            sampling.Decision(sampled=True, attributes=decision_attributes)
+        )
+
+        with self.tracer.start_as_current_span("root2") as root:
+            self.assertEqual(len(root.attributes), 2)
+            self.assertEqual(root.attributes["sampler-attr"], "sample-val")
+            self.assertEqual(root.attributes["attr-in-both"], "decision-attr")
+
+        attributes = {
+            "attr-key": "val",
+            "attr-key2": "val2",
+            "attr-in-both": "span-attr",
+        }
+        with self.tracer.start_as_current_span(
+            "root2", attributes=attributes
+        ) as root:
+            self.assertEqual(len(root.attributes), 4)
+            self.assertEqual(root.attributes["attr-key"], "val")
+            self.assertEqual(root.attributes["attr-key2"], "val2")
+            self.assertEqual(root.attributes["sampler-attr"], "sample-val")
+            self.assertEqual(root.attributes["attr-in-both"], "decision-attr")
+
     def test_events(self):
         self.assertIsNone(self.tracer.get_current_span())
 


### PR DESCRIPTION
Definitely still a work in progress. Removing `add_link` and `add_lazy_link` from api/sdk. From the [open-telemetry/oteps#28](https://github.com/open-telemetry/oteps/pull/28), it appeared the only place where it made sense to add links was in the `start_span`, `create_span` and `start_as_current_span` if we want to be able to add them to the Span before it's constructed. Would love some feedback on this.

Still need to address the other part of the OTEP regarding Attributes
 
Signed-off-by: Alex Boten <aboten@lightstep.com>