### PR TITLE
Add int and valid sequences to AttributeValue type

### DIFF
--- a/opentelemetry-api/src/opentelemetry/util/types.py
+++ b/opentelemetry-api/src/opentelemetry/util/types.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Union, Optional, Dict, Sequence
+from typing import Dict, Optional, Sequence, Union
 
 AttributeValue = Union[
     str,

--- a/opentelemetry-api/src/opentelemetry/util/types.py
+++ b/opentelemetry-api/src/opentelemetry/util/types.py
@@ -13,7 +13,16 @@
 # limitations under the License.
 
 
-import typing
+from typing import Union, Optional, Dict, Sequence
 
-AttributeValue = typing.Union[str, bool, float]
-Attributes = typing.Optional[typing.Dict[str, AttributeValue]]
+AttributeValue = Union[
+    str,
+    bool,
+    int,
+    float,
+    Sequence[str],
+    Sequence[bool],
+    Sequence[int],
+    Sequence[float],
+]
+Attributes = Optional[Dict[str, AttributeValue]]


### PR DESCRIPTION
Split off from #348 

The [OT Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#set-attributes) states one of the valid AttributeValue types are:

> An array of primitive type values. The array MUST be homogeneous, i.e. it MUST NOT contain values of different types.

This change updates the AttributeValue type to include homogeneous sequences of `str`, `bool`, `int`, and `float`