### PR TITLE
Use SDK providers in example code

### DIFF
--- a/docs/examples/metrics/observer_example.py
+++ b/docs/examples/metrics/observer_example.py
@@ -19,7 +19,7 @@ asynchronous metrics data.
 import psutil
 
 from opentelemetry import metrics
-from opentelemetry.sdk.metrics import LabelSet
+from opentelemetry.sdk.metrics import LabelSet, MeterProvider
 from opentelemetry.sdk.metrics.export import ConsoleMetricsExporter
 from opentelemetry.sdk.metrics.export.batcher import UngroupedBatcher
 from opentelemetry.sdk.metrics.export.controller import PushController
@@ -27,6 +27,7 @@ from opentelemetry.sdk.metrics.export.controller import PushController
 # Configure a stateful batcher
 batcher = UngroupedBatcher(stateful=True)
 
+metrics.set_meter_provider(MeterProvider())
 meter = metrics.get_meter(__name__)
 
 # Exporter to export metrics to the console

--- a/docs/examples/metrics/prometheus.py
+++ b/docs/examples/metrics/prometheus.py
@@ -21,13 +21,14 @@ from prometheus_client import start_http_server
 
 from opentelemetry import metrics
 from opentelemetry.ext.prometheus import PrometheusMetricsExporter
-from opentelemetry.sdk.metrics import Counter
+from opentelemetry.sdk.metrics import Counter, MeterProvider
 from opentelemetry.sdk.metrics.export.controller import PushController
 
 # Start Prometheus client
 start_http_server(port=8000, addr="localhost")
 
 # Meter is responsible for creating and recording metrics
+metrics.set_meter_provider(MeterProvider())
 meter = metrics.get_meter(__name__)
 # exporter to export metrics to Prometheus
 prefix = "MyAppPrefix"

--- a/docs/examples/metrics/record.py
+++ b/docs/examples/metrics/record.py
@@ -19,10 +19,12 @@ It demonstrates the different ways you can record metrics via the meter.
 import time
 
 from opentelemetry import metrics
-from opentelemetry.sdk.metrics import Counter
+from opentelemetry.sdk.metrics import Counter, MeterProvider
 from opentelemetry.sdk.metrics.export import ConsoleMetricsExporter
 from opentelemetry.sdk.metrics.export.controller import PushController
 
+# Use the meter type provided by the SDK package
+metrics.set_meter_provider(MeterProvider())
 # Meter is responsible for creating and recording metrics
 meter = metrics.get_meter(__name__)
 # exporter to export metrics to the console

--- a/docs/examples/metrics/simple_example.py
+++ b/docs/examples/metrics/simple_example.py
@@ -23,7 +23,7 @@ import sys
 import time
 
 from opentelemetry import metrics
-from opentelemetry.sdk.metrics import Counter, Measure
+from opentelemetry.sdk.metrics import Counter, Measure, MeterProvider
 from opentelemetry.sdk.metrics.export import ConsoleMetricsExporter
 from opentelemetry.sdk.metrics.export.controller import PushController
 
@@ -43,13 +43,13 @@ if len(sys.argv) >= 2:
         usage(sys.argv)
         sys.exit(1)
 
-# Meter is responsible for creating and recording metrics
 
-# Meter's namespace corresponds to the string passed as the first argument Pass
-# in True/False to indicate whether the batcher is stateful. True indicates the
-# batcher computes checkpoints from over the process lifetime. False indicates
-# the batcher computes checkpoints which describe the updates of a single
-# collection period (deltas)
+# The Meter is responsible for creating and recording metrics. Each meter has a
+# unique name, which we set as the module's name here. The second argument
+# determines whether how metrics are collected: if true, metrics accumulate
+# over the process lifetime. If false, metrics are reset at the beginning of
+# each collection interval.
+metrics.set_meter_provider(MeterProvider())
 meter = metrics.get_meter(__name__, batcher_mode == "stateful")
 
 # Exporter to export metrics to the console

--- a/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
+++ b/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
@@ -23,6 +23,7 @@ import requests
 import opentelemetry.ext.http_requests
 from opentelemetry import trace
 from opentelemetry.ext.flask import instrument_app
+from opentelemetry.sdk.trace import TracerProvider
 
 
 def configure_opentelemetry(flask_app: flask.Flask):
@@ -33,21 +34,16 @@ def configure_opentelemetry(flask_app: flask.Flask):
     * sets tracer to the SDK's Tracer
     * enables requests integration on the Tracer
     * uses a WSGI middleware to enable configuration
-
-    TODO:
-
-    * processors?
-    * exporters?
     """
-    # Start by configuring all objects required to ensure
-    # a complete end to end workflow.
+    # Start by configuring all objects required to ensure a complete end to end
+    # workflow.
+    trace.set_tracer_provider(TracerProvider())
 
-    # Next, we need to configure how the values that are used by
-    # traces and metrics are propagated (such as what specific headers
-    # carry this value).
-    # Integrations are the glue that binds the OpenTelemetry API
-    # and the frameworks and libraries that are used together, automatically
-    # creating Spans and propagating context as appropriate.
+    # Next, we need to configure how the values that are used by traces and
+    # metrics are propagated (such as what specific headers carry this value).
+    # Integrations are the glue that binds the OpenTelemetry API and the
+    # frameworks and libraries that are used together, automatically creating
+    # Spans and propagating context as appropriate.
     opentelemetry.ext.http_requests.enable(trace.get_tracer_provider())
     instrument_app(flask_app)
 
@@ -57,8 +53,7 @@ app = flask.Flask(__name__)
 
 @app.route("/")
 def hello():
-    # emit a trace that measures how long the
-    # sleep takes
+    # Emit a trace that measures how long the sleep takes
     version = pkg_resources.get_distribution(
         "opentelemetry-example-app"
     ).version

--- a/docs/examples/opentracing/main.py
+++ b/docs/examples/opentracing/main.py
@@ -3,9 +3,12 @@
 from opentelemetry import trace
 from opentelemetry.ext import opentracing_shim
 from opentelemetry.ext.jaeger import JaegerSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
 from rediscache import RedisCache
 
+# Configure the tracer using the default implementation
+trace.set_tracer_provider(TracerProvider())
 tracer_provider = trace.get_tracer_provider()
 
 # Configure the tracer to export traces to Jaeger

--- a/examples/metrics/collector.py
+++ b/examples/metrics/collector.py
@@ -21,10 +21,11 @@ from opentelemetry import metrics
 from opentelemetry.ext.otcollector.metrics_exporter import (
     CollectorMetricsExporter,
 )
-from opentelemetry.sdk.metrics import Counter
+from opentelemetry.sdk.metrics import Counter, MeterProvider
 from opentelemetry.sdk.metrics.export.controller import PushController
 
 # Meter is responsible for creating and recording metrics
+metrics.set_meter_provider(MeterProvider())
 meter = metrics.get_meter(__name__)
 # exporter to export metrics to OT Collector
 exporter = CollectorMetricsExporter(

--- a/ext/opentelemetry-ext-dbapi/README.rst
+++ b/ext/opentelemetry-ext-dbapi/README.rst
@@ -12,9 +12,12 @@ Usage
 
     import mysql.connector
     import pyodbc
-    from opentelemetry.trace import tracer_provider
-    from opentelemetry.ext.dbapi import trace_integration
 
+    from opentelemetry.ext.dbapi import trace_integration
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.trace import tracer_provider
+
+    trace.set_tracer_provider(TracerProvider())
     tracer = trace.get_tracer(__name__)
     # Ex: mysql.connector
     trace_integration(tracer_provider(), mysql.connector, "connect", "mysql", "sql")

--- a/ext/opentelemetry-ext-jaeger/README.rst
+++ b/ext/opentelemetry-ext-jaeger/README.rst
@@ -32,8 +32,10 @@ gRPC is still not supported by this implementation.
 
     from opentelemetry import trace
     from opentelemetry.ext import jaeger
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
+    trace.set_tracer_provider(TracerProvider())
     tracer = trace.get_tracer(__name__)
 
     # create a JaegerSpanExporter

--- a/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
+++ b/ext/opentelemetry-ext-jaeger/examples/jaeger_exporter_example.py
@@ -2,8 +2,10 @@ import time
 
 from opentelemetry import trace
 from opentelemetry.ext import jaeger
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
+trace.set_tracer_provider(TracerProvider())
 tracer = trace.get_tracer(__name__)
 
 # create a JaegerSpanExporter

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
@@ -29,7 +29,11 @@ following example::
     import time
 
     from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.ext.opentracing_shim import create_tracer
+
+    # Tell OpenTelemetry which Tracer implementation to use.
+    trace.set_tracer_provider(TracerProvider())
 
     # Create an OpenTelemetry Tracer.
     otel_tracer = trace.get_tracer(__name__)

--- a/ext/opentelemetry-ext-prometheus/README.rst
+++ b/ext/opentelemetry-ext-prometheus/README.rst
@@ -29,7 +29,7 @@ The **OpenTelemetry Prometheus Exporter** allows to export `OpenTelemetry`_ metr
 
     from opentelemetry import metrics
     from opentelemetry.ext.prometheus import PrometheusMetricsExporter
-    from opentelemetry.sdk.metrics import Counter
+    from opentelemetry.sdk.metrics import Counter, MeterProvider
     from opentelemetry.sdk.metrics.export.controller import PushController
     from prometheus_client import start_http_server
 
@@ -37,6 +37,7 @@ The **OpenTelemetry Prometheus Exporter** allows to export `OpenTelemetry`_ metr
     start_http_server(port=8000, addr="localhost")
 
     # Meter is responsible for creating and recording metrics
+    metrics.set_meter_provider(MeterProvider())
     meter = metrics.meter()
     # exporter to export metrics to Prometheus
     prefix = "MyAppPrefix"

--- a/ext/opentelemetry-ext-psycopg2/README.rst
+++ b/ext/opentelemetry-ext-psycopg2/README.rst
@@ -13,8 +13,10 @@ Usage
 
     import psycopg2
     from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.trace.ext.psycopg2 import trace_integration
 
+    trace.set_tracer_provider(TracerProvider())
     tracer = trace.get_tracer(__name__)
     trace_integration(tracer)
     cnx = psycopg2.connect(database='Database')

--- a/ext/opentelemetry-ext-zipkin/README.rst
+++ b/ext/opentelemetry-ext-zipkin/README.rst
@@ -30,8 +30,10 @@ This exporter always send traces to the configured Zipkin collector using HTTP.
 
     from opentelemetry import trace
     from opentelemetry.ext import zipkin
+    from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
+    trace.set_tracer_provider(TracerProvider())
     tracer = trace.get_tracer(__name__)
 
     # create a ZipkinSpanExporter


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-python/pull/466/files#r392613438.

This PR updates docs and example code to use SDK-provided providers following #466.

#466 removed `set_preferred_implementation` in favor of `set_provider` methods. Before this change, most example code and docs loaded the SDK `TracerProvider` and `MeterProvider`. Although we technically don't need these lines now that it's possible to set the default providers in config, I think it's still useful to include them since we expect most users to use the SDK types. Writing the examples this way means they can run as-is without a separate config file.

cc @ocelotl.