### PR TITLE
Upgrading tox envs to python3.8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,14 +12,14 @@ envlist =
     ; pypy3-coverage
 
     lint
-    py37-tracecontext
-    py37-{mypy,mypyinstalled}
+    py38-tracecontext
+    py38-{mypy,mypyinstalled}
     docs
     docker-tests
 
 [travis]
 python =
-  3.7: py37, lint, docs, docker-tests
+  3.8: py38, lint, docs, docker-tests
 
 [testenv]
 deps =
@@ -107,7 +107,7 @@ commands =
 
 
 [testenv:lint]
-basepython: python3.7
+basepython: python3.8
 recreate = True
 deps =
   -c dev-requirements.txt
@@ -139,8 +139,8 @@ changedir = docs
 commands =
   sphinx-build -E -a -W --keep-going -b html -T . _build/html
 
-[testenv:py37-tracecontext]
-basepython: python3.7
+[testenv:py38-tracecontext]
+basepython: python3.8
 deps =
   # needed for tracecontext
   aiohttp~=3.6


### PR DESCRIPTION
Python3.8 is now stable, and we should run the common tasks under 3.8
instead of 3.7