### PR TITLE
Skip pytest 5.2.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,10 @@ python =
 
 [testenv]
 deps =
-  test: pytest
+  ; skip 5.2.3 pytest due to bug
+  ; https://github.com/pytest-dev/pytest/issues/6194
+  test: pytest!=5.2.3
+  coverage: pytest!=5.2.3
   coverage: pytest-cov
   mypy,mypyinstalled: mypy~=0.740
 


### PR DESCRIPTION
An issue in pytest 5.2.3 is causing test failures: https://github.com/pytest-dev/pytest/issues/6194 

Signed-off-by: Alex Boten <aboten@lightstep.com>