### PR TITLE
Updating examples to use tracer_source

### DIFF
--- a/ext/opentelemetry-ext-dbapi/README.rst
+++ b/ext/opentelemetry-ext-dbapi/README.rst
@@ -11,12 +11,12 @@ Usage
 .. code:: python
 
     import mysql.connector
-    from opentelemetry.trace import tracer
+    from opentelemetry.trace import tracer_source
     from opentelemetry.ext.dbapi import trace_integration
 
 
     # Ex: mysql.connector
-    trace_integration(tracer(), mysql.connector, "connect", "mysql")
+    trace_integration(tracer_source(), mysql.connector, "connect", "mysql")
 
 
 References

--- a/ext/opentelemetry-ext-http-requests/README.rst
+++ b/ext/opentelemetry-ext-http-requests/README.rst
@@ -22,9 +22,9 @@ Usage
 
     import requests
     import opentelemetry.ext.http_requests
-    from opentelemetry.trace import tracer
+    from opentelemetry.trace import tracer_source
 
-    opentelemetry.ext.http_requests.enable(tracer())
+    opentelemetry.ext.http_requests.enable(tracer_source())
     response = requests.get(url='https://www.example.org/')
 
 Limitations

--- a/ext/opentelemetry-ext-mysql/README.rst
+++ b/ext/opentelemetry-ext-mysql/README.rst
@@ -12,10 +12,10 @@ Usage
 .. code:: python
 
     import mysql.connector
-    from opentelemetry.trace import tracer
+    from opentelemetry.trace import tracer_source
     from opentelemetry.ext.mysql import trace_integration
 
-    trace_integration(tracer())
+    trace_integration(tracer_source())
     cnx = mysql.connector.connect(database='MySQL_Database')
     cursor = cnx.cursor()
     cursor.execute("INSERT INTO test (testField) VALUES (123)"

--- a/ext/opentelemetry-ext-pymongo/README.rst
+++ b/ext/opentelemetry-ext-pymongo/README.rst
@@ -12,10 +12,10 @@ Usage
 .. code:: python
 
     from pymongo import MongoClient
-    from opentelemetry.trace import tracer
+    from opentelemetry.trace import tracer_source
     from opentelemetry.trace.ext.pymongo import trace_integration
 
-    trace_integration(tracer())
+    trace_integration(tracer_source())
     client = MongoClient()
     db = client["MongoDB_Database"]
     collection = db["MongoDB_Collection"]


### PR DESCRIPTION
Found a few examples that hadn't been updated to use `tracer_source()` instead of `tracer(), updating them here.

Signed-off-by: Alex Boten <aboten@lightstep.com>