### PR TITLE
Update CODEOWNERS to include only python-approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-*               @a-feld @c24t @carlosalberto @lzchen @Oberon00 @reyang @toumorokoshi
+*               @open-telemetry/python-approvers


### PR DESCRIPTION
Make CODEOWNERS use https://github.com/orgs/open-telemetry/teams/python-approvers/members at @a-feld's suggestion.

The only effect of this change is to remove @a-feld -- who isn't currently active in this repo -- from CODEOWNERS.