### PR TITLE
build: adding sdist to build scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@
 set -ev
 
 # Get the latest versions of packaging tools
-python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install --user --upgrade pip setuptools wheel
 
 BASEDIR=$(dirname $(readlink -f $(dirname $0)))
 
@@ -17,8 +17,14 @@ BASEDIR=$(dirname $(readlink -f $(dirname $0)))
 
  for d in opentelemetry-api/ opentelemetry-sdk/ ext/*/ ; do
    (
+     echo "building $d"
      cd "$d"
-     python3 setup.py --verbose bdist_wheel --dist-dir "$BASEDIR/dist/"
+     # some ext directories (such as docker tests)
+     # are not intended to be packaged. Verify the
+     # intent by looking for a setup.py
+     if [ -f setup.py ]; then
+      python3 setup.py --verbose bdist_wheel --dist-dir "$BASEDIR/dist/" sdist --dist-dir "$BASEDIR/dist/"
+     fi
    )
  done
 )

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@
 set -ev
 
 # Get the latest versions of packaging tools
-python3 -m pip install --user --upgrade pip setuptools wheel
+python3 -m pip install --upgrade pip setuptools wheel
 
 BASEDIR=$(dirname $(readlink -f $(dirname $0)))
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,9 @@ BASEDIR=$(dirname $(readlink -f $(dirname $0)))
      # are not intended to be packaged. Verify the
      # intent by looking for a setup.py
      if [ -f setup.py ]; then
-      python3 setup.py --verbose bdist_wheel --dist-dir "$BASEDIR/dist/" sdist --dist-dir "$BASEDIR/dist/"
+      python3 setup.py --verbose bdist_wheel --dist-dir "$BASEDIR/dist/" \
+        sdist --dist-dir "$BASEDIR/dist/" \
+        clean --all
      fi
    )
  done


### PR DESCRIPTION
Some operating systems (such as SUSE with py2pack) have an easier time
packaging source distributions.

Adding a check for the setup.py before attempting to build
distributions.

Addressing part of #427 