### PR TITLE
bugfix: Fixing example app test

### DIFF
--- a/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
+++ b/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
@@ -23,8 +23,10 @@ import opentelemetry.ext.http_requests
 from opentelemetry import trace
 from opentelemetry.ext.flask import instrument_app
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import ConsoleSpanExporter
-from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
+from opentelemetry.sdk.trace.export import (
+    ConsoleSpanExporter,
+    SimpleExportSpanProcessor,
+)
 
 trace.set_tracer_provider(TracerProvider())
 trace.get_tracer_provider().add_span_processor(

--- a/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
+++ b/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
@@ -42,6 +42,3 @@ def hello():
     with tracer.start_as_current_span("example-request"):
         requests.get("http://www.example.com")
     return "hello"
-
-
-app.run(debug=True)


### PR DESCRIPTION
The flask run() call was added for completeness, which causes
the pytest collection to run forever, and time out CI.