### PR TITLE
Bump sphinx-autodoc-typehints to 1.10.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -106,7 +106,7 @@ commands =
 deps =
   sphinx~=2.1
   sphinx-rtd-theme~=0.4
-  sphinx-autodoc-typehints<=1.9
+  sphinx-autodoc-typehints~=1.10.2
 
 changedir = docs
 


### PR DESCRIPTION
Quick update to #267 now that https://github.com/agronholm/sphinx-autodoc-typehints/issues/117 is fixed.