### PR TITLE
Pick up changelogs from #328, update dev version

### DIFF
--- a/examples/opentelemetry-example-app/setup.py
+++ b/examples/opentelemetry-example-app/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="opentelemetry-example-app",
-    version="0.3.dev0",
+    version="0.4.dev0",
     author="OpenTelemetry Authors",
     author_email="cncf-opentelemetry-contributors@lists.cncf.io",
     classifiers=[

--- a/ext/opentelemetry-ext-flask/CHANGELOG.md
+++ b/ext/opentelemetry-ext-flask/CHANGELOG.md
@@ -6,8 +6,4 @@
 
 Released 2019-12-11
 
-## 0.2a0
-
-Released 2019-10-29
-
 - Initial release

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/version.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3dev0"
+__version__ = "0.4.dev0"

--- a/ext/opentelemetry-ext-http-requests/CHANGELOG.md
+++ b/ext/opentelemetry-ext-http-requests/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.3a0
+
+Released 2019-10-29
+
 ## 0.2a0
 
 Released 2019-10-29

--- a/ext/opentelemetry-ext-http-requests/setup.cfg
+++ b/ext/opentelemetry-ext-http-requests/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.3.dev0
+    opentelemetry-api >= 0.4.dev0
     requests ~= 2.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.dev0"
+__version__ = "0.4.dev0"

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.dev0"
+__version__ = "0.4.dev0"

--- a/ext/opentelemetry-ext-opentracing-shim/CHANGELOG.md
+++ b/ext/opentelemetry-ext-opentracing-shim/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
-- Implement extract and inject support for HTTP_HEADERS and TEXT_MAP formats.
+## 0.3a0
+
+Released 2019-12-11
+
+- Implement extract and inject support for HTTP_HEADERS and TEXT_MAP formats
+  ([#256](https://github.com/open-telemetry/opentelemetry-python/pull/290))
 
 ## 0.2a0
 

--- a/ext/opentelemetry-ext-opentracing-shim/CHANGELOG.md
+++ b/ext/opentelemetry-ext-opentracing-shim/CHANGELOG.md
@@ -7,7 +7,7 @@
 Released 2019-12-11
 
 - Implement extract and inject support for HTTP_HEADERS and TEXT_MAP formats
-  ([#256](https://github.com/open-telemetry/opentelemetry-python/pull/290))
+  ([#256](https://github.com/open-telemetry/opentelemetry-python/pull/256))
 
 ## 0.2a0
 

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.dev0"
+__version__ = "0.4.dev0"

--- a/ext/opentelemetry-ext-pymongo/CHANGELOG.md
+++ b/ext/opentelemetry-ext-pymongo/CHANGELOG.md
@@ -6,8 +6,4 @@
 
 Released 2019-12-11
 
-## 0.2a0
-
-Released 2019-10-29
-
 - Initial release

--- a/ext/opentelemetry-ext-pymongo/setup.cfg
+++ b/ext/opentelemetry-ext-pymongo/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.3.dev0
+    opentelemetry-api >= 0.4.dev0
     pymongo ~= 3.1
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/version.py
+++ b/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.dev0"
+__version__ = "0.4.dev0"

--- a/ext/opentelemetry-ext-testutil/src/opentelemetry/ext/testutil/version.py
+++ b/ext/opentelemetry-ext-testutil/src/opentelemetry/ext/testutil/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.3dev0"
+__version__ = "0.4.dev0"

--- a/ext/opentelemetry-ext-wsgi/CHANGELOG.md
+++ b/ext/opentelemetry-ext-wsgi/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.3a0
+
+Released 2019-12-11
+
+- Support new semantic conventions
+  ([#299](https://github.com/open-telemetry/opentelemetry-python/pull/299))
+- Updates for core library changes
+
 ## 0.2a0
 
 Released 2019-10-29

--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.dev0"
+__version__ = "0.4.dev0"

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 0.3a0
+
+Released 2019-12-11
+
+- Multiple tracing API changes
+- Multiple metrics API changes
+- Remove option to create unstarted spans from API
+  ([#290](https://github.com/open-telemetry/opentelemetry-python/pull/290))
+
 ## 0.2a0
 
 Released 2019-10-29

--- a/opentelemetry-api/src/opentelemetry/util/version.py
+++ b/opentelemetry-api/src/opentelemetry/util/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.dev0"
+__version__ = "0.4.dev0"

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 0.3a0
+
+Released 2019-12-11
+
+- Multiple tracing SDK changes
+- Multiple metrics SDK changes
+- Add metrics exporters
+  ([#192](https://github.com/open-telemetry/opentelemetry-python/pull/192))
+- Multiple bugfixes and improvements
+
 ## 0.2a0
 
 Released 2019-10-29

--- a/opentelemetry-sdk/setup.py
+++ b/opentelemetry-sdk/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
     include_package_data=True,
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
-    install_requires=["opentelemetry-api==0.3.dev0"],
+    install_requires=["opentelemetry-api==0.4.dev0"],
     extras_require={},
     license="Apache-2.0",
     package_dir={"": "src"},

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.dev0"
+__version__ = "0.4.dev0"


### PR DESCRIPTION
This PR copies the changelog changes on the release branch from #328 to master, and bumps the development version to `0.4.dev0`.