### PR TITLE
Remove workaround trace-context failures.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -142,8 +142,6 @@ deps =
   # needed for example trace integration
   flask~=1.1
   requests~=2.7
-  # Pinned due to https://github.com/open-telemetry/opentelemetry-python/issues/329
-  multidict==4.6.1
 
 commands_pre =
   pip install -e {toxinidir}/opentelemetry-api \


### PR DESCRIPTION
Resolves #329. 

As @condorcet pointed out, the Multidict bug affecting #329 has been [fixed](https://github.com/aio-libs/multidict/issues/432). This PR removes the workaround added on #330 as it's no longer needed.

Signed-off-by: dgzlopes <danielgonzalezlopes@gmail.com>