### PR TITLE
Rebuild docs only if source files change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,12 @@ on:
   push:
     branches:
     - master
-
+    paths:
+    - 'docs/**'
+    - 'ext/**'
+    - 'opentelemetry-python/opentelemetry-api/src/opentelemetry/**'
+    - 'opentelemetry-python/opentelemetry-sdk/src/opentelemetry/sdk/**'
+    
 jobs:
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR uses `on.push.paths` [workflow syntax](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths), so we don't have to rebuild the docs unless source files have changed  (based on https://github.com/open-telemetry/opentelemetry-python/pull/167 from @c24t).

I think that this path-based approach triggers less unnecessary than a [file-based](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#example-including-paths) one.
 
I asked for feedback on [Gitter](https://gitter.im/open-telemetry/opentelemetry-python?at=5e2adb59f85dba0aab07daf8), and I would love if someone had time to throw some thoughts on this :)

Signed-off-by: Daniel González Lopes <danielgonzalezlopes@gmail.com>