### PR TITLE
Mark new packages as beta

### DIFF
--- a/ext/opentelemetry-ext-grpc/setup.cfg
+++ b/ext/opentelemetry-ext-grpc/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [options]
 python_requires = >=3.4

--- a/ext/opentelemetry-ext-grpc/setup.cfg
+++ b/ext/opentelemetry-ext-grpc/setup.cfg
@@ -23,7 +23,7 @@ url = https://github.com/open-telemetry/opentelemetry-python/ext/opentelemetry-e
 platforms = any
 license = Apache-2.0
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 4 - Beta
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python

--- a/opentelemetry-auto-instrumentation/setup.cfg
+++ b/opentelemetry-auto-instrumentation/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [options]
 python_requires = >=3.4

--- a/opentelemetry-auto-instrumentation/setup.cfg
+++ b/opentelemetry-auto-instrumentation/setup.cfg
@@ -23,7 +23,7 @@ url = https://github.com/open-telemetry/opentelemetry-python/tree/master/opentel
 platforms = any
 license = Apache-2.0
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 4 - Beta
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python


### PR DESCRIPTION
These packages were added after #525, and should have been changed before the release on 3/30.

This change only affects the classifier for packages installed from source, the packages on PyPI will be updated with the next release.