### PR TITLE
All named tracers now share the same context

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/__init__.py
@@ -16,11 +16,4 @@ from typing import Optional
 from opentelemetry.trace import INVALID_SPAN_CONTEXT, Span, SpanContext
 
 _SPAN_CONTEXT_KEY = "extracted-span-context"
-_SPAN_KEY = "current-span"
-
-
-def get_span_key(tracer_source_id: Optional[str] = None) -> str:
-    key = _SPAN_KEY
-    if tracer_source_id is not None:
-        key = "{}-{}".format(key, tracer_source_id)
-    return key
+SPAN_KEY = "current-span"

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -27,7 +27,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.sdk import util
 from opentelemetry.sdk.util import BoundedDict, BoundedList
 from opentelemetry.trace import SpanContext, sampling
-from opentelemetry.trace.propagation import get_span_key
+from opentelemetry.trace.propagation import SPAN_KEY
 from opentelemetry.trace.status import Status, StatusCanonicalCode
 from opentelemetry.util import time_ns, types
 
@@ -543,7 +543,7 @@ class Tracer(trace_api.Tracer):
         try:
             context_snapshot = context_api.get_current()
             context_api.set_current(
-                context_api.set_value(self.source.key, span)
+                context_api.set_value(SPAN_KEY, span)
             )
             try:
                 yield span
@@ -577,9 +577,6 @@ class TracerSource(trace_api.TracerSource):
         sampler: sampling.Sampler = trace_api.sampling.ALWAYS_ON,
         shutdown_on_exit: bool = True,
     ):
-        # TODO: How should multiple TracerSources behave? Should they get their own contexts?
-        # This could be done by adding `str(id(self))` to the slot name.
-        self.key = get_span_key(tracer_source_id=str(id(self)))
         self._active_span_processor = MultiSpanProcessor()
         self.sampler = sampler
         self._atexit_handler = None
@@ -602,7 +599,7 @@ class TracerSource(trace_api.TracerSource):
         )
 
     def get_current_span(self) -> Span:
-        return context_api.get_value(self.key)  # type: ignore
+        return context_api.get_value(SPAN_KEY)  # type: ignore
 
     def add_span_processor(self, span_processor: SpanProcessor) -> None:
         """Registers a new :class:`SpanProcessor` for this `TracerSource`.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -596,7 +596,8 @@ class TracerSource(trace_api.TracerSource):
             ),
         )
 
-    def get_current_span(self) -> Span:
+    @staticmethod
+    def get_current_span() -> Span:
         return context_api.get_value(SPAN_KEY)  # type: ignore
 
     def add_span_processor(self, span_processor: SpanProcessor) -> None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -542,9 +542,7 @@ class Tracer(trace_api.Tracer):
         """See `opentelemetry.trace.Tracer.use_span`."""
         try:
             context_snapshot = context_api.get_current()
-            context_api.set_current(
-                context_api.set_value(SPAN_KEY, span)
-            )
+            context_api.set_current(context_api.set_value(SPAN_KEY, span))
             try:
                 yield span
             finally:

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -213,6 +213,10 @@ class TestSpanCreation(unittest.TestCase):
             self.assertIs(tracer_1.get_current_span(), root)
             self.assertIs(tracer_2.get_current_span(), root)
 
+        # outside of the loop, both should not reference a span.
+        self.assertIs(tracer_1.get_current_span(), None)
+        self.assertIs(tracer_2.get_current_span(), None)
+
     def test_start_span_implicit(self):
         tracer = new_tracer()
 

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -201,6 +201,18 @@ class TestSpanCreation(unittest.TestCase):
             span2.span_processor, tracer_source._active_span_processor
         )
 
+    def test_get_current_span_multiple_tracers(self):
+        """In the case where there are multiple tracers, 
+        get_current_span will return the same active span
+        for both tracers.
+        """
+        tracer_1 = new_tracer()
+        tracer_2 = new_tracer()
+        root = tracer_1.start_span("root")
+        with tracer_1.use_span(root, True):
+            self.assertIs(tracer_1.get_current_span(), root)
+            self.assertIs(tracer_2.get_current_span(), root)
+
     def test_start_span_implicit(self):
         tracer = new_tracer()
 

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -202,7 +202,7 @@ class TestSpanCreation(unittest.TestCase):
         )
 
     def test_get_current_span_multiple_tracers(self):
-        """In the case where there are multiple tracers, 
+        """In the case where there are multiple tracers,
         get_current_span will return the same active span
         for both tracers.
         """


### PR DESCRIPTION
The conversation in https://github.com/open-telemetry/opentelemetry-specification/issues/455
is specifying that the tracer is no longer responsible for handling the setting
and getting of active spans. As such, named tracers would only be respnosible
for creating new spans, but not for setting the active one.

This implies that there tracers do not have their own active spans.

In addition, there is a benefit of having a single active span, as it
vastly simplifies the process to modify the current span (no need to
explicitly retrieve the tracer responsible for getting the span).