### PR TITLE
docs: move ext readmes to docstring

### DIFF
--- a/docs/ext/dbapi/dbapi.rst
+++ b/docs/ext/dbapi/dbapi.rst
@@ -1,8 +1,5 @@
-.. include:: ../../../ext/opentelemetry-ext-dbapi/README.rst
-
-
-Module contents
----------------
+OpenTelemetry Database API integration
+======================================
 
 .. automodule:: opentelemetry.ext.dbapi
     :members:

--- a/docs/ext/flask/flask.rst
+++ b/docs/ext/flask/flask.rst
@@ -1,8 +1,5 @@
-.. include:: ../../../ext/opentelemetry-ext-flask/README.rst
-
-
-Module contents
----------------
+OpenTelemetry Flask Integration
+===============================
 
 .. automodule:: opentelemetry.ext.flask
     :members:

--- a/docs/ext/http_requests/http_requests.rst
+++ b/docs/ext/http_requests/http_requests.rst
@@ -1,7 +1,5 @@
-.. include:: ../../../ext/opentelemetry-ext-http-requests/README.rst
-
-Module contents
----------------
+OpenTelemetry requests Integration
+==================================
 
 .. automodule:: opentelemetry.ext.http_requests
     :members:

--- a/docs/ext/jaeger/jaeger.rst
+++ b/docs/ext/jaeger/jaeger.rst
@@ -1,12 +1,11 @@
-.. include:: ../../../ext/opentelemetry-ext-jaeger/README.rst
-
-Module contents
----------------
+Opentelemetry Jaeger Exporter
+=============================
 
 .. automodule:: opentelemetry.ext.jaeger
     :members:
     :undoc-members:
     :show-inheritance:
+
 
 Submodules
 ----------

--- a/docs/ext/mysql/mysql.rst
+++ b/docs/ext/mysql/mysql.rst
@@ -1,8 +1,5 @@
-.. include:: ../../../ext/opentelemetry-ext-mysql/README.rst
-
-
-Module contents
----------------
+OpenTelemetry MySQL Integration
+===============================
 
 .. automodule:: opentelemetry.ext.mysql
     :members:

--- a/docs/ext/otcollector/otcollector.rst
+++ b/docs/ext/otcollector/otcollector.rst
@@ -1,8 +1,5 @@
-.. include:: ../../../ext/opentelemetry-ext-otcollector/README.rst
-
-
-Module contents
----------------
+OpenTelemetry Collector Exporter
+================================
 
 .. automodule:: opentelemetry.ext.otcollector
     :members:

--- a/docs/ext/prometheus/prometheus.rst
+++ b/docs/ext/prometheus/prometheus.rst
@@ -1,8 +1,5 @@
-.. include:: ../../../ext/opentelemetry-ext-prometheus/README.rst
-
-
-Module contents
----------------
+OpenTelemetry Prometheus Exporter
+=================================
 
 .. automodule:: opentelemetry.ext.prometheus
     :members:

--- a/docs/ext/psycopg2/psycopg2.rst
+++ b/docs/ext/psycopg2/psycopg2.rst
@@ -1,8 +1,5 @@
-.. include:: ../../../ext/opentelemetry-ext-psycopg2/README.rst
-
-
-Module contents
----------------
+OpenTelemetry Psycopg Integration
+=================================
 
 .. automodule:: opentelemetry.ext.psycopg2
     :members:

--- a/docs/ext/pymongo/pymongo.rst
+++ b/docs/ext/pymongo/pymongo.rst
@@ -1,7 +1,5 @@
-.. include:: ../../../ext/opentelemetry-ext-pymongo/README.rst
-
-Module contents
----------------
+OpenTelemetry pymongo Integration
+=================================
 
 .. automodule:: opentelemetry.ext.pymongo
     :members:

--- a/docs/ext/wsgi/wsgi.rst
+++ b/docs/ext/wsgi/wsgi.rst
@@ -1,8 +1,5 @@
-.. include:: ../../../ext/opentelemetry-ext-wsgi/README.rst
-
-
-Module contents
----------------
+OpenTelemetry WSGI Middleware
+=============================
 
 .. automodule:: opentelemetry.ext.wsgi
     :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,7 +82,7 @@ Metrics
     sdk/sdk
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
     :caption: OpenTelemetry Integrations
     :name: integrations
     :glob:

--- a/ext/opentelemetry-ext-dbapi/README.rst
+++ b/ext/opentelemetry-ext-dbapi/README.rst
@@ -1,29 +1,21 @@
 OpenTelemetry Database API integration
 ======================================
 
-The trace integration with Database API supports libraries following the specification.
+|pypi|
 
-.. PEP 249 -- Python Database API Specification v2.0: https://www.python.org/dev/peps/pep-0249/
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-ext-dbapi.svg
+   :target: https://pypi.org/project/opentelemetry-ext-dbapi/
 
-Usage
------
+Installation
+------------
 
-.. code-block:: python
+::
 
-    import mysql.connector
-    import pyodbc
-    from opentelemetry.trace import tracer_provider
-    from opentelemetry.ext.dbapi import trace_integration
-
-    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
-    tracer = trace.get_tracer(__name__)
-    # Ex: mysql.connector
-    trace_integration(tracer_provider(), mysql.connector, "connect", "mysql", "sql")
-    # Ex: pyodbc
-    trace_integration(tracer_provider(), pyodbc, "Connection", "odbc", "sql")
+    pip install opentelemetry-ext-dbapi
 
 
 References
 ----------
 
+* `OpenTelemetry Database API integration <https://opentelemetry-python.readthedocs.io/en/latest/ext/dbapi/dbapi.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/__init__.py
+++ b/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/__init__.py
@@ -13,9 +13,29 @@
 # limitations under the License.
 
 """
-The opentelemetry-ext-dbapi package allows tracing queries made by the
-ibraries following Ptyhon Database API specification:
-https://www.python.org/dev/peps/pep-0249/
+The trace integration with Database API supports libraries following the specification.
+
+.. PEP 249 -- Python Database API Specification v2.0: https://www.python.org/dev/peps/pep-0249/
+
+Usage
+-----
+
+.. code-block:: python
+
+    import mysql.connector
+    import pyodbc
+    from opentelemetry.trace import tracer_provider
+    from opentelemetry.ext.dbapi import trace_integration
+
+    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
+    tracer = trace.get_tracer(__name__)
+    # Ex: mysql.connector
+    trace_integration(tracer_provider(), mysql.connector, "connect", "mysql", "sql")
+    # Ex: pyodbc
+    trace_integration(tracer_provider(), pyodbc, "Connection", "odbc", "sql")
+
+API
+---
 """
 
 import functools
@@ -40,6 +60,7 @@ def trace_integration(
 ):
     """Integrate with DB API library.
         https://www.python.org/dev/peps/pep-0249/
+
         Args:
             tracer: The :class:`Tracer` to use.
             connect_module: Module name where connect method is available.

--- a/ext/opentelemetry-ext-flask/README.rst
+++ b/ext/opentelemetry-ext-flask/README.rst
@@ -1,35 +1,24 @@
-OpenTelemetry Flask tracing
+OpenTelemetry Flask Tracing
 ===========================
 
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-ext-flask.svg
+   :target: https://pypi.org/project/opentelemetry-ext-flask/
+
 This library builds on the OpenTelemetry WSGI middleware to track web requests
-in Flask applications. In addition to opentelemetry-ext-wsgi, it supports
-flask-specific features such as:
+in Flask applications.
 
-* The Flask endpoint name is used as the Span name.
-* The ``http.route`` Span attribute is set so that one can see which URL rule
-  matched a request.
+Installation
+------------
 
-Usage
------
+::
 
-.. code-block:: python
-
-    from flask import Flask
-    from opentelemetry.ext.flask import instrument_app
-
-    app = Flask(__name__)
-    instrument_app(app)  # This is where the magic happens. ✨
-
-    @app.route("/")
-    def hello():
-        return "Hello!"
-
-    if __name__ == "__main__":
-        app.run(debug=True)
+    pip install opentelemetry-ext-flask
 
 
 References
 ----------
 
+* `OpenTelemetry Flask Tracing <https://opentelemetry-python.readthedocs.io/en/latest/ext/flask/flask.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
-* `OpenTelemetry WSGI extension <https://github.com/open-telemetry/opentelemetry-python/tree/master/ext/opentelemetry-ext-wsgi>`_

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
@@ -1,6 +1,37 @@
 # Note: This package is not named "flask" because of
 # https://github.com/PyCQA/pylint/issues/2648
 
+"""
+This library builds on the OpenTelemetry WSGI middleware to track web requests
+in Flask applications. In addition to opentelemetry-ext-wsgi, it supports
+flask-specific features such as:
+
+* The Flask endpoint name is used as the Span name.
+* The ``http.route`` Span attribute is set so that one can see which URL rule
+  matched a request.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from flask import Flask
+    from opentelemetry.ext.flask import instrument_app
+
+    app = Flask(__name__)
+    instrument_app(app)  # This is where the magic happens. ✨
+
+    @app.route("/")
+    def hello():
+        return "Hello!"
+
+    if __name__ == "__main__":
+        app.run(debug=True)
+
+API
+---
+"""
+
 import logging
 
 from flask import request as flask_request

--- a/ext/opentelemetry-ext-http-requests/README.rst
+++ b/ext/opentelemetry-ext-http-requests/README.rst
@@ -1,4 +1,4 @@
-OpenTelemetry requests integration
+OpenTelemetry requests Integration
 ==================================
 
 |pypi|
@@ -6,7 +6,8 @@ OpenTelemetry requests integration
 .. |pypi| image:: https://badge.fury.io/py/opentelemetry-ext-http-requests.svg
    :target: https://pypi.org/project/opentelemetry-ext-http-requests/
 
-This library allows tracing HTTP requests made by the popular `requests <https://requests.kennethreitz.org/en/master/>`_ library.
+This library allows tracing HTTP requests made by the popular
+`requests <https://requests.kennethreitz.org/en/master/>`_ library.
 
 Installation
 ------------
@@ -15,28 +16,8 @@ Installation
 
      pip install opentelemetry-ext-http-requests
 
-Usage
------
-
-.. code-block:: python
-
-    import requests
-    import opentelemetry.ext.http_requests
-    from opentelemetry.trace import tracer_provider
-
-    opentelemetry.ext.http_requests.enable(tracer_provider())
-    response = requests.get(url='https://www.example.org/')
-
-Limitations
------------
-
-Note that calls that do not use the higher-level APIs but use
-:code:`requests.sessions.Session.send` (or an alias thereof) directly, are
-currently not traced. If you find any other way to trigger an untraced HTTP
-request, please report it via a GitHub issue with :code:`[requests: untraced
-API]` in the title.
-
 References
 ----------
 
+* `OpenTelemetry requests Integration <https://opentelemetry-python.readthedocs.io/en/latest/ext/http_requests/http_requests..html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
@@ -13,8 +13,32 @@
 # limitations under the License.
 
 """
-The opentelemetry-ext-requests package allows tracing HTTP requests made by the
-popular requests library.
+This library allows tracing HTTP requests made by the popular
+`requests <https://requests.kennethreitz.org/en/master/>`_ library.
+
+Usage
+-----
+
+.. code-block:: python
+
+    import requests
+    import opentelemetry.ext.http_requests
+    from opentelemetry.trace import tracer_provider
+
+    opentelemetry.ext.http_requests.enable(tracer_provider())
+    response = requests.get(url='https://www.example.org/')
+
+Limitations
+-----------
+
+Note that calls that do not use the higher-level APIs but use
+:code:`requests.sessions.Session.send` (or an alias thereof) directly, are
+currently not traced. If you find any other way to trigger an untraced HTTP
+request, please report it via a GitHub issue with :code:`[requests: untraced
+API]` in the title.
+
+API
+---
 """
 
 import functools

--- a/ext/opentelemetry-ext-jaeger/README.rst
+++ b/ext/opentelemetry-ext-jaeger/README.rst
@@ -13,58 +13,16 @@ Installation
 
 ::
 
-     pip install opentelemetry-ext-jaeger
-
-
-Usage
------
-
-The **OpenTelemetry Jaeger Exporter** allows to export `OpenTelemetry`_ traces to `Jaeger`_.
-This exporter always send traces to the configured agent using Thrift compact protocol over UDP.
-An optional collector can be configured, in this case Thrift binary protocol over HTTP is used.
-gRPC is still not supported by this implementation.
+    pip install opentelemetry-ext-jaeger
 
 
 .. _Jaeger: https://www.jaegertracing.io/
 .. _OpenTelemetry: https://github.com/open-telemetry/opentelemetry-python/
 
-.. code:: python
-
-    from opentelemetry import trace
-    from opentelemetry.ext import jaeger
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
-
-    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
-    tracer = trace.get_tracer(__name__)
-
-    # create a JaegerSpanExporter
-    jaeger_exporter = jaeger.JaegerSpanExporter(
-        service_name='my-helloworld-service',
-        # configure agent
-        agent_host_name='localhost',
-        agent_port=6831,
-        # optional: configure also collector
-        # collector_host_name='localhost',
-        # collector_port=14268,
-        # collector_endpoint='/api/traces?format=jaeger.thrift',
-        # username=xxxx, # optional
-        # password=xxxx, # optional
-    )
-
-    # Create a BatchExportSpanProcessor and add the exporter to it
-    span_processor = BatchExportSpanProcessor(jaeger_exporter)
-
-    # add to the tracer
-    trace.tracer_provider().add_span_processor(span_processor)
-
-    with tracer.start_as_current_span('foo'):
-        print('Hello world!')
-
-The `examples <./examples>`_ folder contains more elaborated examples.
 
 References
 ----------
 
+* `OpenTelemetry Jaeger Exporter <https://opentelemetry-python.readthedocs.io/en/latest/ext/jaeger/jaeger.html>`_
 * `Jaeger <https://www.jaegertracing.io/>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -13,7 +13,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Jaeger Span Exporter for OpenTelemetry."""
+"""
+The **OpenTelemetry Jaeger Exporter** allows to export `OpenTelemetry`_ traces to `Jaeger`_.
+This exporter always send traces to the configured agent using Thrift compact protocol over UDP.
+An optional collector can be configured, in this case Thrift binary protocol over HTTP is used.
+gRPC is still not supported by this implementation.
+
+Usage
+-----
+
+.. code:: python
+
+    from opentelemetry import trace
+    from opentelemetry.ext import jaeger
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+
+    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
+    tracer = trace.get_tracer(__name__)
+
+    # create a JaegerSpanExporter
+    jaeger_exporter = jaeger.JaegerSpanExporter(
+        service_name='my-helloworld-service',
+        # configure agent
+        agent_host_name='localhost',
+        agent_port=6831,
+        # optional: configure also collector
+        # collector_host_name='localhost',
+        # collector_port=14268,
+        # collector_endpoint='/api/traces?format=jaeger.thrift',
+        # username=xxxx, # optional
+        # password=xxxx, # optional
+    )
+
+    # Create a BatchExportSpanProcessor and add the exporter to it
+    span_processor = BatchExportSpanProcessor(jaeger_exporter)
+
+    # add to the tracer
+    trace.tracer_provider().add_span_processor(span_processor)
+
+    with tracer.start_as_current_span('foo'):
+        print('Hello world!')
+
+API
+---
+.. _Jaeger: https://www.jaegertracing.io/
+.. _OpenTelemetry: https://github.com/open-telemetry/opentelemetry-python/
+"""
 
 import base64
 import logging

--- a/ext/opentelemetry-ext-mysql/README.rst
+++ b/ext/opentelemetry-ext-mysql/README.rst
@@ -1,29 +1,25 @@
-OpenTelemetry MySQL integration
+OpenTelemetry MySQL Integration
 ===============================
 
-The integration with MySQL supports the `mysql-connector`_ library and is specified
-to ``trace_integration`` using ``'MySQL'``.
+|pypi|
 
-.. _mysql-connector: https://pypi.org/project/mysql-connector/
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-ext-mysql.svg
+   :target: https://pypi.org/project/opentelemetry-ext-mysql/
 
-Usage
------
+Integration with MySQL that supports the mysql-connector library and is
+specified to trace_integration using 'MySQL'.
 
-.. code:: python
 
-    import mysql.connector
-    from opentelemetry.trace import tracer_provider
-    from opentelemetry.ext.mysql import trace_integration
+Installation
+------------
 
-    trace_integration(tracer_provider())
-    cnx = mysql.connector.connect(database='MySQL_Database')
-    cursor = cnx.cursor()
-    cursor.execute("INSERT INTO test (testField) VALUES (123)"
-    cursor.close()
-    cnx.close()
+::
+
+    pip install opentelemetry-ext-mysql
 
 
 References
 ----------
-
+* `OpenTelemetry MySQL Integration <https://opentelemetry-python.readthedocs.io/en/latest/ext/mysql/mysql.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
+

--- a/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/__init__.py
+++ b/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/__init__.py
@@ -13,8 +13,29 @@
 # limitations under the License.
 
 """
-The opentelemetry-ext-mysql package allows tracing MySQL queries made by the
-MySQL Connector/Python library.
+The integration with MySQL supports the `mysql-connector`_ library and is specified
+to ``trace_integration`` using ``'MySQL'``.
+
+.. _mysql-connector: https://pypi.org/project/mysql-connector/
+
+Usage
+-----
+
+.. code:: python
+
+    import mysql.connector
+    from opentelemetry.trace import tracer_provider
+    from opentelemetry.ext.mysql import trace_integration
+
+    trace_integration(tracer_provider())
+    cnx = mysql.connector.connect(database='MySQL_Database')
+    cursor = cnx.cursor()
+    cursor.execute("INSERT INTO test (testField) VALUES (123)"
+    cursor.close()
+    cnx.close()
+
+API
+---
 """
 
 import mysql.connector

--- a/ext/opentelemetry-ext-opentracing-shim/README.rst
+++ b/ext/opentelemetry-ext-opentracing-shim/README.rst
@@ -1,5 +1,5 @@
 OpenTracing Shim for OpenTelemetry
-============================================================================
+==================================
 
 |pypi|
 
@@ -16,4 +16,5 @@ Installation
 References
 ----------
 
+* `OpenTracing Shim for OpenTelemetry <https://opentelemetry-python.readthedocs.io/en/latest/ext/opentracing_shim/opentracing_shim.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/ext/opentelemetry-ext-otcollector/README.rst
+++ b/ext/opentelemetry-ext-otcollector/README.rst
@@ -16,83 +16,9 @@ Installation
      pip install opentelemetry-ext-otcollector
 
 
-Traces Usage
-------------
-
-The **OpenTelemetry Collector Exporter** allows to export `OpenTelemetry`_ traces to `OpenTelemetry Collector`_.
-
-.. code:: python
-
-    from opentelemetry import trace
-    from opentelemetry.ext.otcollector.trace_exporter  import CollectorSpanExporter
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
-
-
-    # create a CollectorSpanExporter
-    collector_exporter = CollectorSpanExporter(
-        # optional:
-        # endpoint="myCollectorUrl:55678",
-        # service_name="test_service",
-        # host_name="machine/container name",
-    )
-
-    # Create a BatchExportSpanProcessor and add the exporter to it
-    span_processor = BatchExportSpanProcessor(collector_exporter)
-
-    # Configure the tracer to use the collector exporter
-    tracer_provider = TracerProvider()
-    tracer_provider.add_span_processor(span_processor)
-    tracer = TracerProvider().get_tracer(__name__)
-
-    with tracer.start_as_current_span("foo"):
-        print("Hello world!")
-
-Metrics Usage
--------------
-
-The **OpenTelemetry Collector Exporter** allows to export `OpenTelemetry`_ metrics to `OpenTelemetry Collector`_.
-
-.. code:: python
-
-    from opentelemetry import metrics
-    from opentelemetry.ext.otcollector.metrics_exporter import CollectorMetricsExporter
-    from opentelemetry.sdk.metrics import Counter, MeterProvider
-    from opentelemetry.sdk.metrics.export.controller import PushController
-
-
-    # create a CollectorMetricsExporter
-    collector_exporter = CollectorMetricsExporter(
-        # optional:
-        # endpoint="myCollectorUrl:55678",
-        # service_name="test_service",
-        # host_name="machine/container name",
-    )
-
-    # Meter is responsible for creating and recording metrics
-    metrics.set_preferred_meter_provider_implementation(lambda _: MeterProvider())
-    meter = metrics.get_meter(__name__)
-    # controller collects metrics created from meter and exports it via the
-    # exporter every interval
-    controller = PushController(meter, collector_exporter, 5)
-    counter = meter.create_metric(
-        "requests",
-        "number of requests",
-        "requests",
-        int,
-        Counter,
-        ("environment",),
-    )
-    # Labelsets are used to identify key-values that are associated with a specific
-    # metric that you want to record. These are useful for pre-aggregation and can
-    # be used to store custom dimensions pertaining to a metric
-    label_set = meter.get_label_set({"environment": "staging"})
-    
-    counter.add(25, label_set)
-
-
 References
 ----------
 
+* `OpenTelemetry Collector Exporter <https://opentelemetry-python.readthedocs.io/en/latest/ext/otcollector/otcollector.html>`_
 * `OpenTelemetry Collector <https://github.com/open-telemetry/opentelemetry-collector/>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/ext/opentelemetry-ext-otcollector/src/opentelemetry/ext/otcollector/__init__.py
+++ b/ext/opentelemetry-ext-otcollector/src/opentelemetry/ext/otcollector/__init__.py
@@ -11,3 +11,81 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+This library allows to export data to `OpenTelemetry Collector <https://github.com/open-telemetry/opentelemetry-collector/>`_ , currently using OpenCensus receiver in Collector side.
+
+Traces Usage
+------------
+
+The **OpenTelemetry Collector Exporter** allows to export `OpenTelemetry`_ traces to `OpenTelemetry Collector`_.
+
+.. code:: python
+
+    from opentelemetry import trace
+    from opentelemetry.ext.otcollector.trace_exporter  import CollectorSpanExporter
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+
+
+    # create a CollectorSpanExporter
+    collector_exporter = CollectorSpanExporter(
+        # optional:
+        # endpoint="myCollectorUrl:55678",
+        # service_name="test_service",
+        # host_name="machine/container name",
+    )
+
+    # Create a BatchExportSpanProcessor and add the exporter to it
+    span_processor = BatchExportSpanProcessor(collector_exporter)
+
+    # Configure the tracer to use the collector exporter
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(span_processor)
+    tracer = TracerProvider().get_tracer(__name__)
+
+    with tracer.start_as_current_span("foo"):
+        print("Hello world!")
+
+Metrics Usage
+-------------
+
+The **OpenTelemetry Collector Exporter** allows to export `OpenTelemetry`_ metrics to `OpenTelemetry Collector`_.
+
+.. code:: python
+
+    from opentelemetry import metrics
+    from opentelemetry.ext.otcollector.metrics_exporter import CollectorMetricsExporter
+    from opentelemetry.sdk.metrics import Counter, MeterProvider
+    from opentelemetry.sdk.metrics.export.controller import PushController
+
+
+    # create a CollectorMetricsExporter
+    collector_exporter = CollectorMetricsExporter(
+        # optional:
+        # endpoint="myCollectorUrl:55678",
+        # service_name="test_service",
+        # host_name="machine/container name",
+    )
+
+    # Meter is responsible for creating and recording metrics
+    metrics.set_preferred_meter_provider_implementation(lambda _: MeterProvider())
+    meter = metrics.get_meter(__name__)
+    # controller collects metrics created from meter and exports it via the
+    # exporter every interval
+    controller = PushController(meter, collector_exporter, 5)
+    counter = meter.create_metric(
+        "requests",
+        "number of requests",
+        "requests",
+        int,
+        Counter,
+        ("environment",),
+    )
+    # Labelsets are used to identify key-values that are associated with a specific
+    # metric that you want to record. These are useful for pre-aggregation and can
+    # be used to store custom dimensions pertaining to a metric
+    label_set = meter.get_label_set({"environment": "staging"})
+
+    counter.add(25, label_set)
+"""

--- a/ext/opentelemetry-ext-prometheus/README.rst
+++ b/ext/opentelemetry-ext-prometheus/README.rst
@@ -15,58 +15,9 @@ Installation
 
      pip install opentelemetry-ext-prometheus
 
-
-Usage
------
-
-The **OpenTelemetry Prometheus Exporter** allows to export `OpenTelemetry`_ metrics to `Prometheus`_.
-
-
-.. _Prometheus: https://prometheus.io/
-.. _OpenTelemetry: https://github.com/open-telemetry/opentelemetry-python/
-
-.. code:: python
-
-    from opentelemetry import metrics
-    from opentelemetry.ext.prometheus import PrometheusMetricsExporter
-    from opentelemetry.sdk.metrics import Counter, Meter
-    from opentelemetry.sdk.metrics.export.controller import PushController
-    from prometheus_client import start_http_server
-
-    # Start Prometheus client
-    start_http_server(port=8000, addr="localhost")
-
-    # Meter is responsible for creating and recording metrics
-    metrics.set_preferred_meter_implementation(lambda _: Meter())
-    meter = metrics.meter()
-    # exporter to export metrics to Prometheus
-    prefix = "MyAppPrefix"
-    exporter = PrometheusMetricsExporter(prefix)
-    # controller collects metrics created from meter and exports it via the
-    # exporter every interval
-    controller = PushController(meter, exporter, 5)
-
-    counter = meter.create_metric(
-        "requests",
-        "number of requests",
-        "requests",
-        int,
-        Counter,
-        ("environment",),
-    )
-
-    # Labelsets are used to identify key-values that are associated with a specific
-    # metric that you want to record. These are useful for pre-aggregation and can
-    # be used to store custom dimensions pertaining to a metric
-    label_set = meter.get_label_set({"environment": "staging"})
-
-    counter.add(25, label_set)
-    input("Press any key to exit...")
-
-
-
 References
 ----------
 
+* `OpenTelemetry Prometheus Exporter <https://opentelemetry-python.readthedocs.io/en/latest/ext/prometheus/prometheus.html>`_
 * `Prometheus <https://prometheus.io/>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/ext/opentelemetry-ext-prometheus/src/opentelemetry/ext/prometheus/__init__.py
+++ b/ext/opentelemetry-ext-prometheus/src/opentelemetry/ext/prometheus/__init__.py
@@ -12,7 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Prometheus Metrics Exporter for OpenTelemetry."""
+"""
+This library allows to export metrics data to `Prometheus <https://prometheus.io/>`_.
+
+Usage
+-----
+
+The **OpenTelemetry Prometheus Exporter** allows to export `OpenTelemetry`_ metrics to `Prometheus`_.
+
+
+.. _Prometheus: https://prometheus.io/
+.. _OpenTelemetry: https://github.com/open-telemetry/opentelemetry-python/
+
+.. code:: python
+
+    from opentelemetry import metrics
+    from opentelemetry.ext.prometheus import PrometheusMetricsExporter
+    from opentelemetry.sdk.metrics import Counter, Meter
+    from opentelemetry.sdk.metrics.export.controller import PushController
+    from prometheus_client import start_http_server
+
+    # Start Prometheus client
+    start_http_server(port=8000, addr="localhost")
+
+    # Meter is responsible for creating and recording metrics
+    metrics.set_preferred_meter_implementation(lambda _: Meter())
+    meter = metrics.meter()
+    # exporter to export metrics to Prometheus
+    prefix = "MyAppPrefix"
+    exporter = PrometheusMetricsExporter(prefix)
+    # controller collects metrics created from meter and exports it via the
+    # exporter every interval
+    controller = PushController(meter, exporter, 5)
+
+    counter = meter.create_metric(
+        "requests",
+        "number of requests",
+        "requests",
+        int,
+        Counter,
+        ("environment",),
+    )
+
+    # Labelsets are used to identify key-values that are associated with a specific
+    # metric that you want to record. These are useful for pre-aggregation and can
+    # be used to store custom dimensions pertaining to a metric
+    label_set = meter.get_label_set({"environment": "staging"})
+
+    counter.add(25, label_set)
+    input("Press any key to exit...")
+
+API
+---
+"""
 
 import collections
 import logging

--- a/ext/opentelemetry-ext-psycopg2/README.rst
+++ b/ext/opentelemetry-ext-psycopg2/README.rst
@@ -1,30 +1,20 @@
-OpenTelemetry Psycopg integration
+OpenTelemetry Psycopg Integration
 =================================
 
-The integration with PostgreSQL supports the `Psycopg`_ library and is specified
-to ``trace_integration`` using ``'PostgreSQL'``.
+|pypi|
 
-.. _Psycopg: http://initd.org/psycopg/
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-ext-psycopg2.svg
+   :target: https://pypi.org/project/opentelemetry-ext-psycopg2/
 
-Usage
------
+Installation
+------------
 
-.. code-block:: python
+::
 
-    import psycopg2
-    from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.trace.ext.psycopg2 import trace_integration
+    pip install opentelemetry-ext-psycopg2
 
-    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
-    tracer = trace.get_tracer(__name__)
-    trace_integration(tracer)
-    cnx = psycopg2.connect(database='Database')
-    cursor = cnx.cursor()
-    cursor.execute("INSERT INTO test (testField) VALUES (123)")
-    cursor.close()
-    cnx.close()
 
 References
 ----------
+* `OpenTelemetry Psycopg Integration <https://opentelemetry-python.readthedocs.io/en/latest/ext/psycopg2/psycopg2.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/ext/opentelemetry-ext-psycopg2/src/opentelemetry/ext/psycopg2/__init__.py
+++ b/ext/opentelemetry-ext-psycopg2/src/opentelemetry/ext/psycopg2/__init__.py
@@ -13,8 +13,32 @@
 # limitations under the License.
 
 """
-The opentelemetry-ext-psycopg2 package allows tracing PostgreSQL queries made by the
-Psycopg2 library.
+The integration with PostgreSQL supports the `Psycopg`_ library and is specified
+to ``trace_integration`` using ``'PostgreSQL'``.
+
+.. _Psycopg: http://initd.org/psycopg/
+
+Usage
+-----
+
+.. code-block:: python
+
+    import psycopg2
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.trace.ext.psycopg2 import trace_integration
+
+    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
+    tracer = trace.get_tracer(__name__)
+    trace_integration(tracer)
+    cnx = psycopg2.connect(database='Database')
+    cursor = cnx.cursor()
+    cursor.execute("INSERT INTO test (testField) VALUES (123)")
+    cursor.close()
+    cnx.close()
+
+API
+---
 """
 
 import logging

--- a/ext/opentelemetry-ext-pymongo/README.rst
+++ b/ext/opentelemetry-ext-pymongo/README.rst
@@ -1,27 +1,21 @@
-OpenTelemetry pymongo integration
+OpenTelemetry pymongo Integration
 =================================
 
-The integration with MongoDB supports the `pymongo`_ library and is specified
-to ``trace_integration`` using ``'pymongo'``.
+|pypi|
 
-.. _pymongo: https://pypi.org/project/pymongo
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-ext-pymongo.svg
+   :target: https://pypi.org/project/opentelemetry-ext-pymongo/
 
-Usage
------
+Installation
+------------
 
-.. code:: python
+::
 
-    from pymongo import MongoClient
-    from opentelemetry.trace import tracer_provider
-    from opentelemetry.trace.ext.pymongo import trace_integration
+    pip install opentelemetry-ext-pymongo
 
-    trace_integration(tracer_provider())
-    client = MongoClient()
-    db = client["MongoDB_Database"]
-    collection = db["MongoDB_Collection"]
-    collection.find_one()
 
 References
 ----------
-
+* `OpenTelemetry pymongo Integration <https://opentelemetry-python.readthedocs.io/en/latest/ext/pymongo/pymongo.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
+

--- a/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/__init__.py
+++ b/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/__init__.py
@@ -13,8 +13,28 @@
 # limitations under the License.
 
 """
-The opentelemetry-ext-pymongo package allows tracing commands made by the
-pymongo library.
+The integration with MongoDB supports the `pymongo`_ library and is specified
+to ``trace_integration`` using ``'pymongo'``.
+
+.. _pymongo: https://pypi.org/project/pymongo
+
+Usage
+-----
+
+.. code:: python
+
+    from pymongo import MongoClient
+    from opentelemetry.trace import tracer_provider
+    from opentelemetry.trace.ext.pymongo import trace_integration
+
+    trace_integration(tracer_provider())
+    client = MongoClient()
+    db = client["MongoDB_Database"]
+    collection = db["MongoDB_Collection"]
+    collection.find_one()
+
+API
+---
 """
 
 from pymongo import monitoring

--- a/ext/opentelemetry-ext-wsgi/README.rst
+++ b/ext/opentelemetry-ext-wsgi/README.rst
@@ -18,43 +18,9 @@ Installation
     pip install opentelemetry-ext-wsgi
 
 
-Usage (Flask)
--------------
-
-.. code-block:: python
-
-    from flask import Flask
-    from opentelemetry.ext.wsgi import OpenTelemetryMiddleware
-
-    app = Flask(__name__)
-    app.wsgi_app = OpenTelemetryMiddleware(app.wsgi_app)
-
-    @app.route("/")
-    def hello():
-        return "Hello!"
-
-    if __name__ == "__main__":
-        app.run(debug=True)
-
-
-Usage (Django)
---------------
-
-Modify the application's ``wsgi.py`` file as shown below.
-
-.. code-block:: python
-
-    import os
-    from opentelemetry.ext.wsgi import OpenTelemetryMiddleware
-    from django.core.wsgi import get_wsgi_application
-
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'application.settings')
-
-    application = get_wsgi_application()
-    application = OpenTelemetryMiddleware(application)
-
 References
 ----------
 
+* `OpenTelemetry WSGI Middleware <https://opentelemetry-python.readthedocs.io/en/latest/ext/wsgi/wsgi.html>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
 * `WSGI <https://www.python.org/dev/peps/pep-3333>`_

--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
@@ -13,9 +13,43 @@
 # limitations under the License.
 
 """
-The opentelemetry-ext-wsgi package provides a WSGI middleware that can be used
-on any WSGI framework (such as Django / Flask) to track requests timing through
-OpenTelemetry.
+This library provides a WSGI middleware that can be used on any WSGI framework
+(such as Django / Flask) to track requests timing through OpenTelemetry.
+
+Usage (Flask)
+-------------
+
+.. code-block:: python
+
+    from flask import Flask
+    from opentelemetry.ext.wsgi import OpenTelemetryMiddleware
+
+    app = Flask(__name__)
+    app.wsgi_app = OpenTelemetryMiddleware(app.wsgi_app)
+
+    @app.route("/")
+    def hello():
+        return "Hello!"
+
+    if __name__ == "__main__":
+        app.run(debug=True)
+
+
+Usage (Django)
+--------------
+
+Modify the application's ``wsgi.py`` file as shown below.
+
+.. code-block:: python
+
+    import os
+    from opentelemetry.ext.wsgi import OpenTelemetryMiddleware
+    from django.core.wsgi import get_wsgi_application
+
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'application.settings')
+
+    application = get_wsgi_application()
+    application = OpenTelemetryMiddleware(application)
 """
 
 import functools

--- a/ext/opentelemetry-ext-zipkin/README.rst
+++ b/ext/opentelemetry-ext-zipkin/README.rst
@@ -16,52 +16,9 @@ Installation
      pip install opentelemetry-ext-zipkin
 
 
-Usage
------
-
-The **OpenTelemetry Zipkin Exporter** allows to export `OpenTelemetry`_ traces to `Zipkin`_.
-This exporter always send traces to the configured Zipkin collector using HTTP.
-
-
-.. _Zipkin: https://zipkin.io/
-.. _OpenTelemetry: https://github.com/open-telemetry/opentelemetry-python/
-
-.. code:: python
-
-    from opentelemetry import trace
-    from opentelemetry.ext import zipkin
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
-
-    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
-    tracer = trace.get_tracer(__name__)
-
-    # create a ZipkinSpanExporter
-    zipkin_exporter = zipkin.ZipkinSpanExporter(
-        service_name="my-helloworld-service",
-        # optional:
-        # host_name="localhost",
-        # port=9411,
-        # endpoint="/api/v2/spans",
-        # protocol="http",
-        # ipv4="",
-        # ipv6="",
-        # retry=False,
-    )
-
-    # Create a BatchExportSpanProcessor and add the exporter to it
-    span_processor = BatchExportSpanProcessor(zipkin_exporter)
-
-    # add to the tracer
-    trace.tracer_provider().add_span_processor(span_processor)
-
-    with tracer.start_as_current_span("foo"):
-        print("Hello world!")
-
-The `examples <./examples>`_ folder contains more elaborated examples.
-
 References
 ----------
 
+* `OpenTelemetry Zipkin Exporter <https://opentelemetry-python.readthedocs.io/en/latest/ext/zipkin/zipkin.html>`_
 * `Zipkin <https://zipkin.io/>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/__init__.py
+++ b/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/__init__.py
@@ -12,7 +12,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Zipkin Span Exporter for OpenTelemetry."""
+"""
+This library allows to export tracing data to `Zipkin <https://zipkin.io/>`_.
+
+Installation
+------------
+
+::
+
+     pip install opentelemetry-ext-zipkin
+
+
+Usage
+-----
+
+The **OpenTelemetry Zipkin Exporter** allows to export `OpenTelemetry`_ traces to `Zipkin`_.
+This exporter always send traces to the configured Zipkin collector using HTTP.
+
+
+.. _Zipkin: https://zipkin.io/
+.. _OpenTelemetry: https://github.com/open-telemetry/opentelemetry-python/
+
+.. code:: python
+
+    from opentelemetry import trace
+    from opentelemetry.ext import zipkin
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+
+    trace.set_preferred_tracer_provider_implementation(lambda T: TracerProvider())
+    tracer = trace.get_tracer(__name__)
+
+    # create a ZipkinSpanExporter
+    zipkin_exporter = zipkin.ZipkinSpanExporter(
+        service_name="my-helloworld-service",
+        # optional:
+        # host_name="localhost",
+        # port=9411,
+        # endpoint="/api/v2/spans",
+        # protocol="http",
+        # ipv4="",
+        # ipv6="",
+        # retry=False,
+    )
+
+    # Create a BatchExportSpanProcessor and add the exporter to it
+    span_processor = BatchExportSpanProcessor(zipkin_exporter)
+
+    # add to the tracer
+    trace.tracer_provider().add_span_processor(span_processor)
+
+    with tracer.start_as_current_span("foo"):
+        print("Hello world!")
+
+API
+---
+"""
 
 import json
 import logging


### PR DESCRIPTION
This commit moves the text on the readmes of the external packages to their
source code as a docstring. This improves the generated documentation and helps
to consolidate the documentation in a single place.

This commit uniforms all the readmes present on each packager, they only contain
a 1 line description, installation instructions and a link to the online
documentation of such package. This small readme will be the one shown on Github
and on PyPI.

The full documentation will be generated by autodoc and stored in readthedocs
or whatever site we choose.