### PR TITLE
Bump version to 0.3.dev0

### DIFF
--- a/examples/opentelemetry-example-app/setup.py
+++ b/examples/opentelemetry-example-app/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="opentelemetry-example-app",
-    version="0.1.dev0",
+    version="0.3.dev0",
     author="OpenTelemetry Authors",
     author_email="cncf-opentelemetry-contributors@lists.cncf.io",
     classifiers=[

--- a/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/version.py
+++ b/ext/opentelemetry-ext-azure-monitor/src/opentelemetry/ext/azure_monitor/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.3.dev0"

--- a/ext/opentelemetry-ext-http-requests/setup.cfg
+++ b/ext/opentelemetry-ext-http-requests/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.1.dev0
+    opentelemetry-api >= 0.3.dev0
     requests ~= 2.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.3.dev0"

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.3.dev0"

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.3.dev0"

--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.3.dev0"

--- a/opentelemetry-api/src/opentelemetry/util/version.py
+++ b/opentelemetry-api/src/opentelemetry/util/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.3.dev0"

--- a/opentelemetry-sdk/setup.py
+++ b/opentelemetry-sdk/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
     include_package_data=True,
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
-    install_requires=["opentelemetry-api==0.1.dev0"],
+    install_requires=["opentelemetry-api==0.3.dev0"],
     extras_require={},
     license="Apache-2.0",
     package_dir={"": "src"},

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.dev0"
+__version__ = "0.3.dev0"


### PR DESCRIPTION
This PR bumps the version (and required versions) for all packages to `0.3.dev0`, which puts it ahead of the latest release version, `0.2a0`.