### PR TITLE
Fix example tests on Win32.

### DIFF
--- a/examples/basic_tracer/tests/test_tracer.py
+++ b/examples/basic_tracer/tests/test_tracer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import subprocess
+import sys
 import unittest
 
 
@@ -20,7 +21,9 @@ class TestBasicTracerExample(unittest.TestCase):
     def test_basic_tracer(self):
         dirpath = os.path.dirname(os.path.realpath(__file__))
         test_script = "{}/../tracer.py".format(dirpath)
-        output = subprocess.check_output(test_script).decode()
+        output = subprocess.check_output(
+            (sys.executable, test_script)
+        ).decode()
 
         self.assertIn('name="foo"', output)
         self.assertIn('name="bar"', output)

--- a/examples/http/tests/test_http.py
+++ b/examples/http/tests/test_http.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import subprocess
+import sys
 import unittest
 from time import sleep
 
@@ -22,13 +23,15 @@ class TestHttpExample(unittest.TestCase):
     def setup_class(cls):
         dirpath = os.path.dirname(os.path.realpath(__file__))
         server_script = "{}/../server.py".format(dirpath)
-        cls.server = subprocess.Popen([server_script])
+        cls.server = subprocess.Popen([sys.executable, server_script])
         sleep(1)
 
     def test_http(self):
         dirpath = os.path.dirname(os.path.realpath(__file__))
         test_script = "{}/../tracer_client.py".format(dirpath)
-        output = subprocess.check_output(test_script).decode()
+        output = subprocess.check_output(
+            (sys.executable, test_script)
+        ).decode()
         self.assertIn('name="/"', output)
 
     @classmethod


### PR DESCRIPTION
They were previously failing with

    OSError: [WinError 193] %1 is not a valid Win32 application

Since subprocess.Popen directly calls CreateProcess and the Windows
kernel doesn't support shebangs (even if it did, /usr/bin/env is not a
path that leads to a valid executable usually), we need to manually
specify sys.executable ('python' would not work since it would leave the
virtualenv).