### PR TITLE
sdk: fix ConsoleSpanExporter

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -270,7 +270,8 @@ class ConsoleSpanExporter(SpanExporter):
     def __init__(
         self,
         out: typing.IO = sys.stdout,
-        formatter: typing.Callable[[Span], str] = str,
+        formatter: typing.Callable[[Span], str] = lambda span: str(span)
+        + "\n",
     ):
         self.out = out
         self.formatter = formatter
@@ -278,4 +279,5 @@ class ConsoleSpanExporter(SpanExporter):
     def export(self, spans: typing.Sequence[Span]) -> SpanExportResult:
         for span in spans:
             self.out.write(self.formatter(span))
+        self.out.flush()
         return SpanExportResult.SUCCESS

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import collections
+import os
 import logging
 import sys
 import threading
@@ -271,7 +272,7 @@ class ConsoleSpanExporter(SpanExporter):
         self,
         out: typing.IO = sys.stdout,
         formatter: typing.Callable[[Span], str] = lambda span: str(span)
-        + "\n",
+        + os.linesep,
     ):
         self.out = out
         self.formatter = formatter

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import collections
-import os
 import logging
+import os
 import sys
 import threading
 import typing

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -288,8 +288,9 @@ class TestConsoleSpanExporter(unittest.TestCase):
         span = trace.Span("span name", mock.Mock())
         with mock.patch.object(exporter, "out") as mock_stdout:
             exporter.export([span])
-        mock_stdout.write.assert_called_once_with(str(span))
+        mock_stdout.write.assert_called_once_with(str(span) + "\n")
         self.assertEqual(mock_stdout.write.call_count, 1)
+        self.assertEqual(mock_stdout.flush.call_count, 1)
 
     def test_export_custom(self):  # pylint: disable=no-self-use
         """Check that console exporter uses custom io, formatter."""

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import time
 import unittest
 from logging import WARNING
@@ -288,7 +289,7 @@ class TestConsoleSpanExporter(unittest.TestCase):
         span = trace.Span("span name", mock.Mock())
         with mock.patch.object(exporter, "out") as mock_stdout:
             exporter.export([span])
-        mock_stdout.write.assert_called_once_with(str(span) + "\n")
+        mock_stdout.write.assert_called_once_with(str(span) + os.linesep)
         self.assertEqual(mock_stdout.write.call_count, 1)
         self.assertEqual(mock_stdout.flush.call_count, 1)
 


### PR DESCRIPTION
19d573af0275 ("Add io and formatter options to console exporter (#412)")
changed the way spans are printed by using write() instead of print().
In Python 3.x sys.stdout is line-buffered, so the spans were not being printed
to the console at the right timing.

This commit fixes that by adding an explicit flush() call at the end of the
export function , it also changes the default formatter to include a line break.

To be precise, only one of the changes was needed to solve the problem, but as
a matter of completness both are included, i.e, to handle the case where the
formatter chosen by the user doesn't append a line break.


Fixes: https://github.com/open-telemetry/opentelemetry-python/issues/448
Supersedes: https://github.com/open-telemetry/opentelemetry-python/pull/451