### PR TITLE
add check for event attribute values

### DIFF
--- a/ext/opentelemetry-ext-opentracing-shim/tests/test_shim.py
+++ b/ext/opentelemetry-ext-opentracing-shim/tests/test_shim.py
@@ -463,9 +463,6 @@ class TestShim(TestCase):
 
         # Verify exception details have been added to span.
         self.assertEqual(scope.span.unwrap().attributes["error"], True)
-        self.assertEqual(
-            scope.span.unwrap().events[0].attributes["error.kind"], Exception
-        )
 
     def test_inject_http_headers(self):
         """Test `inject()` method for Format.HTTP_HEADERS."""

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate span attribute types in SDK (#678)
+
 ## 0.7b1
 
 Released 2020-05-12

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -204,30 +204,25 @@ def _is_valid_attribute_value(value: types.AttributeValue) -> bool:
 
         if first_element_type not in VALID_ATTR_VALUE_TYPES:
             logger.warning(
-                "Invalid type {} in attribute value sequence. Expected one of {} or a sequence of those types".format(
-                    first_element_type.__name__,
-                    [
-                        valid_type.__name__
-                        for valid_type in VALID_ATTR_VALUE_TYPES
-                    ],
-                )
+                "Invalid type %s in attribute value sequence. Expected one of %s or a sequence of those types",
+                first_element_type.__name__,
+                [valid_type.__name__ for valid_type in VALID_ATTR_VALUE_TYPES],
             )
             return False
 
         for element in list(value)[1:]:
             if not isinstance(element, first_element_type):
                 logger.warning(
-                    "Mixed types {} and {} in attribute value sequence".format(
-                        first_element_type.__name__, type(element).__name__
-                    )
+                    "Mixed types %s and %s in attribute value sequence",
+                    first_element_type.__name__,
+                    type(element).__name__,
                 )
                 return False
     elif not isinstance(value, VALID_ATTR_VALUE_TYPES):
         logger.warning(
-            "Invalid type {} for attribute value. Expected one of {} or a sequence of those types".format(
-                type(value).__name__,
-                [valid_type.__name__ for valid_type in VALID_ATTR_VALUE_TYPES],
-            )
+            "Invalid type %s for attribute value. Expected one of %s or a sequence of those types",
+            type(value).__name__,
+            [valid_type.__name__ for valid_type in VALID_ATTR_VALUE_TYPES],
         )
         return False
     return True
@@ -427,7 +422,8 @@ class Span(trace_api.Span):
             with self._lock:
                 self.attributes[key] = value
 
-    def _filter_attribute_values(self, attributes: types.Attributes):
+    @staticmethod
+    def _filter_attribute_values(attributes: types.Attributes):
         if attributes:
             for attr_key, attr_value in list(attributes.items()):
                 if _is_valid_attribute_value(attr_value):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -192,8 +192,9 @@ class LazyEvent(EventBase):
 def _is_valid_attribute_value(value: types.AttributeValue) -> bool:
     """Checks if attribute value is valid.
 
-    An attribute value is valid if it is one of the valid types. If the value is a sequence, it is only valid
-    if all items in the sequence are of valid type, not a sequence, and are of the same type.
+    An attribute value is valid if it is one of the valid types. If the value
+    is a sequence, it is only valid if all items in the sequence are of valid
+    type, not a sequence, and are of the same type.
     """
 
     if isinstance(value, Sequence):
@@ -204,7 +205,8 @@ def _is_valid_attribute_value(value: types.AttributeValue) -> bool:
 
         if first_element_type not in VALID_ATTR_VALUE_TYPES:
             logger.warning(
-                "Invalid type %s in attribute value sequence. Expected one of %s or a sequence of those types",
+                "Invalid type %s in attribute value sequence. Expected one of "
+                "%s or a sequence of those types",
                 first_element_type.__name__,
                 [valid_type.__name__ for valid_type in VALID_ATTR_VALUE_TYPES],
             )
@@ -220,7 +222,8 @@ def _is_valid_attribute_value(value: types.AttributeValue) -> bool:
                 return False
     elif not isinstance(value, VALID_ATTR_VALUE_TYPES):
         logger.warning(
-            "Invalid type %s for attribute value. Expected one of %s or a sequence of those types",
+            "Invalid type %s for attribute value. Expected one of %s or a "
+            "sequence of those types",
             type(value).__name__,
             [valid_type.__name__ for valid_type in VALID_ATTR_VALUE_TYPES],
         )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -387,7 +387,9 @@ class Span(trace_api.Span):
     @staticmethod
     def _check_attribute_value(value: types.AttributeValue) -> Optional[str]:
         """
-        Checks if sequence items are valid and are of the same type
+        Checks if attribute value is valid.
+        An attribute value is valid if it is one of the valid types. If the value is a sequence, it is only valid
+        if all items in the sequence are of valid type, not a sequence, and are of the same type.
         """
         valid_types = (bool, str, int, float)
         if isinstance(value, Sequence):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -246,7 +246,7 @@ class Span(trace_api.Span):
         self._lock = threading.Lock()
 
         self._filter_attribute_values(attributes)
-        if attributes is None or len(attributes) == 0:
+        if not attributes:
             self.attributes = Span._empty_attributes
         else:
             self.attributes = BoundedDict.from_map(MAX_NUM_ATTRIBUTES, attributes)
@@ -446,7 +446,7 @@ class Span(trace_api.Span):
         timestamp: Optional[int] = None,
     ) -> None:
         self._filter_attribute_values(attributes)
-        if attributes is None or len(attributes) == 0:
+        if not attributes:
             attributes = Span._empty_attributes
         self._add_event(
             Event(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -397,19 +397,19 @@ class Span(trace_api.Span):
             first_element_type = type(value[0])
 
             if first_element_type not in valid_types:
-                return "Invalid type {} in attribute value sequence. Expected one of {}".format(
+                return "Invalid type {} in attribute value sequence. Expected one of {} or a sequence of those types".format(
                     first_element_type.__name__,
                     [valid_type.__name__ for valid_type in valid_types],
                 )
 
-            for element in value:
+            for element in list(value)[1:]:
                 if not isinstance(element, first_element_type):
                     return "Mixed types {} and {} in attribute value sequence".format(
                         first_element_type.__name__, type(element).__name__
                     )
             return None
         elif not isinstance(value, valid_types):
-            return "Invalid type {} for attribute value. Expected one of {}".format(
+            return "Invalid type {} for attribute value. Expected one of {} or a sequence of those types".format(
                 type(value).__name__,
                 [valid_type.__name__ for valid_type in valid_types],
             )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -188,7 +188,8 @@ class LazyEvent(EventBase):
     def attributes(self) -> types.Attributes:
         return self._event_formatter()
 
-def is_valid_attribute_value(value: types.AttributeValue) -> bool:
+
+def _is_valid_attribute_value(value: types.AttributeValue) -> bool:
     """Checks if attribute value is valid.
 
     An attribute value is valid if it is one of the valid types. If the value is a sequence, it is only valid
@@ -202,23 +203,32 @@ def is_valid_attribute_value(value: types.AttributeValue) -> bool:
         first_element_type = type(value[0])
 
         if first_element_type not in VALID_ATTR_VALUE_TYPES:
-            logger.warning("Invalid type {} in attribute value sequence. Expected one of {} or a sequence of those types".format(
-                first_element_type.__name__,
-                [valid_type.__name__ for valid_type in VALID_ATTR_VALUE_TYPES],
-            ))
+            logger.warning(
+                "Invalid type {} in attribute value sequence. Expected one of {} or a sequence of those types".format(
+                    first_element_type.__name__,
+                    [
+                        valid_type.__name__
+                        for valid_type in VALID_ATTR_VALUE_TYPES
+                    ],
+                )
+            )
             return False
 
         for element in list(value)[1:]:
             if not isinstance(element, first_element_type):
-                logger.warning("Mixed types {} and {} in attribute value sequence".format(
-                    first_element_type.__name__, type(element).__name__
-                ))
+                logger.warning(
+                    "Mixed types {} and {} in attribute value sequence".format(
+                        first_element_type.__name__, type(element).__name__
+                    )
+                )
                 return False
     elif not isinstance(value, VALID_ATTR_VALUE_TYPES):
-        logger.warning("Invalid type {} for attribute value. Expected one of {} or a sequence of those types".format(
-            type(value).__name__,
-            [valid_type.__name__ for valid_type in VALID_ATTR_VALUE_TYPES],
-        ))
+        logger.warning(
+            "Invalid type {} for attribute value. Expected one of {} or a sequence of those types".format(
+                type(value).__name__,
+                [valid_type.__name__ for valid_type in VALID_ATTR_VALUE_TYPES],
+            )
+        )
         return False
     return True
 
@@ -283,7 +293,9 @@ class Span(trace_api.Span):
         if not attributes:
             self.attributes = Span._empty_attributes
         else:
-            self.attributes = BoundedDict.from_map(MAX_NUM_ATTRIBUTES, attributes)
+            self.attributes = BoundedDict.from_map(
+                MAX_NUM_ATTRIBUTES, attributes
+            )
 
         if events is None:
             self.events = Span._empty_events
@@ -408,7 +420,7 @@ class Span(trace_api.Span):
             logger.warning("invalid key (empty or null)")
             return
 
-        if is_valid_attribute_value(value):
+        if _is_valid_attribute_value(value):
             # Freeze mutable sequences defensively
             if isinstance(value, MutableSequence):
                 value = tuple(value)
@@ -418,7 +430,7 @@ class Span(trace_api.Span):
     def _filter_attribute_values(self, attributes: types.Attributes):
         if attributes:
             for attr_key, attr_value in list(attributes.items()):
-                if is_valid_attribute_value(attr_value):
+                if _is_valid_attribute_value(attr_value):
                     if isinstance(attr_value, MutableSequence):
                         attributes[attr_key] = tuple(attr_value)
                     else:
@@ -537,7 +549,6 @@ class Span(trace_api.Span):
             and self._set_status_on_exception
             and exc_val is not None
         ):
-
             self.set_status(
                 Status(
                     canonical_code=StatusCanonicalCode.UNKNOWN,

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -487,38 +487,60 @@ class TestSpan(unittest.TestCase):
 
             self.assertEqual(len(root.attributes), 0)
 
-    def test_check_sequence_helper(self):
+    def test_check_attribute_helper(self):
         # pylint: disable=protected-access
         self.assertEqual(
-            trace.Span._check_attribute_value_sequence([1, 2, 3.4, "ss", 4]),
-            "different type",
+            trace.Span._check_attribute_value([1, 2, 3.4, "ss", 4]),
+            "different types in attribute value sequence",
         )
         self.assertEqual(
-            trace.Span._check_attribute_value_sequence([dict(), 1, 2, 3.4, 4]),
-            "invalid type",
+            trace.Span._check_attribute_value([dict(), 1, 2, 3.4, 4]),
+            "invalid type in attribute value sequence",
         )
         self.assertEqual(
-            trace.Span._check_attribute_value_sequence(
+            trace.Span._check_attribute_value(
                 ["sw", "lf", 3.4, "ss"]
             ),
-            "different type",
+            "different types in attribute value sequence",
         )
         self.assertEqual(
-            trace.Span._check_attribute_value_sequence([1, 2, 3.4, 5]),
-            "different type",
+            trace.Span._check_attribute_value([1, 2, 3.4, 5]),
+            "different types in attribute value sequence",
         )
         self.assertIsNone(
-            trace.Span._check_attribute_value_sequence([1, 2, 3, 5])
+            trace.Span._check_attribute_value([1, 2, 3, 5])
         )
         self.assertIsNone(
-            trace.Span._check_attribute_value_sequence([1.2, 2.3, 3.4, 4.5])
+            trace.Span._check_attribute_value([1.2, 2.3, 3.4, 4.5])
         )
         self.assertIsNone(
-            trace.Span._check_attribute_value_sequence([True, False])
+            trace.Span._check_attribute_value([True, False])
         )
         self.assertIsNone(
-            trace.Span._check_attribute_value_sequence(["ss", "dw", "fw"])
+            trace.Span._check_attribute_value(["ss", "dw", "fw"])
         )
+        self.assertIsNone(
+            trace.Span._check_attribute_value([])
+        )
+
+
+        self.assertEqual(
+            trace.Span._check_attribute_value(dict()),
+            "invalid type for attribute value",
+        )
+        self.assertIsNone(
+            trace.Span._check_attribute_value(True)
+        )
+        self.assertIsNone(
+            trace.Span._check_attribute_value('hi')
+        )
+        self.assertIsNone(
+            trace.Span._check_attribute_value(3.4)
+        )
+        self.assertIsNone(
+            trace.Span._check_attribute_value(15)
+        )
+
 
     def test_sampling_attributes(self):
         decision_attributes = {
@@ -561,33 +583,52 @@ class TestSpan(unittest.TestCase):
 
             # event name and attributes
             now = time_ns()
-            root.add_event("event1", {"name": "pluto"})
+            root.add_event("event1", {"name": "pluto", "some_bools": [True, False]})
 
             # event name, attributes and timestamp
             now = time_ns()
-            root.add_event("event2", {"name": "birthday"}, now)
+            root.add_event("event2", {"name": ["birthday"]}, now)
+
+            mutable_list = ["original_contents"]
+            root.add_event("event3", {"name": mutable_list})
 
             def event_formatter():
                 return {"name": "hello"}
 
             # lazy event
-            root.add_lazy_event("event3", event_formatter, now)
+            root.add_lazy_event("event4", event_formatter, now)
 
-            self.assertEqual(len(root.events), 4)
+            self.assertEqual(len(root.events), 5)
 
             self.assertEqual(root.events[0].name, "event0")
             self.assertEqual(root.events[0].attributes, {})
 
             self.assertEqual(root.events[1].name, "event1")
-            self.assertEqual(root.events[1].attributes, {"name": "pluto"})
+            self.assertEqual(root.events[1].attributes, {"name": "pluto", "some_bools": (True, False)})
 
             self.assertEqual(root.events[2].name, "event2")
-            self.assertEqual(root.events[2].attributes, {"name": "birthday"})
+            self.assertEqual(root.events[2].attributes, {"name": ("birthday",)})
             self.assertEqual(root.events[2].timestamp, now)
 
             self.assertEqual(root.events[3].name, "event3")
-            self.assertEqual(root.events[3].attributes, {"name": "hello"})
-            self.assertEqual(root.events[3].timestamp, now)
+            self.assertEqual(root.events[3].attributes, {"name": ("original_contents",)})
+            mutable_list = ["new_contents"]
+            self.assertEqual(root.events[3].attributes, {"name": ("original_contents",)})
+
+            self.assertEqual(root.events[4].name, "event4")
+            self.assertEqual(root.events[4].attributes, {"name": "hello"})
+            self.assertEqual(root.events[4].timestamp, now)
+
+    def test_invalid_event_attributes(self):
+        self.assertIsNone(self.tracer.get_current_span())
+
+        with self.tracer.start_as_current_span("root") as root:
+            root.add_event("event0", {"attr1": True, "attr2": ['hi', False]})
+            root.add_event("event0", {"attr1": dict()})
+            root.add_event("event0", {"attr1": [[True]]})
+            root.add_event("event0", {"attr1": [dict()]})
+
+            self.assertEqual(len(root.events), 0)
 
     def test_links(self):
         other_context1 = trace_api.SpanContext(
@@ -882,3 +923,4 @@ class TestSpanProcessor(unittest.TestCase):
         expected_list.append(span_event_end_fmt("SP1", "foo"))
 
         self.assertListEqual(spans_calls_list, expected_list)
+        

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -491,56 +491,38 @@ class TestSpan(unittest.TestCase):
         # pylint: disable=protected-access
         self.assertEqual(
             trace.Span._check_attribute_value([1, 2, 3.4, "ss", 4]),
-            "different types in attribute value sequence",
+            "Mixed types int and float in attribute value sequence",
         )
         self.assertEqual(
             trace.Span._check_attribute_value([dict(), 1, 2, 3.4, 4]),
-            "invalid type in attribute value sequence",
+            "Invalid type dict in attribute value sequence. Expected one of ['bool', 'str', 'int', 'float']",
         )
         self.assertEqual(
-            trace.Span._check_attribute_value(
-                ["sw", "lf", 3.4, "ss"]
-            ),
-            "different types in attribute value sequence",
+            trace.Span._check_attribute_value(["sw", "lf", 3.4, "ss"]),
+            "Mixed types str and float in attribute value sequence",
         )
         self.assertEqual(
             trace.Span._check_attribute_value([1, 2, 3.4, 5]),
-            "different types in attribute value sequence",
+            "Mixed types int and float in attribute value sequence",
         )
-        self.assertIsNone(
-            trace.Span._check_attribute_value([1, 2, 3, 5])
-        )
+        self.assertIsNone(trace.Span._check_attribute_value([1, 2, 3, 5]))
         self.assertIsNone(
             trace.Span._check_attribute_value([1.2, 2.3, 3.4, 4.5])
         )
-        self.assertIsNone(
-            trace.Span._check_attribute_value([True, False])
-        )
+        self.assertIsNone(trace.Span._check_attribute_value([True, False]))
         self.assertIsNone(
             trace.Span._check_attribute_value(["ss", "dw", "fw"])
         )
-        self.assertIsNone(
-            trace.Span._check_attribute_value([])
-        )
-
+        self.assertIsNone(trace.Span._check_attribute_value([]))
 
         self.assertEqual(
             trace.Span._check_attribute_value(dict()),
-            "invalid type for attribute value",
+            "Invalid type dict for attribute value. Expected one of ['bool', 'str', 'int', 'float']",
         )
-        self.assertIsNone(
-            trace.Span._check_attribute_value(True)
-        )
-        self.assertIsNone(
-            trace.Span._check_attribute_value('hi')
-        )
-        self.assertIsNone(
-            trace.Span._check_attribute_value(3.4)
-        )
-        self.assertIsNone(
-            trace.Span._check_attribute_value(15)
-        )
-
+        self.assertIsNone(trace.Span._check_attribute_value(True))
+        self.assertIsNone(trace.Span._check_attribute_value("hi"))
+        self.assertIsNone(trace.Span._check_attribute_value(3.4))
+        self.assertIsNone(trace.Span._check_attribute_value(15))
 
     def test_sampling_attributes(self):
         decision_attributes = {
@@ -583,7 +565,9 @@ class TestSpan(unittest.TestCase):
 
             # event name and attributes
             now = time_ns()
-            root.add_event("event1", {"name": "pluto", "some_bools": [True, False]})
+            root.add_event(
+                "event1", {"name": "pluto", "some_bools": [True, False]}
+            )
 
             # event name, attributes and timestamp
             now = time_ns()
@@ -604,16 +588,25 @@ class TestSpan(unittest.TestCase):
             self.assertEqual(root.events[0].attributes, {})
 
             self.assertEqual(root.events[1].name, "event1")
-            self.assertEqual(root.events[1].attributes, {"name": "pluto", "some_bools": (True, False)})
+            self.assertEqual(
+                root.events[1].attributes,
+                {"name": "pluto", "some_bools": (True, False)},
+            )
 
             self.assertEqual(root.events[2].name, "event2")
-            self.assertEqual(root.events[2].attributes, {"name": ("birthday",)})
+            self.assertEqual(
+                root.events[2].attributes, {"name": ("birthday",)}
+            )
             self.assertEqual(root.events[2].timestamp, now)
 
             self.assertEqual(root.events[3].name, "event3")
-            self.assertEqual(root.events[3].attributes, {"name": ("original_contents",)})
+            self.assertEqual(
+                root.events[3].attributes, {"name": ("original_contents",)}
+            )
             mutable_list = ["new_contents"]
-            self.assertEqual(root.events[3].attributes, {"name": ("original_contents",)})
+            self.assertEqual(
+                root.events[3].attributes, {"name": ("original_contents",)}
+            )
 
             self.assertEqual(root.events[4].name, "event4")
             self.assertEqual(root.events[4].attributes, {"name": "hello"})
@@ -623,7 +616,7 @@ class TestSpan(unittest.TestCase):
         self.assertIsNone(self.tracer.get_current_span())
 
         with self.tracer.start_as_current_span("root") as root:
-            root.add_event("event0", {"attr1": True, "attr2": ['hi', False]})
+            root.add_event("event0", {"attr1": True, "attr2": ["hi", False]})
             root.add_event("event0", {"attr1": dict()})
             root.add_event("event0", {"attr1": [[True]]})
             root.add_event("event0", {"attr1": [dict()]})
@@ -923,4 +916,3 @@ class TestSpanProcessor(unittest.TestCase):
         expected_list.append(span_event_end_fmt("SP1", "foo"))
 
         self.assertListEqual(spans_calls_list, expected_list)
-        

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -495,7 +495,7 @@ class TestSpan(unittest.TestCase):
         )
         self.assertEqual(
             trace.Span._check_attribute_value([dict(), 1, 2, 3.4, 4]),
-            "Invalid type dict in attribute value sequence. Expected one of ['bool', 'str', 'int', 'float']",
+            "Invalid type dict in attribute value sequence. Expected one of ['bool', 'str', 'int', 'float'] or a sequence of those types",
         )
         self.assertEqual(
             trace.Span._check_attribute_value(["sw", "lf", 3.4, "ss"]),
@@ -517,7 +517,7 @@ class TestSpan(unittest.TestCase):
 
         self.assertEqual(
             trace.Span._check_attribute_value(dict()),
-            "Invalid type dict for attribute value. Expected one of ['bool', 'str', 'int', 'float']",
+            "Invalid type dict for attribute value. Expected one of ['bool', 'str', 'int', 'float'] or a sequence of those types",
         )
         self.assertIsNone(trace.Span._check_attribute_value(True))
         self.assertIsNone(trace.Span._check_attribute_value("hi"))

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -489,40 +489,20 @@ class TestSpan(unittest.TestCase):
 
     def test_check_attribute_helper(self):
         # pylint: disable=protected-access
-        self.assertEqual(
-            trace.Span._check_attribute_value([1, 2, 3.4, "ss", 4]),
-            "Mixed types int and float in attribute value sequence",
-        )
-        self.assertEqual(
-            trace.Span._check_attribute_value([dict(), 1, 2, 3.4, 4]),
-            "Invalid type dict in attribute value sequence. Expected one of ['bool', 'str', 'int', 'float'] or a sequence of those types",
-        )
-        self.assertEqual(
-            trace.Span._check_attribute_value(["sw", "lf", 3.4, "ss"]),
-            "Mixed types str and float in attribute value sequence",
-        )
-        self.assertEqual(
-            trace.Span._check_attribute_value([1, 2, 3.4, 5]),
-            "Mixed types int and float in attribute value sequence",
-        )
-        self.assertIsNone(trace.Span._check_attribute_value([1, 2, 3, 5]))
-        self.assertIsNone(
-            trace.Span._check_attribute_value([1.2, 2.3, 3.4, 4.5])
-        )
-        self.assertIsNone(trace.Span._check_attribute_value([True, False]))
-        self.assertIsNone(
-            trace.Span._check_attribute_value(["ss", "dw", "fw"])
-        )
-        self.assertIsNone(trace.Span._check_attribute_value([]))
-
-        self.assertEqual(
-            trace.Span._check_attribute_value(dict()),
-            "Invalid type dict for attribute value. Expected one of ['bool', 'str', 'int', 'float'] or a sequence of those types",
-        )
-        self.assertIsNone(trace.Span._check_attribute_value(True))
-        self.assertIsNone(trace.Span._check_attribute_value("hi"))
-        self.assertIsNone(trace.Span._check_attribute_value(3.4))
-        self.assertIsNone(trace.Span._check_attribute_value(15))
+        self.assertFalse(trace.is_valid_attribute_value([1, 2, 3.4, "ss", 4]))
+        self.assertFalse(trace.is_valid_attribute_value([dict(), 1, 2, 3.4, 4]))
+        self.assertFalse(trace.is_valid_attribute_value(["sw", "lf", 3.4, "ss"]))
+        self.assertFalse(trace.is_valid_attribute_value([1, 2, 3.4, 5]))
+        self.assertTrue(trace.is_valid_attribute_value([1, 2, 3, 5]))
+        self.assertTrue(trace.is_valid_attribute_value([1.2, 2.3, 3.4, 4.5]))
+        self.assertTrue(trace.is_valid_attribute_value([True, False]))
+        self.assertTrue(trace.is_valid_attribute_value(["ss", "dw", "fw"]))
+        self.assertTrue(trace.is_valid_attribute_value([]))
+        self.assertFalse(trace.is_valid_attribute_value(dict()))
+        self.assertTrue(trace.is_valid_attribute_value(True))
+        self.assertTrue(trace.is_valid_attribute_value("hi"))
+        self.assertTrue(trace.is_valid_attribute_value(3.4))
+        self.assertTrue(trace.is_valid_attribute_value(15))
 
     def test_sampling_attributes(self):
         decision_attributes = {

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -489,20 +489,24 @@ class TestSpan(unittest.TestCase):
 
     def test_check_attribute_helper(self):
         # pylint: disable=protected-access
-        self.assertFalse(trace.is_valid_attribute_value([1, 2, 3.4, "ss", 4]))
-        self.assertFalse(trace.is_valid_attribute_value([dict(), 1, 2, 3.4, 4]))
-        self.assertFalse(trace.is_valid_attribute_value(["sw", "lf", 3.4, "ss"]))
-        self.assertFalse(trace.is_valid_attribute_value([1, 2, 3.4, 5]))
-        self.assertTrue(trace.is_valid_attribute_value([1, 2, 3, 5]))
-        self.assertTrue(trace.is_valid_attribute_value([1.2, 2.3, 3.4, 4.5]))
-        self.assertTrue(trace.is_valid_attribute_value([True, False]))
-        self.assertTrue(trace.is_valid_attribute_value(["ss", "dw", "fw"]))
-        self.assertTrue(trace.is_valid_attribute_value([]))
-        self.assertFalse(trace.is_valid_attribute_value(dict()))
-        self.assertTrue(trace.is_valid_attribute_value(True))
-        self.assertTrue(trace.is_valid_attribute_value("hi"))
-        self.assertTrue(trace.is_valid_attribute_value(3.4))
-        self.assertTrue(trace.is_valid_attribute_value(15))
+        self.assertFalse(trace._is_valid_attribute_value([1, 2, 3.4, "ss", 4]))
+        self.assertFalse(
+            trace._is_valid_attribute_value([dict(), 1, 2, 3.4, 4])
+        )
+        self.assertFalse(
+            trace._is_valid_attribute_value(["sw", "lf", 3.4, "ss"])
+        )
+        self.assertFalse(trace._is_valid_attribute_value([1, 2, 3.4, 5]))
+        self.assertTrue(trace._is_valid_attribute_value([1, 2, 3, 5]))
+        self.assertTrue(trace._is_valid_attribute_value([1.2, 2.3, 3.4, 4.5]))
+        self.assertTrue(trace._is_valid_attribute_value([True, False]))
+        self.assertTrue(trace._is_valid_attribute_value(["ss", "dw", "fw"]))
+        self.assertTrue(trace._is_valid_attribute_value([]))
+        self.assertFalse(trace._is_valid_attribute_value(dict()))
+        self.assertTrue(trace._is_valid_attribute_value(True))
+        self.assertTrue(trace._is_valid_attribute_value("hi"))
+        self.assertTrue(trace._is_valid_attribute_value(3.4))
+        self.assertTrue(trace._is_valid_attribute_value(15))
 
     def test_sampling_attributes(self):
         decision_attributes = {

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -619,9 +619,13 @@ class TestSpan(unittest.TestCase):
             root.add_event("event0", {"attr1": True, "attr2": ["hi", False]})
             root.add_event("event0", {"attr1": dict()})
             root.add_event("event0", {"attr1": [[True]]})
-            root.add_event("event0", {"attr1": [dict()]})
+            root.add_event("event0", {"attr1": [dict()], "attr2": [1, 2]})
 
-            self.assertEqual(len(root.events), 0)
+            self.assertEqual(len(root.events), 4)
+            self.assertEqual(root.events[0].attributes, {"attr1": True})
+            self.assertEqual(root.events[1].attributes, {})
+            self.assertEqual(root.events[2].attributes, {})
+            self.assertEqual(root.events[3].attributes, {"attr2": (1, 2)})
 
     def test_links(self):
         other_context1 = trace_api.SpanContext(


### PR DESCRIPTION
This PR addresses issue https://github.com/open-telemetry/opentelemetry-python/issues/352

Validates attribute values and events upon span creation and setting attributes on spans.

Validation logic involves checking if value is one of (int, float, str, bool, list), and if list, each element must be valid and must be all the same primitive, valid type
list values will not contain nested lists
If value is a list, grants immutable property by converting value to a tuple.