### PR TITLE
infra: reduce build time by running longest job early

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,3 +18,4 @@ exclude =
   ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/gen/
   ext/opentelemetry-ext-jaeger/build/*
   docs/examples/opentelemetry-example-app/src/opentelemetry_example_app/grpc/gen/
+  docs/examples/opentelemetry-example-app/build/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ language: python
 cache: pip
 
 python:
+  - 'pypy3'
+  - '3.8'
   - '3.4'
   - '3.5'
   - '3.6'
   - '3.7'
-  - '3.8'
-  - 'pypy3'
 
 #matrix:
 #  allow_failures:


### PR DESCRIPTION
Currently builds take roughly 15 minutes, as the longest job (pypy3) isn't kicked off until one of the other jobs is finished running (max 5 concurrent jobs). Prioritizing the longer jobs first should reduce the build time by about 5 minutes.