### PR TITLE
Build wheels from source dists

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@
 set -ev
 
 # Get the latest versions of packaging tools
-python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install --user --upgrade pip setuptools wheel
 
 BASEDIR=$(dirname $(readlink -f $(dirname $0)))
 
@@ -17,8 +17,14 @@ BASEDIR=$(dirname $(readlink -f $(dirname $0)))
 
  for d in opentelemetry-api/ opentelemetry-sdk/ ext/*/ ; do
    (
+     echo "building $d"
      cd "$d"
-     python3 setup.py --verbose bdist_wheel --dist-dir "$BASEDIR/dist/"
+     # some ext directories (such as docker tests)
+     # are not intended to be packaged. Verify the
+     # intent by looking for a setup.py
+     if [ -f setup.py ]; then
+      python3 setup.py --verbose bdist_wheel --dist-dir "$BASEDIR/dist/" sdist --dist-dir "$BASEDIR/dist/"
+     fi
    )
  done
 )

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ DISTDIR=dist
 (
   cd $BASEDIR
   mkdir -p $DISTDIR
-  rm -rf $DISTDIR/*
+  rm -r $DISTDIR/*
 
  for d in opentelemetry-api/ opentelemetry-sdk/ ext/*/ ; do
    (

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,25 +6,32 @@
 set -ev
 
 # Get the latest versions of packaging tools
-python3 -m pip install --user --upgrade pip setuptools wheel
+python3 -m pip install --upgrade pip setuptools wheel
 
 BASEDIR=$(dirname $(readlink -f $(dirname $0)))
+DISTDIR=dist
 
 (
   cd $BASEDIR
-  mkdir -p dist
-  rm -rf dist/*
+  mkdir -p $DISTDIR
+  rm -rf $DISTDIR/*
 
  for d in opentelemetry-api/ opentelemetry-sdk/ ext/*/ ; do
    (
      echo "building $d"
      cd "$d"
-     # some ext directories (such as docker tests)
-     # are not intended to be packaged. Verify the
-     # intent by looking for a setup.py
+     # Some ext directories (such as docker tests) are not intended to be
+     # packaged. Verify the intent by looking for a setup.py.
      if [ -f setup.py ]; then
-      python3 setup.py --verbose bdist_wheel --dist-dir "$BASEDIR/dist/" sdist --dist-dir "$BASEDIR/dist/"
+      python3 setup.py sdist --dist-dir "$BASEDIR/dist/" clean --all
      fi
    )
  done
+ # Build a wheel for each source distribution
+ (
+   cd $DISTDIR
+   for x in *.tar.gz ; do
+     pip wheel --no-deps $x
+   done
+ )
 )


### PR DESCRIPTION
Fixes #252 

Follow up to #433. This replaces `setup.py bdist_wheel` with `pip wheel`, but should produce the same artifacts. @Oberon00, @toumorokoshi, please sanity check me on this.