### PR TITLE
Version bump for 0.6b.0 release

### DIFF
--- a/docs/examples/opentelemetry-example-app/setup.py
+++ b/docs/examples/opentelemetry-example-app/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name="opentelemetry-example-app",
-    version="0.6.dev0",
+    version="0.6b0",
     author="OpenTelemetry Authors",
     author_email="cncf-opentelemetry-contributors@lists.cncf.io",
     classifiers=[

--- a/ext/opentelemetry-ext-dbapi/setup.cfg
+++ b/ext/opentelemetry-ext-dbapi/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.6.dev0
+    opentelemetry-api >= 0.6b0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/version.py
+++ b/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/version.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-grpc/src/opentelemetry/ext/grpc/version.py
+++ b/ext/opentelemetry-ext-grpc/src/opentelemetry/ext/grpc/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-http-requests/setup.cfg
+++ b/ext/opentelemetry-ext-http-requests/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.6.dev0
+    opentelemetry-api >= 0.6b0
     requests ~= 2.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-mysql/setup.cfg
+++ b/ext/opentelemetry-ext-mysql/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.6.dev0
+    opentelemetry-api >= 0.6b0
     mysql-connector-python ~=  8.0
     wrapt >= 1.0.0, < 2.0.0
 

--- a/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/version.py
+++ b/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-otcollector/setup.cfg
+++ b/ext/opentelemetry-ext-otcollector/setup.cfg
@@ -42,8 +42,8 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     opencensus-proto >= 0.1.0, < 1.0.0
-    opentelemetry-api >= 0.6.dev0
-    opentelemetry-sdk >= 0.6.dev0
+    opentelemetry-api >= 0.6b0
+    opentelemetry-sdk >= 0.6b0
     protobuf >= 3.8.0
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-otcollector/src/opentelemetry/ext/otcollector/version.py
+++ b/ext/opentelemetry-ext-otcollector/src/opentelemetry/ext/otcollector/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-prometheus/src/opentelemetry/ext/prometheus/version.py
+++ b/ext/opentelemetry-ext-prometheus/src/opentelemetry/ext/prometheus/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-psycopg2/setup.cfg
+++ b/ext/opentelemetry-ext-psycopg2/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.6.dev0
+    opentelemetry-api >= 0.6b0
     psycopg2-binary >= 2.7.3.1
     wrapt >= 1.0.0, < 2.0.0
 

--- a/ext/opentelemetry-ext-psycopg2/src/opentelemetry/ext/psycopg2/version.py
+++ b/ext/opentelemetry-ext-psycopg2/src/opentelemetry/ext/psycopg2/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-pymongo/setup.cfg
+++ b/ext/opentelemetry-ext-pymongo/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.6.dev0
+    opentelemetry-api >= 0.6b0
     pymongo ~= 3.1
 
 [options.packages.find]

--- a/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/version.py
+++ b/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-testutil/src/opentelemetry/ext/testutil/version.py
+++ b/ext/opentelemetry-ext-testutil/src/opentelemetry/ext/testutil/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
+++ b/ext/opentelemetry-ext-wsgi/src/opentelemetry/ext/wsgi/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/version.py
+++ b/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/opentelemetry-api/src/opentelemetry/util/version.py
+++ b/opentelemetry-api/src/opentelemetry/util/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/opentelemetry-auto-instrumentation/setup.cfg
+++ b/opentelemetry-auto-instrumentation/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
 packages=find_namespace:
 zip_safe = False
 include_package_data = True
-install_requires = opentelemetry-api==0.6.dev0
+install_requires = opentelemetry-api==0.6b0
 
 [options.packages.find]
 where = src

--- a/opentelemetry-auto-instrumentation/src/opentelemetry/auto_instrumentation/version.py
+++ b/opentelemetry-auto-instrumentation/src/opentelemetry/auto_instrumentation/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"

--- a/opentelemetry-sdk/setup.py
+++ b/opentelemetry-sdk/setup.py
@@ -45,7 +45,7 @@ setuptools.setup(
     include_package_data=True,
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
-    install_requires=["opentelemetry-api==0.6.dev0"],
+    install_requires=["opentelemetry-api==0.6b0"],
     extras_require={},
     license="Apache-2.0",
     package_dir={"": "src"},

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.dev0"
+__version__ = "0.6b0"


### PR DESCRIPTION
Update version numbers for `0.6b.0` on the release branch. See #533 for the changelog updates.