### PR TITLE
v0.4a1 release to host alpha docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+build:
+  image: latest
+
+python:
+  version: 3.8
+  install:
+    - requirements: docs-requirements.txt

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,10 @@
+sphinx~=2.4
+sphinx-rtd-theme~=0.4
+sphinx-autodoc-typehints~=1.10.2
+
+# Required by ext packages
+opentracing~=2.2.0
+Deprecated>=1.2.6
+thrift>=0.10.0
+pymongo~=3.1
+flask~=1.0

--- a/examples/opentelemetry-example-app/setup.py
+++ b/examples/opentelemetry-example-app/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="opentelemetry-example-app",
-    version="0.4a0",
+    version="0.4a1",
     author="OpenTelemetry Authors",
     author_email="cncf-opentelemetry-contributors@lists.cncf.io",
     classifiers=[

--- a/ext/opentelemetry-ext-dbapi/CHANGELOG.md
+++ b/ext/opentelemetry-ext-dbapi/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.4a1
+
+Released 2020-03-02
+
+- Update docs
+
 ## 0.4a0
 
 Released 2020-02-21

--- a/ext/opentelemetry-ext-dbapi/setup.cfg
+++ b/ext/opentelemetry-ext-dbapi/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.4a0
+    opentelemetry-api >= 0.4a1
     wrapt >= 1.0.0, < 2.0.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/version.py
+++ b/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/ext/opentelemetry-ext-flask/CHANGELOG.md
+++ b/ext/opentelemetry-ext-flask/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## Unreleased
 
+## 0.4a1
+
+Released 2020-03-02
+
+- Update docs
+
 ## 0.4a0
 
 - Use string keys for WSGI environ values
   ([#366](https://github.com/open-telemetry/opentelemetry-python/pull/366))
-
 
 ## 0.3a0
 

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/version.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/ext/opentelemetry-ext-http-requests/setup.cfg
+++ b/ext/opentelemetry-ext-http-requests/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.4a0
+    opentelemetry-api >= 0.4a1
     requests ~= 2.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/ext/opentelemetry-ext-jaeger/CHANGELOG.md
+++ b/ext/opentelemetry-ext-jaeger/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.4a1
+
+Released 2020-03-02
+
+- Update docs
+
 ## 0.4a0
 
 Released 2020-02-21

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/ext/opentelemetry-ext-mysql/CHANGELOG.md
+++ b/ext/opentelemetry-ext-mysql/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.4a1
+
+Released 2020-03-02
+
+- Update docs
+
 ## 0.4a0
 
 Released 2020-02-21

--- a/ext/opentelemetry-ext-mysql/setup.cfg
+++ b/ext/opentelemetry-ext-mysql/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.4a0
+    opentelemetry-api >= 0.4a1
     mysql-connector-python ~=  8.0
     wrapt >= 1.0.0, < 2.0.0
 

--- a/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/version.py
+++ b/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/ext/opentelemetry-ext-prometheus/CHANGELOG.md
+++ b/ext/opentelemetry-ext-prometheus/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+## 0.4a1
+
+Released 2020-03-02
+
+- Update docs
+
 ## 0.4a0
 
 Released 2020-02-21
 
 - Initial release
-

--- a/ext/opentelemetry-ext-prometheus/src/opentelemetry/ext/prometheus/version.py
+++ b/ext/opentelemetry-ext-prometheus/src/opentelemetry/ext/prometheus/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/ext/opentelemetry-ext-psycopg2/CHANGELOG.md
+++ b/ext/opentelemetry-ext-psycopg2/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.4a1
+
+Released 2020-03-02
+
+- Update docs
+
 ## 0.4a0
 
 Released 2020-02-21

--- a/ext/opentelemetry-ext-psycopg2/setup.cfg
+++ b/ext/opentelemetry-ext-psycopg2/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.4a0
+    opentelemetry-api >= 0.4a1
     psycopg2-binary >= 2.7.3.1
     wrapt >= 1.0.0, < 2.0.0
 

--- a/ext/opentelemetry-ext-psycopg2/src/opentelemetry/ext/psycopg2/version.py
+++ b/ext/opentelemetry-ext-psycopg2/src/opentelemetry/ext/psycopg2/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/ext/opentelemetry-ext-pymongo/CHANGELOG.md
+++ b/ext/opentelemetry-ext-pymongo/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## Unreleased
 
+## 0.4a1
+
+Released 2020-03-02
+
+- Update docs
+
 ## 0.4a0
 
 Released 2020-02-21
 
 - Updating network connection attribute names
   ([#350](https://github.com/open-telemetry/opentelemetry-python/pull/350))
-
 
 ## 0.3a0
 

--- a/ext/opentelemetry-ext-pymongo/setup.cfg
+++ b/ext/opentelemetry-ext-pymongo/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.4a0
+    opentelemetry-api >= 0.4a1
     pymongo ~= 3.1
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/version.py
+++ b/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/ext/opentelemetry-ext-testutil/src/opentelemetry/ext/testutil/version.py
+++ b/ext/opentelemetry-ext-testutil/src/opentelemetry/ext/testutil/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/ext/opentelemetry-ext-wsgi/CHANGELOG.md
+++ b/ext/opentelemetry-ext-wsgi/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.4a1
+
+Released 2020-03-02
+
+- Update docs
+
 ## 0.4a0
 
 Released 2020-02-21

--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/ext/opentelemetry-ext-zipkin/CHANGELOG.md
+++ b/ext/opentelemetry-ext-zipkin/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.4a1
+
+Released 2020-03-02
+
+- Update docs
+
 ## 0.4a0
 
 Released 2020-02-21

--- a/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/version.py
+++ b/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.4a1
+
+Released 2020-03-02
+
+- Update docs
+
 ## 0.4a0
 
 Released 2020-02-21
@@ -22,9 +28,6 @@ Released 2020-02-21
   ([#410](https://github.com/open-telemetry/opentelemetry-python/pull/410))
 - Adding trace.get_tracer function
   ([#430](https://github.com/open-telemetry/opentelemetry-python/pull/430))
-
-
-
 
 ## 0.3a0
 

--- a/opentelemetry-api/src/opentelemetry/util/version.py
+++ b/opentelemetry-api/src/opentelemetry/util/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 ## Unreleased
 
-## 0.4a0 
+## 0.4a1
+
+Released 2020-03-02
+
+- Update docs
+
+## 0.4a0
 
 Released 2020-02-21
 
 - Added named Tracers
   ([#301](https://github.com/open-telemetry/opentelemetry-python/pull/301))
-- Set status for ended spans 
+- Set status for ended spans
   ([#297](https://github.com/open-telemetry/opentelemetry-python/pull/297) and
   [#358](https://github.com/open-telemetry/opentelemetry-python/pull/358))
 - Use module loggers
@@ -37,7 +43,6 @@ Released 2020-02-21
   ([#410](https://github.com/open-telemetry/opentelemetry-python/pull/410))
 - Implement MinMaxSumCount aggregator
   ([#422](https://github.com/open-telemetry/opentelemetry-python/pull/422))
-
 
 ## 0.3a0
 

--- a/opentelemetry-sdk/setup.py
+++ b/opentelemetry-sdk/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
     include_package_data=True,
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
-    install_requires=["opentelemetry-api==0.4a0"],
+    install_requires=["opentelemetry-api==0.4a1"],
     extras_require={},
     license="Apache-2.0",
     package_dir={"": "src"},

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4a0"
+__version__ = "0.4a1"

--- a/tox.ini
+++ b/tox.ini
@@ -192,14 +192,16 @@ commands =
 [testenv:docs]
 deps =
   -c dev-requirements.txt
+  -c docs-requirements.txt
   sphinx
   sphinx-rtd-theme
   sphinx-autodoc-typehints
-  opentracing~=2.2.0
-  Deprecated>=1.2.6
-  thrift>=0.10.0
-  pymongo ~= 3.1
-  flask~=1.0
+  # Required by ext packages
+  opentracing
+  Deprecated
+  thrift
+  pymongo
+  flask
 
 changedir = docs
 


### PR DESCRIPTION
This PR cherry-picks a9e52b8 from master onto the `0.4a.x` release branch so we can build docs for the last-released version of the library and host on readthedocs.org. The goal is to make the default "stable" release docs on readthedocs.org match the version of the library that users get by installing the package from PyPI when they don't specify a version.

This will be the first micro/patch-level release for this library, which would usually be reserved for non-API-breaking bug fixes. The process I've followed for this release is:

1. Patch changes in from master
2. Update all version numbers and dependencies (`0.4a0` packages can use `0.4a1` dependencies, but not vice-versa)
3. Update changelogs
4. (TODO after merging this PR) cut a new release from the target branch
5. (also TODO) push new artifacts built from this branch to PyPI

This is a lot of ceremony for a trivial change, but AFAICT this is all required if we want every change to a release branch to result in a micro/patch version update, and if we want to keep the version numbers for all packages in sync.