### PR TITLE
Export span status to Jaeger

### DIFF
--- a/ext/opentelemetry-ext-jaeger/CHANGELOG.md
+++ b/ext/opentelemetry-ext-jaeger/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Export span status ([#367](https://github.com/open-telemetry/opentelemetry-python/pull/367))
+
 ## 0.3a0
 
 Released 2019-12-11

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -233,9 +233,7 @@ def _extract_logs_from_span(span):
     logs = []
 
     for event in span.events:
-        fields = []
-        if event.attributes is not None:
-            fields = _extract_tags(event.attributes)
+        fields = _extract_tags(event.attributes)
 
         fields.append(
             jaeger.Tag(

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -26,6 +26,7 @@ import opentelemetry.trace as trace_api
 from opentelemetry.ext.jaeger.gen.agent import Agent as agent
 from opentelemetry.ext.jaeger.gen.jaeger import Collector as jaeger
 from opentelemetry.sdk.trace.export import Span, SpanExporter, SpanExportResult
+from opentelemetry.trace.status import StatusCanonicalCode
 
 DEFAULT_AGENT_HOST_NAME = "localhost"
 DEFAULT_AGENT_PORT = 6831
@@ -145,6 +146,8 @@ def _translate_to_jaeger(spans: Span):
         start_time_us = _nsec_to_usec_round(span.start_time)
         duration_us = _nsec_to_usec_round(span.end_time - span.start_time)
 
+        status = span.status
+
         parent_id = 0
         if isinstance(span.parent, trace_api.Span):
             parent_id = span.parent.get_context().span_id
@@ -152,6 +155,21 @@ def _translate_to_jaeger(spans: Span):
             parent_id = span.parent.span_id
 
         tags = _extract_tags(span.attributes)
+
+        if status is not None:
+            if tags is None:
+                tags = []
+
+            tags.extend(
+                [
+                    _get_long_tag("status.code", status.canonical_code.value),
+                    _get_string_tag("status.message", status.description),
+                ]
+            )
+
+            # Ensure that if Status.Code is not OK, that we set the "error" tag on the Jaeger span.
+            if status.canonical_code is not StatusCanonicalCode.OK:
+                tags.append(_get_bool_tag("error", True))
 
         refs = _extract_refs_from_span(span)
         logs = _extract_logs_from_span(span)
@@ -260,6 +278,18 @@ def _convert_attribute_to_tag(key, attr):
         return jaeger.Tag(key=key, vDouble=attr, vType=jaeger.TagType.DOUBLE)
     logger.warning("Could not serialize attribute %s:%r to tag", key, attr)
     return None
+
+
+def _get_long_tag(key, val):
+    return jaeger.Tag(key=key, vLong=val, vType=jaeger.TagType.LONG)
+
+
+def _get_string_tag(key, val):
+    return jaeger.Tag(key=key, vStr=val, vType=jaeger.TagType.STRING)
+
+
+def _get_bool_tag(key, val):
+    return jaeger.Tag(key=key, vBool=val, vType=jaeger.TagType.BOOL)
 
 
 class AgentClientUDP:

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -153,9 +153,6 @@ def _translate_to_jaeger(spans: Span):
 
         tags = _extract_tags(span.attributes)
 
-        # TODO: status is missing:
-        # https://github.com/open-telemetry/opentelemetry-python/issues/98
-
         refs = _extract_refs_from_span(span)
         logs = _extract_logs_from_span(span)
 

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -156,20 +156,19 @@ def _translate_to_jaeger(spans: Span):
 
         tags = _extract_tags(span.attributes)
 
-        if status is not None:
-            if tags is None:
-                tags = []
+        if tags is None:
+            tags = []
 
-            tags.extend(
-                [
-                    _get_long_tag("status.code", status.canonical_code.value),
-                    _get_string_tag("status.message", status.description),
-                ]
-            )
+        tags.extend(
+            [
+                _get_long_tag("status.code", status.canonical_code.value),
+                _get_string_tag("status.message", status.description),
+            ]
+        )
 
-            # Ensure that if Status.Code is not OK, that we set the "error" tag on the Jaeger span.
-            if status.canonical_code is not StatusCanonicalCode.OK:
-                tags.append(_get_bool_tag("error", True))
+        # Ensure that if Status.Code is not OK, that we set the "error" tag on the Jaeger span.
+        if status.canonical_code is not StatusCanonicalCode.OK:
+            tags.append(_get_bool_tag("error", True))
 
         refs = _extract_refs_from_span(span)
         logs = _extract_logs_from_span(span)

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -156,9 +156,6 @@ def _translate_to_jaeger(spans: Span):
 
         tags = _extract_tags(span.attributes)
 
-        if tags is None:
-            tags = []
-
         tags.extend(
             [
                 _get_long_tag("status.code", status.canonical_code.value),
@@ -255,7 +252,7 @@ def _extract_logs_from_span(span):
 
 def _extract_tags(attr):
     if not attr:
-        return None
+        return []
     tags = []
     for attribute_key, attribute_value in attr.items():
         tag = _convert_attribute_to_tag(attribute_key, attribute_value)

--- a/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
+++ b/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
@@ -20,9 +20,9 @@ from unittest import mock
 # pylint:disable=import-error
 import opentelemetry.ext.jaeger as jaeger_exporter
 from opentelemetry import trace as trace_api
-from opentelemetry.trace.status import Status, StatusCanonicalCode
 from opentelemetry.ext.jaeger.gen.jaeger import ttypes as jaeger
 from opentelemetry.sdk import trace
+from opentelemetry.trace.status import Status, StatusCanonicalCode
 
 
 class TestJaegerSpanExporter(unittest.TestCase):

--- a/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
+++ b/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
@@ -156,6 +156,13 @@ class TestJaegerSpanExporter(unittest.TestCase):
             context=other_context, attributes=link_attributes
         )
 
+        default_status_tags = [
+            jaeger.Tag(key="status.code", vType=jaeger.TagType.LONG, vLong=0,),
+            jaeger.Tag(
+                key="status.message", vType=jaeger.TagType.STRING, vStr=None,
+            ),
+        ]
+
         otel_spans = [
             trace.Span(
                 name=span_names[0],
@@ -176,7 +183,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
         otel_spans[0].set_attribute("key_string", "hello_world")
         otel_spans[0].set_attribute("key_float", 111.22)
         otel_spans[0].set_status(
-            Status(StatusCanonicalCode.OK, "Example description")
+            Status(StatusCanonicalCode.UNKNOWN, "Example description")
         )
         otel_spans[0].end(end_time=end_times[0])
 
@@ -214,12 +221,15 @@ class TestJaegerSpanExporter(unittest.TestCase):
                         vDouble=111.22,
                     ),
                     jaeger.Tag(
-                        key="status.code", vType=jaeger.TagType.LONG, vLong=0,
+                        key="status.code", vType=jaeger.TagType.LONG, vLong=2,
                     ),
                     jaeger.Tag(
                         key="status.message",
                         vType=jaeger.TagType.STRING,
                         vStr="Example description",
+                    ),
+                    jaeger.Tag(
+                        key="error", vType=jaeger.TagType.BOOL, vBool=True,
                     ),
                 ],
                 references=[
@@ -267,6 +277,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
                 startTime=start_times[1] // 10 ** 3,
                 duration=durations[1] // 10 ** 3,
                 flags=0,
+                tags=default_status_tags,
             ),
             jaeger.Span(
                 operationName=span_names[2],
@@ -277,6 +288,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
                 startTime=start_times[2] // 10 ** 3,
                 duration=durations[2] // 10 ** 3,
                 flags=0,
+                tags=default_status_tags,
             ),
         ]
 

--- a/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
+++ b/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
@@ -20,6 +20,7 @@ from unittest import mock
 # pylint:disable=import-error
 import opentelemetry.ext.jaeger as jaeger_exporter
 from opentelemetry import trace as trace_api
+from opentelemetry.trace.status import Status, StatusCanonicalCode
 from opentelemetry.ext.jaeger.gen.jaeger import ttypes as jaeger
 from opentelemetry.sdk import trace
 
@@ -174,6 +175,9 @@ class TestJaegerSpanExporter(unittest.TestCase):
         otel_spans[0].set_attribute("key_bool", False)
         otel_spans[0].set_attribute("key_string", "hello_world")
         otel_spans[0].set_attribute("key_float", 111.22)
+        otel_spans[0].set_status(
+            Status(StatusCanonicalCode.OK, "Example description")
+        )
         otel_spans[0].end(end_time=end_times[0])
 
         otel_spans[1].start(start_time=start_times[1])
@@ -208,6 +212,14 @@ class TestJaegerSpanExporter(unittest.TestCase):
                         key="key_float",
                         vType=jaeger.TagType.DOUBLE,
                         vDouble=111.22,
+                    ),
+                    jaeger.Tag(
+                        key="status.code", vType=jaeger.TagType.LONG, vLong=0,
+                    ),
+                    jaeger.Tag(
+                        key="status.message",
+                        vType=jaeger.TagType.STRING,
+                        vStr="Example description",
                     ),
                 ],
                 references=[

--- a/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
+++ b/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
@@ -157,7 +157,11 @@ class TestJaegerSpanExporter(unittest.TestCase):
         )
 
         default_status_tags = [
-            jaeger.Tag(key="status.code", vType=jaeger.TagType.LONG, vLong=0,),
+            jaeger.Tag(
+                key="status.code",
+                vType=jaeger.TagType.LONG,
+                vLong=StatusCanonicalCode.OK.value,
+            ),
             jaeger.Tag(
                 key="status.message", vType=jaeger.TagType.STRING, vStr=None,
             ),
@@ -221,7 +225,9 @@ class TestJaegerSpanExporter(unittest.TestCase):
                         vDouble=111.22,
                     ),
                     jaeger.Tag(
-                        key="status.code", vType=jaeger.TagType.LONG, vLong=2,
+                        key="status.code",
+                        vType=jaeger.TagType.LONG,
+                        vLong=StatusCanonicalCode.UNKNOWN.value,
                     ),
                     jaeger.Tag(
                         key="status.message",


### PR DESCRIPTION
- Sets status tags on the Jaeger span.
- Removes TODO from the Jaeger integration that points to a closed [issue](#98) with a merged  [PR](https://github.com/open-telemetry/opentelemetry-python/pull/213).

Signed-off-by: Daniel González Lopes <danielgonzalezlopes@gmail.com>