### PR TITLE
ext/jaeger: add span kind jaeger exporter

### DIFF
--- a/ext/opentelemetry-ext-jaeger/CHANGELOG.md
+++ b/ext/opentelemetry-ext-jaeger/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Export span status ([#367](https://github.com/open-telemetry/opentelemetry-python/pull/367))
+- Export span kind ([#387](https://github.com/open-telemetry/opentelemetry-python/pull/387))
 
 ## 0.3a0
 

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -160,6 +160,7 @@ def _translate_to_jaeger(spans: Span):
             [
                 _get_long_tag("status.code", status.canonical_code.value),
                 _get_string_tag("status.message", status.description),
+                _get_string_tag("span.kind", span.kind.name),
             ]
         )
 

--- a/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
+++ b/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
@@ -156,7 +156,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
             context=other_context, attributes=link_attributes
         )
 
-        default_status_tags = [
+        default_tags = [
             jaeger.Tag(
                 key="status.code",
                 vType=jaeger.TagType.LONG,
@@ -164,6 +164,11 @@ class TestJaegerSpanExporter(unittest.TestCase):
             ),
             jaeger.Tag(
                 key="status.message", vType=jaeger.TagType.STRING, vStr=None,
+            ),
+            jaeger.Tag(
+                key="span.kind",
+                vType=jaeger.TagType.STRING,
+                vStr=trace_api.SpanKind.INTERNAL.name,
             ),
         ]
 
@@ -174,6 +179,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
                 parent=parent_context,
                 events=(event,),
                 links=(link,),
+                kind=trace_api.SpanKind.CLIENT,
             ),
             trace.Span(
                 name=span_names[1], context=parent_context, parent=None
@@ -235,6 +241,11 @@ class TestJaegerSpanExporter(unittest.TestCase):
                         vStr="Example description",
                     ),
                     jaeger.Tag(
+                        key="span.kind",
+                        vType=jaeger.TagType.STRING,
+                        vStr=trace_api.SpanKind.CLIENT.name,
+                    ),
+                    jaeger.Tag(
                         key="error", vType=jaeger.TagType.BOOL, vBool=True,
                     ),
                 ],
@@ -283,7 +294,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
                 startTime=start_times[1] // 10 ** 3,
                 duration=durations[1] // 10 ** 3,
                 flags=0,
-                tags=default_status_tags,
+                tags=default_tags,
             ),
             jaeger.Span(
                 operationName=span_names[2],
@@ -294,7 +305,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
                 startTime=start_times[2] // 10 ** 3,
                 duration=durations[2] // 10 ** 3,
                 flags=0,
-                tags=default_status_tags,
+                tags=default_tags,
             ),
         ]
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-python/issues/369.

Export the span kind as "span.kind" tag.

This PR contains https://github.com/open-telemetry/opentelemetry-python/pull/367, so it should be merged after it.