### PR TITLE
Remove monotonic and absolute metrics intrument options

### DIFF
--- a/opentelemetry-api/src/opentelemetry/metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/__init__.py
@@ -208,9 +208,7 @@ class Gauge(Metric):
 class Measure(Metric):
     """A measure type metric that represent raw stats that are recorded.
 
-    Measure metrics represent raw statistics that are recorded. By
-    default, measure metrics can accept both positive and negatives.
-    Negative inputs will be discarded when monotonic is True.
+    Measure metrics represent raw statistics that are recorded.
     """
 
     def get_handle(self, label_set: LabelSet) -> "MeasureHandle":
@@ -268,8 +266,6 @@ class Meter(abc.ABC):
         metric_type: Type[MetricT],
         label_keys: Sequence[str] = (),
         enabled: bool = True,
-        monotonic: bool = False,
-        absolute: bool = True,
     ) -> "Metric":
         """Creates a ``metric_kind`` metric with type ``value_type``.
 
@@ -281,10 +277,6 @@ class Meter(abc.ABC):
             metric_type: The type of metric being created.
             label_keys: The keys for the labels with dynamic values.
             enabled: Whether to report the metric by default.
-            monotonic: Configure a counter or gauge that accepts only
-                monotonic/non-monotonic updates.
-            absolute: Configure a measure that does or does not accept negative
-                updates.
         Returns: A new ``metric_type`` metric with values of ``value_type``.
         """
 
@@ -318,8 +310,6 @@ class DefaultMeter(Meter):
         metric_type: Type[MetricT],
         label_keys: Sequence[str] = (),
         enabled: bool = True,
-        monotonic: bool = False,
-        absolute: bool = True,
     ) -> "Metric":
         # pylint: disable=no-self-use
         return DefaultMetric()

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -203,28 +203,20 @@ class TestMeasure(unittest.TestCase):
 class TestCounterHandle(unittest.TestCase):
     def test_add(self):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.CounterHandle(int, True, False, False, aggregator)
+        handle = metrics.CounterHandle(int, True, aggregator)
         handle.add(3)
         self.assertEqual(handle.aggregator.current, 3)
 
     def test_add_disabled(self):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.CounterHandle(int, False, False, False, aggregator)
+        handle = metrics.CounterHandle(int, False, aggregator)
         handle.add(3)
         self.assertEqual(handle.aggregator.current, 0)
 
     @mock.patch("opentelemetry.sdk.metrics.logger")
-    def test_add_monotonic(self, logger_mock):
-        aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.CounterHandle(int, True, True, False, aggregator)
-        handle.add(-3)
-        self.assertEqual(handle.aggregator.current, 0)
-        self.assertTrue(logger_mock.warning.called)
-
-    @mock.patch("opentelemetry.sdk.metrics.logger")
     def test_add_incorrect_type(self, logger_mock):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.CounterHandle(int, True, False, False, aggregator)
+        handle = metrics.CounterHandle(int, True, aggregator)
         handle.add(3.0)
         self.assertEqual(handle.aggregator.current, 0)
         self.assertTrue(logger_mock.warning.called)
@@ -232,7 +224,7 @@ class TestCounterHandle(unittest.TestCase):
     @mock.patch("opentelemetry.sdk.metrics.time_ns")
     def test_update(self, time_mock):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.CounterHandle(int, True, False, False, aggregator)
+        handle = metrics.CounterHandle(int, True, aggregator)
         time_mock.return_value = 123
         handle.update(4.0)
         self.assertEqual(handle.last_update_timestamp, 123)
@@ -243,28 +235,20 @@ class TestCounterHandle(unittest.TestCase):
 class TestGaugeHandle(unittest.TestCase):
     def test_set(self):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.GaugeHandle(int, True, False, False, aggregator)
+        handle = metrics.GaugeHandle(int, True, aggregator)
         handle.set(3)
         self.assertEqual(handle.aggregator.current, 3)
 
     def test_set_disabled(self):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.GaugeHandle(int, False, False, False, aggregator)
+        handle = metrics.GaugeHandle(int, False, aggregator)
         handle.set(3)
         self.assertEqual(handle.aggregator.current, 0)
 
     @mock.patch("opentelemetry.sdk.metrics.logger")
-    def test_set_monotonic(self, logger_mock):
-        aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.GaugeHandle(int, True, True, False, aggregator)
-        handle.set(-3)
-        self.assertEqual(handle.aggregator.current, 0)
-        self.assertTrue(logger_mock.warning.called)
-
-    @mock.patch("opentelemetry.sdk.metrics.logger")
     def test_set_incorrect_type(self, logger_mock):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.GaugeHandle(int, True, False, False, aggregator)
+        handle = metrics.GaugeHandle(int, True, aggregator)
         handle.set(3.0)
         self.assertEqual(handle.aggregator.current, 0)
         self.assertTrue(logger_mock.warning.called)
@@ -272,7 +256,7 @@ class TestGaugeHandle(unittest.TestCase):
     @mock.patch("opentelemetry.sdk.metrics.time_ns")
     def test_update(self, time_mock):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.GaugeHandle(int, True, False, False, aggregator)
+        handle = metrics.GaugeHandle(int, True, aggregator)
         time_mock.return_value = 123
         handle.update(4.0)
         self.assertEqual(handle.last_update_timestamp, 123)
@@ -283,28 +267,20 @@ class TestGaugeHandle(unittest.TestCase):
 class TestMeasureHandle(unittest.TestCase):
     def test_record(self):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.MeasureHandle(int, False, False, False, aggregator)
+        handle = metrics.MeasureHandle(int, False, aggregator)
         handle.record(3)
         self.assertEqual(handle.aggregator.current, 0)
 
     def test_record_disabled(self):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.MeasureHandle(int, False, False, False, aggregator)
+        handle = metrics.MeasureHandle(int, False, aggregator)
         handle.record(3)
         self.assertEqual(handle.aggregator.current, 0)
 
     @mock.patch("opentelemetry.sdk.metrics.logger")
-    def test_record_monotonic(self, logger_mock):
-        aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.MeasureHandle(int, True, False, True, aggregator)
-        handle.record(-3)
-        self.assertEqual(handle.aggregator.current, 0)
-        self.assertTrue(logger_mock.warning.called)
-
-    @mock.patch("opentelemetry.sdk.metrics.logger")
     def test_record_incorrect_type(self, logger_mock):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.MeasureHandle(int, True, False, False, aggregator)
+        handle = metrics.MeasureHandle(int, True, aggregator)
         handle.record(3.0)
         self.assertEqual(handle.aggregator.current, 0)
         self.assertTrue(logger_mock.warning.called)
@@ -312,7 +288,7 @@ class TestMeasureHandle(unittest.TestCase):
     @mock.patch("opentelemetry.sdk.metrics.time_ns")
     def test_update(self, time_mock):
         aggregator = export.aggregate.CounterAggregator()
-        handle = metrics.MeasureHandle(int, True, False, False, aggregator)
+        handle = metrics.MeasureHandle(int, True, aggregator)
         time_mock.return_value = 123
         handle.update(4.0)
         self.assertEqual(handle.last_update_timestamp, 123)


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-python/issues/404.

Following the spec https://github.com/open-telemetry/opentelemetry-specification/pull/430.

Just some cleanup before implementing other things in the metrics.