### PR TITLE
Add general timeout mechanism in the export layer

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -71,7 +71,7 @@ class SimpleExportSpanProcessor(SpanProcessor):
     """
 
     def __init__(
-        self, span_exporter: SpanExporter, timeout: int = None,
+        self, span_exporter: SpanExporter, timeout: int = 60,
     ):
         self.span_exporter = span_exporter
         self.timeout = timeout
@@ -106,7 +106,7 @@ class BatchExportSpanProcessor(SpanProcessor):
         max_queue_size: int = 2048,
         schedule_delay_millis: float = 5000,
         max_export_batch_size: int = 512,
-        timeout: int = None,
+        timeout: int = 60,
     ):
         if max_queue_size <= 0:
             raise ValueError("max_queue_size must be a positive integer.")


### PR DESCRIPTION
This PR implements:
- A general timeout mechanism in `utils.py` using [signal](https://docs.python.org/3/library/signal.html). Example usage:
```python
from opentelemetry.sdk.util import timeout_in_seconds
try:
  with timeout_in_seconds(5):
    func_example()
except TimeoutError:
  print('func_example took too long to complete')
```
> Added `set_timeout_signal_handler()` for it's usage on multithreaded code (all signal handler functions must be set in the main thread).

- Timeouts to exports in `SimpleExportSpanProcessor()` and `BatchExportSpanProcessor()`.

Closes #346 

Signed-off-by: Daniel González Lopes <danielgonzalezlopes@gmail.com>