### PR TITLE
ext/jaeger - Transform resource to tags when exporting

### DIFF
--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -197,6 +197,8 @@ def _translate_to_jaeger(spans: Span):
         parent_id = span.parent.span_id if span.parent else 0
 
         tags = _extract_tags(span.attributes)
+        if span.resource is not None:
+            tags.extend(_extract_tags(span.resource.labels))
 
         tags.extend(
             [

--- a/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
+++ b/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
@@ -214,7 +214,6 @@ class TestJaegerSpanExporter(unittest.TestCase):
 
         # pylint: disable=protected-access
         spans = jaeger_exporter._translate_to_jaeger(otel_spans)
-        # print(spans[0])
 
         expected_spans = [
             jaeger.Span(


### PR DESCRIPTION
This PR implements the missing part of exporting the TraceProvider resource into Jaeger.
Same as in [js](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-exporter-jaeger/src/transform.ts#L67).