### PR TITLE
Change v3 alpha release date to 12/6

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,16 +162,16 @@ estimates, and subject to change.
 
 Future releases targets include:
 
-| Component                           | Version    | Target Date      |
-| ----------------------------------- | ---------- | ---------------- |
-| Zipkin Trace Exporter               | Alpha v0.3 | November 15 2019 |
-| W3C Correlation Context Propagation | Alpha v0.3 | November 15 2019 |
-| Support for Tags/Baggage            | Alpha v0.3 | November 15 2019 |
-| Metrics Aggregation                 | Alpha v0.3 | November 15 2019 |
-| gRPC Integrations                   | Alpha v0.3 | November 15 2019 |
-| Prometheus Metrics Exporter         | Alpha v0.3 | November 15 2019 |
+| Component                           | Version    | Target Date     |
+| ----------------------------------- | ---------- | --------------- |
+| Zipkin Trace Exporter               | Alpha v0.3 | December 6 2019 |
+| W3C Correlation Context Propagation | Alpha v0.3 | December 6 2019 |
+| Support for Tags/Baggage            | Alpha v0.3 | December 6 2019 |
+| Metrics Aggregation                 | Alpha v0.3 | December 6 2019 |
+| gRPC Integrations                   | Alpha v0.3 | December 6 2019 |
+| Prometheus Metrics Exporter         | Alpha v0.3 | December 6 2019 |
 
 | Component              | Version    | Target Date      |
 | ---------------------- | ---------- | ---------------- |
 | OpenCensus Bridge      | Alpha v0.4 | December 31 2019 |
-| Metrics SDK (Complete) | Alpha v0.4 | December 31 2019  |
+| Metrics SDK (Complete) | Alpha v0.4 | December 31 2019 |


### PR DESCRIPTION
As discussed in yesterday's SIG meetingm, this PR moves the v3 target release date out three weeks to 12/6 without changing the list of features. I'll update the milestone after this is merged.