### PR TITLE
docs: fix link to stable versions

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,6 +1,7 @@
 sphinx~=2.4
 sphinx-rtd-theme~=0.4
 sphinx-autodoc-typehints~=1.10.2
+semver~=2.9
 
 # Required by ext packages
 opentracing~=2.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -202,6 +202,7 @@ deps =
   sphinx
   sphinx-rtd-theme
   sphinx-autodoc-typehints
+  semver
   # Required by ext packages
   opentracing
   Deprecated


### PR DESCRIPTION
The "scm_raw_web" and "scm_web" macros are used in the documentation to create
links to specific versions of the documents. It's useful to point to the right
version of the examples for instance.

There is a special "stable" version in readthedocs that points to the highest
release, generated links to that version are wrongly pointing to a non existing
"stable" release. This commit fixes that logic by getting the highest release
by using the Github API when building documents for the stable release.