### PR TITLE
Django tracing middleware

### DIFF
--- a/ext/opentelemetry-ext-django/LICENSE
+++ b/ext/opentelemetry-ext-django/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/ext/opentelemetry-ext-django/MANIFEST.in
+++ b/ext/opentelemetry-ext-django/MANIFEST.in
@@ -1,0 +1,9 @@
+graft src
+graft tests
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*
+include CHANGELOG.md
+include MANIFEST.in
+include README.rst
+include LICENSE

--- a/ext/opentelemetry-ext-django/README.rst
+++ b/ext/opentelemetry-ext-django/README.rst
@@ -1,0 +1,24 @@
+OpenTelemetry Django Tracing
+============================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-ext-django.svg
+   :target: https://pypi.org/project/opentelemetry-ext-django/
+
+This library builds on the OpenTelemetry WSGI middleware to track web requests
+in Django applications.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-ext-django
+
+
+References
+----------
+
+* `OpenTelemetry Django Tracing <https://opentelemetry-python.readthedocs.io/en/latest/ext/django/django.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/ext/opentelemetry-ext-django/setup.cfg
+++ b/ext/opentelemetry-ext-django/setup.cfg
@@ -1,0 +1,53 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[metadata]
+name = opentelemetry-ext-django
+description = Django tracing for OpenTelemetry (based on opentelemetry-ext-wsgi)
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = OpenTelemetry Authors
+author_email = cncf-opentelemetry-contributors@lists.cncf.io
+url = https://github.com/open-telemetry/opentelemetry-python/ext/opentelemetry-ext-django
+platforms = any
+license = Apache-2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+python_requires = >=3.4
+package_dir=
+    =src
+packages=find_namespace:
+install_requires =
+    django >= 2.2
+    opentelemetry-ext-wsgi == 0.7.dev0
+    opentelemetry-auto-instrumentation == 0.7.dev0
+    opentelemetry-api == 0.7.dev0
+
+[options.extras_require]
+test =
+    opentelemetry-ext-testutil == 0.7.dev0
+
+[options.packages.find]
+where = src

--- a/ext/opentelemetry-ext-django/setup.py
+++ b/ext/opentelemetry-ext-django/setup.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import setuptools
+
+BASE_DIR = os.path.dirname(__file__)
+VERSION_FILENAME = os.path.join(
+    BASE_DIR, "src", "opentelemetry", "ext", "django", "version.py"
+)
+PACKAGE_INFO = {}
+with open(VERSION_FILENAME) as f:
+    exec(f.read(), PACKAGE_INFO)
+
+setuptools.setup(version=PACKAGE_INFO["__version__"],)

--- a/ext/opentelemetry-ext-django/src/opentelemetry/ext/django/__init__.py
+++ b/ext/opentelemetry-ext-django/src/opentelemetry/ext/django/__init__.py
@@ -1,0 +1,110 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+This library builds on the OpenTelemetry WSGI middleware to track web requests
+in Django applications. In addition to opentelemetry-ext-wsgi, it supports
+django-specific features such as:
+
+# TODO: mathieu, look at flask doc and write similar thing
+"""
+
+import logging
+from typing import List
+
+import django
+
+from opentelemetry import trace
+from opentelemetry.ext.django.version import __version__
+
+logger = logging.getLogger(__name__)
+
+
+def get_func_name(func):
+    """Return a name which includes the module name and function name."""
+    func_name = getattr(func, "__name__", func.__class__.__name__)
+    module_name = func.__module__
+
+    if module_name is not None:
+        module_name = func.__module__
+        return f"{module_name}.{func_name}"
+
+    return func_name
+
+
+def enable_tracing_url(path: str, blacklisted_paths: List[str]) -> bool:
+    """ Returns whether or not a path should be traced.
+        TODO: more extensive behaviour, e.g. prefix matching and regexes?
+    """
+    for disabled_path in blacklisted_paths:
+        if path == disabled_path:
+            return False
+    return False
+
+
+class OpenTelemetryTracingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+        self.trace_settings = getattr(
+            django.conf.settings, "OPENTELEMETRY", {}
+        ).get("TRACE", {})
+        self.blacklisted_paths = self.trace_settings.get(
+            "BLACKLISTED_PATHS", []
+        )
+
+        self.tracer = trace.get_tracer(__name__, __version__)
+
+    def get_span_name(self, request) -> str:  # pylint: disable=no-self-use
+        try:
+            return get_func_name(request.resolver_match.func)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.warning("Could not determine view name: %s", exc)
+            return request.path_info
+
+    def process_view(self, request, *args, **kwargs):  # pylint: disable=W0613
+        """ Once known which view is handling this request, we can better
+            modify the name of the span.
+        """
+        if hasattr(self, "get_span_name"):
+            self.tracer.get_current_span().name = self.get_span_name(request)
+
+    def __call__(self, request):
+        if enable_tracing_url(request.path, self.blacklisted_paths):
+            # Default to path, will possibly be customized later when the view is known
+            span_name = request.path_info
+
+            attributes = {
+                "http.method": request.method,
+                "http.url": request.build_absolute_uri(),
+                "http.target": request.get_full_path(),
+                "http.host": request.headers.get("Host"),
+                "http.scheme": request.scheme,
+                "http.user_agent": request.headers.get("User-Agent"),
+            }
+
+            span = self.tracer.start_span(
+                span_name, kind=trace.SpanKind.SERVER, attributes=attributes,
+            )
+
+            with self.tracer.use_span(span, end_on_exit=True):
+                response = self.get_response(request)
+                self.tracer.get_current_span().set_attribute(
+                    "http.status_code", response.status_code
+                )
+        else:
+            response = self.get_response(request)
+
+        return response

--- a/ext/opentelemetry-ext-django/src/opentelemetry/ext/django/version.py
+++ b/ext/opentelemetry-ext-django/src/opentelemetry/ext/django/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.7.dev0"

--- a/ext/opentelemetry-ext-django/tests/test_django_integration.py
+++ b/ext/opentelemetry-ext-django/tests/test_django_integration.py
@@ -39,7 +39,7 @@ def get_func_name(func):
 
     if module_name is not None:
         module_name = func.__module__
-        return f"{module_name}.{func_name}"
+        return "{}.{}".format(module_name, func_name)
 
     return func_name
 

--- a/ext/opentelemetry-ext-django/tests/test_django_integration.py
+++ b/ext/opentelemetry-ext-django/tests/test_django_integration.py
@@ -1,0 +1,262 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+import unittest
+from unittest import mock
+
+from django.conf import settings as django_settings
+from django.conf.urls import url
+from django.http import HttpResponse
+from django.test import Client, RequestFactory
+from django.test.utils import setup_test_environment, teardown_test_environment
+from django.urls.resolvers import ResolverMatch
+from django.views import View
+
+from opentelemetry import trace as trace_api
+from opentelemetry.ext.django import OpenTelemetryTracingMiddleware
+from opentelemetry.ext.testutil.wsgitestutil import WsgiTestBase
+
+logger = logging.getLogger(__name__)
+
+
+def get_func_name(func):
+    """Return a name which includes the module name and function name."""
+    func_name = getattr(func, "__name__", func.__class__.__name__)
+    module_name = func.__module__
+
+    if module_name is not None:
+        module_name = func.__module__
+        return f"{module_name}.{func_name}"
+
+    return func_name
+
+
+class MockViewError(View):
+    def get(self, *args, **kwargs):  # pylint: disable=unused-argument
+        return HttpResponse(
+            f"request: {self.request}, args: {args}, kwargs: {kwargs}",
+            status=500,
+        )
+
+    def post(self, *args, **kwargs):  # pylint: disable=unused-argument
+        return HttpResponse(
+            f"request: {self.request}, args: {args}, kwargs: {kwargs}",
+            status=500,
+        )
+
+
+class MockViewOk(View):
+    def get(self, *args, **kwargs):  # pylint: disable=unused-argument
+        return HttpResponse(
+            f"request: {self.request}, args: {args}, kwargs: {kwargs}",
+            status=200,
+        )
+
+    def post(self, *args, **kwargs):  # pylint: disable=unused-argument
+        return HttpResponse(
+            f"request: {self.request}, args: {args}, kwargs: {kwargs}",
+            status=200,
+        )
+
+
+class CustomMiddleware(OpenTelemetryTracingMiddleware):
+    """ Use the name of the view as the span name instead of the request path """
+
+    def get_span_name(self, request) -> str:  # pylint: disable=no-self-use
+        try:
+            return get_func_name(request.resolver_match.func)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Could not determine view name: %s", exc)
+            return request.path_info
+
+
+urlpatterns = [
+    url(r"^ok", MockViewOk.as_view()),
+    url(r"^error", MockViewError.as_view()),
+]
+
+
+class TestDjangoIntegration(WsgiTestBase):
+    def setUp(self):
+        super().setUp()
+
+        if not django_settings.configured:
+            django_settings.configure(ROOT_URLCONF=sys.modules[__name__])
+        setup_test_environment()
+
+    def tearDown(self):
+        super().tearDown()
+        teardown_test_environment()
+
+    def test_constructor_default(self):  # pylint: disable=no-self-use
+        middleware_obj = OpenTelemetryTracingMiddleware(mock.Mock())
+
+        assert middleware_obj.blacklisted_paths == []
+
+    def test_constructor_blacklist_settings(
+        self,
+    ):  # pylint: disable=no-self-use
+        settings = type("Test", (object,), {})
+        settings.OPENTELEMETRY = {
+            "TRACE": {"BLACKLISTED_PATHS": ["/_ah/health/"]}
+        }
+        patch_settings = mock.patch("django.conf.settings", settings)
+
+        with patch_settings:
+            middleware_obj = OpenTelemetryTracingMiddleware(mock.Mock())
+
+        assert middleware_obj.blacklisted_paths == ["/_ah/health/"]
+
+    def test_span_attributes_get_200(self):
+        django_request = RequestFactory().get("/hello_endpoint/", **{})
+        django_request.resolver_match = ResolverMatch(
+            MockViewOk.as_view(), None, None
+        )
+
+        middleware_obj = OpenTelemetryTracingMiddleware(MockViewOk.as_view())
+
+        expected_attributes = {
+            "http.method": "GET",
+            "http.url": "http://testserver/hello_endpoint/",
+            "http.target": "/hello_endpoint/",
+            "http.host": None,
+            "http.scheme": "http",
+            "http.user_agent": None,
+            "http.status_code": 200,
+        }
+
+        middleware_obj(django_request)
+
+        span_list = self.memory_exporter.get_finished_spans()
+
+        assert len(span_list) == 1
+        assert span_list[0].name == "/hello_endpoint/"
+        assert span_list[0].kind == trace_api.SpanKind.SERVER
+        assert span_list[0].attributes == expected_attributes
+
+    def test_span_attributes_post_200(self):
+        django_request = RequestFactory().post("/hello_endpoint/", **{})
+        django_request.resolver_match = ResolverMatch(
+            MockViewOk.as_view(), None, None
+        )
+
+        middleware_obj = OpenTelemetryTracingMiddleware(MockViewOk.as_view())
+
+        expected_attributes = {
+            "http.method": "POST",
+            "http.url": "http://testserver/hello_endpoint/",
+            "http.target": "/hello_endpoint/",
+            "http.host": None,
+            "http.scheme": "http",
+            "http.user_agent": None,
+            "http.status_code": 200,
+        }
+
+        middleware_obj(django_request)
+
+        span_list = self.memory_exporter.get_finished_spans()
+
+        assert len(span_list) == 1
+        assert span_list[0].name == "/hello_endpoint/"
+        assert span_list[0].kind == trace_api.SpanKind.SERVER
+        assert span_list[0].attributes == expected_attributes
+
+    def test_span_attributes_get_500(self):
+        django_request = RequestFactory().get("/error/", **{})
+        django_request.resolver_match = ResolverMatch(
+            MockViewError.as_view(), None, None
+        )
+
+        middleware_obj = OpenTelemetryTracingMiddleware(
+            MockViewError.as_view()
+        )
+
+        expected_attributes = {
+            "http.method": "GET",
+            "http.url": "http://testserver/error/",
+            "http.target": "/error/",
+            "http.host": None,
+            "http.scheme": "http",
+            "http.user_agent": None,
+            "http.status_code": 500,
+        }
+
+        middleware_obj(django_request)
+
+        span_list = self.memory_exporter.get_finished_spans()
+        assert len(span_list) == 1
+        assert span_list[0].name == "/error/"
+        assert span_list[0].kind == trace_api.SpanKind.SERVER
+        assert span_list[0].attributes == expected_attributes
+
+    def test_blacklist_nospan(self):
+        settings = type("Test", (object,), {})
+        settings.OPENTELEMETRY = {
+            "TRACE": {"BLACKLISTED_PATHS": ["/_ah/health/"]}
+        }
+        patch_settings = mock.patch("django.conf.settings", settings)
+
+        with patch_settings:
+            middleware_obj = OpenTelemetryTracingMiddleware(
+                MockViewOk.as_view()
+            )
+
+        django_request = RequestFactory().get("/_ah/health/", **{})
+        django_request.resolver_match = ResolverMatch(
+            MockViewOk.as_view(), None, None
+        )
+
+        middleware_obj(django_request)
+
+        span_list = self.memory_exporter.get_finished_spans()
+        assert len(span_list) == 0
+
+
+class TestDjangoIntegrationSubclassedMiddleware(WsgiTestBase):
+    def setUp(self):
+        super().setUp()
+        if not django_settings.configured:
+            django_settings.configure(ROOT_URLCONF=sys.modules[__name__])
+        setup_test_environment()
+
+    def tearDown(self):
+        super().tearDown()
+        teardown_test_environment()
+
+    def test_customized_span_naming_get_200(self):
+        django_settings.MIDDLEWARE = [__name__ + ".CustomMiddleware"]
+
+        Client().get("/ok/")
+
+        expected_attributes = {
+            "http.method": "GET",
+            "http.url": "http://testserver/ok/",
+            "http.target": "/ok/",
+            "http.host": None,
+            "http.scheme": "http",
+            "http.user_agent": None,
+            "http.status_code": 200,
+        }
+
+        span_list = self.memory_exporter.get_finished_spans()
+        assert len(span_list) == 1
+        assert span_list[0].name == "tests.test_django_integration.MockViewOk"
+        assert span_list[0].kind == trace_api.SpanKind.SERVER
+        assert span_list[0].attributes == expected_attributes
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ext/opentelemetry-ext-django/tests/test_django_integration.py
+++ b/ext/opentelemetry-ext-django/tests/test_django_integration.py
@@ -45,29 +45,37 @@ def get_func_name(func):
 
 
 class MockViewError(View):
-    def get(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def get(self, *args, **kwargs):
         return HttpResponse(
-            f"request: {self.request}, args: {args}, kwargs: {kwargs}",
+            "request: {}, args: {}, kwargs: {}".format(
+                self.request, args, kwargs
+            ),
             status=500,
         )
 
-    def post(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def post(self, *args, **kwargs):
         return HttpResponse(
-            f"request: {self.request}, args: {args}, kwargs: {kwargs}",
+            "request: {}, args: {}, kwargs: {}".format(
+                self.request, args, kwargs
+            ),
             status=500,
         )
 
 
 class MockViewOk(View):
-    def get(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def get(self, *args, **kwargs):
         return HttpResponse(
-            f"request: {self.request}, args: {args}, kwargs: {kwargs}",
+            "request: {}, args: {}, kwargs: {}".format(
+                self.request, args, kwargs
+            ),
             status=200,
         )
 
-    def post(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def post(self, *args, **kwargs):
         return HttpResponse(
-            f"request: {self.request}, args: {args}, kwargs: {kwargs}",
+            "request: {}, args: {}, kwargs: {}".format(
+                self.request, args, kwargs
+            ),
             status=200,
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,10 @@ envlist =
     py3{4,5,6,7,8}-test-ext-dbapi
     pypy3-test-ext-dbapi
 
+    ; opentelemetry-ext-django
+    py3{4,5,6,7,8}-test-ext-django
+    pypy3-test-ext-django
+
     ; opentelemetry-ext-flask
     py3{4,5,6,7,8}-test-ext-flask
     pypy3-test-ext-flask
@@ -122,6 +126,7 @@ changedir =
   test-ext-psycopg2: ext/opentelemetry-ext-psycopg2/tests
   test-ext-wsgi: ext/opentelemetry-ext-wsgi/tests
   test-ext-zipkin: ext/opentelemetry-ext-zipkin/tests
+  test-ext-django: ext/opentelemetry-ext-django/tests
   test-ext-flask: ext/opentelemetry-ext-flask/tests
   test-example-app: docs/examples/opentelemetry-example-app/tests
   test-example-basic-tracer: docs/examples/basic_tracer/tests
@@ -138,6 +143,7 @@ commands_pre =
   example-app: pip install {toxinidir}/opentelemetry-auto-instrumentation
   example-app: pip install {toxinidir}/ext/opentelemetry-ext-http-requests
   example-app: pip install {toxinidir}/ext/opentelemetry-ext-wsgi
+  example-app: pip install {toxinidir}/ext/opentelemetry-ext-django
   example-app: pip install {toxinidir}/ext/opentelemetry-ext-flask
   example-app: pip install {toxinidir}/docs/examples/opentelemetry-example-app
   example-basic-tracer: pip install -e {toxinidir}/opentelemetry-api
@@ -151,9 +157,11 @@ commands_pre =
   ext: pip install {toxinidir}/opentelemetry-api
   grpc: pip install {toxinidir}/ext/opentelemetry-ext-grpc
   grpc: pip install {toxinidir}/opentelemetry-sdk
-  wsgi,flask: pip install {toxinidir}/ext/opentelemetry-ext-testutil
-  wsgi,flask: pip install {toxinidir}/ext/opentelemetry-ext-wsgi
-  wsgi,flask: pip install {toxinidir}/opentelemetry-sdk
+  wsgi,flask,django: pip install {toxinidir}/ext/opentelemetry-ext-testutil
+  wsgi,flask,django: pip install {toxinidir}/ext/opentelemetry-ext-wsgi
+  wsgi,flask,django: pip install {toxinidir}/opentelemetry-sdk
+  django: pip install {toxinidir}/opentelemetry-auto-instrumentation
+  django: pip install {toxinidir}/ext/opentelemetry-ext-django[test]
   flask: pip install {toxinidir}/opentelemetry-auto-instrumentation
   flask: pip install {toxinidir}/ext/opentelemetry-ext-flask[test]
   dbapi: pip install {toxinidir}/ext/opentelemetry-ext-dbapi
@@ -224,6 +232,7 @@ deps =
   Deprecated
   thrift
   pymongo
+  django
   flask
   mysql-connector-python
   wrapt


### PR DESCRIPTION
Add middleware to use OpenTelemetry tracing with Django

- TODO: add some formal tests
- TODO: add documentation / descriptions
- TODO: header propagation from incoming request