### PR TITLE
docs: Add missing dependencies and fix django

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -14,6 +14,6 @@ prometheus_client>=0.5.0,<1.0.0
 psycopg2-binary>=2.7.3.1
 pymongo~=3.1
 redis>=2.6
-sqlalchemy
+sqlalchemy>=1.0
 thrift>=0.10.0
 wrapt >=1.0.0,<2.0.0

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -5,6 +5,7 @@ sphinx-autodoc-typehints~=1.10.2
 # Required by ext packages
 aiohttp ~= 3.0
 Deprecated>=1.2.6
+django>=2.2
 PyMySQL~=0.9.3
 flask~=1.0
 mysql-connector-python~=8.0
@@ -13,5 +14,6 @@ prometheus_client>=0.5.0,<1.0.0
 psycopg2-binary>=2.7.3.1
 pymongo~=3.1
 redis>=2.6
+sqlalchemy
 thrift>=0.10.0
 wrapt >=1.0.0,<2.0.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@ from os.path import isdir, join
 # are not configured. You must either define the environment variable
 # DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
 from django.conf import settings
+
 settings.configure()
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,10 @@ import sys
 from os import listdir
 from os.path import isdir, join
 
+# configure django to avoid the following exception:
+# django.core.exceptions.ImproperlyConfigured: Requested settings, but settings
+# are not configured. You must either define the environment variable
+# DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
 import django
 from django.conf import settings
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,12 @@ import sys
 from os import listdir
 from os.path import isdir, join
 
+import django
+from django.conf import settings
+
+settings.configure()
+django.setup()
+
 source_dirs = [
     os.path.abspath("../opentelemetry-api/src/"),
     os.path.abspath("../opentelemetry-sdk/src/"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,11 +19,9 @@ from os.path import isdir, join
 # django.core.exceptions.ImproperlyConfigured: Requested settings, but settings
 # are not configured. You must either define the environment variable
 # DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
-import django
 from django.conf import settings
-
 settings.configure()
-django.setup()
+
 
 source_dirs = [
     os.path.abspath("../opentelemetry-api/src/"),


### PR DESCRIPTION
- Add missing sqlalchemy and django dependencies
- Configure django in docs/conf.py to avoid non configured exeception

Preview here https://opentelemetry-python-mauricio.readthedocs.io/en/latest/.

