### PR TITLE
Add missing dependency

### DIFF
--- a/eachdist.ini
+++ b/eachdist.ini
@@ -6,6 +6,7 @@ sortfirst=
     opentelemetry-sdk
     opentelemetry-auto-instrumentation
     ext/opentelemetry-ext-wsgi
+    ext/opentelemetry-ext-dbapi
     ext/*
 
 [lintroots]


### PR DESCRIPTION
Without this, `tox -e lint` fails in my computer.

Fixes #613