### PR TITLE
api: change order of arguments in add_event

### DIFF
--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
@@ -75,7 +75,7 @@ class SpanShim(opentracing.Span):
             event_timestamp = None
 
         event_name = util.event_name_from_kv(key_values)
-        self._otel_span.add_event(event_name, event_timestamp, key_values)
+        self._otel_span.add_event(event_name, key_values, event_timestamp)
         return self
 
     @deprecated(reason="This method is deprecated in favor of log_kv")

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -95,7 +95,7 @@ class Event:
     """A text annotation with a set of attributes."""
 
     def __init__(
-        self, name: str, timestamp: int, attributes: types.Attributes = None
+        self, name: str, attributes: types.Attributes, timestamp: int
     ) -> None:
         self._name = name
         self._attributes = attributes
@@ -182,8 +182,8 @@ class Span:
     def add_event(
         self,
         name: str,
-        timestamp: int = None,
         attributes: types.Attributes = None,
+        timestamp: int = None,
     ) -> None:
         """Adds an `Event`.
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -202,14 +202,14 @@ class Span(trace_api.Span):
     def add_event(
         self,
         name: str,
-        timestamp: int = None,
         attributes: types.Attributes = None,
+        timestamp: int = None,
     ) -> None:
         self.add_lazy_event(
             trace_api.Event(
                 name,
-                time_ns() if timestamp is None else timestamp,
                 Span.empty_attributes if attributes is None else attributes,
+                time_ns() if timestamp is None else timestamp,
             )
         )
 

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -264,27 +264,37 @@ class TestSpan(unittest.TestCase):
             self.assertEqual(root.attributes["attr-key"], "attr-value2")
 
             # events
+            # only event name
             root.add_event("event0")
+
+            # event name and attributes
             now = time_ns()
-            root.add_event(
-                "event1", timestamp=now, attributes={"name": "birthday"}
-            )
+            root.add_event("event1", {"name": "pluto"})
+
+            # event name, attributes and timestamp
+            now = time_ns()
+            root.add_event("event2", {"name": "birthday"}, now)
+
+            # lazy event
             root.add_lazy_event(
-                trace_api.Event("event2", now, {"name": "hello"})
+                trace_api.Event("event3", {"name": "hello"}, now)
             )
 
-            self.assertEqual(len(root.events), 3)
+            self.assertEqual(len(root.events), 4)
 
             self.assertEqual(root.events[0].name, "event0")
             self.assertEqual(root.events[0].attributes, {})
 
             self.assertEqual(root.events[1].name, "event1")
-            self.assertEqual(root.events[1].attributes, {"name": "birthday"})
-            self.assertEqual(root.events[1].timestamp, now)
+            self.assertEqual(root.events[1].attributes, {"name": "pluto"})
 
             self.assertEqual(root.events[2].name, "event2")
-            self.assertEqual(root.events[2].attributes, {"name": "hello"})
+            self.assertEqual(root.events[2].attributes, {"name": "birthday"})
             self.assertEqual(root.events[2].timestamp, now)
+
+            self.assertEqual(root.events[3].name, "event3")
+            self.assertEqual(root.events[3].attributes, {"name": "hello"})
+            self.assertEqual(root.events[3].timestamp, now)
 
             # links
             root.add_link(other_context1)


### PR DESCRIPTION
e4d89490e870 ("OpenTracing Bridge - Initial implementation (#211)") introduced
a new timestamp argument to the add_event method. This commit moves that
argument to be the last one because it is more common to have event attributes
than an explicitly timestamp.