### PR TITLE
Adding trace.get_tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
 trace.tracer_source().add_span_processor(
     SimpleExportSpanProcessor(ConsoleSpanExporter())
 )
-tracer = trace.tracer_source().get_tracer(__name__)
+tracer = trace.get_tracer(__name__)
 with tracer.start_as_current_span('foo'):
     with tracer.start_as_current_span('bar'):
         with tracer.start_as_current_span('baz'):

--- a/examples/basic_tracer/tracer.py
+++ b/examples/basic_tracer/tracer.py
@@ -41,7 +41,7 @@ trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
 # We tell OpenTelemetry who it is that is creating spans. In this case, we have
 # no real name (no setup.py), so we make one up. If we had a version, we would
 # also specify it here.
-tracer = trace.tracer_source().get_tracer(__name__)
+tracer = trace.get_tracer(__name__)
 
 # SpanExporter receives the spans and send them to the target location.
 span_processor = BatchExportSpanProcessor(exporter)

--- a/examples/http/server.py
+++ b/examples/http/server.py
@@ -42,7 +42,7 @@ else:
 # The preferred tracer implementation must be set, as the opentelemetry-api
 # defines the interface with a no-op implementation.
 trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
-tracer = trace.tracer_source().get_tracer(__name__)
+tracer = trace.get_tracer(__name__)
 
 # SpanExporter receives the spans and send them to the target location.
 span_processor = BatchExportSpanProcessor(exporter)

--- a/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
+++ b/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
@@ -67,7 +67,7 @@ def hello():
     version = pkg_resources.get_distribution(
         "opentelemetry-example-app"
     ).version
-    tracer = trace.tracer_source().get_tracer(__name__, version)
+    tracer = trace.get_tracer(__name__, version)
     with tracer.start_as_current_span("example-request"):
         requests.get("http://www.example.com")
     return "hello"

--- a/examples/opentracing/main.py
+++ b/examples/opentracing/main.py
@@ -28,7 +28,7 @@ opentracing_tracer = opentracing_shim.create_tracer(tracer_source)
 redis_cache = RedisCache(opentracing_tracer)
 
 # Appication code uses an OpenTelemetry Tracer as usual.
-tracer = trace.tracer_source().get_tracer(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 @redis_cache

--- a/ext/opentelemetry-ext-dbapi/README.rst
+++ b/ext/opentelemetry-ext-dbapi/README.rst
@@ -15,7 +15,7 @@ Usage
     from opentelemetry.ext.dbapi import trace_integration
 
     trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
-    tracer = trace.tracer_source().get_tracer(__name__)
+    tracer = trace.get_tracer(__name__)
     # Ex: mysql.connector
     trace_integration(tracer_source(), mysql.connector, "connect", "mysql")
 

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
@@ -61,7 +61,7 @@ def _before_flask_request():
         otel_wsgi.get_header_from_environ, environ
     )
 
-    tracer = trace.tracer_source().get_tracer(__name__, __version__)
+    tracer = trace.get_tracer(__name__, __version__)
 
     attributes = otel_wsgi.collect_request_attributes(environ)
     if flask_request.url_rule:

--- a/ext/opentelemetry-ext-jaeger/README.rst
+++ b/ext/opentelemetry-ext-jaeger/README.rst
@@ -36,7 +36,7 @@ gRPC is still not supported by this implementation.
     from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
     trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
-    tracer = trace.tracer_source().get_tracer(__name__)
+    tracer = trace.get_tracer(__name__)
 
     # create a JaegerSpanExporter
     jaeger_exporter = jaeger.JaegerSpanExporter(

--- a/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
+++ b/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
@@ -6,7 +6,7 @@ from opentelemetry.sdk.trace import TracerSource
 from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
 trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
-tracer = trace.tracer_source().get_tracer(__name__)
+tracer = trace.get_tracer(__name__)
 
 # create a JaegerSpanExporter
 jaeger_exporter = jaeger.JaegerSpanExporter(

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
@@ -36,7 +36,7 @@ following example::
     trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
 
     # Create an OpenTelemetry Tracer.
-    otel_tracer = trace.tracer_source().get_tracer(__name__)
+    otel_tracer = trace.get_tracer(__name__)
 
     # Create an OpenTracing shim.
     shim = create_tracer(otel_tracer)

--- a/ext/opentelemetry-ext-psycopg2/README.rst
+++ b/ext/opentelemetry-ext-psycopg2/README.rst
@@ -16,7 +16,7 @@ Usage
     from opentelemetry.trace.ext.psycopg2 import trace_integration
 
     trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
-    tracer = trace.tracer_source().get_tracer(__name__)
+    tracer = trace.get_tracer(__name__)
     trace_integration(tracer)
     cnx = psycopg2.connect(database='Database')
     cursor = cnx.cursor()

--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
@@ -162,7 +162,7 @@ class OpenTelemetryMiddleware:
 
     def __init__(self, wsgi):
         self.wsgi = wsgi
-        self.tracer = trace.tracer_source().get_tracer(__name__, __version__)
+        self.tracer = trace.get_tracer(__name__, __version__)
 
     @staticmethod
     def _create_start_response(span, start_response):

--- a/ext/opentelemetry-ext-zipkin/README.rst
+++ b/ext/opentelemetry-ext-zipkin/README.rst
@@ -34,7 +34,7 @@ This exporter always send traces to the configured Zipkin collector using HTTP.
     from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
     trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
-    tracer = trace.tracer_source().get_tracer(__name__)
+    tracer = trace.get_tracer(__name__)
 
     # create a ZipkinSpanExporter
     zipkin_exporter = zipkin.ZipkinSpanExporter(

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -36,7 +36,7 @@ can optionally become the new active span::
 
     from opentelemetry import trace
 
-    tracer = trace.tracer_source().get_tracer(__name__)
+    tracer = trace.get_tracer(__name__)
 
     # Create a new root span, set it as the current span in context
     with tracer.start_as_current_span("parent"):
@@ -645,6 +645,19 @@ ImplementationFactory = typing.Callable[
 
 _TRACER_SOURCE = None  # type: typing.Optional[TracerSource]
 _TRACER_SOURCE_FACTORY = None  # type: typing.Optional[ImplementationFactory]
+
+
+def get_tracer(
+    instrumenting_module_name: str, instrumenting_library_version: str = ""
+) -> "Tracer":
+    """Returns a `Tracer` for use by the given instrumentation library.
+
+    This function is a convenience wrapper for
+    `opentelemetry.trace.tracer_source().get_tracer`
+    """
+    return tracer_source().get_tracer(
+        instrumenting_module_name, instrumenting_library_version
+    )
 
 
 def tracer_source() -> TracerSource:

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -68,12 +68,15 @@ implicit or explicit context propagation consistently throughout.
 
 import abc
 import enum
+import logging
 import types as python_types
 import typing
 from contextlib import contextmanager
 
 from opentelemetry.trace.status import Status
 from opentelemetry.util import loader, types
+
+logger = logging.getLogger(__name__)
 
 # TODO: quarantine
 ParentSpan = typing.Optional[typing.Union["Span", "SpanContext"]]
@@ -676,6 +679,10 @@ def tracer_source() -> TracerSource:
         except TypeError:
             # if we raised an exception trying to instantiate an
             # abstract class, default to no-op tracer impl
+            logger.warning(
+                "Unable to instantiate TracerSource from tracer source factory.",
+                exc_info=True,
+            )
             _TRACER_SOURCE = DefaultTracerSource()
         del _TRACER_SOURCE_FACTORY
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -656,7 +656,7 @@ def get_tracer(
     """Returns a `Tracer` for use by the given instrumentation library.
 
     This function is a convenience wrapper for
-    `opentelemetry.trace.tracer_source().get_tracer`
+    opentelemetry.trace.tracer_source().get_tracer
     """
     return tracer_source().get_tracer(
         instrumenting_module_name, instrumenting_library_version

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -35,7 +35,7 @@ class TestGlobals(unittest.TestCase):
         importlib.reload(trace)
 
     def test_get_tracer(self):
-        """trace.get_tracer should proxy to the
+        """trace.get_tracer should proxy to the global tracer source."""
         global tracer sourceA
         """
         from_global_api = trace.get_tracer("foo")

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -31,7 +31,7 @@ class TestGlobals(unittest.TestCase):
         )
 
     @staticmethod
-    def tearDown():
+    def tearDown() -> None:
         importlib.reload(trace)
 
     def test_get_tracer(self):

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -1,0 +1,43 @@
+import importlib
+import unittest
+
+from opentelemetry import trace
+
+
+class TestGlobals(unittest.TestCase):
+    def setUp(self):
+        importlib.reload(trace)
+
+        # this class has to be declared after the importlib
+        # reload, or else it will inherit from an old
+        # TracerSource, rather than the new TraceSource ABC.
+        # created from reload.
+
+        static_tracer = trace.DefaultTracer()
+
+        class DummyTracerSource(trace.TracerSource):
+            """TraceSource used for testing"""
+
+            def get_tracer(
+                self,
+                instrumenting_module_name: str,
+                instrumenting_library_version: str = "",
+            ) -> trace.Tracer:
+                # pylint:disable=no-self-use,unused-argument
+                return static_tracer
+
+        trace.set_preferred_tracer_source_implementation(
+            lambda _: DummyTracerSource()
+        )
+
+    @staticmethod
+    def teardown():
+        importlib.reload(trace)
+
+    def test_get_tracer(self):
+        """trace.get_tracer should proxy to the
+        global tracer sourceA
+        """
+        from_global_api = trace.get_tracer("foo")
+        from_tracer_api = trace.tracer_source().get_tracer("foo")
+        self.assertEqual(from_global_api, from_tracer_api)

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -31,12 +31,11 @@ class TestGlobals(unittest.TestCase):
         )
 
     @staticmethod
-    def teardown():
+    def tearDown():
         importlib.reload(trace)
 
     def test_get_tracer(self):
         """trace.get_tracer should proxy to the global tracer source."""
-        """
         from_global_api = trace.get_tracer("foo")
         from_tracer_api = trace.tracer_source().get_tracer("foo")
         self.assertEqual(from_global_api, from_tracer_api)

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -36,7 +36,6 @@ class TestGlobals(unittest.TestCase):
 
     def test_get_tracer(self):
         """trace.get_tracer should proxy to the global tracer source."""
-        global tracer sourceA
         """
         from_global_api = trace.get_tracer("foo")
         from_tracer_api = trace.tracer_source().get_tracer("foo")

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -38,4 +38,4 @@ class TestGlobals(unittest.TestCase):
         """trace.get_tracer should proxy to the global tracer source."""
         from_global_api = trace.get_tracer("foo")
         from_tracer_api = trace.tracer_source().get_tracer("foo")
-        self.assertEqual(from_global_api, from_tracer_api)
+        self.assertIs(from_global_api, from_tracer_api)


### PR DESCRIPTION
As a convenience method to retrieve a tracer, introducing trace.get_tracer.

Overall I think this removes an extra element that is strongly implied. 