### PR TITLE
updating psycopg2 dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -266,7 +266,7 @@ deps =
   docker-compose >= 1.25.2
   mysql-connector-python ~=  8.0
   pymongo ~= 3.1
-  psycopg2 ~= 2.8.4
+  psycopg2-binary ~= 2.8.4
 
 changedir =
   ext/opentelemetry-ext-docker-tests/tests


### PR DESCRIPTION
Without using binary here, users will need the tools to compile psycopg2 on their systems.