### PR TITLE
Pin pylint

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pylint~=2.3
+pylint==2.4.4
 flake8~=3.7
 isort~=4.3
 black>=19.3b0,==19.*


### PR DESCRIPTION
Pinning the version of pylint as it's causing failures in our build. Related issue: https://github.com/PyCQA/pylint/issues/3524