### PR TITLE
Update README for 0.6.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Libraries that produce telemetry data should only depend on `opentelemetry-api`,
 and defer the choice of the SDK to the application developer. Applications may
 depend on `opentelemetry-sdk` or another package that implements the API.
 
-**Please note** that this library is currently in _alpha_, and shouldn't be
-used in production environments.
+**Please note** that this library is currently in _beta_, and shouldn't
+generally be used in production environments.
 
 The API and SDK packages are available on PyPI, and can installed via `pip`:
 
@@ -91,8 +91,8 @@ OpenTelemetry Python is under active development.
 The library is not yet _generally available_, and releases aren't guaranteed to
 conform to a specific version of the specification. Future releases will not
 attempt to maintain backwards compatibility with previous releases. Each alpha
-release includes significant changes to the API and SDK packages, making them
-incompatible with each other.
+and beta release includes significant changes to the API and SDK packages,
+making them incompatible with each other.
 
 The [v0.1 alpha
 release](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.1.0)
@@ -123,7 +123,8 @@ includes:
 - PyMongo Integration
 
 The [v0.4 alpha
-release](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.4.0) release includes:
+release](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.4.0)
+includes:
 
 - Metrics MinMaxSumCount Aggregator
 - Context API
@@ -137,7 +138,8 @@ release](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.
 - New Examples and Improvements to Existing Examples
 
 The [v0.5 beta
-release](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.5.0) release includes:
+release](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.5.0)
+includes:
 
 - W3C Correlation Context Propagation
 - OpenTelemetry Collector Exporter Integration for both metrics and traces
@@ -145,15 +147,15 @@ release](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.
 - Global configuration module
 - Documentation improvements
 
+The [v0.6 beta
+release](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.6.0)
+includes:
+
+- API changes and bugfixes
+- An autoinstrumentation package and updated Flask instrumentation
+- gRPC integration
+
 See the [project
 milestones](https://github.com/open-telemetry/opentelemetry-python/milestones)
-for details on upcoming releases. The dates and features described here are
-estimates, and subject to change.
-
-Future releases targets include:
-
-| Component                          | Version | Target Date   |
-| ---------------------------------- | ------- | ------------- |
-| Stable API for metrics and tracing | Beta v2 | March 31 2020 |
-| Support for Tags/Baggage           | Beta v2 | March 31 2020 |
-| gRPC Integration                   | Beta v2 | March 31 2020 |
+for details on upcoming releases. The dates and features described in issues
+and milestones are estimates, and subject to change.


### PR DESCRIPTION
Change the status from "alpha" to "beta" in the project README, remove the upcoming features table, and fix some typos.

At this point we may want to remove the details on past releases or otherwise rewrite the README, but the goal of this PR is just to get it in sync with the last release.