### PR TITLE
Allow digit as first chr in vendor specific trace state key

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontexthttptextformat.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontexthttptextformat.py
@@ -33,7 +33,7 @@ from opentelemetry.trace.propagation import (
 
 _KEY_WITHOUT_VENDOR_FORMAT = r"[a-z][_0-9a-z\-\*\/]{0,255}"
 _KEY_WITH_VENDOR_FORMAT = (
-    r"[a-z][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}"
+    r"[a-z0-9][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}"
 )
 
 _KEY_FORMAT = _KEY_WITHOUT_VENDOR_FORMAT + "|" + _KEY_WITH_VENDOR_FORMAT

--- a/opentelemetry-api/tests/trace/propagation/test_tracecontexthttptextformat.py
+++ b/opentelemetry-api/tests/trace/propagation/test_tracecontexthttptextformat.py
@@ -224,7 +224,7 @@ class TestTraceContextFormat(unittest.TestCase):
         self.assertEqual(span.get_context().trace_state["foo"], "1")
 
     def test_tracestate_keys(self):
-        """Do not propagate invalid trace context.
+        """Test for valid key patterns in the tracestate
         """
         tracestate_value = ",".join(
             [

--- a/opentelemetry-api/tests/trace/propagation/test_tracecontexthttptextformat.py
+++ b/opentelemetry-api/tests/trace/propagation/test_tracecontexthttptextformat.py
@@ -222,3 +222,32 @@ class TestTraceContextFormat(unittest.TestCase):
             )
         )
         self.assertEqual(span.get_context().trace_state["foo"], "1")
+
+    def test_tracestate_keys(self):
+        """Do not propagate invalid trace context.
+        """
+        tracestate_value = ",".join(
+            [
+                "1a-2f@foo=bar1",
+                "1a-_*/2b@foo=bar2",
+                "foo=bar3",
+                "foo-_*/bar=bar4",
+            ]
+        )
+        span = get_span_from_context(
+            FORMAT.extract(
+                get_as_list,
+                {
+                    "traceparent": [
+                        "00-12345678901234567890123456789012-1234567890123456-00"
+                    ],
+                    "tracestate": [tracestate_value],
+                },
+            )
+        )
+        self.assertEqual(span.get_context().trace_state["1a-2f@foo"], "bar1")
+        self.assertEqual(
+            span.get_context().trace_state["1a-_*/2b@foo"], "bar2"
+        )
+        self.assertEqual(span.get_context().trace_state["foo"], "bar3")
+        self.assertEqual(span.get_context().trace_state["foo-_*/bar"], "bar4")


### PR DESCRIPTION
Allows vendor specific trace state keys to start with a digit as specified in: https://github.com/w3c/trace-context/blob/master/spec/20-http_header_format.md#key