### PR TITLE
Move alpha v4 release date target to 2/21

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,13 @@ estimates, and subject to change.
 
 Future releases targets include:
 
-| Component                           | Version    | Target Date      |
-| ----------------------------------- | ---------- | ---------------- |
-| Zipkin Trace Exporter               | Alpha v0.4 | January 28 2020  |
-| W3C Correlation Context Propagation | Alpha v0.4 | January 28 2020  |
-| Support for Tags/Baggage            | Alpha v0.4 | January 28 2020  |
-| Metrics Aggregation                 | Alpha v0.4 | January 28 2020  |
-| gRPC Integrations                   | Alpha v0.4 | January 28 2020  |
-| Prometheus Metrics Exporter         | Alpha v0.4 | January 28 2020  |
-| OpenCensus Bridge                   | Alpha v0.4 | January 28 2020  |
-| Metrics SDK (Complete)              | Alpha v0.4 | January 28 2020  |
+| Component                           | Version    | Target Date       |
+| ----------------------------------- | ---------- | ----------------- |
+| Zipkin Trace Exporter               | Alpha v0.4 | February 21 2020  |
+| W3C Correlation Context Propagation | Alpha v0.4 | February 21 2020  |
+| Support for Tags/Baggage            | Alpha v0.4 | February 21 2020  |
+| Metrics Aggregation                 | Alpha v0.4 | February 21 2020  |
+| gRPC Integrations                   | Alpha v0.4 | February 21 2020  |
+| Prometheus Metrics Exporter         | Alpha v0.4 | February 21 2020  |
+| OpenCensus Bridge                   | Alpha v0.4 | February 21 2020  |
+| Metrics SDK (Complete)              | Alpha v0.4 | February 21 2020  |


### PR DESCRIPTION
As discussed in the SIG call, move the alpha v4 release date three weeks back to account for ongoing work.