### PR TITLE
api: Renaming TraceOptions to TraceFlags

### DIFF
--- a/examples/opentelemetry-example-app/tests/test_flask_example.py
+++ b/examples/opentelemetry-example-app/tests/test_flask_example.py
@@ -59,7 +59,7 @@ class TestFlaskExample(unittest.TestCase):
                 "traceparent": "00-{:032x}-{:016x}-{:02x}".format(
                     trace_id,
                     trace_sdk.generate_span_id(),
-                    trace.TraceOptions.SAMPLED,
+                    trace.TraceFlags.SAMPLED,
                 )
             },
         )

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -171,7 +171,7 @@ def _translate_to_jaeger(spans: Span):
         refs = _extract_refs_from_span(span)
         logs = _extract_logs_from_span(span)
 
-        flags = int(ctx.trace_options)
+        flags = int(ctx.trace_flags)
 
         jaeger_span = jaeger.Span(
             traceIdHigh=_get_trace_id_high(trace_id),

--- a/ext/opentelemetry-ext-otcollector/tests/test_otcollector_exporter.py
+++ b/ext/opentelemetry-ext-otcollector/tests/test_otcollector_exporter.py
@@ -27,7 +27,7 @@ from opentelemetry.ext.otcollector.trace_exporter import (
 )
 from opentelemetry.sdk import trace
 from opentelemetry.sdk.trace.export import SpanExportResult
-from opentelemetry.trace import TraceOptions
+from opentelemetry.trace import TraceFlags
 
 
 # pylint: disable=no-member
@@ -92,7 +92,7 @@ class TestCollectorSpanExporter(unittest.TestCase):
         span_context = trace_api.SpanContext(
             trace_id,
             span_id,
-            trace_options=TraceOptions(TraceOptions.SAMPLED),
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
             trace_state=trace_api.TraceState({"testKey": "testValue"}),
         )
         parent_context = trace_api.SpanContext(trace_id, parent_id)
@@ -279,7 +279,7 @@ class TestCollectorSpanExporter(unittest.TestCase):
         trace_id = 0x6E0C63257DE34C926F9EFCD03927272E
         span_id = 0x34BF92DEEFC58C92
         span_context = trace_api.SpanContext(
-            trace_id, span_id, trace_options=TraceOptions(TraceOptions.SAMPLED)
+            trace_id, span_id, trace_flags=TraceFlags(TraceFlags.SAMPLED)
         )
         otel_spans = [
             trace.Span(

--- a/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/__init__.py
+++ b/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/__init__.py
@@ -132,7 +132,7 @@ class ZipkinSpanExporter(SpanExporter):
                 "annotations": _extract_annotations_from_events(span.events),
             }
 
-            if context.trace_options.sampled:
+            if context.trace_flags.sampled:
                 zipkin_span["debug"] = 1
 
             if isinstance(span.parent, Span):

--- a/ext/opentelemetry-ext-zipkin/tests/test_zipkin_exporter.py
+++ b/ext/opentelemetry-ext-zipkin/tests/test_zipkin_exporter.py
@@ -20,7 +20,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.ext.zipkin import ZipkinSpanExporter
 from opentelemetry.sdk import trace
 from opentelemetry.sdk.trace.export import SpanExportResult
-from opentelemetry.trace import TraceOptions
+from opentelemetry.trace import TraceFlags
 
 
 class MockResponse:
@@ -114,7 +114,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
         )
 
         span_context = trace_api.SpanContext(
-            trace_id, span_id, trace_options=TraceOptions(TraceOptions.SAMPLED)
+            trace_id, span_id, trace_flags=TraceFlags(TraceFlags.SAMPLED)
         )
         parent_context = trace_api.SpanContext(trace_id, parent_id)
         other_context = trace_api.SpanContext(trace_id, other_id)

--- a/opentelemetry-api/src/opentelemetry/context/propagation/tracecontexthttptextformat.py
+++ b/opentelemetry-api/src/opentelemetry/context/propagation/tracecontexthttptextformat.py
@@ -77,7 +77,7 @@ class TraceContextHTTPTextFormat(httptextformat.HTTPTextFormat):
         version = match.group(1)
         trace_id = match.group(2)
         span_id = match.group(3)
-        trace_options = match.group(4)
+        trace_flags = match.group(4)
 
         if trace_id == "0" * 32 or span_id == "0" * 16:
             return trace.INVALID_SPAN_CONTEXT
@@ -96,7 +96,7 @@ class TraceContextHTTPTextFormat(httptextformat.HTTPTextFormat):
         span_context = trace.SpanContext(
             trace_id=int(trace_id, 16),
             span_id=int(span_id, 16),
-            trace_options=trace.TraceOptions(trace_options),
+            trace_flags=trace.TraceFlags(trace_flags),
             trace_state=tracestate,
         )
 
@@ -115,7 +115,7 @@ class TraceContextHTTPTextFormat(httptextformat.HTTPTextFormat):
         if context == trace.INVALID_SPAN_CONTEXT:
             return
         traceparent_string = "00-{:032x}-{:016x}-{:02x}".format(
-            context.trace_id, context.span_id, context.trace_options
+            context.trace_id, context.span_id, context.trace_flags
         )
         set_in_carrier(
             carrier, cls._TRACEPARENT_HEADER_NAME, traceparent_string

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -249,7 +249,7 @@ class Span(abc.ABC):
         self.end()
 
 
-class TraceOptions(int):
+class TraceFlags(int):
     """A bitmask that represents options specific to the trace.
 
     The only supported option is the "sampled" flag (``0x01``). If set, this
@@ -265,15 +265,15 @@ class TraceOptions(int):
     SAMPLED = 0x01
 
     @classmethod
-    def get_default(cls) -> "TraceOptions":
+    def get_default(cls) -> "TraceFlags":
         return cls(cls.DEFAULT)
 
     @property
     def sampled(self) -> bool:
-        return bool(self & TraceOptions.SAMPLED)
+        return bool(self & TraceFlags.SAMPLED)
 
 
-DEFAULT_TRACE_OPTIONS = TraceOptions.get_default()
+DEFAULT_TRACE_OPTIONS = TraceFlags.get_default()
 
 
 class TraceState(typing.Dict[str, str]):
@@ -312,7 +312,7 @@ class SpanContext:
     Args:
         trace_id: The ID of the trace that this span belongs to.
         span_id: This span's ID.
-        trace_options: Trace options to propagate.
+        trace_flags: Trace options to propagate.
         trace_state: Tracing-system-specific info to propagate.
     """
 
@@ -320,16 +320,16 @@ class SpanContext:
         self,
         trace_id: int,
         span_id: int,
-        trace_options: "TraceOptions" = DEFAULT_TRACE_OPTIONS,
+        trace_flags: "TraceFlags" = DEFAULT_TRACE_OPTIONS,
         trace_state: "TraceState" = DEFAULT_TRACE_STATE,
     ) -> None:
-        if trace_options is None:
-            trace_options = DEFAULT_TRACE_OPTIONS
+        if trace_flags is None:
+            trace_flags = DEFAULT_TRACE_OPTIONS
         if trace_state is None:
             trace_state = DEFAULT_TRACE_STATE
         self.trace_id = trace_id
         self.span_id = span_id
-        self.trace_options = trace_options
+        self.trace_flags = trace_flags
         self.trace_state = trace_state
 
     def __repr__(self) -> str:

--- a/opentelemetry-api/src/opentelemetry/trace/sampling.py
+++ b/opentelemetry-api/src/opentelemetry/trace/sampling.py
@@ -113,7 +113,7 @@ class ProbabilitySampler(Sampler):
         links: Sequence["Link"] = (),
     ) -> "Decision":
         if parent_context is not None:
-            return Decision(parent_context.trace_options.sampled)
+            return Decision(parent_context.trace_flags.sampled)
 
         return Decision(trace_id & self.TRACE_ID_LIMIT < self.bound)
 

--- a/opentelemetry-api/tests/trace/test_sampling.py
+++ b/opentelemetry-api/tests/trace/test_sampling.py
@@ -18,16 +18,14 @@ import unittest
 from opentelemetry import trace
 from opentelemetry.trace import sampling
 
-TO_DEFAULT = trace.TraceOptions(trace.TraceOptions.DEFAULT)
-TO_SAMPLED = trace.TraceOptions(trace.TraceOptions.SAMPLED)
+TO_DEFAULT = trace.TraceFlags(trace.TraceFlags.DEFAULT)
+TO_SAMPLED = trace.TraceFlags(trace.TraceFlags.SAMPLED)
 
 
 class TestSampler(unittest.TestCase):
     def test_always_on(self):
         no_record_always_on = sampling.ALWAYS_ON.should_sample(
-            trace.SpanContext(
-                0xDEADBEEF, 0xDEADBEF0, trace_options=TO_DEFAULT
-            ),
+            trace.SpanContext(0xDEADBEEF, 0xDEADBEF0, trace_flags=TO_DEFAULT),
             0xDEADBEF1,
             0xDEADBEF2,
             "unsampled parent, sampling on",
@@ -36,9 +34,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(no_record_always_on.attributes, {})
 
         sampled_always_on = sampling.ALWAYS_ON.should_sample(
-            trace.SpanContext(
-                0xDEADBEEF, 0xDEADBEF0, trace_options=TO_SAMPLED
-            ),
+            trace.SpanContext(0xDEADBEEF, 0xDEADBEF0, trace_flags=TO_SAMPLED),
             0xDEADBEF1,
             0xDEADBEF2,
             "sampled parent, sampling on",
@@ -48,9 +44,7 @@ class TestSampler(unittest.TestCase):
 
     def test_always_off(self):
         no_record_always_off = sampling.ALWAYS_OFF.should_sample(
-            trace.SpanContext(
-                0xDEADBEEF, 0xDEADBEF0, trace_options=TO_DEFAULT
-            ),
+            trace.SpanContext(0xDEADBEEF, 0xDEADBEF0, trace_flags=TO_DEFAULT),
             0xDEADBEF1,
             0xDEADBEF2,
             "unsampled parent, sampling off",
@@ -59,9 +53,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(no_record_always_off.attributes, {})
 
         sampled_always_on = sampling.ALWAYS_OFF.should_sample(
-            trace.SpanContext(
-                0xDEADBEEF, 0xDEADBEF0, trace_options=TO_SAMPLED
-            ),
+            trace.SpanContext(0xDEADBEEF, 0xDEADBEF0, trace_flags=TO_SAMPLED),
             0xDEADBEF1,
             0xDEADBEF2,
             "sampled parent, sampling off",
@@ -71,9 +63,7 @@ class TestSampler(unittest.TestCase):
 
     def test_default_on(self):
         no_record_default_on = sampling.DEFAULT_ON.should_sample(
-            trace.SpanContext(
-                0xDEADBEEF, 0xDEADBEF0, trace_options=TO_DEFAULT
-            ),
+            trace.SpanContext(0xDEADBEEF, 0xDEADBEF0, trace_flags=TO_DEFAULT),
             0xDEADBEF1,
             0xDEADBEF2,
             "unsampled parent, sampling on",
@@ -82,9 +72,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(no_record_default_on.attributes, {})
 
         sampled_default_on = sampling.DEFAULT_ON.should_sample(
-            trace.SpanContext(
-                0xDEADBEEF, 0xDEADBEF0, trace_options=TO_SAMPLED
-            ),
+            trace.SpanContext(0xDEADBEEF, 0xDEADBEF0, trace_flags=TO_SAMPLED),
             0xDEADBEF1,
             0xDEADBEF2,
             "sampled parent, sampling on",
@@ -94,9 +82,7 @@ class TestSampler(unittest.TestCase):
 
     def test_default_off(self):
         no_record_default_off = sampling.DEFAULT_OFF.should_sample(
-            trace.SpanContext(
-                0xDEADBEEF, 0xDEADBEF0, trace_options=TO_DEFAULT
-            ),
+            trace.SpanContext(0xDEADBEEF, 0xDEADBEF0, trace_flags=TO_DEFAULT),
             0xDEADBEF1,
             0xDEADBEF2,
             "unsampled parent, sampling off",
@@ -105,9 +91,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(no_record_default_off.attributes, {})
 
         sampled_default_off = sampling.DEFAULT_OFF.should_sample(
-            trace.SpanContext(
-                0xDEADBEEF, 0xDEADBEF0, trace_options=TO_SAMPLED
-            ),
+            trace.SpanContext(0xDEADBEEF, 0xDEADBEF0, trace_flags=TO_SAMPLED),
             0xDEADBEF1,
             0xDEADBEF2,
             "sampled parent, sampling off",
@@ -136,7 +120,7 @@ class TestSampler(unittest.TestCase):
         self.assertFalse(
             sampler.should_sample(
                 trace.SpanContext(
-                    0xDEADBEF0, 0xDEADBEF1, trace_options=TO_DEFAULT
+                    0xDEADBEF0, 0xDEADBEF1, trace_flags=TO_DEFAULT
                 ),
                 0x7FFFFFFFFFFFFFFF,
                 0xDEADBEEF,
@@ -146,7 +130,7 @@ class TestSampler(unittest.TestCase):
         self.assertTrue(
             sampler.should_sample(
                 trace.SpanContext(
-                    0xDEADBEF0, 0xDEADBEF1, trace_options=TO_SAMPLED
+                    0xDEADBEF0, 0xDEADBEF1, trace_flags=TO_SAMPLED
                 ),
                 0x8000000000000000,
                 0xDEADBEEF,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/context/propagation/b3_format.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/context/propagation/b3_format.py
@@ -91,20 +91,18 @@ class B3Format(HTTPTextFormat):
         # the desire for some form of sampling, propagate if either
         # header is set to allow.
         if sampled in cls._SAMPLE_PROPAGATE_VALUES or flags == "1":
-            options |= trace.TraceOptions.SAMPLED
+            options |= trace.TraceFlags.SAMPLED
         return trace.SpanContext(
             # trace an span ids are encoded in hex, so must be converted
             trace_id=int(trace_id, 16),
             span_id=int(span_id, 16),
-            trace_options=trace.TraceOptions(options),
+            trace_flags=trace.TraceFlags(options),
             trace_state=trace.TraceState(),
         )
 
     @classmethod
     def inject(cls, span, set_in_carrier, carrier):
-        sampled = (
-            trace.TraceOptions.SAMPLED & span.context.trace_options
-        ) != 0
+        sampled = (trace.TraceFlags.SAMPLED & span.context.trace_flags) != 0
         set_in_carrier(
             carrier, cls.TRACE_ID_KEY, format_trace_id(span.context.trace_id)
         )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -486,15 +486,15 @@ class Tracer(trace_api.Tracer):
         if parent_context is None or not parent_context.is_valid():
             parent = parent_context = None
             trace_id = generate_trace_id()
-            trace_options = None
+            trace_flags = None
             trace_state = None
         else:
             trace_id = parent_context.trace_id
-            trace_options = parent_context.trace_options
+            trace_flags = parent_context.trace_flags
             trace_state = parent_context.trace_state
 
         context = trace_api.SpanContext(
-            trace_id, generate_span_id(), trace_options, trace_state
+            trace_id, generate_span_id(), trace_flags, trace_state
         )
 
         # The sampler decides whether to create a real or no-op span at the
@@ -512,8 +512,8 @@ class Tracer(trace_api.Tracer):
         )
 
         if sampling_decision.sampled:
-            options = context.trace_options | trace_api.TraceOptions.SAMPLED
-            context.trace_options = trace_api.TraceOptions(options)
+            options = context.trace_flags | trace_api.TraceFlags.SAMPLED
+            context.trace_flags = trace_api.TraceFlags(options)
             if attributes is None:
                 span_attributes = sampling_decision.attributes
             else:

--- a/opentelemetry-sdk/tests/context/propagation/test_b3_format.py
+++ b/opentelemetry-sdk/tests/context/propagation/test_b3_format.py
@@ -36,7 +36,7 @@ def get_child_parent_new_carrier(old_carrier):
         trace_api.SpanContext(
             parent_context.trace_id,
             trace.generate_span_id(),
-            trace_options=parent_context.trace_options,
+            trace_flags=parent_context.trace_flags,
             trace_state=parent_context.trace_state,
         ),
         parent=parent,

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -117,7 +117,7 @@ class TestTracerSampling(unittest.TestCase):
         self.assertIsInstance(root_span, trace.Span)
         child_span = tracer.start_span(name="child span", parent=root_span)
         self.assertIsInstance(child_span, trace.Span)
-        self.assertTrue(root_span.context.trace_options.sampled)
+        self.assertTrue(root_span.context.trace_flags.sampled)
 
     def test_sampler_no_sampling(self):
         tracer_provider = trace.TracerProvider(sampling.ALWAYS_OFF)
@@ -251,7 +251,7 @@ class TestSpanCreation(unittest.TestCase):
                     root_context.trace_state, child_context.trace_state
                 )
                 self.assertEqual(
-                    root_context.trace_options, child_context.trace_options
+                    root_context.trace_flags, child_context.trace_flags
                 )
 
                 # Verify start_span() did not set the current span.
@@ -268,9 +268,7 @@ class TestSpanCreation(unittest.TestCase):
         other_parent = trace_api.SpanContext(
             trace_id=0x000000000000000000000000DEADBEEF,
             span_id=0x00000000DEADBEF0,
-            trace_options=trace_api.TraceOptions(
-                trace_api.TraceOptions.SAMPLED
-            ),
+            trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         )
 
         self.assertIsNone(tracer.get_current_span())
@@ -303,7 +301,7 @@ class TestSpanCreation(unittest.TestCase):
                     other_parent.trace_state, child_context.trace_state
                 )
                 self.assertEqual(
-                    other_parent.trace_options, child_context.trace_options
+                    other_parent.trace_flags, child_context.trace_flags
                 )
 
                 # Verify start_span() did not set the current span.


### PR DESCRIPTION
Renaming TraceOptions to TraceFlags, which is the term
used to describe the flags associated with the trace in
the OpenTelemetry specification.

Closes #434 