### PR TITLE
Changelog and version updates for 0.5b0 release

### DIFF
--- a/docs/examples/opentelemetry-example-app/setup.py
+++ b/docs/examples/opentelemetry-example-app/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="opentelemetry-example-app",
-    version="0.5.dev0",
+    version="0.5b0",
     author="OpenTelemetry Authors",
     author_email="cncf-opentelemetry-contributors@lists.cncf.io",
     classifiers=[

--- a/ext/opentelemetry-ext-dbapi/setup.cfg
+++ b/ext/opentelemetry-ext-dbapi/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.5.dev0
+    opentelemetry-api >= 0.5b0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/version.py
+++ b/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/version.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-http-requests/setup.cfg
+++ b/ext/opentelemetry-ext-http-requests/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.5.dev0
+    opentelemetry-api >= 0.5b0
     requests ~= 2.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-mysql/setup.cfg
+++ b/ext/opentelemetry-ext-mysql/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.5.dev0
+    opentelemetry-api >= 0.5b0
     mysql-connector-python ~=  8.0
     wrapt >= 1.0.0, < 2.0.0
 

--- a/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/version.py
+++ b/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-otcollector/CHANGELOG.md
+++ b/ext/opentelemetry-ext-otcollector/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## Unreleased
 
 ## 0.5b0
+
+Released 2020-03-16
+
+Initial release.

--- a/ext/opentelemetry-ext-otcollector/CHANGELOG.md
+++ b/ext/opentelemetry-ext-otcollector/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## Unreleased
 
+## 0.5b0

--- a/ext/opentelemetry-ext-otcollector/setup.cfg
+++ b/ext/opentelemetry-ext-otcollector/setup.cfg
@@ -41,8 +41,8 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     opencensus-proto >= 0.1.0, < 1.0.0
-    opentelemetry-api >= 0.5.dev0
-    opentelemetry-sdk >= 0.5.dev0
+    opentelemetry-api >= 0.5b0
+    opentelemetry-sdk >= 0.5b0
     protobuf >= 3.8.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-otcollector/src/opentelemetry/ext/otcollector/version.py
+++ b/ext/opentelemetry-ext-otcollector/src/opentelemetry/ext/otcollector/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-prometheus/src/opentelemetry/ext/prometheus/version.py
+++ b/ext/opentelemetry-ext-prometheus/src/opentelemetry/ext/prometheus/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-psycopg2/setup.cfg
+++ b/ext/opentelemetry-ext-psycopg2/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.5.dev0
+    opentelemetry-api >= 0.5b0
     psycopg2-binary >= 2.7.3.1
     wrapt >= 1.0.0, < 2.0.0
 

--- a/ext/opentelemetry-ext-psycopg2/src/opentelemetry/ext/psycopg2/version.py
+++ b/ext/opentelemetry-ext-psycopg2/src/opentelemetry/ext/psycopg2/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-pymongo/setup.cfg
+++ b/ext/opentelemetry-ext-pymongo/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.5.dev0
+    opentelemetry-api >= 0.5b0
     pymongo ~= 3.1
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/version.py
+++ b/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-testutil/src/opentelemetry/ext/testutil/version.py
+++ b/ext/opentelemetry-ext-testutil/src/opentelemetry/ext/testutil/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/version.py
+++ b/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 0.5b0
+
+- Adding Correlation Context API and propagator
+  ([#471](https://github.com/open-telemetry/opentelemetry-python/pull/471))
+- Adding a global configuration module to simplify setting and getting globals
+  ([#466](https://github.com/open-telemetry/opentelemetry-python/pull/466))
+- Rename metric handle to bound metric
+  ([#470](https://github.com/open-telemetry/opentelemetry-python/pull/470))
+- Moving resources to sdk
+  ([#464](https://github.com/open-telemetry/opentelemetry-python/pull/464))
+- Implementing propagators to API to use context
+  ([#446](https://github.com/open-telemetry/opentelemetry-python/pull/446))
+- Adding named meters, removing batchers
+  ([#431](https://github.com/open-telemetry/opentelemetry-python/pull/431))
+- Renaming TraceOptions to TraceFlags
+  ([#450](https://github.com/open-telemetry/opentelemetry-python/pull/450))
+- Renaming TracerSource to TraceProvider
+  ([#441](https://github.com/open-telemetry/opentelemetry-python/pull/441))
+- Adding attach/detach methods as per spec
+  ([#429](https://github.com/open-telemetry/opentelemetry-python/pull/450) 
+
 ## 0.4a0
 
 Released 2020-02-21

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -10,7 +10,7 @@ Released 2020-03-16
   ([#471](https://github.com/open-telemetry/opentelemetry-python/pull/471))
 - Adding a global configuration module to simplify setting and getting globals
   ([#466](https://github.com/open-telemetry/opentelemetry-python/pull/466))
-- Rename metric handle to bound metric
+- Rename metric handle to bound metric instrument
   ([#470](https://github.com/open-telemetry/opentelemetry-python/pull/470))
 - Moving resources to sdk
   ([#464](https://github.com/open-telemetry/opentelemetry-python/pull/464))

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 0.5b0
 
+Released 2020-03-16
+
 - Adding Correlation Context API and propagator
   ([#471](https://github.com/open-telemetry/opentelemetry-python/pull/471))
 - Adding a global configuration module to simplify setting and getting globals

--- a/opentelemetry-api/src/opentelemetry/util/version.py
+++ b/opentelemetry-api/src/opentelemetry/util/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## 0.5b0
+
+- Adding Correlation Context SDK and propagator
+  ([#471](https://github.com/open-telemetry/opentelemetry-python/pull/471))
+- Adding OT Collector metrics exporter
+  ([#454](https://github.com/open-telemetry/opentelemetry-python/pull/454))
+- Improve validation of attributes
+  ([#460](https://github.com/open-telemetry/opentelemetry-python/pull/460))
+- Moving resources to sdk
+  ([#464](https://github.com/open-telemetry/opentelemetry-python/pull/464))
+- Re-raise errors caught in opentelemetry.sdk.trace.Tracer.use_span()
+  ([#469](https://github.com/open-telemetry/opentelemetry-python/pull/469))
+- Implement observer instrument
+  ([#425](https://github.com/open-telemetry/opentelemetry-python/pull/425))
+
 ## 0.4a0 
 
 Released 2020-02-21

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 0.5b0
 
+Released 2020-03-16
+
 - Adding Correlation Context SDK and propagator
   ([#471](https://github.com/open-telemetry/opentelemetry-python/pull/471))
 - Adding OT Collector metrics exporter

--- a/opentelemetry-sdk/setup.py
+++ b/opentelemetry-sdk/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
     include_package_data=True,
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
-    install_requires=["opentelemetry-api==0.5.dev0"],
+    install_requires=["opentelemetry-api==0.5b0"],
     extras_require={},
     license="Apache-2.0",
     package_dir={"": "src"},

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.dev0"
+__version__ = "0.5b0"


### PR DESCRIPTION
Total Changelog:

Documentations has been significantly overhauled, including:

* a getting started guide
* examples has been consolidated to an docs/examples folder
* several minor improvements to the examples in each extension's readme.

- Adding Correlation Context API and propagator
  ([#471](https://github.com/open-telemetry/opentelemetry-python/pull/471))
- Adding a global configuration module to simplify setting and getting
  globals
  ([#466](https://github.com/open-telemetry/opentelemetry-python/pull/466))
- Rename metric handle to bound metric
  ([#470](https://github.com/open-telemetry/opentelemetry-python/pull/470))
- Moving resources to sdk
  ([#464](https://github.com/open-telemetry/opentelemetry-python/pull/464))
- Implementing propagators to API to use context
  ([#446](https://github.com/open-telemetry/opentelemetry-python/pull/446))
- Implement observer instrument for metrics
  ([#425](https://github.com/open-telemetry/opentelemetry-python/pull/425))
- Adding named meters, removing batchers
  ([#431](https://github.com/open-telemetry/opentelemetry-python/pull/431))
- Renaming TraceOptions to TraceFlags
  ([#450](https://github.com/open-telemetry/opentelemetry-python/pull/450))
- Renaming TracerSource to TraceProvider
  ([#441](https://github.com/open-telemetry/opentelemetry-python/pull/441))

- Adding Correlation Context SDK and propagator
  ([#471](https://github.com/open-telemetry/opentelemetry-python/pull/471))
- Adding OT Collector metrics exporter
  ([#454](https://github.com/open-telemetry/opentelemetry-python/pull/454))
- Improve validation of attributes
  ([#460](https://github.com/open-telemetry/opentelemetry-python/pull/460))
- Re-raise errors caught in opentelemetry.sdk.trace.Tracer.use_span()
  (#469)
  ([#469](https://github.com/open-telemetry/opentelemetry-python/pull/469))
- Adding named meters, removing batchers
  ([#431](https://github.com/open-telemetry/opentelemetry-python/pull/431))
- Make counter and MinMaxSumCount aggregators thread safe
  ([#439](https://github.com/open-telemetry/opentelemetry-python/pull/439))

- Initial release. Support is included for both trace and metrics.