### PR TITLE
Usage README Update for opentelemetry-ext-jaeger

### DIFF
--- a/ext/opentelemetry-ext-jaeger/README.rst
+++ b/ext/opentelemetry-ext-jaeger/README.rst
@@ -56,7 +56,7 @@ gRPC is still not supported by this implementation.
     span_processor = BatchExportSpanProcessor(jaeger_exporter)
 
     # add to the tracer
-    tracer.add_span_processor(span_processor)
+    trace.tracer_source().add_span_processor(span_processor)
 
     with tracer.start_as_current_span('foo'):
         print('Hello world!')

--- a/ext/opentelemetry-ext-jaeger/README.rst
+++ b/ext/opentelemetry-ext-jaeger/README.rst
@@ -56,7 +56,7 @@ gRPC is still not supported by this implementation.
     span_processor = BatchExportSpanProcessor(jaeger_exporter)
 
     # add to the tracer
-    trace.tracer_source().add_span_processor(span_processor)
+    trace.tracer_provider().add_span_processor(span_processor)
 
     with tracer.start_as_current_span('foo'):
         print('Hello world!')


### PR DESCRIPTION
Usage docs for opentelemetry-ext-jaeger need to be updated after the change to `TracerSource` with v0.4. Looks like it was partially updated already.

Users following the usage docs will currently run into this error:
`AttributeError: 'Tracer' object has no attribute 'add_span_processor'`