### PR TITLE
Change imports to avoid pylint namespace errors

### DIFF
--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
@@ -82,8 +82,16 @@ Note:
 
 import logging
 
-import opentracing
 from deprecated import deprecated
+from opentracing import (  # pylint: disable=no-name-in-module
+    Format,
+    Scope,
+    ScopeManager,
+    Span,
+    SpanContext,
+    Tracer,
+    UnsupportedFormatException,
+)
 
 import opentelemetry.trace as trace_api
 from opentelemetry import propagators
@@ -114,7 +122,7 @@ def create_tracer(otel_tracer_source):
     return TracerShim(otel_tracer_source.get_tracer(__name__, __version__))
 
 
-class SpanContextShim(opentracing.SpanContext):
+class SpanContextShim(SpanContext):
     """Implements :class:`opentracing.SpanContext` by wrapping a
     :class:`opentelemetry.trace.SpanContext` object.
 
@@ -152,7 +160,7 @@ class SpanContextShim(opentracing.SpanContext):
         # TODO: Implement.
 
 
-class SpanShim(opentracing.Span):
+class SpanShim(Span):
     """Implements :class:`opentracing.Span` by wrapping a
     :class:`opentelemetry.trace.Span` object.
 
@@ -293,7 +301,7 @@ class SpanShim(opentracing.Span):
         # TODO: Implement.
 
 
-class ScopeShim(opentracing.Scope):
+class ScopeShim(Scope):
     """A `ScopeShim` wraps the OpenTelemetry functionality related to span
     activation/deactivation while using OpenTracing :class:`opentracing.Scope`
     objects for presentation.
@@ -402,7 +410,7 @@ class ScopeShim(opentracing.Scope):
             self._span.unwrap().end()
 
 
-class ScopeManagerShim(opentracing.ScopeManager):
+class ScopeManagerShim(ScopeManager):
     """Implements :class:`opentracing.ScopeManager` by setting and getting the
     active `opentelemetry.trace.Span` in the OpenTelemetry tracer.
 
@@ -497,7 +505,7 @@ class ScopeManagerShim(opentracing.ScopeManager):
         return self._tracer
 
 
-class TracerShim(opentracing.Tracer):
+class TracerShim(Tracer):
     """Implements :class:`opentracing.Tracer` by wrapping a
     :class:`opentelemetry.trace.Tracer` object.
 
@@ -519,8 +527,8 @@ class TracerShim(opentracing.Tracer):
         super().__init__(scope_manager=ScopeManagerShim(self))
         self._otel_tracer = tracer
         self._supported_formats = (
-            opentracing.Format.TEXT_MAP,
-            opentracing.Format.HTTP_HEADERS,
+            Format.TEXT_MAP,
+            Format.HTTP_HEADERS,
         )
 
     def unwrap(self):
@@ -670,7 +678,7 @@ class TracerShim(opentracing.Tracer):
         # opentelemetry-python.
 
         if format not in self._supported_formats:
-            raise opentracing.UnsupportedFormatException
+            raise UnsupportedFormatException
 
         propagator = propagators.get_global_httptextformat()
 
@@ -690,7 +698,7 @@ class TracerShim(opentracing.Tracer):
         # TODO: Support Format.BINARY once it is supported in
         # opentelemetry-python.
         if format not in self._supported_formats:
-            raise opentracing.UnsupportedFormatException
+            raise UnsupportedFormatException
 
         def get_as_list(dict_object, key):
             value = dict_object.get(key)

--- a/ext/opentelemetry-ext-opentracing-shim/tests/test_shim.py
+++ b/ext/opentelemetry-ext-opentracing-shim/tests/test_shim.py
@@ -15,7 +15,15 @@
 import time
 from unittest import TestCase
 
-import opentracing
+from opentracing import (  # pylint: disable=no-name-in-module
+    Format,
+    Scope,
+    Span,
+    SpanContext,
+    Tracer,
+    UnsupportedFormatException,
+    child_of,
+)
 
 import opentelemetry.ext.opentracing_shim as opentracingshim
 from opentelemetry import propagators, trace
@@ -55,15 +63,15 @@ class TestShim(TestCase):
 
     def test_shim_type(self):
         # Verify shim is an OpenTracing tracer.
-        self.assertIsInstance(self.shim, opentracing.Tracer)
+        self.assertIsInstance(self.shim, Tracer)
 
     def test_start_active_span(self):
         """Test span creation and activation using `start_active_span()`."""
 
         with self.shim.start_active_span("TestSpan") as scope:
             # Verify correct type of Scope and Span objects.
-            self.assertIsInstance(scope, opentracing.Scope)
-            self.assertIsInstance(scope.span, opentracing.Span)
+            self.assertIsInstance(scope, Scope)
+            self.assertIsInstance(scope.span, Span)
 
             # Verify span is started.
             self.assertIsNotNone(scope.span.unwrap().start_time)
@@ -90,7 +98,7 @@ class TestShim(TestCase):
 
         with self.shim.start_span("TestSpan") as span:
             # Verify correct type of Span object.
-            self.assertIsInstance(span, opentracing.Span)
+            self.assertIsInstance(span, Span)
 
             # Verify span is started.
             self.assertIsNotNone(span.unwrap().start_time)
@@ -360,7 +368,7 @@ class TestShim(TestCase):
         """Test span creation using the `references` argument."""
 
         with self.shim.start_span("ParentSpan") as parent:
-            ref = opentracing.child_of(parent.context)
+            ref = child_of(parent.context)
 
             with self.shim.start_active_span(
                 "ChildSpan", references=[ref]
@@ -447,7 +455,7 @@ class TestShim(TestCase):
         otel_context = trace.SpanContext(1234, 5678)
         context = opentracingshim.SpanContextShim(otel_context)
 
-        self.assertIsInstance(context, opentracing.SpanContext)
+        self.assertIsInstance(context, SpanContext)
         self.assertEqual(context.unwrap().trace_id, 1234)
         self.assertEqual(context.unwrap().span_id, 5678)
 
@@ -474,7 +482,7 @@ class TestShim(TestCase):
         context = opentracingshim.SpanContextShim(otel_context)
 
         headers = {}
-        self.shim.inject(context, opentracing.Format.HTTP_HEADERS, headers)
+        self.shim.inject(context, Format.HTTP_HEADERS, headers)
         self.assertEqual(headers[MockHTTPTextFormat.TRACE_ID_KEY], str(1220))
         self.assertEqual(headers[MockHTTPTextFormat.SPAN_ID_KEY], str(7478))
 
@@ -487,7 +495,7 @@ class TestShim(TestCase):
         # Verify Format.TEXT_MAP
         text_map = {}
 
-        self.shim.inject(context, opentracing.Format.TEXT_MAP, text_map)
+        self.shim.inject(context, Format.TEXT_MAP, text_map)
         self.assertEqual(text_map[MockHTTPTextFormat.TRACE_ID_KEY], str(1220))
         self.assertEqual(text_map[MockHTTPTextFormat.SPAN_ID_KEY], str(7478))
 
@@ -498,8 +506,8 @@ class TestShim(TestCase):
         context = opentracingshim.SpanContextShim(otel_context)
 
         # Verify exception for non supported binary format.
-        with self.assertRaises(opentracing.UnsupportedFormatException):
-            self.shim.inject(context, opentracing.Format.BINARY, bytearray())
+        with self.assertRaises(UnsupportedFormatException):
+            self.shim.inject(context, Format.BINARY, bytearray())
 
     def test_extract_http_headers(self):
         """Test `extract()` method for Format.HTTP_HEADERS."""
@@ -509,7 +517,7 @@ class TestShim(TestCase):
             MockHTTPTextFormat.SPAN_ID_KEY: 7478,
         }
 
-        ctx = self.shim.extract(opentracing.Format.HTTP_HEADERS, carrier)
+        ctx = self.shim.extract(Format.HTTP_HEADERS, carrier)
         self.assertEqual(ctx.unwrap().trace_id, 1220)
         self.assertEqual(ctx.unwrap().span_id, 7478)
 
@@ -521,7 +529,7 @@ class TestShim(TestCase):
             MockHTTPTextFormat.SPAN_ID_KEY: 7478,
         }
 
-        ctx = self.shim.extract(opentracing.Format.TEXT_MAP, carrier)
+        ctx = self.shim.extract(Format.TEXT_MAP, carrier)
         self.assertEqual(ctx.unwrap().trace_id, 1220)
         self.assertEqual(ctx.unwrap().span_id, 7478)
 
@@ -529,8 +537,8 @@ class TestShim(TestCase):
         """Test `extract()` method for Format.BINARY."""
 
         # Verify exception for non supported binary format.
-        with self.assertRaises(opentracing.UnsupportedFormatException):
-            self.shim.extract(opentracing.Format.BINARY, bytearray())
+        with self.assertRaises(UnsupportedFormatException):
+            self.shim.extract(Format.BINARY, bytearray())
 
 
 class MockHTTPTextFormat(HTTPTextFormat):


### PR DESCRIPTION
This is `9d3ef06d` split off from #282 at [@mauriciovasquezbernal's request](https://github.com/open-telemetry/opentelemetry-python/pull/282#issuecomment-577710670).

See https://github.com/open-telemetry/opentelemetry-python/pull/282#issuecomment-577458423.

Edit: changed to use `pylint:ignore=no-member` in the modules failing lint instead. These errors are almost never meaningful, and this prevents us from having to play type inference whack-a-mole in the future if these imports change.