### PR TITLE
Misc isort fixes

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -15,4 +15,4 @@ multi_line_output=3
 skip=target
 skip_glob=ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/gen/*,.venv*/*,venv*/*
 known_first_party=opentelemetry
-known_third_party=psutil
+known_third_party=psutil,pytest

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -15,3 +15,4 @@ multi_line_output=3
 skip=target
 skip_glob=ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/gen/*,.venv*/*,venv*/*
 known_first_party=opentelemetry
+known_third_party=psutil

--- a/opentelemetry-api/tests/configuration/test_configuration.py
+++ b/opentelemetry-api/tests/configuration/test_configuration.py
@@ -16,8 +16,9 @@ from json import dumps
 from unittest import TestCase
 from unittest.mock import patch
 
-from opentelemetry.configuration import Configuration  # type: ignore
 from pytest import fixture  # type: ignore # pylint: disable=import-error
+
+from opentelemetry.configuration import Configuration  # type: ignore
 
 
 class TestConfiguration(TestCase):


### PR DESCRIPTION
I noticed that `isort --recursive .` didn't pass on master while working on some unrelated changes.

`isort` also sorted `psutil` as a first-party import in `docs/examples/basic_meter/observer.py` for me.