### PR TITLE
Remove "print(Context)" from basic tracer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ pip install -e ./ext/opentelemetry-ext-{integration}
 
 ```python
 from opentelemetry import trace
-from opentelemetry.context import Context
 from opentelemetry.sdk.trace import TracerSource
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter
 from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
@@ -64,7 +63,7 @@ tracer = trace.tracer_source().get_tracer(__name__)
 with tracer.start_as_current_span('foo'):
     with tracer.start_as_current_span('bar'):
         with tracer.start_as_current_span('baz'):
-            print(Context)
+            print("Hello world from OpenTelemetry Python!")
 ```
 
 ### Metrics

--- a/examples/basic_tracer/tracer.py
+++ b/examples/basic_tracer/tracer.py
@@ -17,7 +17,6 @@
 import os
 
 from opentelemetry import trace
-from opentelemetry.context import Context
 from opentelemetry.sdk.trace import TracerSource
 from opentelemetry.sdk.trace.export import (
     BatchExportSpanProcessor,
@@ -51,4 +50,4 @@ trace.tracer_source().add_span_processor(span_processor)
 with tracer.start_as_current_span("foo"):
     with tracer.start_as_current_span("bar"):
         with tracer.start_as_current_span("baz"):
-            print(Context)
+            print("Hello world from OpenTelemetry Python!")


### PR DESCRIPTION
Two reasons to remove it:
- Now Context is a class and it doesn't print any useful information.
- We don't expect users to interact directly with the context, so avoid it.