### PR TITLE
Fixed `debug` field usage in zipkin exporter

### DIFF
--- a/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/__init__.py
+++ b/ext/opentelemetry-ext-zipkin/src/opentelemetry/ext/zipkin/__init__.py
@@ -180,7 +180,7 @@ class ZipkinSpanExporter(SpanExporter):
             }
 
             if context.trace_flags.sampled:
-                zipkin_span["debug"] = 1
+                zipkin_span["debug"] = True
 
             if isinstance(span.parent, Span):
                 zipkin_span["parentId"] = format(

--- a/ext/opentelemetry-ext-zipkin/tests/test_zipkin_exporter.py
+++ b/ext/opentelemetry-ext-zipkin/tests/test_zipkin_exporter.py
@@ -197,7 +197,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
                         "value": "event0",
                     }
                 ],
-                "debug": 1,
+                "debug": True,
                 "parentId": format(parent_id, "x"),
             },
             {


### PR DESCRIPTION
Zipkin spec expects the debug field to be a boolean, not an integer. OpenTelemetry collector rejects spans exported by the Python Zipkin exporter with the following error message:

```
Traces cannot be uploaded; status code: 400, message json: cannot unmarshal number into Go struct field .debug of type bool
```

Zipkin data model confirms that the field should be a boolean here: https://zipkin.io/zipkin-api/