### PR TITLE
Docs: fix docs dependencies

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -4,13 +4,13 @@ sphinx-autodoc-typehints~=1.10.2
 
 # Required by ext packages
 Deprecated>=1.2.6
-PyMySQL ~=  0.9.3
+PyMySQL~=0.9.3
 flask~=1.0
-mysql-connector-python ~=  8.0
+mysql-connector-python~=8.0
 opentracing~=2.2.0
-prometheus_client >= 0.5.0, < 1.0.0
-psycopg2-binary >= 2.7.3.1
+prometheus_client>=0.5.0,<1.0.0
+psycopg2-binary>=2.7.3.1
 pymongo~=3.1
-redis >= 2.6
+redis>=2.6
 thrift>=0.10.0
-wrapt >= 1.0.0, < 2.0.0
+wrapt >=1.0.0,<2.0.0

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -3,12 +3,14 @@ sphinx-rtd-theme~=0.4
 sphinx-autodoc-typehints~=1.10.2
 
 # Required by ext packages
-opentracing~=2.2.0
 Deprecated>=1.2.6
-thrift>=0.10.0
-pymongo~=3.1
+PyMySQL ~=  0.9.3
 flask~=1.0
 mysql-connector-python ~=  8.0
-wrapt >= 1.0.0, < 2.0.0
-psycopg2-binary >= 2.7.3.1
+opentracing~=2.2.0
 prometheus_client >= 0.5.0, < 1.0.0
+psycopg2-binary >= 2.7.3.1
+pymongo~=3.1
+redis >= 2.6
+thrift>=0.10.0
+wrapt >= 1.0.0, < 2.0.0

--- a/docs/ext/grpc/grpc.client_interceptor.rst
+++ b/docs/ext/grpc/grpc.client_interceptor.rst
@@ -1,7 +1,0 @@
-grpc.client\_interceptor module
-===============================
-
-.. automodule:: opentelemetry.ext.grpc.client_interceptor
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/ext/grpc/grpc.rst
+++ b/docs/ext/grpc/grpc.rst
@@ -1,12 +1,5 @@
-.. include:: ../../../ext/opentelemetry-ext-grpc/README.rst
-
-Submodules
-----------
-
-.. toctree::
-
-   grpc.client_interceptor
-   grpc.server_interceptor
+OpenTelemetry gRPC Integration
+==============================
 
 Module contents
 ---------------

--- a/docs/ext/grpc/grpc.server_interceptor.rst
+++ b/docs/ext/grpc/grpc.server_interceptor.rst
@@ -1,7 +1,0 @@
-grpc.server\_interceptor module
-===============================
-
-.. automodule:: opentelemetry.ext.grpc.server_interceptor
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/tox.ini
+++ b/tox.ini
@@ -241,22 +241,7 @@ commands =
 [testenv:docs]
 deps =
   -c dev-requirements.txt
-  -c docs-requirements.txt
-  sphinx
-  sphinx-rtd-theme
-  sphinx-autodoc-typehints
-  # Required by ext packages
-  opentracing
-  Deprecated
-  thrift
-  pymongo
-  redis
-  flask
-  pymysql
-  mysql-connector-python
-  wrapt
-  psycopg2-binary
-  prometheus_client
+  -r docs-requirements.txt
 
 changedir = docs
 


### PR DESCRIPTION
- Avoid duplicated dependency list in tox and docs-requirements
- Sort list
- Fix grpc duplicated entries

Preview available at https://opentelemetry-python-mauricio.readthedocs.io/en/mauricio-fix-docs-dependencies/.

