### PR TITLE
docs: backfill changelogs since 0.6

### DIFF
--- a/ext/opentelemetry-ext-pymongo/CHANGELOG.md
+++ b/ext/opentelemetry-ext-pymongo/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Implement instrumentor interface ([#612](https://github.com/open-telemetry/opentelemetry-python/pull/612))
 
-
 ## 0.4a0
 
 Released 2020-02-21

--- a/ext/opentelemetry-ext-pymysql/CHANGELOG.md
+++ b/ext/opentelemetry-ext-pymysql/CHANGELOG.md
@@ -2,6 +2,4 @@
 
 ## Unreleased
 
-- Implement instrument_connection and uninstrument_connection ([#624](https://github.com/open-telemetry/opentelemetry-python/pull/624))
-- Implement PyMySQL integration ([#504](https://github.com/open-telemetry/opentelemetry-python/pull/504))
-- Implement instrumentor interface ([#611](https://github.com/open-telemetry/opentelemetry-python/pull/611))
+- Initial release

--- a/ext/opentelemetry-ext-requests/CHANGELOG.md
+++ b/ext/opentelemetry-ext-requests/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## Unreleased
 
-- Rename package to opentelemetry-ext-requests ([#619](https://github.com/open-telemetry/opentelemetry-python/pull/619))
-- Implement instrumentor interface, enabling auto-instrumentation ([#597](https://github.com/open-telemetry/opentelemetry-python/pull/597))
-- Adding disable_session for more granular instrumentation control ([#573](https://github.com/open-telemetry/opentelemetry-python/pull/573))
-- Add a callback for custom attributes ([#656](https://github.com/open-telemetry/opentelemetry-python/pull/656))
+- Rename package to opentelemetry-ext-requests
+  ([#619](https://github.com/open-telemetry/opentelemetry-python/pull/619))
+- Implement instrumentor interface, enabling auto-instrumentation
+  ([#597](https://github.com/open-telemetry/opentelemetry-python/pull/597))
+- Adding disable_session for more granular instrumentation control
+  ([#573](https://github.com/open-telemetry/opentelemetry-python/pull/573))
+- Add a callback for custom attributes
+  ([#656](https://github.com/open-telemetry/opentelemetry-python/pull/656))
 
 ## 0.3a0
 

--- a/ext/opentelemetry-ext-requests/CHANGELOG.md
+++ b/ext/opentelemetry-ext-requests/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 - Rename package to opentelemetry-ext-requests ([#619](https://github.com/open-telemetry/opentelemetry-python/pull/619))
-- Implement instrumentor interface ([#597](https://github.com/open-telemetry/opentelemetry-python/pull/597))
+- Implement instrumentor interface, enabling auto-instrumentation ([#597](https://github.com/open-telemetry/opentelemetry-python/pull/597))
+- Adding disable_session for more granular instrumentation control ([#573](https://github.com/open-telemetry/opentelemetry-python/pull/573))
+- Add a callback for custom attributes ([#656](https://github.com/open-telemetry/opentelemetry-python/pull/656))
 
 ## 0.3a0
 

--- a/ext/opentelemetry-ext-zipkin/CHANGELOG.md
+++ b/ext/opentelemetry-ext-zipkin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- bugfix: 'debug' field is now correct
+  ([#549](https://github.com/open-telemetry/opentelemetry-python/pull/549))
+
 ## 0.4a0
 
 Released 2020-02-21

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -6,7 +6,8 @@
   ([#636](https://github.com/open-telemetry/opentelemetry-python/pull/636))
 - tracer.get_tracer now optionally accepts a TracerProvider
   ([#602](https://github.com/open-telemetry/opentelemetry-python/pull/602))
-- Configuration object can now be used by any component of opentelemetry, including 3rd party instrumentations
+- Configuration object can now be used by any component of opentelemetry,
+  including 3rd party instrumentations
   ([#563](https://github.com/open-telemetry/opentelemetry-python/pull/563))
 - bugfix: configuration object now matches fields in a case-sensitive manner
   ([#583](https://github.com/open-telemetry/opentelemetry-python/pull/583))

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- Add reset for the global configuration object, for testing purposes
+  ([#636](https://github.com/open-telemetry/opentelemetry-python/pull/636))
+- tracer.get_tracer now optionally accepts a TracerProvider
+  ([#602](https://github.com/open-telemetry/opentelemetry-python/pull/602))
+- Configuration object can now be used by any component of opentelemetry, including 3rd party instrumentations
+  ([#563](https://github.com/open-telemetry/opentelemetry-python/pull/563))
+- bugfix: configuration object now matches fields in a case-sensitive manner
+  ([#583](https://github.com/open-telemetry/opentelemetry-python/pull/583))
+- bugfix: configuration object now accepts all valid python variable names
+  ([#583](https://github.com/open-telemetry/opentelemetry-python/pull/583))
+- bugfix: configuration undefined attributes now return None instead of raising
+  an AttributeError.
+  ([#583](https://github.com/open-telemetry/opentelemetry-python/pull/583))
+
 ## 0.6b0
 
 Released 2020-03-30
@@ -36,7 +50,7 @@ Released 2020-03-16
 - Renaming TracerSource to TraceProvider
   ([#441](https://github.com/open-telemetry/opentelemetry-python/pull/441))
 - Adding attach/detach methods as per spec
-  ([#429](https://github.com/open-telemetry/opentelemetry-python/pull/450) 
+  ([#429](https://github.com/open-telemetry/opentelemetry-python/pull/450)
 
 ## 0.4a0
 

--- a/opentelemetry-auto-instrumentation/CHANGELOG.md
+++ b/opentelemetry-auto-instrumentation/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - add support for programmatic instrumentation
   ([#579](https://github.com/open-telemetry/opentelemetry-python/pull/569))
-- bugfix: enable auto-instrumentation command to work for custom entry points (e.g. flask_run)
+- bugfix: enable auto-instrumentation command to work for custom entry points
+  (e.g. flask_run)
   ([#567](https://github.com/open-telemetry/opentelemetry-python/pull/567))
 
 

--- a/opentelemetry-auto-instrumentation/CHANGELOG.md
+++ b/opentelemetry-auto-instrumentation/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- add support for programmatic instrumentation
+  ([#579](https://github.com/open-telemetry/opentelemetry-python/pull/569))
+- bugfix: enable auto-instrumentation command to work for custom entry points (e.g. flask_run)
+  ([#567](https://github.com/open-telemetry/opentelemetry-python/pull/567))
+
+
 ## 0.6b0
 
 Released 2020-03-30

--- a/opentelemetry-auto-instrumentation/CHANGELOG.md
+++ b/opentelemetry-auto-instrumentation/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- add support for programmatic instrumentation
+- Add support for programmatic instrumentation
   ([#579](https://github.com/open-telemetry/opentelemetry-python/pull/569))
 - bugfix: enable auto-instrumentation command to work for custom entry points
   (e.g. flask_run)

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- exports api: span parents are now always spancontext
+- exporter api: span parents are now always spancontext
   ([#548](https://github.com/open-telemetry/opentelemetry-python/pull/548))
 - tracer.get_tracer now optionally accepts a TracerProvider
   ([#602](https://github.com/open-telemetry/opentelemetry-python/pull/602))

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -12,9 +12,11 @@
   ([#621](https://github.com/open-telemetry/opentelemetry-python/pull/621))
 - bugfix: a DefaultSpan now longer causes an exception when used with tracer
   ([#577](https://github.com/open-telemetry/opentelemetry-python/pull/577))
-- move last_updated_timestamp into aggregators instead of bound metric instrument
+- move last_updated_timestamp into aggregators instead of bound metric
+  instrument
   ([#522](https://github.com/open-telemetry/opentelemetry-python/pull/522))
-- bugfix: suppressing instrumentation in metrics to eliminate an infinite loop of telemetry
+- bugfix: suppressing instrumentation in metrics to eliminate an infinite loop
+  of telemetry
   ([#529](https://github.com/open-telemetry/opentelemetry-python/pull/529))
 - bugfix: freezing span attribute sequences, reducing potential user errors
   ([#529](https://github.com/open-telemetry/opentelemetry-python/pull/529))

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- exports api: span parents are now always spancontext
+  ([#548](https://github.com/open-telemetry/opentelemetry-python/pull/548))
+- tracer.get_tracer now optionally accepts a TracerProvider
+  ([#602](https://github.com/open-telemetry/opentelemetry-python/pull/602))
+- console span exporter now prints prettier, more legible messages
+  ([#505](https://github.com/open-telemetry/opentelemetry-python/pull/505))
+- bugfix: B3 propagation now retrieves parentSpanId correctly
+  ([#621](https://github.com/open-telemetry/opentelemetry-python/pull/621))
+- bugfix: a DefaultSpan now longer causes an exception when used with tracer
+  ([#577](https://github.com/open-telemetry/opentelemetry-python/pull/577))
+- move last_updated_timestamp into aggregators instead of bound metric instrument
+  ([#522](https://github.com/open-telemetry/opentelemetry-python/pull/522))
+- bugfix: suppressing instrumentation in metrics to eliminate an infinite loop of telemetry
+  ([#529](https://github.com/open-telemetry/opentelemetry-python/pull/529))
+- bugfix: freezing span attribute sequences, reducing potential user errors
+  ([#529](https://github.com/open-telemetry/opentelemetry-python/pull/529))
+
 ## 0.6b0
 
 Released 2020-03-30
@@ -32,13 +49,13 @@ Released 2020-03-16
 - Implement observer instrument
   ([#425](https://github.com/open-telemetry/opentelemetry-python/pull/425))
 
-## 0.4a0 
+## 0.4a0
 
 Released 2020-02-21
 
 - Added named Tracers
   ([#301](https://github.com/open-telemetry/opentelemetry-python/pull/301))
-- Set status for ended spans 
+- Set status for ended spans
   ([#297](https://github.com/open-telemetry/opentelemetry-python/pull/297) and
   [#358](https://github.com/open-telemetry/opentelemetry-python/pull/358))
 - Use module loggers

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
-- exporter api: span parents are now always spancontext
+- Exporter API: span parents are now always spancontext
   ([#548](https://github.com/open-telemetry/opentelemetry-python/pull/548))
 - tracer.get_tracer now optionally accepts a TracerProvider
   ([#602](https://github.com/open-telemetry/opentelemetry-python/pull/602))
-- console span exporter now prints prettier, more legible messages
+- Console span exporter now prints prettier, more legible messages
   ([#505](https://github.com/open-telemetry/opentelemetry-python/pull/505))
 - bugfix: B3 propagation now retrieves parentSpanId correctly
   ([#621](https://github.com/open-telemetry/opentelemetry-python/pull/621))


### PR DESCRIPTION
Halfway through the 0.6 to 0.7 release, a policy was added to
ensure changelogs are added to each PR as they are merged in.

Retroactively backfilling changelog entries that were missed
before the policy was enacted.