### PR TITLE
Prepare to host on readthedocs.org

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+build:
+  image: latest
+
+python:
+  version: 3.8
+  install:
+    - requirements: docs-requirements.txt

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,3 @@
-sphinx
-sphinx-rtd-theme
-sphinx-autodoc-typehints
+sphinx~=2.1
+sphinx-rtd-theme~=0.4
+sphinx-autodoc-typehints~=1.10.2

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,3 @@
-sphinx~=2.1
+sphinx~=2.4
 sphinx-rtd-theme~=0.4
 sphinx-autodoc-typehints~=1.10.2

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,3 @@
+sphinx~=2.1
+sphinx-rtd-theme~=0.4
+sphinx-autodoc-typehints~=1.10.2

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,10 @@
 sphinx~=2.4
 sphinx-rtd-theme~=0.4
 sphinx-autodoc-typehints~=1.10.2
+
+# Required by ext packages
+opentracing~=2.2.0
+Deprecated>=1.2.6
+thrift>=0.10.0
+pymongo~=3.1
+flask~=1.0

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,3 @@
-sphinx~=2.1
-sphinx-rtd-theme~=0.4
-sphinx-autodoc-typehints~=1.10.2
+sphinx
+sphinx-rtd-theme
+sphinx-autodoc-typehints

--- a/tox.ini
+++ b/tox.ini
@@ -182,7 +182,7 @@ commands =
 basepython: python3.8
 recreate = True
 deps =
-  -r dev-requirements.txt
+  -c dev-requirements.txt
   pylint
   flake8
   isort
@@ -196,8 +196,11 @@ commands =
 
 [testenv:docs]
 deps =
-  -r dev-requirements.txt
-  -r docs-requirements.txt
+  -c dev-requirements.txt
+  -c docs-requirements.txt
+  sphinx
+  sphinx-rtd-theme
+  sphinx-autodoc-typehints
   opentracing~=2.2.0
   Deprecated>=1.2.6
   thrift>=0.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -182,7 +182,7 @@ commands =
 basepython: python3.8
 recreate = True
 deps =
-  -c dev-requirements.txt
+  -r dev-requirements.txt
   pylint
   flake8
   isort
@@ -196,10 +196,8 @@ commands =
 
 [testenv:docs]
 deps =
-  -c dev-requirements.txt
-  sphinx
-  sphinx-rtd-theme
-  sphinx-autodoc-typehints
+  -r dev-requirements.txt
+  -r docs-requirements.txt
   opentracing~=2.2.0
   Deprecated>=1.2.6
   thrift>=0.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -201,11 +201,12 @@ deps =
   sphinx
   sphinx-rtd-theme
   sphinx-autodoc-typehints
-  opentracing~=2.2.0
-  Deprecated>=1.2.6
-  thrift>=0.10.0
-  pymongo ~= 3.1
-  flask~=1.0
+  # Required by ext packages
+  opentracing
+  Deprecated
+  thrift
+  pymongo
+  flask
 
 changedir = docs
 


### PR DESCRIPTION
Fixes #171

You can see the hosted docs built from this branch on https://opentelemetry-python.readthedocs.io/en/readthedocs/, and the successful build from 3e7a9e9 at https://readthedocs.org/projects/opentelemetry-python/builds/10524660/.

Note that the docs can still fail to build on RTD even if `tox -e docs` passes on CI. See https://readthedocs.org/projects/opentelemetry-python/builds/10524617/ for an example of a failing build that passed CI.

I'll delete the branch and build the docs from master (which should populate the "latest" and "stable" versions on RTD) once this PR is merged.