### PR TITLE
docs: standard usage format across ext packages

### DIFF
--- a/docs/ext/zipkin/zipkin.rst
+++ b/docs/ext/zipkin/zipkin.rst
@@ -1,8 +1,5 @@
-.. include:: ../../../ext/opentelemetry-ext-zipkin/README.rst
-
-
-Module contents
----------------
+Opentelemetry Zipkin Exporter
+=============================
 
 .. automodule:: opentelemetry.ext.zipkin
     :members:

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
@@ -76,6 +76,8 @@ Note:
     While testing this library, the aforementioned imprecisions were observed
     to be of *less than a microsecond*.
 
+API
+---
 .. _Floating Point Arithmetic\\: Issues and Limitations:
     https://docs.python.org/3/tutorial/floatingpoint.html
 """

--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/__init__.py
@@ -50,6 +50,9 @@ Modify the application's ``wsgi.py`` file as shown below.
 
     application = get_wsgi_application()
     application = OpenTelemetryMiddleware(application)
+
+API
+---
 """
 
 import functools

--- a/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/__init__.py
+++ b/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/__init__.py
@@ -15,14 +15,6 @@
 """
 This library allows to export tracing data to `Zipkin <https://zipkin.io/>`_.
 
-Installation
-------------
-
-::
-
-     pip install opentelemetry-ext-zipkin
-
-
 Usage
 -----
 


### PR DESCRIPTION
The rendered documentation is a little out of sync in a couple areas.
Resolving those.

- Adding an API subsection footer to those that don't have it
- Removing installation instructions in the readme
- Referencing automodule vs a direct include of the readme