### PR TITLE
ext/pymongo: Add instrumentor

### DIFF
--- a/ext/opentelemetry-ext-docker-tests/tests/pymongo/test_pymongo_functional.py
+++ b/ext/opentelemetry-ext-docker-tests/tests/pymongo/test_pymongo_functional.py
@@ -17,7 +17,7 @@ import os
 from pymongo import MongoClient
 
 from opentelemetry import trace as trace_api
-from opentelemetry.ext.pymongo import trace_integration
+from opentelemetry.ext.pymongo import PymongoInstrumentor
 from opentelemetry.test.test_base import TestBase
 
 MONGODB_HOST = os.getenv("MONGODB_HOST ", "localhost")
@@ -31,7 +31,7 @@ class TestFunctionalPymongo(TestBase):
     def setUpClass(cls):
         super().setUpClass()
         cls._tracer = cls.tracer_provider.get_tracer(__name__)
-        trace_integration(cls.tracer_provider)
+        PymongoInstrumentor().instrument()
         client = MongoClient(
             MONGODB_HOST, MONGODB_PORT, serverSelectionTimeoutMS=2000
         )
@@ -94,3 +94,23 @@ class TestFunctionalPymongo(TestBase):
         with self._tracer.start_as_current_span("rootSpan"):
             self._collection.delete_one({"name": "testName"})
         self.validate_spans()
+
+    def test_uninstrument(self):
+        # check that integration is working
+        self._collection.find_one()
+        spans = self.memory_exporter.get_finished_spans()
+        self.memory_exporter.clear()
+        self.assertEqual(len(spans), 1)
+
+        # uninstrument and check not new spans are created
+        PymongoInstrumentor().uninstrument()
+        self._collection.find_one()
+        spans = self.memory_exporter.get_finished_spans()
+        self.memory_exporter.clear()
+        self.assertEqual(len(spans), 0)
+
+        # re-enable and check that it works again
+        PymongoInstrumentor().instrument()
+        self._collection.find_one()
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)

--- a/ext/opentelemetry-ext-pymongo/CHANGELOG.md
+++ b/ext/opentelemetry-ext-pymongo/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
-## 0.7b0
-
-Unreleased
+## Unreleased
 
 - Implement instrumentor interface ([#612](https://github.com/open-telemetry/opentelemetry-python/pull/612))
+
 
 ## 0.4a0
 

--- a/ext/opentelemetry-ext-pymongo/CHANGELOG.md
+++ b/ext/opentelemetry-ext-pymongo/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.7b0
+
+Unreleased
+
+- Implement instrumentor interface ([#612](https://github.com/open-telemetry/opentelemetry-python/pull/612))
 
 ## 0.4a0
 

--- a/ext/opentelemetry-ext-pymongo/setup.cfg
+++ b/ext/opentelemetry-ext-pymongo/setup.cfg
@@ -53,4 +53,4 @@ where = src
 
 [options.entry_points]
 opentelemetry_instrumentor =
-    pymongo = opentelemetry.instrumentation.pymongo:PymongoInstrumentor
+    pymongo = opentelemetry.ext.pymongo:PymongoInstrumentor

--- a/ext/opentelemetry-ext-pymongo/setup.cfg
+++ b/ext/opentelemetry-ext-pymongo/setup.cfg
@@ -41,6 +41,7 @@ package_dir=
 packages=find_namespace:
 install_requires =
     opentelemetry-api == 0.7.dev0
+    opentelemetry-auto-instrumentation == 0.7.dev0
     pymongo ~= 3.1
 
 [options.extras_require]
@@ -49,3 +50,7 @@ test =
 
 [options.packages.find]
 where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    pymongo = opentelemetry.instrumentation.pymongo:PymongoInstrumentor

--- a/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/__init__.py
+++ b/ext/opentelemetry-ext-pymongo/src/opentelemetry/ext/pymongo/__init__.py
@@ -129,7 +129,7 @@ def _get_span_dict_key(event):
 
 
 class PymongoInstrumentor(BaseInstrumentor):
-    _commandtracer_instance: CommandTracer = None
+    _commandtracer_instance = None  # type CommandTracer
     # The instrumentation for PyMongo is based on the event listener interface
     # https://api.mongodb.com/python/current/api/pymongo/monitoring.html.
     # This interface only allows to register listeners and does not provide

--- a/ext/opentelemetry-ext-pymongo/tests/test_pymongo.py
+++ b/ext/opentelemetry-ext-pymongo/tests/test_pymongo.py
@@ -50,7 +50,7 @@ class TestPymongo(TestBase):
         # the memory exporter can't be used here because the span isn't ended
         # yet
         # pylint: disable=protected-access
-        span = command_tracer._get_span(mock_event)
+        span = command_tracer._pop_span(mock_event)
         self.assertIs(span.kind, trace_api.SpanKind.CLIENT)
         self.assertEqual(span.name, "mongodb.command_name.find")
         self.assertEqual(span.attributes["component"], "mongodb")

--- a/ext/opentelemetry-ext-pymongo/tests/test_pymongo.py
+++ b/ext/opentelemetry-ext-pymongo/tests/test_pymongo.py
@@ -15,7 +15,7 @@
 from unittest import mock
 
 from opentelemetry import trace as trace_api
-from opentelemetry.ext.pymongo import CommandTracer, trace_integration
+from opentelemetry.ext.pymongo import CommandTracer, PymongoInstrumentor
 from opentelemetry.test.test_base import TestBase
 
 
@@ -24,13 +24,13 @@ class TestPymongo(TestBase):
         super().setUp()
         self.tracer = self.tracer_provider.get_tracer(__name__)
 
-    def test_trace_integration(self):
+    def test_pymongo_instrumentor(self):
         mock_register = mock.Mock()
         patch = mock.patch(
             "pymongo.monitoring.register", side_effect=mock_register
         )
         with patch:
-            trace_integration(self.tracer_provider)
+            PymongoInstrumentor().instrument()
 
         self.assertTrue(mock_register.called)
 

--- a/tox.ini
+++ b/tox.ini
@@ -166,6 +166,7 @@ commands_pre =
 
   prometheus: pip install {toxinidir}/ext/opentelemetry-ext-prometheus
 
+  pymongo: pip install {toxinidir}/opentelemetry-auto-instrumentation
   pymongo: pip install {toxinidir}/ext/opentelemetry-ext-pymongo[test]
 
   psycopg2: pip install {toxinidir}/ext/opentelemetry-ext-dbapi
@@ -276,6 +277,7 @@ changedir =
 commands_pre =
   pip install -e {toxinidir}/opentelemetry-api \
               -e {toxinidir}/opentelemetry-sdk \
+              -e {toxinidir}/opentelemetry-auto-instrumentation \
               -e {toxinidir}/tests/util \
               -e {toxinidir}/ext/opentelemetry-ext-dbapi \
               -e {toxinidir}/ext/opentelemetry-ext-mysql \


### PR DESCRIPTION
This PR implements the Instrumentor interface for the Pymongo integration. It also implements a way to disable instrumentation.

I compared with the DataDog donated implementation available at https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/reference/ddtrace/contrib/pymongo, the already existing implementation is good enough and we do not need to take any from that in this case.

I'm opening a new PR to supersedes https://github.com/open-telemetry/opentelemetry-python/pull/598 to avoid reviewing and approving my own changes there.

How to try:

```
# install
pip install -e ext/opentelemetry-ext-pymymongo/
# set up test db
opentelemetry-ext-docker-tests/tests
docker-compose up
```

pymongo_example.py:
```
# Configuration code
from opentelemetry import trace

from opentelemetry.sdk.trace.export import (
    SimpleExportSpanProcessor,
    ConsoleSpanExporter,
)

trace.get_tracer_provider().add_span_processor(
    SimpleExportSpanProcessor(ConsoleSpanExporter())
)

# Real example starts here
import os

from pymongo import MongoClient

MONGODB_HOST = os.getenv("MONGODB_HOST ", "localhost")
MONGODB_PORT = int(os.getenv("MONGODB_PORT ", "27017"))
MONGODB_DB_NAME = os.getenv("MONGODB_DB_NAME ", "opentelemetry-tests")
MONGODB_COLLECTION_NAME = "test"

client = MongoClient(
    MONGODB_HOST, MONGODB_PORT, serverSelectionTimeoutMS=2000
)
db = client[MONGODB_DB_NAME]
collection = db[MONGODB_COLLECTION_NAME]

collection.insert_one({"name": "testName", "value": "testValue"})
```

```
OPENTELEMETRY_PYTHON_TRACER_PROVIDER=sdk_tracer_provider opentelemetry-auto-instrumentation pymongo_example.py
```
If everything went fine you see some spans on the terminal.