### PR TITLE
Add typeguard, use with pytest

### DIFF
--- a/opentelemetry-api/tests/conftest.py
+++ b/opentelemetry-api/tests/conftest.py
@@ -1,0 +1,19 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def pytest_sessionstart(session):
+    from typeguard.importhook import install_import_hook
+
+    install_import_hook("opentelemetry")

--- a/opentelemetry-sdk/tests/conftest.py
+++ b/opentelemetry-sdk/tests/conftest.py
@@ -1,0 +1,19 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def pytest_sessionstart(session):
+    from typeguard.importhook import install_import_hook
+
+    install_import_hook("opentelemetry")

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
   ; skip 5.2.3 pytest due to bug
   ; https://github.com/pytest-dev/pytest/issues/6194
   test: pytest!=5.2.3
+  test: typeguard
   coverage: pytest!=5.2.3
   coverage: pytest-cov
   mypy,mypyinstalled: mypy==0.740


### PR DESCRIPTION
Inspired by https://github.com/open-telemetry/opentelemetry-python/pull/258#discussion_r352705122. It would be great to use our existing type annotations in tests at *run*time. I.e., without annotating the tests themselves. Hopefully this uncovers some false-positive tests.

This uses [typeguard](https://github.com/agronholm/typeguard) to do runtime checking via an [import hook](https://typeguard.readthedocs.io/en/latest/#using-the-import-hook), which should earmark all `opentelemetry` code for checking.

This PR is very experimental, and may not be a good approach. Caveat reviewer!