### PR TITLE
Handle another exception on setting status on exception

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -667,18 +667,24 @@ class Tracer(trace_api.Tracer):
                 context_api.detach(token)
 
         except Exception as error:  # pylint: disable=broad-except
-            if (
-                isinstance(span, Span)
-                and span.status is None
-                and span._set_status_on_exception  # pylint:disable=protected-access  # noqa
-            ):
-                span.set_status(
-                    Status(
-                        canonical_code=StatusCanonicalCode.UNKNOWN,
-                        description="{}: {}".format(
-                            type(error).__name__, error
-                        ),
+            try:
+                if (
+                    isinstance(span, Span)
+                    and span.status is None
+                    and span._set_status_on_exception  # pylint:disable=protected-access  # noqa
+                ):
+                    span.set_status(
+                        Status(
+                            canonical_code=StatusCanonicalCode.UNKNOWN,
+                            description="{}: {}".format(
+                                type(error).__name__, error
+                            ),
+                        )
                     )
+            except Exception as e:
+                logger.error(
+                    "Got another exception while setting status on exception: %s"
+                    % e
                 )
 
             raise

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -882,3 +882,14 @@ class TestSpanProcessor(unittest.TestCase):
         expected_list.append(span_event_end_fmt("SP1", "foo"))
 
         self.assertListEqual(spans_calls_list, expected_list)
+
+    def test_use_span_set_status_on_exception(self):
+        """In the case where tracer sets status on exception,
+        it shouldn't raise another exception instead of the original one.
+        """
+        tracer = new_tracer()
+        invalid_span = None
+        with self.assertRaises(RuntimeError) as cm:
+            with tracer.use_span(invalid_span, False):
+                raise RuntimeError("intended error")
+        self.assertEqual(str(cm.exception), "intended error")


### PR DESCRIPTION
I realized [the gRPC interceptor](https://github.com/open-telemetry/opentelemetry-python/blob/7cb57c78d38836c9b75de720f6a43d648ff600e4/ext/opentelemetry-ext-grpc/src/opentelemetry/ext/grpc/__init__.py#L24) raises another exception while setting status on exception. The bug itself has been fixed by #577, but I think this kind of error should not be propagated to the caller as tracing should be a secondary thing.