### PR TITLE
Fix a few ext package READMEs

### DIFF
--- a/ext/opentelemetry-ext-dbapi/README.rst
+++ b/ext/opentelemetry-ext-dbapi/README.rst
@@ -1,5 +1,5 @@
 OpenTelemetry Database API integration
-=================================
+======================================
 
 The trace integration with Database API supports libraries following the specification.
 
@@ -8,7 +8,7 @@ The trace integration with Database API supports libraries following the specifi
 Usage
 -----
 
-.. code:: python
+.. code-block:: python
 
     import mysql.connector
     from opentelemetry.trace import tracer_source

--- a/ext/opentelemetry-ext-mysql/README.rst
+++ b/ext/opentelemetry-ext-mysql/README.rst
@@ -1,10 +1,10 @@
 OpenTelemetry MySQL integration
-=================================
+===============================
 
 The integration with MySQL supports the `mysql-connector`_ library and is specified
 to ``trace_integration`` using ``'MySQL'``.
 
-.. mysql-connector: https://pypi.org/project/mysql-connector/
+.. _mysql-connector: https://pypi.org/project/mysql-connector/
 
 Usage
 -----

--- a/ext/opentelemetry-ext-prometheus/README.rst
+++ b/ext/opentelemetry-ext-prometheus/README.rst
@@ -1,5 +1,5 @@
 OpenTelemetry Prometheus Exporter
-=============================
+=================================
 
 |pypi|
 

--- a/ext/opentelemetry-ext-psycopg2/README.rst
+++ b/ext/opentelemetry-ext-psycopg2/README.rst
@@ -4,12 +4,13 @@ OpenTelemetry Psycopg integration
 The integration with PostgreSQL supports the `Psycopg`_ library and is specified
 to ``trace_integration`` using ``'PostgreSQL'``.
 
-.. Psycopg: http://initd.org/psycopg/
+.. _Psycopg: http://initd.org/psycopg/
 
 Usage
 -----
 
-.. code:: python
+.. code-block:: python
+
     import psycopg2
     from opentelemetry import trace
     from opentelemetry.sdk.trace import TracerSource


### PR DESCRIPTION
Some of the new ext packages had ReStructuredText errors. PyPI rejected the uploads for these packages with:

`HTTPError: 400 Client Error: The description failed to render for 'text/x-rst'. See https://pypi.org/help/#description-content-type for more information. for url: https://upload.pypi.org/legacy/`