### PR TITLE
flask: using string keys for wsgi environ values

### DIFF
--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
@@ -3,9 +3,8 @@
 
 import logging
 
-from flask import request as flask_request
-
 import opentelemetry.ext.wsgi as otel_wsgi
+from flask import request as flask_request
 from opentelemetry import propagators, trace
 from opentelemetry.ext.flask.version import __version__
 from opentelemetry.util import time_ns

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
@@ -3,8 +3,9 @@
 
 import logging
 
-import opentelemetry.ext.wsgi as otel_wsgi
 from flask import request as flask_request
+
+import opentelemetry.ext.wsgi as otel_wsgi
 from opentelemetry import propagators, trace
 from opentelemetry.ext.flask.version import __version__
 from opentelemetry.util import time_ns

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
@@ -12,9 +12,9 @@ from opentelemetry.util import time_ns
 
 logger = logging.getLogger(__name__)
 
-_ENVIRON_STARTTIME_KEY = object()
-_ENVIRON_SPAN_KEY = object()
-_ENVIRON_ACTIVATION_KEY = object()
+_ENVIRON_STARTTIME_KEY = "opentelemetry-flask.starttime_key"
+_ENVIRON_SPAN_KEY = "opentelemetry-flask.span_key"
+_ENVIRON_ACTIVATION_KEY = "opentelemetry-flask.activation_key"
 
 
 def instrument_app(flask):

--- a/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
+++ b/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
@@ -14,12 +14,13 @@
 
 import unittest
 
-import opentelemetry.ext.flask as otel_flask
 from flask import Flask
-from opentelemetry import trace as trace_api
-from opentelemetry.ext.testutil.wsgitestutil import WsgiTestBase
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
+
+import opentelemetry.ext.flask as otel_flask
+from opentelemetry import trace as trace_api
+from opentelemetry.ext.testutil.wsgitestutil import WsgiTestBase
 
 
 def expected_attributes(override_attributes):

--- a/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
+++ b/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
@@ -75,7 +75,7 @@ class TestFlaskIntegration(WsgiTestBase):
 
         self.app.route("/assert_environ")(assert_environ)
         self.client.get("/assert_environ")
-        self.assertEqual(nonstring_keys, set()) 
+        self.assertEqual(nonstring_keys, set())
 
     def test_simple(self):
         expected_attrs = expected_attributes(

--- a/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
+++ b/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
@@ -14,13 +14,12 @@
 
 import unittest
 
-from flask import Flask
-from werkzeug.test import Client
-from werkzeug.wrappers import BaseResponse
-
 import opentelemetry.ext.flask as otel_flask
+from flask import Flask
 from opentelemetry import trace as trace_api
 from opentelemetry.ext.testutil.wsgitestutil import WsgiTestBase
+from werkzeug.test import Client
+from werkzeug.wrappers import BaseResponse
 
 
 def expected_attributes(override_attributes):
@@ -59,7 +58,7 @@ class TestFlaskIntegration(WsgiTestBase):
 
     def test_only_strings_in_environ(self):
         """
-        Some WSGI servers (such as Gunicorn) expect keys in the environ object 
+        Some WSGI servers (such as Gunicorn) expect keys in the environ object
         to be strings
 
         OpenTelemetry should adhere to this convention.

--- a/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
+++ b/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
@@ -76,7 +76,7 @@ class TestFlaskIntegration(WsgiTestBase):
 
         self.app.route("/assert_environ")(assert_environ)
         self.client.get("/assert_environ")
-        self.assertEqual(nonstring_keys, set()) 
+        self.assertEqual(nonstring_keys, set())
 
     def test_simple(self):
         expected_attrs = expected_attributes(

--- a/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
+++ b/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
@@ -58,7 +58,7 @@ class TestFlaskIntegration(WsgiTestBase):
 
     def test_only_strings_in_environ(self):
         """
-        Some WSGI servers (such as Gunicorn) expect keys in the environ object
+        Some WSGI servers (such as Gunicorn) expect keys in the environ object 
         to be strings
 
         OpenTelemetry should adhere to this convention.
@@ -75,7 +75,7 @@ class TestFlaskIntegration(WsgiTestBase):
 
         self.app.route("/assert_environ")(assert_environ)
         self.client.get("/assert_environ")
-        self.assertEqual(nonstring_keys, set())
+        self.assertEqual(nonstring_keys, set()) 
 
     def test_simple(self):
         expected_attrs = expected_attributes(

--- a/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
+++ b/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
@@ -59,7 +59,7 @@ class TestFlaskIntegration(WsgiTestBase):
 
     def test_only_strings_in_environ(self):
         """
-        Some WSGI servers (such as Gunicorn) expect keys in the environ object 
+        Some WSGI servers (such as Gunicorn) expect keys in the environ object
         to be strings
 
         OpenTelemetry should adhere to this convention.

--- a/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
+++ b/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from flask import Flask
+from flask import Flask, request
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
 
@@ -67,11 +67,9 @@ class TestFlaskIntegration(WsgiTestBase):
         nonstring_keys = set()
 
         def assert_environ():
-            from flask import request
-
-            for k in request.environ:
-                if not isinstance(k, str):
-                    nonstring_keys.add(k)
+            for key in request.environ:
+                if not isinstance(key, str):
+                    nonstring_keys.add(key)
             return "hi"
 
         self.app.route("/assert_environ")(assert_environ)


### PR DESCRIPTION
Some WSGI servers (such as Gunicorn) expect keys in the environ object
to be strings.

fixes #354.