### PR TITLE
Improve attributes validation

### DIFF
--- a/opentelemetry-api/src/opentelemetry/util/types.py
+++ b/opentelemetry-api/src/opentelemetry/util/types.py
@@ -22,6 +22,7 @@ AttributeValue = Union[
     float,
     Sequence[str],
     Sequence[bool],
-    Sequence[Union[int, float]],
+    Sequence[int],
+    Sequence[float],
 ]
 Attributes = Optional[Dict[str, AttributeValue]]

--- a/opentelemetry-api/src/opentelemetry/util/types.py
+++ b/opentelemetry-api/src/opentelemetry/util/types.py
@@ -22,7 +22,6 @@ AttributeValue = Union[
     float,
     Sequence[str],
     Sequence[bool],
-    Sequence[int],
-    Sequence[float],
+    Sequence[Union[int, float]],
 ]
 Attributes = Optional[Dict[str, AttributeValue]]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -18,7 +18,6 @@ import logging
 import random
 import threading
 from contextlib import contextmanager
-from numbers import Number
 from types import TracebackType
 from typing import Iterator, Optional, Sequence, Tuple, Type
 
@@ -238,7 +237,7 @@ class Span(trace_api.Span):
             if error_message is not None:
                 logger.warning("%s in attribute value sequence", error_message)
                 return
-        elif not isinstance(value, (bool, str, Number, Sequence)):
+        elif not isinstance(value, (bool, str, int, float)):
             logger.warning("invalid type for attribute value")
             return
 
@@ -254,11 +253,12 @@ class Span(trace_api.Span):
 
         first_element_type = type(sequence[0])
 
-        if issubclass(first_element_type, Number):
-            first_element_type = Number
-
-        if first_element_type not in (bool, str, Number):
+        if first_element_type not in (bool, str, int, float):
             return "invalid type"
+
+        # int and float are both numeric types, allow mixed arrays of those
+        if first_element_type in (int, float):
+            first_element_type = (int, float)
 
         for element in sequence:
             if not isinstance(element, first_element_type):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -232,6 +232,10 @@ class Span(trace_api.Span):
             logger.warning("Setting attribute on ended span.")
             return
 
+        if not key:
+            logger.warning("invalid key (empty or null)")
+            return
+
         if isinstance(value, Sequence):
             error_message = self._check_attribute_value_sequence(value)
             if error_message is not None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -260,10 +260,6 @@ class Span(trace_api.Span):
         if first_element_type not in (bool, str, int, float):
             return "invalid type"
 
-        # int and float are both numeric types, allow mixed arrays of those
-        if first_element_type in (int, float):
-            first_element_type = (int, float)
-
         for element in sequence:
             if not isinstance(element, first_element_type):
                 return "different type"

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -440,6 +440,9 @@ class TestSpan(unittest.TestCase):
                 "list-with-non-primitive-data-type", [dict(), 123]
             )
 
+            root.set_attribute("", 123)
+            root.set_attribute(None, 123)
+
             self.assertEqual(len(root.attributes), 0)
 
     def test_check_sequence_helper(self):

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -391,7 +391,7 @@ class TestSpan(unittest.TestCase):
 
             root.set_attribute("empty-list", [])
             root.set_attribute("list-of-bools", [True, True, False])
-            root.set_attribute("list-of-numerics", [123, 3.14, 0])
+            root.set_attribute("list-of-numerics", [123, 314, 0])
 
             self.assertEqual(len(root.attributes), 10)
             self.assertEqual(root.attributes["component"], "http")
@@ -409,7 +409,7 @@ class TestSpan(unittest.TestCase):
                 root.attributes["list-of-bools"], [True, True, False]
             )
             self.assertEqual(
-                root.attributes["list-of-numerics"], [123, 3.14, 0]
+                root.attributes["list-of-numerics"], [123, 314, 0]
             )
 
         attributes = {
@@ -461,8 +461,18 @@ class TestSpan(unittest.TestCase):
             ),
             "different type",
         )
+        self.assertEqual(
+            trace.Span._check_attribute_value_sequence([1, 2, 3.4, 5]),
+            "different type",
+        )
         self.assertIsNone(
-            trace.Span._check_attribute_value_sequence([1, 2, 3.4, 5])
+            trace.Span._check_attribute_value_sequence([1, 2, 3, 5])
+        )
+        self.assertIsNone(
+            trace.Span._check_attribute_value_sequence([1.2, 2.3, 3.4, 4.5])
+        )
+        self.assertIsNone(
+            trace.Span._check_attribute_value_sequence([True, False])
         )
         self.assertIsNone(
             trace.Span._check_attribute_value_sequence(["ss", "dw", "fw"])


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-python/pull/348 added some runtime checks for attributes values, however I think this could create some issues to the exporter because it's accepting types as fractions, decimal and complex. This PR changes the logic to only accept int and float, otherwise exporter will have to handle all those different datatypes, something that is clearly not done now:

https://github.com/open-telemetry/opentelemetry-python/blob/005575e537ff97f345610c92276d6b55c32e65e5/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py#L266-L273

https://github.com/open-telemetry/opentelemetry-python/blob/005575e537ff97f345610c92276d6b55c32e65e5/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/__init__.py#L157-L163

https://github.com/open-telemetry/opentelemetry-python/blob/005575e537ff97f345610c92276d6b55c32e65e5/ext/opentelemetry-ext-otcollector/src/opentelemetry/ext/otcollector/util.py#L65-L74


I'm aware of https://github.com/open-telemetry/opentelemetry-specification/issues/425, the outcome appears to be that `numeric` refers to `int` and `float` types.

This PR also handles the case of an empty key https://github.com/open-telemetry/opentelemetry-specification/pull/459.

There are still some things this PR is not handling:
- Validation for attributes in links and events.
- Accept None as value to delete an attribute.