### PR TITLE
Make Counter and MinMaxSumCount aggregators thread safe

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import abc
+import threading
 from collections import namedtuple
 
 
@@ -47,13 +48,16 @@ class CounterAggregator(Aggregator):
         super().__init__()
         self.current = 0
         self.checkpoint = 0
+        self._lock = threading.Lock()
 
     def update(self, value):
-        self.current += value
+        with self._lock:
+            self.current += value
 
     def take_checkpoint(self):
-        self.checkpoint = self.current
-        self.current = 0
+        with self._lock:
+            self.checkpoint = self.current
+            self.current = 0
 
     def merge(self, other):
         self.checkpoint += other.checkpoint

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
@@ -60,7 +60,8 @@ class CounterAggregator(Aggregator):
             self.current = 0
 
     def merge(self, other):
-        self.checkpoint += other.checkpoint
+        with self._lock:
+            self.checkpoint += other.checkpoint
 
 
 class MinMaxSumCountAggregator(Aggregator):
@@ -106,6 +107,7 @@ class MinMaxSumCountAggregator(Aggregator):
             self.current = self._EMPTY
 
     def merge(self, other):
-        self.checkpoint = self._merge_checkpoint(
-            self.checkpoint, other.checkpoint
-        )
+        with self._lock:
+            self.checkpoint = self._merge_checkpoint(
+                self.checkpoint, other.checkpoint
+            )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
@@ -67,46 +67,45 @@ class MinMaxSumCountAggregator(Aggregator):
     """Agregator for Measure metrics that keeps min, max, sum and count."""
 
     _TYPE = namedtuple("minmaxsumcount", "min max sum count")
+    _EMPTY = _TYPE(None, None, None, 0)
 
     @classmethod
-    def _min(cls, val1, val2):
-        if val1 is None and val2 is None:
-            return None
-        return min(val1 or val2, val2 or val1)
-
-    @classmethod
-    def _max(cls, val1, val2):
-        if val1 is None and val2 is None:
-            return None
-        return max(val1 or val2, val2 or val1)
-
-    @classmethod
-    def _sum(cls, val1, val2):
-        if val1 is None and val2 is None:
-            return None
-        return (val1 or 0) + (val2 or 0)
+    def _merge_checkpoint(cls, val1, val2):
+        if val1 is cls._EMPTY:
+            return val2
+        if val2 is cls._EMPTY:
+            return val1
+        return cls._TYPE(
+            min(val1.min, val2.min),
+            max(val1.max, val2.max),
+            val1.sum + val2.sum,
+            val1.count + val2.count,
+        )
 
     def __init__(self):
         super().__init__()
-        self.current = self._TYPE(None, None, None, 0)
-        self.checkpoint = self._TYPE(None, None, None, 0)
+        self.current = self._EMPTY
+        self.checkpoint = self._EMPTY
+        self._lock = threading.Lock()
 
     def update(self, value):
-        self.current = self._TYPE(
-            self._min(self.current.min, value),
-            self._max(self.current.max, value),
-            self._sum(self.current.sum, value),
-            self.current.count + 1,
-        )
+        with self._lock:
+            if self.current is self._EMPTY:
+                self.current = self._TYPE(value, value, value, 1)
+            else:
+                self.current = self._TYPE(
+                    min(self.current.min, value),
+                    max(self.current.max, value),
+                    self.current.sum + value,
+                    self.current.count + 1,
+                )
 
     def take_checkpoint(self):
-        self.checkpoint = self.current
-        self.current = self._TYPE(None, None, None, 0)
+        with self._lock:
+            self.checkpoint = self.current
+            self.current = self._EMPTY
 
     def merge(self, other):
-        self.checkpoint = self._TYPE(
-            self._min(self.checkpoint.min, other.checkpoint.min),
-            self._max(self.checkpoint.max, other.checkpoint.max),
-            self._sum(self.checkpoint.sum, other.checkpoint.sum),
-            self.checkpoint.count + other.checkpoint.count,
+        self.checkpoint = self._merge_checkpoint(
+            self.checkpoint, other.checkpoint
         )

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -286,8 +286,8 @@ class TestCounterAggregator(unittest.TestCase):
 class TestMinMaxSumCountAggregator(unittest.TestCase):
     @classmethod
     def call_update(cls, mmsc):
-        min_ = 2 ** 32
-        max_ = 0
+        min_ = float("inf")
+        max_ = float("-inf")
         sum_ = 0
         count_ = 0
         for _ in range(0, 100000):

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -273,7 +273,7 @@ class TestCounterAggregator(unittest.TestCase):
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             fut = executor.submit(self.call_update, counter)
 
-            while fut.running():
+            while not fut.done():
                 counter.take_checkpoint()
                 checkpoint_total += counter.checkpoint
 
@@ -417,7 +417,7 @@ class TestMinMaxSumCountAggregator(unittest.TestCase):
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
             fut = ex.submit(self.call_update, mmsc)
 
-            while fut.running():
+            while not fut.done():
                 mmsc.take_checkpoint()
                 checkpoint_total = MinMaxSumCountAggregator._merge_checkpoint(
                     checkpoint_total, mmsc.checkpoint

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -224,8 +224,8 @@ class TestBatcher(unittest.TestCase):
 
 
 class TestCounterAggregator(unittest.TestCase):
-    @classmethod
-    def call_update(cls, counter):
+    @staticmethod
+    def call_update(counter):
         update_total = 0
         for _ in range(0, 100000):
             val = random.getrandbits(32)
@@ -284,8 +284,8 @@ class TestCounterAggregator(unittest.TestCase):
 
 
 class TestMinMaxSumCountAggregator(unittest.TestCase):
-    @classmethod
-    def call_update(cls, mmsc):
+    @staticmethod
+    def call_update(mmsc):
         min_ = float("inf")
         max_ = float("-inf")
         sum_ = 0


### PR DESCRIPTION
The `update()` and the `take_checkpoint()` functions on these aggregators can be called concurrently, `update()` is called from the user context while `take_checkpoint()` is invoked from the controller. It is also possible to receive concurrent calls to the `update()` function from the user. For these reasons this PR adds a locking mechanism to guarantee that those functions are thread safe. This PR also implements some concurrency tests for those aggregators.

 As a note, it could be a temporal solution as in the future we want to explore atomic to avoid the cost of locking.