### PR TITLE
Do full Sphinx build every time to not hide errors.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -160,7 +160,7 @@ deps =
 changedir = docs
 
 commands =
-  sphinx-build -W --keep-going -b html -T . _build/html
+  sphinx-build -E -a -W --keep-going -b html -T . _build/html
 
 [testenv:py37-tracecontext]
 basepython: python3.7


### PR DESCRIPTION
See https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-e and https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-a. Otherwise, if you run the build two times, most warnings from the first build will be silently ignored if you didn't change the affected files.