### PR TITLE
ext/docker-tests: Fix SQL docker tests

### DIFF
--- a/ext/opentelemetry-ext-docker-tests/tests/mysql/test_mysql_functional.py
+++ b/ext/opentelemetry-ext-docker-tests/tests/mysql/test_mysql_functional.py
@@ -82,7 +82,7 @@ class TestFunctionalMysql(TestBase):
         """Should create a child span for executemany
         """
         with self._tracer.start_as_current_span("rootSpan"):
-            data = ["1", "2", "3"]
+            data = (("1",), ("2",), ("3",))
             stmt = "INSERT INTO test (id) VALUES (%s)"
             self._cursor.executemany(stmt, data)
         self.validate_spans()

--- a/ext/opentelemetry-ext-docker-tests/tests/postgres/test_psycopg_functional.py
+++ b/ext/opentelemetry-ext-docker-tests/tests/postgres/test_psycopg_functional.py
@@ -89,7 +89,7 @@ class TestFunctionalPsycopg(TestBase):
         """Should create a child span for executemany
         """
         with self._tracer.start_as_current_span("rootSpan"):
-            data = ("1", "2", "3")
+            data = (("1",), ("2",), ("3",))
             stmt = "INSERT INTO test (id) VALUES (%s)"
             self._cursor.executemany(stmt, data)
         self.validate_spans()

--- a/ext/opentelemetry-ext-docker-tests/tests/pymysql/test_pymysql_functional.py
+++ b/ext/opentelemetry-ext-docker-tests/tests/pymysql/test_pymysql_functional.py
@@ -81,7 +81,7 @@ class TestFunctionalPyMysql(TestBase):
         """Should create a child span for executemany
         """
         with self._tracer.start_as_current_span("rootSpan"):
-            data = ["1", "2", "3"]
+            data = (("1",), ("2",), ("3",))
             stmt = "INSERT INTO test (id) VALUES (%s)"
             self._cursor.executemany(stmt, data)
         self.validate_spans()


### PR DESCRIPTION
The executemany test fails in some conditions because the argument used is
a sequence and not a sequence of sequences as it should be:

https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlcursor-executemany.html
https://pymysql.readthedocs.io/en/latest/modules/cursors.html#pymysql.cursors.Cursor.executemany
https://www.psycopg.org/docs/cursor.html#cursor.executemany

Link to CI failures:
- https://travis-ci.org/github/mauriciovasquezbernal/opentelemetry-python/jobs/683021674#L7842
- https://travis-ci.org/github/open-telemetry/opentelemetry-python/jobs/683000037#L7824

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/589.