### PR TITLE
Force remove empty dist dir on builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ DISTDIR=dist
 (
   cd $BASEDIR
   mkdir -p $DISTDIR
-  rm -r $DISTDIR/*
+  rm -rf $DISTDIR/*
 
  for d in opentelemetry-api/ opentelemetry-sdk/ ext/*/ ; do
    (


### PR DESCRIPTION
Before #437, `scripts/build.sh` force-removed old built distributions with `rm -rf $DISTDIR/*`.

This change caused the build script to fail if the dir was empty, which happens e.g. during automated builds: https://github.com/open-telemetry/opentelemetry-python/commit/1e3768c802465c5c59f944276e89ddd0f66ee70f/checks?check_suite_id=499159591.

