### PR TITLE
ext/jaeger: fix example

### DIFF
--- a/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
+++ b/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
@@ -31,8 +31,8 @@ tracer.add_span_processor(span_processor)
 # create some spans for testing
 with tracer.start_as_current_span("foo") as foo:
     time.sleep(0.1)
-    foo.set_attribute("my_atribbute", True)
-    foo.add_event("event in foo", {"name": "foo1"})
+    foo.set_attribute("my_attribute", True)
+    foo.add_event("event in foo", attributes={"name": "foo1"})
     with tracer.start_as_current_span("bar") as bar:
         time.sleep(0.2)
         bar.set_attribute("speed", 100.0)


### PR DESCRIPTION
The example of the jaeger exporter is failing because
e4d89490e870 ("OpenTracing Bridge - Initial implementation (#211)") introduced
a new timestamp parameter to add_event, the example was passing parameter by
position so it was messed up.

I tried to add this to the CI but didn't find an easy way to do it, if somebody has a suggestion it's welcome!