### PR TITLE
Cleanup tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,15 +2,69 @@
 skipsdist = True
 skip_missing_interpreters = True
 envlist =
-    py3{4,5,6,7,8}-test-{api,sdk}
-    pypy3-test-{api,sdk}
 
-    py3{4,5,6,7,8}-test-{example-app,example-basic-tracer,example-http}
-    pypy3-test-{example-app,example-basic-tracer,example-http}
+    ; Environments are organized by individual package, allowing
+    ; for specifying supported Python versions per package.
+    ; opentelemetry-api
+    py3{4,5,6,7,8}-test-api
+    pypy3-test-api
 
-    py3{4,5,6,7,8}-test-{ext-dbapi,ext-flask,ext-http-requests,ext-jaeger,ext-mysql,ext-psycopg2,ext-pymongo,ext-wsgi,ext-zipkin,opentracing-shim}
+    ; opentelemetry-sdk
+    py3{4,5,6,7,8}-test-sdk
+    pypy3-test-sdk
+
+    ; opentelemetry-example-app
+    py3{4,5,6,7,8}-test-example-app
+    pypy3-test-example-app
+
+    ; examples/basic_tracer
+    py3{4,5,6,7,8}-test-example-basic-tracer
+    pypy3-test-example-basic-tracer
+
+    ; examples/http
+    py3{4,5,6,7,8}-test-example-http
+    pypy3-test-example-http
+
+    ; opentelemetry-ext-dbapi
+    py3{4,5,6,7,8}-test-ext-dbapi
+    pypy3-test-ext-dbapi
+
+    ; opentelemetry-ext-flask
+    py3{4,5,6,7,8}-test-ext-flask
+    pypy3-test-ext-flask
+
+    ; opentelemetry-ext-http-requests
+    py3{4,5,6,7,8}-test-ext-http-requests
+    pypy3-test-ext-http-requests
+
+    ; opentelemetry-ext-jaeger
+    py3{4,5,6,7,8}-test-ext-jaeger
+    pypy3-test-ext-jaeger
+
+    ; opentelemetry-ext-mysql
+    py3{4,5,6,7,8}-test-ext-mysql
+    pypy3-test-ext-mysql
+
+    ; opentelemetry-ext-psycopg2
+    py3{4,5,6,7,8}-test-ext-psycopg2
     ; ext-psycopg2 intentionally excluded from pypy3
-    pypy3-test-{ext-dbapi,ext-flask,ext-http-requests,ext-jaeger,ext-mysql,ext-pymongo,ext-wsgi,ext-zipkin,opentracing-shim}
+
+    ; opentelemetry-ext-pymongo
+    py3{4,5,6,7,8}-test-ext-pymongo
+    pypy3-test-ext-pymongo
+
+    ; opentelemetry-ext-wsgi
+    py3{4,5,6,7,8}-test-ext-wsgi
+    pypy3-test-ext-wsgi
+
+    ; opentelemetry-ext-zipkin
+    py3{4,5,6,7,8}-test-ext-zipkin
+    pypy3-test-ext-zipkin
+
+    ; opentelemetry-opentracing-shim
+    py3{4,5,6,7,8}-test-opentracing-shim
+    pypy3-test-opentracing-shim
+
 
     py3{4,5,6,7,8}-coverage
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,15 @@
 skipsdist = True
 skip_missing_interpreters = True
 envlist =
-    py3{4,5,6,7,8}-test-{api,sdk,example-app,ext-wsgi,ext-flask,ext-http-requests,ext-jaeger,ext-dbapi,ext-mysql,ext-psycopg2,ext-pymongo,ext-zipkin,opentracing-shim}
-    pypy3-test-{api,sdk,example-app,ext-wsgi,ext-flask,ext-http-requests,ext-jaeger,ext-dbapi,ext-mysql,ext-pymongo,ext-zipkin,opentracing-shim}
-    py3{4,5,6,7,8}-test-{api,sdk,example-app,example-basic-tracer,example-http,ext-wsgi,ext-flask,ext-http-requests,ext-jaeger,ext-dbapi,ext-mysql,ext-psycopg2,ext-pymongo,ext-zipkin,opentracing-shim}
-    pypy3-test-{api,sdk,example-app,example-basic-tracer,example-http,ext-wsgi,ext-flask,ext-http-requests,ext-jaeger,ext-dbapi,ext-mysql,ext-pymongo,ext-zipkin,opentracing-shim}
+    py3{4,5,6,7,8}-test-{api,sdk}
+    pypy3-test-{api,sdk}
+
+    py3{4,5,6,7,8}-test-{example-app,example-basic-tracer,example-http}
+    pypy3-test-{example-app,example-basic-tracer,example-http}
+
+    py3{4,5,6,7,8}-test-{ext-dbapi,ext-flask,ext-http-requests,ext-jaeger,ext-mysql,ext-psycopg2,ext-pymongo,ext-wsgi,ext-zipkin,opentracing-shim}
+    pypy3-test-{ext-dbapi,ext-flask,ext-http-requests,ext-jaeger,ext-mysql,ext-psycopg2,ext-pymongo,ext-wsgi,ext-zipkin,opentracing-shim}
+
     py3{4,5,6,7,8}-coverage
 
     ; Coverage is temporarily disabled for pypy3 due to the pytest bug.

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,8 @@ envlist =
     pypy3-test-{example-app,example-basic-tracer,example-http}
 
     py3{4,5,6,7,8}-test-{ext-dbapi,ext-flask,ext-http-requests,ext-jaeger,ext-mysql,ext-psycopg2,ext-pymongo,ext-wsgi,ext-zipkin,opentracing-shim}
-    pypy3-test-{ext-dbapi,ext-flask,ext-http-requests,ext-jaeger,ext-mysql,ext-psycopg2,ext-pymongo,ext-wsgi,ext-zipkin,opentracing-shim}
+    ; ext-psycopg2 intentionally excluded from pypy3
+    pypy3-test-{ext-dbapi,ext-flask,ext-http-requests,ext-jaeger,ext-mysql,ext-pymongo,ext-wsgi,ext-zipkin,opentracing-shim}
 
     py3{4,5,6,7,8}-coverage
 


### PR DESCRIPTION
Remove redundant environments.
Separate environments into logical groupings for maintainability.