### PR TITLE
ext/requests: Add instrumentor

### DIFF
--- a/docs/examples/http/client.py
+++ b/docs/examples/http/client.py
@@ -28,15 +28,18 @@ from opentelemetry.sdk.trace.export import (
 
 # The preferred tracer implementation must be set, as the opentelemetry-api
 # defines the interface with a no-op implementation.
+# It must be done before instrumenting any library.
 trace.set_tracer_provider(TracerProvider())
-tracer_provider = trace.get_tracer_provider()
 
+# Enable instrumentation in the requests library.
+http_requests.RequestsInstrumentor().instrument()
+
+# Configure a console span exporter.
 exporter = ConsoleSpanExporter()
 span_processor = BatchExportSpanProcessor(exporter)
-tracer_provider.add_span_processor(span_processor)
+trace.get_tracer_provider().add_span_processor(span_processor)
 
 # Integrations are the glue that binds the OpenTelemetry API and the
 # frameworks and libraries that are used together, automatically creating
 # Spans and propagating context as appropriate.
-http_requests.enable(tracer_provider)
 response = requests.get(url="http://127.0.0.1:5000/")

--- a/docs/examples/http/server.py
+++ b/docs/examples/http/server.py
@@ -30,19 +30,22 @@ from opentelemetry.sdk.trace.export import (
 
 # The preferred tracer implementation must be set, as the opentelemetry-api
 # defines the interface with a no-op implementation.
+# It must be done before instrumenting any library.
 trace.set_tracer_provider(TracerProvider())
-tracer = trace.get_tracer(__name__)
-
-exporter = ConsoleSpanExporter()
-span_processor = BatchExportSpanProcessor(exporter)
-trace.get_tracer_provider().add_span_processor(span_processor)
 
 # Integrations are the glue that binds the OpenTelemetry API and the
 # frameworks and libraries that are used together, automatically creating
 # Spans and propagating context as appropriate.
-http_requests.enable(trace.get_tracer_provider())
+http_requests.RequestsInstrumentor().instrument()
 app = flask.Flask(__name__)
 app.wsgi_app = OpenTelemetryMiddleware(app.wsgi_app)
+
+# Configure a console span exporter.
+exporter = ConsoleSpanExporter()
+span_processor = BatchExportSpanProcessor(exporter)
+trace.get_tracer_provider().add_span_processor(span_processor)
+
+tracer = trace.get_tracer(__name__)
 
 
 @app.route("/")

--- a/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
+++ b/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
@@ -29,13 +29,16 @@ from opentelemetry.sdk.trace.export import (
 )
 
 trace.set_tracer_provider(TracerProvider())
+
+opentelemetry.ext.http_requests.RequestsInstrumentor().instrument()
+FlaskInstrumentor().instrument()
+
 trace.get_tracer_provider().add_span_processor(
     SimpleExportSpanProcessor(ConsoleSpanExporter())
 )
 
-FlaskInstrumentor().instrument()
+
 app = flask.Flask(__name__)
-opentelemetry.ext.http_requests.enable(trace.get_tracer_provider())
 
 
 @app.route("/")

--- a/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
+++ b/docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/flask_example.py
@@ -28,6 +28,9 @@ from opentelemetry.sdk.trace.export import (
     SimpleExportSpanProcessor,
 )
 
+# The preferred tracer implementation must be set, as the opentelemetry-api
+# defines the interface with a no-op implementation.
+# It must be done before instrumenting any library
 trace.set_tracer_provider(TracerProvider())
 
 opentelemetry.ext.http_requests.RequestsInstrumentor().instrument()

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -202,7 +202,7 @@ And let's write a small Flask application that sends an HTTP request, activating
     )
 
     app = flask.Flask(__name__)
-    opentelemetry.ext.http_requests.enable(trace.get_tracer_provider())
+    opentelemetry.ext.http_requests.RequestsInstrumentor().instrument()
 
     @app.route("/")
     def hello():

--- a/ext/opentelemetry-ext-http-requests/CHANGELOG.md
+++ b/ext/opentelemetry-ext-http-requests/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Implement instrumentor interface ([#597](https://github.com/open-telemetry/opentelemetry-python/pull/597))
+
 ## 0.3a0
 
 Released 2019-10-29

--- a/ext/opentelemetry-ext-http-requests/setup.cfg
+++ b/ext/opentelemetry-ext-http-requests/setup.cfg
@@ -41,6 +41,7 @@ package_dir=
 packages=find_namespace:
 install_requires =
     opentelemetry-api == 0.7.dev0
+    opentelemetry-auto-instrumentation == 0.7.dev0
     requests ~= 2.0
 
 [options.extras_require]
@@ -50,3 +51,7 @@ test =
 
 [options.packages.find]
 where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    requests = opentelemetry.ext.http_requests:RequestsInstrumentor

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
@@ -51,6 +51,7 @@ from opentelemetry import context, propagators, trace
 from opentelemetry.auto_instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.ext.http_requests.version import __version__
 from opentelemetry.trace import SpanKind, get_tracer_provider
+from opentelemetry.trace.status import Status, StatusCanonicalCode
 
 _tracer = None
 
@@ -109,11 +110,11 @@ def _instrument(tracer_provider=None):
 
             span.set_attribute("http.status_code", result.status_code)
             span.set_attribute("http.status_text", result.reason)
+            span.set_status(
+                Status(_http_status_to_canonical_code(result.status_code))
+            )
 
             return result
-
-        # TODO: How to handle exceptions? Should we create events for them? Set
-        # certain attributes?
 
     instrumented_request.opentelemetry_ext_requests_applied = True
 
@@ -136,6 +137,37 @@ def _uninstrument():
         original = Session.request.__wrapped__  # pylint:disable=no-member
         Session.request = original
         _tracer = None
+
+
+def _http_status_to_canonical_code(code: int, allow_redirect: bool = True):
+    # pylint:disable=too-many-branches,too-many-return-statements
+    if code < 100:
+        return StatusCanonicalCode.UNKNOWN
+    if code <= 299:
+        return StatusCanonicalCode.OK
+    if code <= 399:
+        if allow_redirect:
+            return StatusCanonicalCode.OK
+        return StatusCanonicalCode.DEADLINE_EXCEEDED
+    if code <= 499:
+        if code == 401:  # HTTPStatus.UNAUTHORIZED:
+            return StatusCanonicalCode.UNAUTHENTICATED
+        if code == 403:  # HTTPStatus.FORBIDDEN:
+            return StatusCanonicalCode.PERMISSION_DENIED
+        if code == 404:  # HTTPStatus.NOT_FOUND:
+            return StatusCanonicalCode.NOT_FOUND
+        if code == 429:  # HTTPStatus.TOO_MANY_REQUESTS:
+            return StatusCanonicalCode.RESOURCE_EXHAUSTED
+        return StatusCanonicalCode.INVALID_ARGUMENT
+    if code <= 599:
+        if code == 501:  # HTTPStatus.NOT_IMPLEMENTED:
+            return StatusCanonicalCode.UNIMPLEMENTED
+        if code == 503:  # HTTPStatus.SERVICE_UNAVAILABLE:
+            return StatusCanonicalCode.UNAVAILABLE
+        if code == 504:  # HTTPStatus.GATEWAY_TIMEOUT:
+            return StatusCanonicalCode.DEADLINE_EXCEEDED
+        return StatusCanonicalCode.INTERNAL
+    return StatusCanonicalCode.UNKNOWN
 
 
 class RequestsInstrumentor(BaseInstrumentor):

--- a/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
+++ b/ext/opentelemetry-ext-http-requests/src/opentelemetry/ext/http_requests/__init__.py
@@ -77,7 +77,7 @@ def _instrument(tracer_provider=None):
             return wrapped(self, method, url, *args, **kwargs)
 
         # See
-        # https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md#http-client
+        # https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#http-client
         try:
             parsed_url = urlparse(url)
         except ValueError as exc:  # Invalid URL

--- a/tests/w3c_tracecontext_validation_server.py
+++ b/tests/w3c_tracecontext_validation_server.py
@@ -40,7 +40,7 @@ from opentelemetry.sdk.trace.export import (  # noqa # isort:skip
 # frameworks and libraries that are used together, automatically creating
 # Spans and propagating context as appropriate.
 trace.set_tracer_provider(TracerProvider())
-http_requests.enable(trace.get_tracer_provider())
+http_requests.RequestsInstrumentor().instrument()
 
 # SpanExporter receives the spans and send them to the target location.
 span_processor = SimpleExportSpanProcessor(ConsoleSpanExporter())

--- a/tox.ini
+++ b/tox.ini
@@ -146,6 +146,7 @@ commands_pre =
   example-app: pip install {toxinidir}/ext/opentelemetry-ext-flask
   example-app: pip install {toxinidir}/docs/examples/opentelemetry-example-app
 
+  example-http: pip install -e {toxinidir}/opentelemetry-auto-instrumentation
   example-http: pip install -e {toxinidir}/ext/opentelemetry-ext-http-requests
   example-http: pip install -e {toxinidir}/ext/opentelemetry-ext-wsgi
   example-http: pip install -r {toxinidir}/docs/examples/http/requirements.txt
@@ -171,6 +172,7 @@ commands_pre =
   psycopg2: pip install {toxinidir}/ext/opentelemetry-ext-dbapi
   psycopg2: pip install {toxinidir}/ext/opentelemetry-ext-psycopg2
 
+  http-requests: pip install {toxinidir}/opentelemetry-auto-instrumentation
   http-requests: pip install {toxinidir}/ext/opentelemetry-ext-http-requests[test]
 
   jaeger: pip install {toxinidir}/ext/opentelemetry-ext-jaeger
@@ -254,9 +256,9 @@ deps =
 commands_pre =
   pip install -e {toxinidir}/opentelemetry-api \
               -e {toxinidir}/opentelemetry-sdk \
+              -e {toxinidir}/opentelemetry-auto-instrumentation \
               -e {toxinidir}/ext/opentelemetry-ext-http-requests \
               -e {toxinidir}/ext/opentelemetry-ext-wsgi \
-              -e {toxinidir}/opentelemetry-auto-instrumentation \
               -e {toxinidir}/ext/opentelemetry-ext-flask
 
 commands =


### PR DESCRIPTION
Implement the `BaseInstrumentor` interface to make this library compatible with the opentelemetry-auto-instr command.  

There is an issue about getting the span when the global tracer provider hasn't been configured, this should be changed in the future once we extend the opentelemetry-auto-instr command to also configure the SDK.