### PR TITLE
Add pip caching to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: xenial
 
 language: python
 
+cache: pip
+
 python:
   - '3.4'
   - '3.5'


### PR DESCRIPTION
> Caches lets Travis CI store directories between builds, which is useful for storing dependencies that take longer to compile or download. -[Travis CI Docs](https://docs.travis-ci.com/user/caching/)

PR adds [pip caching](https://docs.travis-ci.com/user/caching/#pip-cache) to the `.travis.yml`
This could be helpful for #513 

Signed-off-by: Daniel González Lopes <danielgonzalezlopes@gmail.com>