### PR TITLE
Rename TracerSource to TracerProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ pip install -e ./ext/opentelemetry-ext-{integration}
 
 ```python
 from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerSource
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter
 from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
 
-trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
-trace.tracer_source().add_span_processor(
+trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
+trace.tracer_provider().add_span_processor(
     SimpleExportSpanProcessor(ConsoleSpanExporter())
 )
 tracer = trace.get_tracer(__name__)

--- a/examples/basic_tracer/tracer.py
+++ b/examples/basic_tracer/tracer.py
@@ -17,7 +17,7 @@
 import os
 
 from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerSource
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchExportSpanProcessor,
     ConsoleSpanExporter,
@@ -36,7 +36,7 @@ else:
 
 # The preferred tracer implementation must be set, as the opentelemetry-api
 # defines the interface with a no-op implementation.
-trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
+trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
 
 # We tell OpenTelemetry who it is that is creating spans. In this case, we have
 # no real name (no setup.py), so we make one up. If we had a version, we would
@@ -46,7 +46,7 @@ tracer = trace.get_tracer(__name__)
 # SpanExporter receives the spans and send them to the target location.
 span_processor = BatchExportSpanProcessor(exporter)
 
-trace.tracer_source().add_span_processor(span_processor)
+trace.tracer_provider().add_span_processor(span_processor)
 with tracer.start_as_current_span("foo"):
     with tracer.start_as_current_span("bar"):
         with tracer.start_as_current_span("baz"):

--- a/examples/http/server.py
+++ b/examples/http/server.py
@@ -22,7 +22,7 @@ import requests
 from opentelemetry import trace
 from opentelemetry.ext import http_requests
 from opentelemetry.ext.wsgi import OpenTelemetryMiddleware
-from opentelemetry.sdk.trace import TracerSource
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchExportSpanProcessor,
     ConsoleSpanExporter,
@@ -41,17 +41,17 @@ else:
 
 # The preferred tracer implementation must be set, as the opentelemetry-api
 # defines the interface with a no-op implementation.
-trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
+trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
 tracer = trace.get_tracer(__name__)
 
 # SpanExporter receives the spans and send them to the target location.
 span_processor = BatchExportSpanProcessor(exporter)
-trace.tracer_source().add_span_processor(span_processor)
+trace.tracer_provider().add_span_processor(span_processor)
 
 # Integrations are the glue that binds the OpenTelemetry API and the
 # frameworks and libraries that are used together, automatically creating
 # Spans and propagating context as appropriate.
-http_requests.enable(trace.tracer_source())
+http_requests.enable(trace.tracer_provider())
 app = flask.Flask(__name__)
 app.wsgi_app = OpenTelemetryMiddleware(app.wsgi_app)
 

--- a/examples/http/tracer_client.py
+++ b/examples/http/tracer_client.py
@@ -20,7 +20,7 @@ import requests
 
 from opentelemetry import trace
 from opentelemetry.ext import http_requests
-from opentelemetry.sdk.trace import TracerSource
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchExportSpanProcessor,
     ConsoleSpanExporter,
@@ -39,15 +39,15 @@ else:
 
 # The preferred tracer implementation must be set, as the opentelemetry-api
 # defines the interface with a no-op implementation.
-trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
-tracer_source = trace.tracer_source()
+trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
+tracer_provider = trace.tracer_provider()
 
 # SpanExporter receives the spans and send them to the target location.
 span_processor = BatchExportSpanProcessor(exporter)
-tracer_source.add_span_processor(span_processor)
+tracer_provider.add_span_processor(span_processor)
 
 # Integrations are the glue that binds the OpenTelemetry API and the
 # frameworks and libraries that are used together, automatically creating
 # Spans and propagating context as appropriate.
-http_requests.enable(tracer_source)
+http_requests.enable(tracer_provider)
 response = requests.get(url="http://127.0.0.1:5000/")

--- a/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
+++ b/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
@@ -23,7 +23,7 @@ import requests
 import opentelemetry.ext.http_requests
 from opentelemetry import trace
 from opentelemetry.ext.flask import instrument_app
-from opentelemetry.sdk.trace import TracerSource
+from opentelemetry.sdk.trace import TracerProvider
 
 
 def configure_opentelemetry(flask_app: flask.Flask):
@@ -45,7 +45,9 @@ def configure_opentelemetry(flask_app: flask.Flask):
     # The preferred implementation of these objects must be set,
     # as the opentelemetry-api defines the interface with a no-op
     # implementation.
-    trace.set_preferred_tracer_source_implementation(lambda _: TracerSource())
+    trace.set_preferred_tracer_provider_implementation(
+        lambda _: TracerProvider()
+    )
 
     # Next, we need to configure how the values that are used by
     # traces and metrics are propagated (such as what specific headers
@@ -53,7 +55,7 @@ def configure_opentelemetry(flask_app: flask.Flask):
     # Integrations are the glue that binds the OpenTelemetry API
     # and the frameworks and libraries that are used together, automatically
     # creating Spans and propagating context as appropriate.
-    opentelemetry.ext.http_requests.enable(trace.tracer_source())
+    opentelemetry.ext.http_requests.enable(trace.tracer_provider())
     instrument_app(flask_app)
 
 

--- a/examples/opentracing/main.py
+++ b/examples/opentracing/main.py
@@ -3,13 +3,13 @@
 from opentelemetry import trace
 from opentelemetry.ext import opentracing_shim
 from opentelemetry.ext.jaeger import JaegerSpanExporter
-from opentelemetry.sdk.trace import TracerSource
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
 from rediscache import RedisCache
 
 # Configure the tracer using the default implementation
-trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
-tracer_source = trace.tracer_source()
+trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
+tracer_provider = trace.tracer_provider()
 
 # Configure the tracer to export traces to Jaeger
 jaeger_exporter = JaegerSpanExporter(
@@ -18,11 +18,11 @@ jaeger_exporter = JaegerSpanExporter(
     agent_port=6831,
 )
 span_processor = SimpleExportSpanProcessor(jaeger_exporter)
-tracer_source.add_span_processor(span_processor)
+tracer_provider.add_span_processor(span_processor)
 
 # Create an OpenTracing shim. This implements the OpenTracing tracer API, but
 # forwards calls to the underlying OpenTelemetry tracer.
-opentracing_tracer = opentracing_shim.create_tracer(tracer_source)
+opentracing_tracer = opentracing_shim.create_tracer(tracer_provider)
 
 # Our example caching library expects an OpenTracing-compliant tracer.
 redis_cache = RedisCache(opentracing_tracer)

--- a/ext/opentelemetry-ext-dbapi/README.rst
+++ b/ext/opentelemetry-ext-dbapi/README.rst
@@ -11,13 +11,13 @@ Usage
 .. code:: python
 
     import mysql.connector
-    from opentelemetry.trace import tracer_source
+    from opentelemetry.trace import tracer_provider
     from opentelemetry.ext.dbapi import trace_integration
 
-    trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
+    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
     tracer = trace.get_tracer(__name__)
     # Ex: mysql.connector
-    trace_integration(tracer_source(), mysql.connector, "connect", "mysql")
+    trace_integration(tracer_provider(), mysql.connector, "connect", "mysql")
 
 
 References

--- a/ext/opentelemetry-ext-docker-tests/tests/pymongo/test_pymongo_functional.py
+++ b/ext/opentelemetry-ext-docker-tests/tests/pymongo/test_pymongo_functional.py
@@ -20,7 +20,7 @@ from pymongo import MongoClient
 
 from opentelemetry import trace as trace_api
 from opentelemetry.ext.pymongo import trace_integration
-from opentelemetry.sdk.trace import Span, Tracer, TracerSource
+from opentelemetry.sdk.trace import Span, Tracer, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
@@ -35,11 +35,11 @@ MONGODB_COLLECTION_NAME = "test"
 class TestFunctionalPymongo(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls._tracer_source = TracerSource()
-        cls._tracer = Tracer(cls._tracer_source, None)
+        cls._tracer_provider = TracerProvider()
+        cls._tracer = Tracer(cls._tracer_provider, None)
         cls._span_exporter = InMemorySpanExporter()
         cls._span_processor = SimpleExportSpanProcessor(cls._span_exporter)
-        cls._tracer_source.add_span_processor(cls._span_processor)
+        cls._tracer_provider.add_span_processor(cls._span_processor)
         trace_integration(cls._tracer)
         client = MongoClient(
             MONGODB_HOST, MONGODB_PORT, serverSelectionTimeoutMS=2000

--- a/ext/opentelemetry-ext-http-requests/README.rst
+++ b/ext/opentelemetry-ext-http-requests/README.rst
@@ -22,9 +22,9 @@ Usage
 
     import requests
     import opentelemetry.ext.http_requests
-    from opentelemetry.trace import tracer_source
+    from opentelemetry.trace import tracer_provider
 
-    opentelemetry.ext.http_requests.enable(tracer_source())
+    opentelemetry.ext.http_requests.enable(tracer_provider())
     response = requests.get(url='https://www.example.org/')
 
 Limitations

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
@@ -32,7 +32,7 @@ from opentelemetry.trace import SpanKind
 # if the SDK/tracer is already using `requests` they may, in theory, bypass our
 # instrumentation when using `import from`, etc. (currently we only instrument
 # a instance method so the probability for that is very low).
-def enable(tracer_source):
+def enable(tracer_provider):
     """Enables tracing of all requests calls that go through
       :code:`requests.session.Session.request` (this includes
       :code:`requests.get`, etc.)."""
@@ -47,7 +47,7 @@ def enable(tracer_source):
     # Guard against double instrumentation
     disable()
 
-    tracer = tracer_source.get_tracer(__name__, __version__)
+    tracer = tracer_provider.get_tracer(__name__, __version__)
 
     wrapped = Session.request
 

--- a/ext/opentelemetry-ext-http-requests/tests/test_requests_integration.py
+++ b/ext/opentelemetry-ext-http-requests/tests/test_requests_integration.py
@@ -29,10 +29,10 @@ class TestRequestsIntegration(unittest.TestCase):
     # TODO: Copy & paste from test_wsgi_middleware
     def setUp(self):
         self.span_attrs = {}
-        self.tracer_source = trace.DefaultTracerSource()
+        self.tracer_provider = trace.DefaultTracerProvider()
         self.tracer = trace.DefaultTracer()
         self.get_tracer_patcher = mock.patch.object(
-            self.tracer_source,
+            self.tracer_provider,
             "get_tracer",
             autospec=True,
             spec_set=True,
@@ -70,7 +70,7 @@ class TestRequestsIntegration(unittest.TestCase):
         self.start_as_current_span = self.start_span_patcher.start()
         self.send = self.send_patcher.start()
 
-        opentelemetry.ext.http_requests.enable(self.tracer_source)
+        opentelemetry.ext.http_requests.enable(self.tracer_provider)
         distver = pkg_resources.get_distribution(
             "opentelemetry-ext-http-requests"
         ).version

--- a/ext/opentelemetry-ext-jaeger/README.rst
+++ b/ext/opentelemetry-ext-jaeger/README.rst
@@ -32,10 +32,10 @@ gRPC is still not supported by this implementation.
 
     from opentelemetry import trace
     from opentelemetry.ext import jaeger
-    from opentelemetry.sdk.trace import TracerSource
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
-    trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
+    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
     tracer = trace.get_tracer(__name__)
 
     # create a JaegerSpanExporter

--- a/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
+++ b/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
@@ -2,10 +2,10 @@ import time
 
 from opentelemetry import trace
 from opentelemetry.ext import jaeger
-from opentelemetry.sdk.trace import TracerSource
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
-trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
+trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
 tracer = trace.get_tracer(__name__)
 
 # create a JaegerSpanExporter
@@ -26,7 +26,7 @@ jaeger_exporter = jaeger.JaegerSpanExporter(
 span_processor = BatchExportSpanProcessor(jaeger_exporter)
 
 # add to the tracer factory
-trace.tracer_source().add_span_processor(span_processor)
+trace.tracer_provider().add_span_processor(span_processor)
 
 # create some spans for testing
 with tracer.start_as_current_span("foo") as foo:

--- a/ext/opentelemetry-ext-mysql/README.rst
+++ b/ext/opentelemetry-ext-mysql/README.rst
@@ -12,10 +12,10 @@ Usage
 .. code:: python
 
     import mysql.connector
-    from opentelemetry.trace import tracer_source
+    from opentelemetry.trace import tracer_provider
     from opentelemetry.ext.mysql import trace_integration
 
-    trace_integration(tracer_source())
+    trace_integration(tracer_provider())
     cnx = mysql.connector.connect(database='MySQL_Database')
     cursor = cnx.cursor()
     cursor.execute("INSERT INTO test (testField) VALUES (123)"

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
@@ -29,11 +29,11 @@ following example::
     import time
 
     from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerSource
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.ext.opentracing_shim import create_tracer
 
     # Tell OpenTelemetry which Tracer implementation to use.
-    trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
+    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
 
     # Create an OpenTelemetry Tracer.
     otel_tracer = trace.get_tracer(__name__)
@@ -97,15 +97,15 @@ from opentelemetry.trace import DefaultSpan
 logger = logging.getLogger(__name__)
 
 
-def create_tracer(otel_tracer_source):
+def create_tracer(otel_tracer_provider):
     """Creates a :class:`TracerShim` object from the provided OpenTelemetry
-    :class:`opentelemetry.trace.TracerSource`.
+    :class:`opentelemetry.trace.TracerProvider`.
 
     The returned :class:`TracerShim` is an implementation of
     :class:`opentracing.Tracer` using OpenTelemetry under the hood.
 
     Args:
-        otel_tracer_source: A :class:`opentelemetry.trace.TracerSource` to be
+        otel_tracer_provider: A :class:`opentelemetry.trace.TracerProvider` to be
             used for constructing the :class:`TracerShim`. A tracer from this
             source will be used to perform the actual tracing when user code is
             instrumented using the OpenTracing API.
@@ -114,7 +114,7 @@ def create_tracer(otel_tracer_source):
         The created :class:`TracerShim`.
     """
 
-    return TracerShim(otel_tracer_source.get_tracer(__name__, __version__))
+    return TracerShim(otel_tracer_provider.get_tracer(__name__, __version__))
 
 
 class SpanContextShim(opentracing.SpanContext):

--- a/ext/opentelemetry-ext-opentracing-shim/tests/test_shim.py
+++ b/ext/opentelemetry-ext-opentracing-shim/tests/test_shim.py
@@ -24,7 +24,7 @@ import opentelemetry.ext.opentracing_shim as opentracingshim
 from opentelemetry import propagators, trace
 from opentelemetry.context.propagation.httptextformat import HTTPTextFormat
 from opentelemetry.ext.opentracing_shim import util
-from opentelemetry.sdk.trace import TracerSource
+from opentelemetry.sdk.trace import TracerProvider
 
 
 class TestShim(TestCase):
@@ -33,7 +33,7 @@ class TestShim(TestCase):
     def setUp(self):
         """Create an OpenTelemetry tracer and a shim before every test case."""
 
-        self.shim = opentracingshim.create_tracer(trace.tracer_source())
+        self.shim = opentracingshim.create_tracer(trace.tracer_provider())
 
     @classmethod
     def setUpClass(cls):
@@ -41,8 +41,8 @@ class TestShim(TestCase):
         every test method.
         """
 
-        trace.set_preferred_tracer_source_implementation(
-            lambda T: TracerSource()
+        trace.set_preferred_tracer_provider_implementation(
+            lambda T: TracerProvider()
         )
 
         # Save current propagator to be restored on teardown.

--- a/ext/opentelemetry-ext-psycopg2/README.rst
+++ b/ext/opentelemetry-ext-psycopg2/README.rst
@@ -12,10 +12,10 @@ Usage
 .. code:: python
     import psycopg2
     from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerSource
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.trace.ext.psycopg2 import trace_integration
 
-    trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
+    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
     tracer = trace.get_tracer(__name__)
     trace_integration(tracer)
     cnx = psycopg2.connect(database='Database')

--- a/ext/opentelemetry-ext-pymongo/README.rst
+++ b/ext/opentelemetry-ext-pymongo/README.rst
@@ -12,10 +12,10 @@ Usage
 .. code:: python
 
     from pymongo import MongoClient
-    from opentelemetry.trace import tracer_source
+    from opentelemetry.trace import tracer_provider
     from opentelemetry.trace.ext.pymongo import trace_integration
 
-    trace_integration(tracer_source())
+    trace_integration(tracer_provider())
     client = MongoClient()
     db = client["MongoDB_Database"]
     collection = db["MongoDB_Collection"]

--- a/ext/opentelemetry-ext-testutil/src/opentelemetry/ext/testutil/wsgitestutil.py
+++ b/ext/opentelemetry-ext-testutil/src/opentelemetry/ext/testutil/wsgitestutil.py
@@ -4,7 +4,7 @@ import wsgiref.util as wsgiref_util
 from importlib import reload
 
 from opentelemetry import trace as trace_api
-from opentelemetry.sdk.trace import TracerSource, export
+from opentelemetry.sdk.trace import TracerProvider, export
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
@@ -16,13 +16,13 @@ class WsgiTestBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         global _MEMORY_EXPORTER  # pylint:disable=global-statement
-        trace_api.set_preferred_tracer_source_implementation(
-            lambda T: TracerSource()
+        trace_api.set_preferred_tracer_provider_implementation(
+            lambda T: TracerProvider()
         )
-        tracer_source = trace_api.tracer_source()
+        tracer_provider = trace_api.tracer_provider()
         _MEMORY_EXPORTER = InMemorySpanExporter()
         span_processor = export.SimpleExportSpanProcessor(_MEMORY_EXPORTER)
-        tracer_source.add_span_processor(span_processor)
+        tracer_provider.add_span_processor(span_processor)
 
     @classmethod
     def tearDownClass(cls):

--- a/ext/opentelemetry-ext-zipkin/README.rst
+++ b/ext/opentelemetry-ext-zipkin/README.rst
@@ -30,10 +30,10 @@ This exporter always send traces to the configured Zipkin collector using HTTP.
 
     from opentelemetry import trace
     from opentelemetry.ext import zipkin
-    from opentelemetry.sdk.trace import TracerSource
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
-    trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
+    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
     tracer = trace.get_tracer(__name__)
 
     # create a ZipkinSpanExporter
@@ -53,7 +53,7 @@ This exporter always send traces to the configured Zipkin collector using HTTP.
     span_processor = BatchExportSpanProcessor(zipkin_exporter)
 
     # add to the tracer
-    trace.tracer_source().add_span_processor(span_processor)
+    trace.tracer_provider().add_span_processor(span_processor)
 
     with tracer.start_as_current_span("foo"):
         print("Hello world!")

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -26,7 +26,7 @@ tracing, and a concrete no-op :class:`.DefaultSpan` that allows applications
 to use the API package alone without a supporting implementation.
 
 To get a tracer, you need to provide the package name from which you are
-calling the tracer APIs to OpenTelemetry by calling `TracerSource.get_tracer`
+calling the tracer APIs to OpenTelemetry by calling `TracerProvider.get_tracer`
 with the calling module name and the version of your package.
 
 The tracer supports creating spans that are "attached" or "detached" from the
@@ -62,8 +62,8 @@ implicit or explicit context propagation consistently throughout.
 
 .. versionadded:: 0.1.0
 .. versionchanged:: 0.3.0
-    `TracerSource` was introduced and the global ``tracer`` getter was replaced
-    by `tracer_source`.
+    `TracerProvider` was introduced and the global ``tracer`` getter was replaced
+    by `tracer_provider`.
 """
 
 import abc
@@ -405,7 +405,7 @@ INVALID_SPAN_CONTEXT = SpanContext(
 INVALID_SPAN = DefaultSpan(INVALID_SPAN_CONTEXT)
 
 
-class TracerSource(abc.ABC):
+class TracerProvider(abc.ABC):
     @abc.abstractmethod
     def get_tracer(
         self,
@@ -435,8 +435,8 @@ class TracerSource(abc.ABC):
         """
 
 
-class DefaultTracerSource(TracerSource):
-    """The default TracerSource, used when no implementation is available.
+class DefaultTracerProvider(TracerProvider):
+    """The default TracerProvider, used when no implementation is available.
 
     All operations are no-op.
     """
@@ -643,11 +643,11 @@ class DefaultTracer(Tracer):
 # the following type definition should be replaced with
 # from opentelemetry.util.loader import ImplementationFactory
 ImplementationFactory = typing.Callable[
-    [typing.Type[TracerSource]], typing.Optional[TracerSource]
+    [typing.Type[TracerProvider]], typing.Optional[TracerProvider]
 ]
 
-_TRACER_SOURCE = None  # type: typing.Optional[TracerSource]
-_TRACER_SOURCE_FACTORY = None  # type: typing.Optional[ImplementationFactory]
+_TRACER_PROVIDER = None  # type: typing.Optional[TracerProvider]
+_TRACER_PROVIDER_FACTORY = None  # type: typing.Optional[ImplementationFactory]
 
 
 def get_tracer(
@@ -656,40 +656,40 @@ def get_tracer(
     """Returns a `Tracer` for use by the given instrumentation library.
 
     This function is a convenience wrapper for
-    opentelemetry.trace.tracer_source().get_tracer
+    opentelemetry.trace.tracer_provider().get_tracer
     """
-    return tracer_source().get_tracer(
+    return tracer_provider().get_tracer(
         instrumenting_module_name, instrumenting_library_version
     )
 
 
-def tracer_source() -> TracerSource:
-    """Gets the current global :class:`~.TracerSource` object.
+def tracer_provider() -> TracerProvider:
+    """Gets the current global :class:`~.TracerProvider` object.
 
     If there isn't one set yet, a default will be loaded.
     """
-    global _TRACER_SOURCE, _TRACER_SOURCE_FACTORY  # pylint:disable=global-statement
+    global _TRACER_PROVIDER, _TRACER_PROVIDER_FACTORY  # pylint:disable=global-statement
 
-    if _TRACER_SOURCE is None:
+    if _TRACER_PROVIDER is None:
         # pylint:disable=protected-access
         try:
-            _TRACER_SOURCE = loader._load_impl(
-                TracerSource, _TRACER_SOURCE_FACTORY  # type: ignore
+            _TRACER_PROVIDER = loader._load_impl(
+                TracerProvider, _TRACER_PROVIDER_FACTORY  # type: ignore
             )
         except TypeError:
             # if we raised an exception trying to instantiate an
             # abstract class, default to no-op tracer impl
             logger.warning(
-                "Unable to instantiate TracerSource from tracer source factory.",
+                "Unable to instantiate TracerProvider from tracer source factory.",
                 exc_info=True,
             )
-            _TRACER_SOURCE = DefaultTracerSource()
-        del _TRACER_SOURCE_FACTORY
+            _TRACER_PROVIDER = DefaultTracerProvider()
+        del _TRACER_PROVIDER_FACTORY
 
-    return _TRACER_SOURCE
+    return _TRACER_PROVIDER
 
 
-def set_preferred_tracer_source_implementation(
+def set_preferred_tracer_provider_implementation(
     factory: ImplementationFactory,
 ) -> None:
     """Set the factory to be used to create the tracer source.
@@ -699,12 +699,12 @@ def set_preferred_tracer_source_implementation(
     This function may not be called after a tracer is already loaded.
 
     Args:
-        factory: Callback that should create a new :class:`TracerSource`
+        factory: Callback that should create a new :class:`TracerProvider`
             instance.
     """
-    global _TRACER_SOURCE_FACTORY  # pylint:disable=global-statement
+    global _TRACER_PROVIDER_FACTORY  # pylint:disable=global-statement
 
-    if _TRACER_SOURCE:
-        raise RuntimeError("TracerSource already loaded.")
+    if _TRACER_PROVIDER:
+        raise RuntimeError("TracerProvider already loaded.")
 
-    _TRACER_SOURCE_FACTORY = factory
+    _TRACER_PROVIDER_FACTORY = factory

--- a/opentelemetry-api/src/opentelemetry/util/loader.py
+++ b/opentelemetry-api/src/opentelemetry/util/loader.py
@@ -16,7 +16,7 @@
 """
 The OpenTelemetry loader module is mainly used internally to load the
 implementation for global objects like
-:func:`opentelemetry.trace.tracer_source`.
+:func:`opentelemetry.trace.tracer_provider`.
 
 .. _loader-factory:
 
@@ -28,7 +28,7 @@ function with the following signature::
 
 That function is called with e.g., the type of the global object it should
 create as an argument (e.g. the type object
-:class:`opentelemetry.trace.TracerSource`) and should return an instance of that type
+:class:`opentelemetry.trace.TracerProvider`) and should return an instance of that type
 (such that ``instanceof(my_factory_for_t(T), T)`` is true). Alternatively, it
 may return ``None`` to indicate that the no-op default should be used.
 
@@ -37,14 +37,14 @@ factory function or other means to create the global object:
 
     1. If the environment variable
        :samp:`OPENTELEMETRY_PYTHON_IMPLEMENTATION_{getter-name}` (e.g.,
-       ``OPENTELEMETRY_PYTHON_IMPLEMENTATION_TRACERSOURCE``) is set to an
+       ``OPENTELEMETRY_PYTHON_IMPLEMENTATION_TRACERPROVIDER``) is set to an
        nonempty value, an attempt is made to import a module with that name and
        use a factory function named ``get_opentelemetry_implementation`` in it.
     2. Otherwise, the same is tried with the environment variable
        ``OPENTELEMETRY_PYTHON_IMPLEMENTATION_DEFAULT``.
     3. Otherwise, if a :samp:`set_preferred_{<type>}_implementation` was
        called (e.g.
-       :func:`opentelemetry.trace.set_preferred_tracer_source_implementation`),
+       :func:`opentelemetry.trace.set_preferred_tracer_provider_implementation`),
        the callback set there is used (that is, the environment variables
        override the callback set in code).
     4. Otherwise, if :func:`set_preferred_default_implementation` was called,

--- a/opentelemetry-api/tests/mypysmoke.py
+++ b/opentelemetry-api/tests/mypysmoke.py
@@ -15,5 +15,5 @@
 import opentelemetry.trace
 
 
-def dummy_check_mypy_returntype() -> opentelemetry.trace.TracerSource:
-    return opentelemetry.trace.tracer_source()
+def dummy_check_mypy_returntype() -> opentelemetry.trace.TracerProvider:
+    return opentelemetry.trace.tracer_provider()

--- a/opentelemetry-api/tests/test_implementation.py
+++ b/opentelemetry-api/tests/test_implementation.py
@@ -28,11 +28,11 @@ class TestAPIOnlyImplementation(unittest.TestCase):
     def test_tracer(self):
         with self.assertRaises(TypeError):
             # pylint: disable=abstract-class-instantiated
-            trace.TracerSource()  # type:ignore
+            trace.TracerProvider()  # type:ignore
 
     def test_default_tracer(self):
-        tracer_source = trace.DefaultTracerSource()
-        tracer = tracer_source.get_tracer(__name__)
+        tracer_provider = trace.DefaultTracerProvider()
+        tracer = tracer_provider.get_tracer(__name__)
         with tracer.start_span("test") as span:
             self.assertEqual(span.get_context(), trace.INVALID_SPAN_CONTEXT)
             self.assertEqual(span, trace.INVALID_SPAN)

--- a/opentelemetry-api/tests/test_loader.py
+++ b/opentelemetry-api/tests/test_loader.py
@@ -21,10 +21,10 @@ from typing import Any, Callable
 from opentelemetry import trace
 from opentelemetry.util import loader
 
-DUMMY_TRACER_SOURCE = None
+DUMMY_TRACER_PROVIDER = None
 
 
-class DummyTracerSource(trace.TracerSource):
+class DummyTracerProvider(trace.TracerProvider):
     def get_tracer(
         self,
         instrumenting_module_name: str,
@@ -34,10 +34,10 @@ class DummyTracerSource(trace.TracerSource):
 
 
 def get_opentelemetry_implementation(type_):
-    global DUMMY_TRACER_SOURCE  # pylint:disable=global-statement
-    assert type_ is trace.TracerSource
-    DUMMY_TRACER_SOURCE = DummyTracerSource()
-    return DUMMY_TRACER_SOURCE
+    global DUMMY_TRACER_PROVIDER  # pylint:disable=global-statement
+    assert type_ is trace.TracerProvider
+    DUMMY_TRACER_PROVIDER = DummyTracerProvider()
+    return DUMMY_TRACER_PROVIDER
 
 
 # pylint:disable=redefined-outer-name,protected-access,unidiomatic-typecheck
@@ -48,31 +48,31 @@ class TestLoader(unittest.TestCase):
         reload(loader)
         reload(trace)
 
-        # Need to reload self, otherwise DummyTracerSource will have the wrong
+        # Need to reload self, otherwise DummyTracerProvider will have the wrong
         # base class after reloading `trace`.
         reload(sys.modules[__name__])
 
     def test_get_default(self):
-        tracer_source = trace.tracer_source()
-        self.assertIs(type(tracer_source), trace.DefaultTracerSource)
+        tracer_provider = trace.tracer_provider()
+        self.assertIs(type(tracer_provider), trace.DefaultTracerProvider)
 
     def test_preferred_impl(self):
-        trace.set_preferred_tracer_source_implementation(
+        trace.set_preferred_tracer_provider_implementation(
             get_opentelemetry_implementation
         )
-        tracer_source = trace.tracer_source()
-        self.assertIs(tracer_source, DUMMY_TRACER_SOURCE)
+        tracer_provider = trace.tracer_provider()
+        self.assertIs(tracer_provider, DUMMY_TRACER_PROVIDER)
 
     # NOTE: We use do_* + *_<arg> methods because subtest wouldn't run setUp,
     # which we require here.
     def do_test_preferred_impl(self, setter: Callable[[Any], Any]) -> None:
         setter(get_opentelemetry_implementation)
-        tracer_source = trace.tracer_source()
-        self.assertIs(tracer_source, DUMMY_TRACER_SOURCE)
+        tracer_provider = trace.tracer_provider()
+        self.assertIs(tracer_provider, DUMMY_TRACER_PROVIDER)
 
     def test_preferred_impl_with_tracer(self):
         self.do_test_preferred_impl(
-            trace.set_preferred_tracer_source_implementation
+            trace.set_preferred_tracer_provider_implementation
         )
 
     def test_preferred_impl_with_default(self):
@@ -81,16 +81,16 @@ class TestLoader(unittest.TestCase):
         )
 
     def test_try_set_again(self):
-        self.assertTrue(trace.tracer_source())
-        # Try setting after the tracer_source has already been created:
+        self.assertTrue(trace.tracer_provider())
+        # Try setting after the tracer_provider has already been created:
         with self.assertRaises(RuntimeError) as einfo:
-            trace.set_preferred_tracer_source_implementation(
+            trace.set_preferred_tracer_provider_implementation(
                 get_opentelemetry_implementation
             )
         self.assertIn("already loaded", str(einfo.exception))
 
     def do_test_get_envvar(self, envvar_suffix: str) -> None:
-        global DUMMY_TRACER_SOURCE  # pylint:disable=global-statement
+        global DUMMY_TRACER_PROVIDER  # pylint:disable=global-statement
 
         # Test is not runnable with this!
         self.assertFalse(sys.flags.ignore_environment)
@@ -98,15 +98,15 @@ class TestLoader(unittest.TestCase):
         envname = "OPENTELEMETRY_PYTHON_IMPLEMENTATION_" + envvar_suffix
         os.environ[envname] = __name__
         try:
-            tracer_source = trace.tracer_source()
-            self.assertIs(tracer_source, DUMMY_TRACER_SOURCE)
+            tracer_provider = trace.tracer_provider()
+            self.assertIs(tracer_provider, DUMMY_TRACER_PROVIDER)
         finally:
-            DUMMY_TRACER_SOURCE = None
+            DUMMY_TRACER_PROVIDER = None
             del os.environ[envname]
-        self.assertIs(type(tracer_source), DummyTracerSource)
+        self.assertIs(type(tracer_provider), DummyTracerProvider)
 
     def test_get_envvar_tracer(self):
-        return self.do_test_get_envvar("TRACERSOURCE")
+        return self.do_test_get_envvar("TRACERPROVIDER")
 
     def test_get_envvar_default(self):
         return self.do_test_get_envvar("DEFAULT")

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -10,12 +10,12 @@ class TestGlobals(unittest.TestCase):
 
         # this class has to be declared after the importlib
         # reload, or else it will inherit from an old
-        # TracerSource, rather than the new TraceSource ABC.
+        # TracerProvider, rather than the new TraceSource ABC.
         # created from reload.
 
         static_tracer = trace.DefaultTracer()
 
-        class DummyTracerSource(trace.TracerSource):
+        class DummyTracerProvider(trace.TracerProvider):
             """TraceSource used for testing"""
 
             def get_tracer(
@@ -26,8 +26,8 @@ class TestGlobals(unittest.TestCase):
                 # pylint:disable=no-self-use,unused-argument
                 return static_tracer
 
-        trace.set_preferred_tracer_source_implementation(
-            lambda _: DummyTracerSource()
+        trace.set_preferred_tracer_provider_implementation(
+            lambda _: DummyTracerProvider()
         )
 
     @staticmethod
@@ -37,5 +37,5 @@ class TestGlobals(unittest.TestCase):
     def test_get_tracer(self):
         """trace.get_tracer should proxy to the global tracer source."""
         from_global_api = trace.get_tracer("foo")
-        from_tracer_api = trace.tracer_source().get_tracer("foo")
+        from_tracer_api = trace.tracer_provider().get_tracer("foo")
         self.assertIs(from_global_api, from_tracer_api)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -43,7 +43,7 @@ class SpanProcessor:
     invocations.
 
     Span processors can be registered directly using
-    :func:`TracerSource.add_span_processor` and they are invoked
+    :func:`TracerProvider.add_span_processor` and they are invoked
     in the same order as they were registered.
     """
 
@@ -388,7 +388,7 @@ def generate_trace_id() -> int:
 class InstrumentationInfo:
     """Immutable information about an instrumentation library module.
 
-    See `TracerSource.get_tracer` for the meaning of the properties.
+    See `TracerProvider.get_tracer` for the meaning of the properties.
     """
 
     __slots__ = ("_name", "_version")
@@ -435,7 +435,9 @@ class Tracer(trace_api.Tracer):
     """
 
     def __init__(
-        self, source: "TracerSource", instrumentation_info: InstrumentationInfo
+        self,
+        source: "TracerProvider",
+        instrumentation_info: InstrumentationInfo,
     ) -> None:
         self.source = source
         self.instrumentation_info = instrumentation_info
@@ -569,7 +571,7 @@ class Tracer(trace_api.Tracer):
                 span.end()
 
 
-class TracerSource(trace_api.TracerSource):
+class TracerProvider(trace_api.TracerProvider):
     def __init__(
         self,
         sampler: sampling.Sampler = trace_api.sampling.ALWAYS_ON,
@@ -601,7 +603,7 @@ class TracerSource(trace_api.TracerSource):
         return context_api.get_value(SPAN_KEY)  # type: ignore
 
     def add_span_processor(self, span_processor: SpanProcessor) -> None:
-        """Registers a new :class:`SpanProcessor` for this `TracerSource`.
+        """Registers a new :class:`SpanProcessor` for this `TracerProvider`.
 
         The span processors are invoked in the same order they are registered.
         """

--- a/opentelemetry-sdk/tests/context/test_asyncio.py
+++ b/opentelemetry-sdk/tests/context/test_asyncio.py
@@ -65,11 +65,11 @@ class TestAsyncio(unittest.TestCase):
     def setUp(self):
         self.previous_context = context.get_current()
         context.set_current(context.Context())
-        self.tracer_source = trace.TracerSource()
-        self.tracer = self.tracer_source.get_tracer(__name__)
+        self.tracer_provider = trace.TracerProvider()
+        self.tracer = self.tracer_provider.get_tracer(__name__)
         self.memory_exporter = InMemorySpanExporter()
         span_processor = export.SimpleExportSpanProcessor(self.memory_exporter)
-        self.tracer_source.add_span_processor(span_processor)
+        self.tracer_provider.add_span_processor(span_processor)
         self.loop = asyncio.get_event_loop()
 
     def tearDown(self):

--- a/opentelemetry-sdk/tests/test_implementation.py
+++ b/opentelemetry-sdk/tests/test_implementation.py
@@ -28,7 +28,7 @@ class TestSDKImplementation(unittest.TestCase):
     """
 
     def test_tracer(self):
-        tracer = trace.TracerSource().get_tracer(__name__)
+        tracer = trace.TracerProvider().get_tracer(__name__)
         with tracer.start_span("test") as span:
             self.assertNotEqual(span.get_context(), INVALID_SPAN_CONTEXT)
             self.assertNotEqual(span, INVALID_SPAN)

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -52,14 +52,14 @@ class MySpanExporter(export.SpanExporter):
 
 class TestSimpleExportSpanProcessor(unittest.TestCase):
     def test_simple_span_processor(self):
-        tracer_source = trace.TracerSource()
-        tracer = tracer_source.get_tracer(__name__)
+        tracer_provider = trace.TracerProvider()
+        tracer = tracer_provider.get_tracer(__name__)
 
         spans_names_list = []
 
         my_exporter = MySpanExporter(destination=spans_names_list)
         span_processor = export.SimpleExportSpanProcessor(my_exporter)
-        tracer_source.add_span_processor(span_processor)
+        tracer_provider.add_span_processor(span_processor)
 
         with tracer.start_as_current_span("foo"):
             with tracer.start_as_current_span("bar"):
@@ -77,14 +77,14 @@ class TestSimpleExportSpanProcessor(unittest.TestCase):
         SpanProcessors should act on a span's start and end events whether or
         not it is ever the active span.
         """
-        tracer_source = trace.TracerSource()
-        tracer = tracer_source.get_tracer(__name__)
+        tracer_provider = trace.TracerProvider()
+        tracer = tracer_provider.get_tracer(__name__)
 
         spans_names_list = []
 
         my_exporter = MySpanExporter(destination=spans_names_list)
         span_processor = export.SimpleExportSpanProcessor(my_exporter)
-        tracer_source.add_span_processor(span_processor)
+        tracer_provider.add_span_processor(span_processor)
 
         with tracer.start_span("foo"):
             with tracer.start_span("bar"):

--- a/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
+++ b/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
@@ -25,11 +25,11 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 
 class TestInMemorySpanExporter(unittest.TestCase):
     def setUp(self):
-        self.tracer_source = trace.TracerSource()
-        self.tracer = self.tracer_source.get_tracer(__name__)
+        self.tracer_provider = trace.TracerProvider()
+        self.tracer = self.tracer_provider.get_tracer(__name__)
         self.memory_exporter = InMemorySpanExporter()
         span_processor = export.SimpleExportSpanProcessor(self.memory_exporter)
-        self.tracer_source.add_span_processor(span_processor)
+        self.tracer_provider.add_span_processor(span_processor)
         self.exec_scenario()
 
     def exec_scenario(self):

--- a/tests/w3c_tracecontext_validation_server.py
+++ b/tests/w3c_tracecontext_validation_server.py
@@ -26,7 +26,7 @@ import requests
 from opentelemetry import trace
 from opentelemetry.ext import http_requests
 from opentelemetry.ext.wsgi import OpenTelemetryMiddleware
-from opentelemetry.sdk.trace import TracerSource
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     ConsoleSpanExporter,
     SimpleExportSpanProcessor,
@@ -34,16 +34,16 @@ from opentelemetry.sdk.trace.export import (
 
 # The preferred tracer implementation must be set, as the opentelemetry-api
 # defines the interface with a no-op implementation.
-trace.set_preferred_tracer_source_implementation(lambda T: TracerSource())
+trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
 
 # Integrations are the glue that binds the OpenTelemetry API and the
 # frameworks and libraries that are used together, automatically creating
 # Spans and propagating context as appropriate.
-http_requests.enable(trace.tracer_source())
+http_requests.enable(trace.tracer_provider())
 
 # SpanExporter receives the spans and send them to the target location.
 span_processor = SimpleExportSpanProcessor(ConsoleSpanExporter())
-trace.tracer_source().add_span_processor(span_processor)
+trace.tracer_provider().add_span_processor(span_processor)
 
 app = flask.Flask(__name__)
 app.wsgi_app = OpenTelemetryMiddleware(app.wsgi_app)


### PR DESCRIPTION
Following discussion in https://github.com/open-telemetry/opentelemetry-python/issues/434
align the name with the specification https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#obtaining-a-tracer.