### PR TITLE
test fix: removing use of ABC Span in API test

### DIFF
--- a/opentelemetry-api/tests/context/propagation/test_tracecontexthttptextformat.py
+++ b/opentelemetry-api/tests/context/propagation/test_tracecontexthttptextformat.py
@@ -180,7 +180,7 @@ class TestTraceContextFormat(unittest.TestCase):
     def test_propagate_invalid_context(self):
         """Do not propagate invalid trace context."""
         output = {}  # type:typing.Dict[str, str]
-        FORMAT.inject(trace.Span(), dict.__setitem__, output)
+        FORMAT.inject(trace.INVALID_SPAN, dict.__setitem__, output)
         self.assertFalse("traceparent" in output)
 
     def test_tracestate_empty_header(self):


### PR DESCRIPTION
There was one instance of using an ABC Span object
in the unit tests, which is breaking linting and typing.