### PR TITLE
ext/pymysql: Add Instrumentor

### DIFF
--- a/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/__init__.py
+++ b/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/__init__.py
@@ -128,10 +128,9 @@ def wrap_connect(
 def unwrap_connect(
     connect_module: typing.Callable[..., any], connect_method_name: str,
 ):
-    if hasattr(connect_module, connect_method_name):
-        conn = getattr(connect_module, connect_method_name)
-        if isinstance(conn, wrapt.ObjectProxy):
-            setattr(connect_module, connect_method_name, conn.__wrapped__)
+    conn = getattr(connect_module, connect_method_name, None)
+    if isinstance(conn, wrapt.ObjectProxy):
+        setattr(connect_module, connect_method_name, conn.__wrapped__)
 
 
 class DatabaseApiIntegration:

--- a/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/__init__.py
+++ b/ext/opentelemetry-ext-dbapi/src/opentelemetry/ext/dbapi/__init__.py
@@ -125,6 +125,15 @@ def wrap_connect(
         logger.warning("Failed to integrate with DB API. %s", str(ex))
 
 
+def unwrap_connect(
+    connect_module: typing.Callable[..., any], connect_method_name: str,
+):
+    if hasattr(connect_module, connect_method_name):
+        conn = getattr(connect_module, connect_method_name)
+        if isinstance(conn, wrapt.ObjectProxy):
+            setattr(connect_module, connect_method_name, conn.__wrapped__)
+
+
 class DatabaseApiIntegration:
     def __init__(
         self,
@@ -184,7 +193,7 @@ class DatabaseApiIntegration:
             self.name += "." + self.database
         user = self.connection_props.get("user")
         if user is not None:
-            self.span_attributes["db.user"] = user
+            self.span_attributes["db.user"] = str(user)
         host = self.connection_props.get("host")
         if host is not None:
             self.span_attributes["net.peer.name"] = host

--- a/ext/opentelemetry-ext-docker-tests/tests/pymysql/test_pymysql_functional.py
+++ b/ext/opentelemetry-ext-docker-tests/tests/pymysql/test_pymysql_functional.py
@@ -17,7 +17,7 @@ import os
 import pymysql as pymy
 
 from opentelemetry import trace as trace_api
-from opentelemetry.ext.pymysql import trace_integration
+from opentelemetry.ext.pymysql import PymysqlInstrumentor
 from opentelemetry.test.test_base import TestBase
 
 MYSQL_USER = os.getenv("MYSQL_USER ", "testuser")
@@ -34,7 +34,7 @@ class TestFunctionalPyMysql(TestBase):
         cls._connection = None
         cls._cursor = None
         cls._tracer = cls.tracer_provider.get_tracer(__name__)
-        trace_integration()
+        PymysqlInstrumentor().instrument()
         cls._connection = pymy.connect(
             user=MYSQL_USER,
             password=MYSQL_PASSWORD,

--- a/ext/opentelemetry-ext-docker-tests/tests/pymysql/test_pymysql_functional.py
+++ b/ext/opentelemetry-ext-docker-tests/tests/pymysql/test_pymysql_functional.py
@@ -17,7 +17,7 @@ import os
 import pymysql as pymy
 
 from opentelemetry import trace as trace_api
-from opentelemetry.ext.pymysql import PymysqlInstrumentor
+from opentelemetry.ext.pymysql import PyMySQLInstrumentor
 from opentelemetry.test.test_base import TestBase
 
 MYSQL_USER = os.getenv("MYSQL_USER ", "testuser")
@@ -34,7 +34,7 @@ class TestFunctionalPyMysql(TestBase):
         cls._connection = None
         cls._cursor = None
         cls._tracer = cls.tracer_provider.get_tracer(__name__)
-        PymysqlInstrumentor().instrument()
+        PyMySQLInstrumentor().instrument()
         cls._connection = pymy.connect(
             user=MYSQL_USER,
             password=MYSQL_PASSWORD,

--- a/ext/opentelemetry-ext-docker-tests/tests/pymysql/test_pymysql_functional.py
+++ b/ext/opentelemetry-ext-docker-tests/tests/pymysql/test_pymysql_functional.py
@@ -13,18 +13,12 @@
 # limitations under the License.
 
 import os
-import time
-import unittest
 
 import pymysql as pymy
 
 from opentelemetry import trace as trace_api
 from opentelemetry.ext.pymysql import trace_integration
-from opentelemetry.sdk.trace import Tracer, TracerProvider
-from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
-    InMemorySpanExporter,
-)
+from opentelemetry.test.test_base import TestBase
 
 MYSQL_USER = os.getenv("MYSQL_USER ", "testuser")
 MYSQL_PASSWORD = os.getenv("MYSQL_PASSWORD ", "testpassword")
@@ -33,17 +27,14 @@ MYSQL_PORT = int(os.getenv("MYSQL_PORT ", "3306"))
 MYSQL_DB_NAME = os.getenv("MYSQL_DB_NAME ", "opentelemetry-tests")
 
 
-class TestFunctionalPyMysql(unittest.TestCase):
+class TestFunctionalPyMysql(TestBase):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls._connection = None
         cls._cursor = None
-        cls._tracer_provider = TracerProvider()
-        cls._tracer = Tracer(cls._tracer_provider, None)
-        cls._span_exporter = InMemorySpanExporter()
-        cls._span_processor = SimpleExportSpanProcessor(cls._span_exporter)
-        cls._tracer_provider.add_span_processor(cls._span_processor)
-        trace_integration(cls._tracer_provider)
+        cls._tracer = cls.tracer_provider.get_tracer(__name__)
+        trace_integration()
         cls._connection = pymy.connect(
             user=MYSQL_USER,
             password=MYSQL_PASSWORD,
@@ -58,11 +49,8 @@ class TestFunctionalPyMysql(unittest.TestCase):
         if cls._connection:
             cls._connection.close()
 
-    def setUp(self):
-        self._span_exporter.clear()
-
     def validate_spans(self):
-        spans = self._span_exporter.get_finished_spans()
+        spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 2)
         for span in spans:
             if span.name == "rootSpan":

--- a/ext/opentelemetry-ext-http-requests/CHANGELOG.md
+++ b/ext/opentelemetry-ext-http-requests/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Implement instrumentor interface ([#611](https://github.com/open-telemetry/opentelemetry-python/pull/611))
+
 ## 0.3a0
 
 Released 2019-10-29

--- a/ext/opentelemetry-ext-pymysql/CHANGELOG.md
+++ b/ext/opentelemetry-ext-pymysql/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- Implement PyMySQL integration ([#504](https://github.com/open-telemetry/opentelemetry-python/pull/504))
 - Implement instrumentor interface ([#611](https://github.com/open-telemetry/opentelemetry-python/pull/611))

--- a/ext/opentelemetry-ext-pymysql/CHANGELOG.md
+++ b/ext/opentelemetry-ext-pymysql/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
 ## Unreleased
+
+- Implement instrumentor interface ([#611](https://github.com/open-telemetry/opentelemetry-python/pull/611))

--- a/ext/opentelemetry-ext-pymysql/README.rst
+++ b/ext/opentelemetry-ext-pymysql/README.rst
@@ -6,10 +6,6 @@ OpenTelemetry PyMySQL integration
 .. |pypi| image:: https://badge.fury.io/py/opentelemetry-ext-pymysql.svg
    :target: https://pypi.org/project/opentelemetry-ext-pymysql/
 
-Integration with PyMySQL that supports the PyMySQL library and is
-specified to trace_integration using 'PyMySQL'.
-
-
 Installation
 ------------
 

--- a/ext/opentelemetry-ext-pymysql/setup.cfg
+++ b/ext/opentelemetry-ext-pymysql/setup.cfg
@@ -54,4 +54,4 @@ where = src
 
 [options.entry_points]
 opentelemetry_instrumentor =
-    pymysql = opentelemetry.ext.pymysql:PymysqlInstrumentor
+    pymysql = opentelemetry.ext.pymysql:PyMySQLInstrumentor

--- a/ext/opentelemetry-ext-pymysql/setup.cfg
+++ b/ext/opentelemetry-ext-pymysql/setup.cfg
@@ -44,5 +44,9 @@ install_requires =
     opentelemetry-ext-dbapi == 0.7.dev0
     PyMySQL ~=  0.9.3
 
+[options.extras_require]
+test =
+    opentelemetry-test == 0.7.dev0
+
 [options.packages.find]
 where = src

--- a/ext/opentelemetry-ext-pymysql/setup.cfg
+++ b/ext/opentelemetry-ext-pymysql/setup.cfg
@@ -42,6 +42,7 @@ packages=find_namespace:
 install_requires =
     opentelemetry-api == 0.7.dev0
     opentelemetry-ext-dbapi == 0.7.dev0
+    opentelemetry-auto-instrumentation == 0.7.dev0
     PyMySQL ~=  0.9.3
 
 [options.extras_require]
@@ -50,3 +51,7 @@ test =
 
 [options.packages.find]
 where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    pymysql = opentelemetry.ext.pymysql:PymysqlInstrumentor

--- a/ext/opentelemetry-ext-pymysql/src/opentelemetry/ext/pymysql/__init__.py
+++ b/ext/opentelemetry-ext-pymysql/src/opentelemetry/ext/pymysql/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """
-The integration with PyMySQL supports the `PyMySQL`_ library and is specified
-to ``trace_integration`` using ``'PyMySQL'``.
+The integration with PyMySQL supports the `PyMySQL`_ library and can be enabled
+by using ``PyMySQLInstrumentor``.
 
 .. _PyMySQL: https://pypi.org/project/PyMySQL/
 
@@ -25,11 +25,13 @@ Usage
 
     import pymysql
     from opentelemetry import trace
-    from opentelemetry.ext.pymysql import trace_integration
+    from opentelemetry.ext.pymysql import PyMySQLInstrumentor
     from opentelemetry.sdk.trace import TracerProvider
 
     trace.set_tracer_provider(TracerProvider())
-    trace_integration()
+
+    PyMySQLInstrumentor().instrument()
+
     cnx = pymysql.connect(database="MySQL_Database")
     cursor = cnx.cursor()
     cursor.execute("INSERT INTO test (testField) VALUES (123)"
@@ -51,7 +53,7 @@ from opentelemetry.ext.pymysql.version import __version__
 from opentelemetry.trace import TracerProvider, get_tracer
 
 
-class PymysqlInstrumentor(BaseInstrumentor):
+class PyMySQLInstrumentor(BaseInstrumentor):
     def _instrument(self, **kwargs):
         """Integrate with the PyMySQL library.
         https://github.com/PyMySQL/PyMySQL/

--- a/ext/opentelemetry-ext-pymysql/tests/test_pymysql_integration.py
+++ b/ext/opentelemetry-ext-pymysql/tests/test_pymysql_integration.py
@@ -17,7 +17,7 @@ from unittest import mock
 import pymysql
 
 import opentelemetry.ext.pymysql
-from opentelemetry.ext.pymysql import PymysqlInstrumentor
+from opentelemetry.ext.pymysql import PyMySQLInstrumentor
 from opentelemetry.sdk import resources
 from opentelemetry.test.test_base import TestBase
 
@@ -25,13 +25,13 @@ from opentelemetry.test.test_base import TestBase
 class TestPyMysqlIntegration(TestBase):
     def tearDown(self):
         super().tearDown()
-        # ensure that it's uninstrumented if some of the tests fail
-        PymysqlInstrumentor().uninstrument()
+        with self.disable_logging():
+            PyMySQLInstrumentor().uninstrument()
 
     @mock.patch("pymysql.connect")
     # pylint: disable=unused-argument
     def test_instrumentor(self, mock_connect):
-        PymysqlInstrumentor().instrument()
+        PyMySQLInstrumentor().instrument()
 
         cnx = pymysql.connect(database="test")
         cursor = cnx.cursor()
@@ -46,7 +46,7 @@ class TestPyMysqlIntegration(TestBase):
         self.check_span_instrumentation_info(span, opentelemetry.ext.pymysql)
 
         # check that no spans are generated after uninstrument
-        PymysqlInstrumentor().uninstrument()
+        PyMySQLInstrumentor().uninstrument()
 
         cnx = pymysql.connect(database="test")
         cursor = cnx.cursor()
@@ -63,7 +63,7 @@ class TestPyMysqlIntegration(TestBase):
         result = self.create_tracer_provider(resource=resource)
         tracer_provider, exporter = result
 
-        PymysqlInstrumentor().instrument(tracer_provider=tracer_provider)
+        PyMySQLInstrumentor().instrument(tracer_provider=tracer_provider)
 
         cnx = pymysql.connect(database="test")
         cursor = cnx.cursor()

--- a/ext/opentelemetry-ext-pymysql/tests/test_pymysql_integration.py
+++ b/ext/opentelemetry-ext-pymysql/tests/test_pymysql_integration.py
@@ -39,7 +39,7 @@ class TestPyMysqlIntegration(TestBase):
         # Check version and name in span's instrumentation info
         self.check_span_instrumentation_info(span, opentelemetry.ext.pymysql)
 
-        # check that no spans are generated ater uninstrument
+        # check that no spans are generated after uninstrument
         PymysqlInstrumentor().uninstrument()
 
         cnx = pymysql.connect(database="test")

--- a/ext/opentelemetry-ext-pymysql/tests/test_pymysql_integration.py
+++ b/ext/opentelemetry-ext-pymysql/tests/test_pymysql_integration.py
@@ -58,7 +58,7 @@ class TestPyMysqlIntegration(TestBase):
 
     @mock.patch("pymysql.connect")
     # pylint: disable=unused-argument
-    def _test_custom_tracer_provider(self, mock_connect):
+    def test_custom_tracer_provider(self, mock_connect):
         resource = resources.Resource.create({})
         result = self.create_tracer_provider(resource=resource)
         tracer_provider, exporter = result

--- a/ext/opentelemetry-ext-pymysql/tests/test_pymysql_integration.py
+++ b/ext/opentelemetry-ext-pymysql/tests/test_pymysql_integration.py
@@ -23,12 +23,9 @@ from opentelemetry.test.test_base import TestBase
 
 
 class TestPyMysqlIntegration(TestBase):
-    def setUp(self):
-        super().setUp()
-        PymysqlInstrumentor().instrument
-
     def tearDown(self):
         super().tearDown()
+        # ensure that it's uninstrumented if some of the tests fail
         PymysqlInstrumentor().uninstrument()
 
     @mock.patch("pymysql.connect")
@@ -61,7 +58,7 @@ class TestPyMysqlIntegration(TestBase):
 
     @mock.patch("pymysql.connect")
     # pylint: disable=unused-argument
-    def test_custom_tracer_provider(self, mock_connect):
+    def _test_custom_tracer_provider(self, mock_connect):
         resource = resources.Resource.create({})
         result = self.create_tracer_provider(resource=resource)
         tracer_provider, exporter = result

--- a/tests/util/src/opentelemetry/test/test_base.py
+++ b/tests/util/src/opentelemetry/test/test_base.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import unittest
+from contextlib import contextmanager
 
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import TracerProvider, export
@@ -59,3 +61,13 @@ class TestBase(unittest.TestCase):
         tracer_provider.add_span_processor(span_processor)
 
         return tracer_provider, memory_exporter
+
+    @staticmethod
+    @contextmanager
+    def disable_logging(highest_level=logging.CRITICAL):
+        logging.disable(highest_level)
+
+        try:
+            yield
+        finally:
+            logging.disable(logging.NOTSET)

--- a/tox.ini
+++ b/tox.ini
@@ -177,7 +177,7 @@ commands_pre =
   psycopg2: pip install {toxinidir}/ext/opentelemetry-ext-psycopg2
 
   pymysql: pip install {toxinidir}/ext/opentelemetry-ext-dbapi
-  pymysql: pip install {toxinidir}/ext/opentelemetry-ext-pymysql
+  pymysql: pip install {toxinidir}/ext/opentelemetry-ext-pymysql[test]
 
   http-requests: pip install {toxinidir}/ext/opentelemetry-ext-http-requests[test]
 

--- a/tox.ini
+++ b/tox.ini
@@ -176,6 +176,7 @@ commands_pre =
   psycopg2: pip install {toxinidir}/ext/opentelemetry-ext-dbapi
   psycopg2: pip install {toxinidir}/ext/opentelemetry-ext-psycopg2
 
+  pymysql: pip install {toxinidir}/opentelemetry-auto-instrumentation
   pymysql: pip install {toxinidir}/ext/opentelemetry-ext-dbapi
   pymysql: pip install {toxinidir}/ext/opentelemetry-ext-pymysql[test]
 
@@ -286,6 +287,7 @@ changedir =
 commands_pre =
   pip install -e {toxinidir}/opentelemetry-api \
               -e {toxinidir}/opentelemetry-sdk \
+              -e {toxinidir}/opentelemetry-auto-instrumentation \
               -e {toxinidir}/tests/util \
               -e {toxinidir}/ext/opentelemetry-ext-dbapi \
               -e {toxinidir}/ext/opentelemetry-ext-mysql \


### PR DESCRIPTION
- Implement a way to uninstrument dbapi connections
- Update pymysql to implement the instrumentor interface and provide a way to uninstrument

How to try it:
```
# install
pip install -e ext/opentelemetry-ext-pymysql/
# set up test db
opentelemetry-ext-docker-tests/tests
docker-compose up
```
pymysql_example.py
```
# Configuration code
from opentelemetry import trace

from opentelemetry.sdk.trace.export import (
    SimpleExportSpanProcessor,
    ConsoleSpanExporter,
)

trace.get_tracer_provider().add_span_processor(
    SimpleExportSpanProcessor(ConsoleSpanExporter())
)

# Real example starts here
import os

import pymysql

MYSQL_USER = os.getenv("MYSQL_USER ", "testuser")
MYSQL_PASSWORD = os.getenv("MYSQL_PASSWORD ", "testpassword")
MYSQL_HOST = os.getenv("MYSQL_HOST ", "localhost")
MYSQL_PORT = int(os.getenv("MYSQL_PORT ", "3306"))
MYSQL_DB_NAME = os.getenv("MYSQL_DB_NAME ", "opentelemetry-tests")

_connection = None
cursor = None
_connection = pymysql.connect(
   user=MYSQL_USER,
   password=MYSQL_PASSWORD,
   host=MYSQL_HOST,
   port=MYSQL_PORT,
   database=MYSQL_DB_NAME,
)
cursor = _connection.cursor()

cursor.execute("CREATE TABLE IF NOT EXISTS test (id integer)")

data = ((1,), (2,), (3,))
stmt = "INSERT INTO test (id) VALUES (%s)"
cursor.executemany(stmt, data)
```

Run the example:
```
OPENTELEMETRY_PYTHON_TRACER_PROVIDER=sdk_tracer_provider opentelemetry-auto-instrumentation pymysql_example.py
```

If everything went fine you see some spans on the terminal.
