### PR TITLE
Remove obsolete version requirement for pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,8 @@ python =
 
 [testenv]
 deps =
-  ; skip 5.2.3 pytest due to bug
-  ; https://github.com/pytest-dev/pytest/issues/6194
-  test: pytest!=5.2.3
-  coverage: pytest!=5.2.3
+  test: pytest
+  coverage: pytest
   coverage: pytest-cov
   mypy,mypyinstalled: mypy==0.740
 


### PR DESCRIPTION
Quick update to #293 now that https://github.com/pytest-dev/pytest/issues/6194 is fixed.

Note that there wouldn't be any harm in leaving the required version as is: users should pick up the latest version (`5.3.1` as of this writing) which include the fix in either case.