### PR TITLE
pin flake8 at 3.7.9

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 pylint==2.4.4
-flake8~=3.7
+flake8==3.7.9
 isort~=4.3
 black>=19.3b0,==19.*
 mypy==0.740


### PR DESCRIPTION
Workaround for new version of flake8 causing lint failures. We should probably figure out if these are valid failures, but this will unblock the current release.