### PR TITLE
Add exclude lists for flask integration

### DIFF
--- a/ext/opentelemetry-ext-flask/CHANGELOG.md
+++ b/ext/opentelemetry-ext-flask/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add exclude list for paths and hosts
-  ([#6300](https://github.com/open-telemetry/opentelemetry-python/pull/630))
+  ([#630](https://github.com/open-telemetry/opentelemetry-python/pull/630))
 
 ## 0.6b0
 

--- a/ext/opentelemetry-ext-flask/CHANGELOG.md
+++ b/ext/opentelemetry-ext-flask/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add blacklisting for paths and hosts
-  ([#327](https://github.com/open-telemetry/opentelemetry-python/pull/327))
+  ([#6300](https://github.com/open-telemetry/opentelemetry-python/pull/630))
 
 ## 0.6b0
 

--- a/ext/opentelemetry-ext-flask/CHANGELOG.md
+++ b/ext/opentelemetry-ext-flask/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add blacklisting for paths and hosts
+- Add exclude list for paths and hosts
   ([#6300](https://github.com/open-telemetry/opentelemetry-python/pull/630))
 
 ## 0.6b0

--- a/ext/opentelemetry-ext-flask/CHANGELOG.md
+++ b/ext/opentelemetry-ext-flask/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add blacklisting for paths and hosts
+  ([#327](https://github.com/open-telemetry/opentelemetry-python/pull/327))
+
 ## 0.6b0
 
 Released 2020-03-30

--- a/ext/opentelemetry-ext-flask/README.rst
+++ b/ext/opentelemetry-ext-flask/README.rst
@@ -19,12 +19,12 @@ Installation
 Configuration
 -------------
 
-Blacklist
-*********
+Exclude lists
+*************
 Excludes certain hosts and paths from being tracked. Pass in comma delimited string into environment variables.
 
-Blacklisted hosts: OPENTELEMETRY_PYTHON_FLASK_BLACKLIST_HOSTS
-Blacklisted paths: OPENTELEMETRY_PYTHON_FLASK_BLACKLIST_PATHS
+Excluded hosts: OPENTELEMETRY_PYTHON_FLASK_EXCLUDED_HOSTS
+Excluded paths: OPENTELEMETRY_PYTHON_FLASK_EXCLUDED_PATHS
 
 
 References

--- a/ext/opentelemetry-ext-flask/README.rst
+++ b/ext/opentelemetry-ext-flask/README.rst
@@ -22,6 +22,7 @@ Configuration
 Exclude lists
 *************
 Excludes certain hosts and paths from being tracked. Pass in comma delimited string into environment variables.
+Host refers to the entire url and path refers to the part of the url after the domain. Host matches the exact string that is given, where as path matches if the url starts with the given excluded path.
 
 Excluded hosts: OPENTELEMETRY_PYTHON_FLASK_EXCLUDED_HOSTS
 Excluded paths: OPENTELEMETRY_PYTHON_FLASK_EXCLUDED_PATHS

--- a/ext/opentelemetry-ext-flask/README.rst
+++ b/ext/opentelemetry-ext-flask/README.rst
@@ -16,6 +16,16 @@ Installation
 
     pip install opentelemetry-ext-flask
 
+Configuration
+-------------
+
+Blacklist
+*********
+Excludes certain hosts and paths from being tracked. Pass in comma delimited string into environment variables.
+
+Blacklisted hosts: OPENTELEMETRY_PYTHON_FLASK_BLACKLIST_HOSTS
+Blacklisted paths: OPENTELEMETRY_PYTHON_FLASK_BLACKLIST_PATHS
+
 
 References
 ----------

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
@@ -56,7 +56,7 @@ from opentelemetry.auto_instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.ext.flask.version import __version__
 from opentelemetry.util import (
     disable_tracing_hostname,
-    disable_tracing_url,
+    disable_tracing_path,
     time_ns
 )
 
@@ -170,7 +170,7 @@ def _disable_trace(url):
             return True
     if excluded_paths:
         excluded_paths = str.split(excluded_paths, ',')
-        if disable_tracing_url(url, excluded_paths):
+        if disable_tracing_path(url, excluded_paths):
             return True
     return False
 

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
@@ -107,7 +107,7 @@ class _InstrumentedFlask(flask.Flask):
 
         @self.before_request
         def _before_flask_request():
-            # Do not trace if the url is blacklisted
+            # Do not trace if the url is excluded
             if _disable_trace(flask.request.url):
                 return
             environ = flask.request.environ
@@ -140,7 +140,7 @@ class _InstrumentedFlask(flask.Flask):
 
         @self.teardown_request
         def _teardown_flask_request(exc):
-            # Do not trace if the url is blacklisted
+            # Not traced if the url is excluded
             if _disable_trace(flask.request.url):
                 return
             activation = flask.request.environ.get(_ENVIRON_ACTIVATION_KEY)
@@ -162,15 +162,15 @@ class _InstrumentedFlask(flask.Flask):
 
 
 def _disable_trace(url):
-    blacklist_hosts = configuration.Configuration().FLASK_BLACKLIST_HOSTS
-    blacklist_paths = configuration.Configuration().FLASK_BLACKLIST_PATHS
-    if blacklist_hosts:
-        blacklist_hosts = str.split(blacklist_hosts, ',')
-        if disable_tracing_hostname(url, blacklist_hosts):
+    excluded_hosts = configuration.Configuration().FLASK_EXCLUDED_HOSTS
+    excluded_paths = configuration.Configuration().FLASK_EXCLUDED_PATHS
+    if excluded_hosts:
+        excluded_hosts = str.split(excluded_hosts, ',')
+        if disable_tracing_hostname(url, excluded_hosts):
             return True
-    if blacklist_paths:
-        blacklist_paths = str.split(blacklist_paths, ',')
-        if disable_tracing_url(url, blacklist_paths):
+    if excluded_paths:
+        excluded_paths = str.split(excluded_paths, ',')
+        if disable_tracing_url(url, excluded_paths):
             return True
     return False
 

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
@@ -57,7 +57,7 @@ from opentelemetry.ext.flask.version import __version__
 from opentelemetry.util import (
     disable_tracing_hostname,
     disable_tracing_path,
-    time_ns
+    time_ns,
 )
 
 logger = logging.getLogger(__name__)
@@ -165,11 +165,11 @@ def _disable_trace(url):
     excluded_hosts = configuration.Configuration().FLASK_EXCLUDED_HOSTS
     excluded_paths = configuration.Configuration().FLASK_EXCLUDED_PATHS
     if excluded_hosts:
-        excluded_hosts = str.split(excluded_hosts, ',')
+        excluded_hosts = str.split(excluded_hosts, ",")
         if disable_tracing_hostname(url, excluded_hosts):
             return True
     if excluded_paths:
-        excluded_paths = str.split(excluded_paths, ',')
+        excluded_paths = str.split(excluded_paths, ",")
         if disable_tracing_path(url, excluded_paths):
             return True
     return False

--- a/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
+++ b/ext/opentelemetry-ext-flask/src/opentelemetry/ext/flask/__init__.py
@@ -51,10 +51,14 @@ import logging
 import flask
 
 import opentelemetry.ext.wsgi as otel_wsgi
-from opentelemetry import context, propagators, trace
+from opentelemetry import configuration, context, propagators, trace
 from opentelemetry.auto_instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.ext.flask.version import __version__
-from opentelemetry.util import time_ns
+from opentelemetry.util import (
+    disable_tracing_hostname,
+    disable_tracing_url,
+    time_ns
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,17 +84,18 @@ class _InstrumentedFlask(flask.Flask):
             environ[_ENVIRON_STARTTIME_KEY] = time_ns()
 
             def _start_response(status, response_headers, *args, **kwargs):
-                span = flask.request.environ.get(_ENVIRON_SPAN_KEY)
-                if span:
-                    otel_wsgi.add_response_attributes(
-                        span, status, response_headers
-                    )
-                else:
-                    logger.warning(
-                        "Flask environ's OpenTelemetry span "
-                        "missing at _start_response(%s)",
-                        status,
-                    )
+                if not _disable_trace(flask.request.url):
+                    span = flask.request.environ.get(_ENVIRON_SPAN_KEY)
+                    if span:
+                        otel_wsgi.add_response_attributes(
+                            span, status, response_headers
+                        )
+                    else:
+                        logger.warning(
+                            "Flask environ's OpenTelemetry span "
+                            "missing at _start_response(%s)",
+                            status,
+                        )
 
                 return start_response(
                     status, response_headers, *args, **kwargs
@@ -102,6 +107,9 @@ class _InstrumentedFlask(flask.Flask):
 
         @self.before_request
         def _before_flask_request():
+            # Do not trace if the url is blacklisted
+            if _disable_trace(flask.request.url):
+                return
             environ = flask.request.environ
             span_name = (
                 flask.request.endpoint
@@ -132,6 +140,9 @@ class _InstrumentedFlask(flask.Flask):
 
         @self.teardown_request
         def _teardown_flask_request(exc):
+            # Do not trace if the url is blacklisted
+            if _disable_trace(flask.request.url):
+                return
             activation = flask.request.environ.get(_ENVIRON_ACTIVATION_KEY)
             if not activation:
                 logger.warning(
@@ -148,6 +159,20 @@ class _InstrumentedFlask(flask.Flask):
                     type(exc), exc, getattr(exc, "__traceback__", None)
                 )
             context.detach(flask.request.environ.get(_ENVIRON_TOKEN))
+
+
+def _disable_trace(url):
+    blacklist_hosts = configuration.Configuration().FLASK_BLACKLIST_HOSTS
+    blacklist_paths = configuration.Configuration().FLASK_BLACKLIST_PATHS
+    if blacklist_hosts:
+        blacklist_hosts = str.split(blacklist_hosts, ',')
+        if disable_tracing_hostname(url, blacklist_hosts):
+            return True
+    if blacklist_paths:
+        blacklist_paths = str.split(blacklist_paths, ',')
+        if disable_tracing_url(url, blacklist_paths):
+            return True
+    return False
 
 
 class FlaskInstrumentor(BaseInstrumentor):

--- a/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
+++ b/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import patch
 
 from flask import Flask, request
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
 
 from opentelemetry import trace as trace_api
+from opentelemetry.configuration import Configuration 
 from opentelemetry.test.wsgitestutil import WsgiTestBase
 
 
@@ -45,7 +47,8 @@ class TestFlaskIntegration(WsgiTestBase):
         # No instrumentation code is here because it is present in the
         # conftest.py file next to this file.
         super().setUp()
-
+        Configuration._instance = None  # pylint:disable=protected-access
+        Configuration.__slots__ = []
         self.app = Flask(__name__)
 
         def hello_endpoint(helloid):
@@ -53,9 +56,21 @@ class TestFlaskIntegration(WsgiTestBase):
                 raise ValueError(":-(")
             return "Hello: " + str(helloid)
 
+        def blacklist_endpoint():
+            return "blacklist"
+
+        def blacklist2_endpoint():
+            return "blacklist2"
+
         self.app.route("/hello/<int:helloid>")(hello_endpoint)
+        self.app.route("/blacklist")(blacklist_endpoint)
+        self.app.route("/blacklist2")(blacklist2_endpoint)
 
         self.client = Client(self.app, BaseResponse)
+
+    def tearDown(self):
+        Configuration._instance = None  # pylint:disable=protected-access
+        Configuration.__slots__ = []
 
     def test_only_strings_in_environ(self):
         """
@@ -81,8 +96,7 @@ class TestFlaskIntegration(WsgiTestBase):
             {"http.target": "/hello/123", "http.route": "/hello/<int:helloid>"}
         )
         resp = self.client.get("/hello/123")
-        self.assertEqual(200, resp.status_code)
-        self.assertEqual([b"Hello: 123"], list(resp.response))
+        
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
         self.assertEqual(span_list[0].name, "hello_endpoint")
@@ -125,6 +139,21 @@ class TestFlaskIntegration(WsgiTestBase):
         self.assertEqual(span_list[0].name, "hello_endpoint")
         self.assertEqual(span_list[0].kind, trace_api.SpanKind.SERVER)
         self.assertEqual(span_list[0].attributes, expected_attrs)
+
+    @patch.dict(
+        "os.environ",  # type: ignore
+        {
+            "OPENTELEMETRY_PYTHON_FLASK_BLACKLIST_HOSTS": "http://localhost/blacklist",
+            "OPENTELEMETRY_PYTHON_FLASK_BLACKLIST_PATHS": "blacklist2",
+        },
+    )
+    def test_blacklist_path(self):
+        self.client.get("/hello/123")
+        self.client.get("/blacklist")
+        self.client.get("/blacklist2")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        self.assertEqual(span_list[0].name, "hello_endpoint")
 
 
 if __name__ == "__main__":

--- a/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
+++ b/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
@@ -95,7 +95,7 @@ class TestFlaskIntegration(WsgiTestBase):
         expected_attrs = expected_attributes(
             {"http.target": "/hello/123", "http.route": "/hello/<int:helloid>"}
         )
-        resp = self.client.get("/hello/123")
+        self.client.get("/hello/123")
 
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)

--- a/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
+++ b/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
@@ -56,15 +56,15 @@ class TestFlaskIntegration(WsgiTestBase):
                 raise ValueError(":-(")
             return "Hello: " + str(helloid)
 
-        def blacklist_endpoint():
-            return "blacklist"
+        def excluded_endpoint():
+            return "excluded"
 
-        def blacklist2_endpoint():
-            return "blacklist2"
+        def excluded2_endpoint():
+            return "excluded2"
 
         self.app.route("/hello/<int:helloid>")(hello_endpoint)
-        self.app.route("/blacklist")(blacklist_endpoint)
-        self.app.route("/blacklist2")(blacklist2_endpoint)
+        self.app.route("/excluded")(excluded_endpoint)
+        self.app.route("/excluded2")(excluded2_endpoint)
 
         self.client = Client(self.app, BaseResponse)
 
@@ -143,14 +143,14 @@ class TestFlaskIntegration(WsgiTestBase):
     @patch.dict(
         "os.environ",  # type: ignore
         {
-            "OPENTELEMETRY_PYTHON_FLASK_BLACKLIST_HOSTS": "http://localhost/blacklist",
-            "OPENTELEMETRY_PYTHON_FLASK_BLACKLIST_PATHS": "blacklist2",
+            "OPENTELEMETRY_PYTHON_FLASK_EXCLUDED_HOSTS": "http://localhost/excluded",
+            "OPENTELEMETRY_PYTHON_FLASK_EXCLUDED_PATHS": "excluded2",
         },
     )
-    def test_blacklist_path(self):
+    def test_excluded_path(self):
         self.client.get("/hello/123")
-        self.client.get("/blacklist")
-        self.client.get("/blacklist2")
+        self.client.get("/excluded")
+        self.client.get("/excluded2")
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
         self.assertEqual(span_list[0].name, "hello_endpoint")

--- a/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
+++ b/ext/opentelemetry-ext-flask/tests/test_flask_integration.py
@@ -20,7 +20,7 @@ from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
 
 from opentelemetry import trace as trace_api
-from opentelemetry.configuration import Configuration 
+from opentelemetry.configuration import Configuration
 from opentelemetry.test.wsgitestutil import WsgiTestBase
 
 
@@ -96,7 +96,7 @@ class TestFlaskIntegration(WsgiTestBase):
             {"http.target": "/hello/123", "http.route": "/hello/<int:helloid>"}
         )
         resp = self.client.get("/hello/123")
-        
+
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
         self.assertEqual(span_list[0].name, "hello_endpoint")

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -35,7 +35,7 @@ except AttributeError:
 
 
 def _load_provider(
-    provider: str
+    provider: str,
 ) -> Union["TracerProvider", "MeterProvider"]:  # type: ignore
     try:
         return next(  # type: ignore

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -63,8 +63,7 @@ def disable_tracing_path(url: str, excluded_paths: Sequence[str]) -> bool:
         regex = "{}({})".format(URL_PATTERN, "|".join(excluded_paths))
         if re.match(regex, url):
             return True
-        else:
-            return False
+    return False
 
 
 def disable_tracing_hostname(

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -41,10 +41,10 @@ def _load_provider(
         return next(  # type: ignore
             iter_entry_points(
                 "opentelemetry_{}".format(provider),
-                name=getattr(  # type: ignore
-                    Configuration(),
+                name=getattr(
+                    Configuration(),  # type: ignore
                     provider,
-                    "default_{}".format(provider),  # type: ignore
+                    "default_{}".format(provider),
                 ),
             )
         ).load()()

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -53,22 +53,18 @@ def _load_provider(
         raise
 
 
-# Pattern for matching the 'https://', 'http://', 'ftp://' part.
-URL_PATTERN = "^(https?|ftp):\\/\\/"
+# Pattern for matching up until the first '/' after the 'https://' part.
+URL_PATTERN = "^(https?|ftp):\\/\\/.*\\/"
 
 
 def disable_tracing_path(url: str, excluded_paths: Sequence[str]) -> bool:
-    # Remove the 'https?|ftp://' if exists
-    url = re.sub(URL_PATTERN, "", url)
-
-    # Split the url by the first '/' and get the path part
-    url_path = url.split("/", 1)[1]
-
-    for path in excluded_paths:
-        if url_path.startswith(path):
+    if excluded_paths:
+        # Match only the part after the first '/' that is not in URL_PATTERN
+        regex = "{}({})".format(URL_PATTERN, "|".join(excluded_paths))
+        if re.match(regex, url):
             return True
-
-    return False
+        else:
+            return False
 
 
 def disable_tracing_hostname(

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -54,13 +54,13 @@ def _load_provider(
 
 
 # Pattern for matching up until the first '/' after the 'https://' part.
-URL_PATTERN = "^(https?|ftp):\\/\\/.*\\/"
+_URL_PATTERN = r"(https?|ftp)://.*?/"
 
 
 def disable_tracing_path(url: str, excluded_paths: Sequence[str]) -> bool:
     if excluded_paths:
-        # Match only the part after the first '/' that is not in URL_PATTERN
-        regex = "{}({})".format(URL_PATTERN, "|".join(excluded_paths))
+        # Match only the part after the first '/' that is not in _URL_PATTERN
+        regex = "{}({})".format(_URL_PATTERN, "|".join(excluded_paths))
         if re.match(regex, url):
             return True
     return False

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -54,13 +54,13 @@ def _load_provider(provider: str) -> Union["TracerProvider", "MeterProvider"]:  
 URL_PATTERN = '^(https?|ftp):\\/\\/'
 
 
-def disable_tracing_url(url, blacklist_paths):
-    """Disable tracing on the provided blacklist paths
+def disable_tracing_path(url, excluded_paths):
+    """Disable tracing on the provided excluded paths
 
-    If the url path starts with the blacklisted path, return True.
+    If the path starts with the excluded path, return True.
 
-    :type blacklist_paths: list
-    :param blacklist_paths: Paths to prevent from tracing
+    :type excluded_paths: list
+    :param excluded_paths: Paths to exclude from tracing
 
     :rtype: bool
     :returns: True if not tracing, False if tracing
@@ -71,20 +71,20 @@ def disable_tracing_url(url, blacklist_paths):
     # Split the url by the first '/' and get the path part
     url_path = url.split('/', 1)[1]
 
-    for path in blacklist_paths:
+    for path in excluded_paths:
         if url_path.startswith(path):
             return True
 
     return False
 
 
-def disable_tracing_hostname(url, blacklist_hostnames):
-    """Disable tracing for the provided blacklist URLs.
+def disable_tracing_hostname(url, excluded_hostnames):
+    """Disable tracing for the provided excluded hostnames.
 
-    :type blacklist_hostnames: list
-    :param blacklist_hostnames: URLs to prevent tracing
+    :type excluded_hostnames: list
+    :param excluded_hostnames: hostnames to exclude from tracing
 
     :rtype: bool
     :returns: True if not tracing, False if tracing
     """
-    return url in blacklist_hostnames
+    return url in excluded_hostnames

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -14,7 +14,7 @@
 import re
 import time
 from logging import getLogger
-from typing import Union
+from typing import Sequence, Union
 
 from pkg_resources import iter_entry_points
 
@@ -54,17 +54,9 @@ def _load_provider(provider: str) -> Union["TracerProvider", "MeterProvider"]:  
 URL_PATTERN = '^(https?|ftp):\\/\\/'
 
 
-def disable_tracing_path(url, excluded_paths):
-    """Disable tracing on the provided excluded paths
-
-    If the path starts with the excluded path, return True.
-
-    :type excluded_paths: list
-    :param excluded_paths: Paths to exclude from tracing
-
-    :rtype: bool
-    :returns: True if not tracing, False if tracing
-    """
+def disable_tracing_path(
+    url: str,
+    excluded_paths: Sequence[str]) -> bool:
     # Remove the 'https?|ftp://' if exists
     url = re.sub(URL_PATTERN, '', url)
 
@@ -78,13 +70,7 @@ def disable_tracing_path(url, excluded_paths):
     return False
 
 
-def disable_tracing_hostname(url, excluded_hostnames):
-    """Disable tracing for the provided excluded hostnames.
-
-    :type excluded_hostnames: list
-    :param excluded_hostnames: hostnames to exclude from tracing
-
-    :rtype: bool
-    :returns: True if not tracing, False if tracing
-    """
+def disable_tracing_hostname(
+    url: str,
+    excluded_hostnames: Sequence[str]) -> bool:
     return url in excluded_hostnames

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -34,34 +34,35 @@ except AttributeError:
         return int(time.time() * 1e9)
 
 
-def _load_provider(provider: str) -> Union["TracerProvider", "MeterProvider"]:  # type: ignore
+def _load_provider(
+    provider: str
+) -> Union["TracerProvider", "MeterProvider"]:  # type: ignore
     try:
         return next(  # type: ignore
             iter_entry_points(
                 "opentelemetry_{}".format(provider),
                 name=getattr(  # type: ignore
-                    Configuration(), provider, "default_{}".format(provider),  # type: ignore
+                    Configuration(),
+                    provider,
+                    "default_{}".format(provider),  # type: ignore
                 ),
             )
         ).load()()
     except Exception:  # pylint: disable=broad-except
-        logger.error(
-            "Failed to load configured provider %s", provider,
-        )
+        logger.error("Failed to load configured provider %s", provider)
         raise
 
+
 # Pattern for matching the 'https://', 'http://', 'ftp://' part.
-URL_PATTERN = '^(https?|ftp):\\/\\/'
+URL_PATTERN = "^(https?|ftp):\\/\\/"
 
 
-def disable_tracing_path(
-    url: str,
-    excluded_paths: Sequence[str]) -> bool:
+def disable_tracing_path(url: str, excluded_paths: Sequence[str]) -> bool:
     # Remove the 'https?|ftp://' if exists
-    url = re.sub(URL_PATTERN, '', url)
+    url = re.sub(URL_PATTERN, "", url)
 
     # Split the url by the first '/' and get the path part
-    url_path = url.split('/', 1)[1]
+    url_path = url.split("/", 1)[1]
 
     for path in excluded_paths:
         if url_path.startswith(path):
@@ -71,6 +72,6 @@ def disable_tracing_path(
 
 
 def disable_tracing_hostname(
-    url: str,
-    excluded_hostnames: Sequence[str]) -> bool:
+    url: str, excluded_hostnames: Sequence[str]
+) -> bool:
     return url in excluded_hostnames


### PR DESCRIPTION
Leverage global configurations to allow users to specify paths and hosts that they do not want to trace within their Flask applications. 

`OPENTELEMETRY_PYTHON_FLASK_EXCLUDED_HOSTS` and `OPENTELEMETRY_PYTHON_FLASK_EXCLUDED_PATHS` are the env variables used. Use a comma delimited string to represent seperate hosts/paths to blacklist.

TODO:
1. Perhaps allow users to pro-grammatically configure these (through code, maybe Configurations should be modifiable through code as well)
2. Related to [#581]. Perhaps we should emit a default span instead of not patching. I don't really see a benefit for this though.