### PR TITLE
Fix docs generation issue in Travis build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -106,7 +106,7 @@ commands =
 deps =
   sphinx~=2.1
   sphinx-rtd-theme~=0.4
-  sphinx-autodoc-typehints~=1.6
+  sphinx-autodoc-typehints<=1.9
 
 changedir = docs
 


### PR DESCRIPTION
Latest version of sphinx-autodoc-typehints is causing warnings in Travis build

https://pypi.org/project/sphinx-autodoc-typehints/#history

#263 