### PR TITLE
Add script to generate AUTHORS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Generate Authors
       run: sh ./scripts/generate-authors.sh
     - name: Commit report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,3 +21,18 @@ jobs:
       run: |
         pip install twine
         twine upload --skip-existing --verbose dist/*
+  generate_authors:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Generate Authors
+      run: sh ./scripts/generate-authors.sh
+    - name: Commit report
+      run: |
+        git config --global user.name 'GitHub Action'
+        git config --global user.email 'action@github.com'
+        git add AUTHORS
+        git commit -m "Update authors"
+        git push
+      continue-on-error: true

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,28 @@
+# This file lists all individuals having contributed content to the repository.
+# For how it is generated, see `scripts/generate-authors.sh`.
+
+Alban Crequy <alban@kinvolk.io>
+Aliaksei Urbanski <mimworkmail@gmail.com>
+Allan Feldman <6374032+a-feld@users.noreply.github.com>
+alrex <alrex.boten@gmail.com>
+Bogdan Drutu <bdrutu@google.com>
+Carlos Alberto Cortez <calberto.cortez@gmail.com>
+Cheng-Lung Sung <clsung@gmail.com>
+Chris Kleinknecht <libc@google.com>
+Christian Neumüller <christian.neumueller@dynatrace.com>
+Daniel González <danielgonzalezlopes@gmail.com>
+Dave Grochowski <ThePumpingLemma@users.noreply.github.com>
+Diego Hurtado <ocelotl@users.noreply.github.com>
+Golovin Pavel <gopavel0@gmail.com>
+Gábor Lipták <gliptak@gmail.com>
+Hector Hernandez <39923391+hectorhdzg@users.noreply.github.com>
+Jake Malachowski <5766239+jakemalachowski@users.noreply.github.com>
+Johannes Liebermann <johannes@kinvolk.io>
+joshuahlang <joshuahlang@users.noreply.github.com>
+Leighton Chen <lechen@microsoft.com>
+Liz Fong-Jones <lizf@honeycomb.io>
+Mauricio Vásquez <mauricio@kinvolk.io>
+Ram Thiru <ramthi@users.noreply.github.com>
+Reiley Yang <reyang@microsoft.com>
+Sergey Kanzhelev <S.Kanzhelev@live.com>
+Yusuke Tsutsumi <yusuke@tsutsumi.io>

--- a/README.md
+++ b/README.md
@@ -136,21 +136,6 @@ release](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.
 - Prometheus Metrics Exporter
 - New Examples and Improvements to Existing Examples
 
-Thank you to the following individuals for contributing to this release:
-
-* Alex Boten
-* Chris Kleinknecht
-* Christian Neumüller
-* Daniel González
-* Diego Hurtado
-* Golovin Pavel
-* Hector Hernandez
-* Jake Malachowski
-* Joshua H Lang
-* Leighton Chen
-* Mauricio Vásquez
-* Yusuke Tsutsumi
-
 The [v0.5 beta
 release](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.5.0) release includes:
 
@@ -159,18 +144,6 @@ release](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.
 - Metrics SDK
 - Global configuration module
 - Documentation improvements
-
-Thank you to the following individuals for contributing to this release:
-
-* Alex Boten
-* Chris Kleinknecht
-* Dave Grochowski
-* Diego Hurtado
-* Hector Hernandez
-* Leighton Chen
-* Liz Fong-Jones
-* Mauricio Vásquez
-* Yusuke Tsutsumi
 
 See the [project
 milestones](https://github.com/open-telemetry/opentelemetry-python/milestones)

--- a/scripts/generate-authors.sh
+++ b/scripts/generate-authors.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env fish
+set -e
+
+{
+	cat <<- 'EOH'
+		# This file lists all individuals having contributed content to the repository.
+		# For how it is generated, see `scripts/generate-authors.sh`.
+	EOH
+	echo
+
+    git log --format='%aN <%aE>' | awk '
+    {
+        pos = index($0, "<");
+        name = substr($0, 0, pos - 2);
+        email = substr($0, pos + 1, length($0) - pos - 1);
+        names[name]++;
+        emails[email]++;
+        if (names[name] == 1 && emails[email] == 1) {
+            print $0;
+        }
+    }
+    ' | env LC_ALL=C.UTF-8 sort -uf
+} > AUTHORS

--- a/scripts/generate-authors.sh
+++ b/scripts/generate-authors.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env fish
+#!/usr/bin/env bash
 set -e
 
 {


### PR DESCRIPTION
This PR contains:
- Bash script to generate the AUTHORS file using `git log`.
- Job to run the script on every release.
- The actual AUTHORS file.

Closes #517 

Signed-off-by: Daniel González Lopes <danielgonzalezlopes@gmail.com>