### PR TITLE
Removing reload in testbase

### DIFF
--- a/tests/util/src/opentelemetry/test/test_base.py
+++ b/tests/util/src/opentelemetry/test/test_base.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from importlib import reload
 
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import TracerProvider, export
@@ -30,10 +29,6 @@ class TestBase(unittest.TestCase):
         cls.memory_exporter = InMemorySpanExporter()
         span_processor = export.SimpleExportSpanProcessor(cls.memory_exporter)
         cls.tracer_provider.add_span_processor(span_processor)
-
-    @classmethod
-    def tearDownClass(cls):
-        reload(trace_api)
 
     def setUp(self):
         self.memory_exporter.clear()

--- a/tests/util/src/opentelemetry/test/test_base.py
+++ b/tests/util/src/opentelemetry/test/test_base.py
@@ -25,10 +25,15 @@ class TestBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tracer_provider = TracerProvider()
+        cls.original_provider = trace_api.get_tracer_provider()
         trace_api.set_tracer_provider(cls.tracer_provider)
         cls.memory_exporter = InMemorySpanExporter()
         span_processor = export.SimpleExportSpanProcessor(cls.memory_exporter)
         cls.tracer_provider.add_span_processor(span_processor)
+
+    @classmethod
+    def tearDownClass(cls):
+        trace_api.set_tracer_provider(cls.original_provider)
 
     def setUp(self):
         self.memory_exporter.clear()


### PR DESCRIPTION
This is causing problems with integration tests as reload changes the `id` of `trace.Span` and therefore makes `isinstance` checks fail. Here's a code snippet of the problem:

```python
>>> from opentelemetry import trace as trace_api
>>> from opentelemetry.sdk import trace as trace_sdk
>>> span = trace_sdk.Span("name", None)
>>> isinstance(span, trace_api.Span)
True
>>> from importlib import reload
>>> reload(trace_api)
<module 'opentelemetry.trace' from '/Users/alrex/dev/opentelemetry-python/opentelemetry-api/src/opentelemetry/trace/__init__.py'>
>>> isinstance(span, trace_api.Span)
False
```