### PR TITLE
Use simple processor in http examples

### DIFF
--- a/examples/http/server.py
+++ b/examples/http/server.py
@@ -24,8 +24,8 @@ from opentelemetry.ext import http_requests
 from opentelemetry.ext.wsgi import OpenTelemetryMiddleware
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
-    BatchExportSpanProcessor,
     ConsoleSpanExporter,
+    SimpleExportSpanProcessor,
 )
 
 if os.getenv("EXPORTER") == "jaeger":
@@ -45,7 +45,7 @@ trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
 tracer = trace.get_tracer(__name__)
 
 # SpanExporter receives the spans and send them to the target location.
-span_processor = BatchExportSpanProcessor(exporter)
+span_processor = SimpleExportSpanProcessor(exporter)
 trace.tracer_provider().add_span_processor(span_processor)
 
 # Integrations are the glue that binds the OpenTelemetry API and the

--- a/examples/http/tracer_client.py
+++ b/examples/http/tracer_client.py
@@ -15,15 +15,14 @@
 # limitations under the License.
 
 import os
-
 import requests
 
 from opentelemetry import trace
 from opentelemetry.ext import http_requests
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
-    BatchExportSpanProcessor,
     ConsoleSpanExporter,
+    SimpleExportSpanProcessor,
 )
 
 if os.getenv("EXPORTER") == "jaeger":
@@ -43,7 +42,7 @@ trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
 tracer_provider = trace.tracer_provider()
 
 # SpanExporter receives the spans and send them to the target location.
-span_processor = BatchExportSpanProcessor(exporter)
+span_processor = SimpleExportSpanProcessor(exporter)
 tracer_provider.add_span_processor(span_processor)
 
 # Integrations are the glue that binds the OpenTelemetry API and the

--- a/examples/http/tracer_client.py
+++ b/examples/http/tracer_client.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+
 import requests
 
 from opentelemetry import trace


### PR DESCRIPTION
Fixes #448.

Other examples still use the batching processor, but don't show a delay between recording the span and exporting it because they exit soon after starting.