### PR TITLE
Remove @reyang from maintainers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ Approvers ([@open-telemetry/python-approvers](https://github.com/orgs/open-telem
 - [Carlos Alberto Cortez](https://github.com/carlosalberto), LightStep
 - [Christian Neumüller](https://github.com/Oberon00), Dynatrace
 - [Leighton Chen](https://github.com/lzchen), Microsoft
+- [Reiley Yang](https://github.com/reyang), Microsoft
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
 
 Maintainers ([@open-telemetry/python-maintainers](https://github.com/orgs/open-telemetry/teams/python-maintainers)):
 
 - [Chris Kleinknecht](https://github.com/c24t), Google
-- [Reiley Yang](https://github.com/reyang), Microsoft
 - [Yusuke Tsutsumi](https://github.com/toumorokoshi), Zillow Group
 
 *Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).*


### PR DESCRIPTION
These changes have already been made to the [python-maintainers](https://github.com/orgs/open-telemetry/teams/python-maintainers/members) and [python-approvers](https://github.com/orgs/open-telemetry/teams/python-approvers/members) teams, this PR just updates the README.