### PR TITLE
ext/psycopg2: Implement BaseInstrumentor interface

### DIFF
--- a/ext/opentelemetry-ext-dbapi/tests/test_dbapi_integration.py
+++ b/ext/opentelemetry-ext-dbapi/tests/test_dbapi_integration.py
@@ -125,7 +125,6 @@ class TestDBApiIntegration(TestBase):
         dbapi.wrap_connect(self.tracer, mock_dbapi, "connect", "-")
         connection = mock_dbapi.connect()
         self.assertEqual(mock_dbapi.connect.call_count, 1)
-        self.assertIsInstance(connection, dbapi.TracedConnectionProxy)
         self.assertIsInstance(connection.__wrapped__, mock.Mock)
 
     @mock.patch("opentelemetry.ext.dbapi")
@@ -133,7 +132,6 @@ class TestDBApiIntegration(TestBase):
         dbapi.wrap_connect(self.tracer, mock_dbapi, "connect", "-")
         connection = mock_dbapi.connect()
         self.assertEqual(mock_dbapi.connect.call_count, 1)
-        self.assertIsInstance(connection, dbapi.TracedConnectionProxy)
 
         dbapi.unwrap_connect(mock_dbapi, "connect")
         connection = mock_dbapi.connect()
@@ -145,7 +143,6 @@ class TestDBApiIntegration(TestBase):
         # Avoid get_attributes failing because can't concatenate mock
         connection.database = "-"
         connection2 = dbapi.instrument_connection(self.tracer, connection, "-")
-        self.assertIsInstance(connection2, dbapi.TracedConnectionProxy)
         self.assertIs(connection2.__wrapped__, connection)
 
     def test_uninstrument_connection(self):
@@ -154,7 +151,6 @@ class TestDBApiIntegration(TestBase):
         # be concatenated
         connection.database = "-"
         connection2 = dbapi.instrument_connection(self.tracer, connection, "-")
-        self.assertIsInstance(connection2, dbapi.TracedConnectionProxy)
         self.assertIs(connection2.__wrapped__, connection)
 
         connection3 = dbapi.uninstrument_connection(connection2)

--- a/ext/opentelemetry-ext-docker-tests/tests/postgres/test_psycopg_functional.py
+++ b/ext/opentelemetry-ext-docker-tests/tests/postgres/test_psycopg_functional.py
@@ -18,7 +18,7 @@ import time
 import psycopg2
 
 from opentelemetry import trace as trace_api
-from opentelemetry.ext.psycopg2 import trace_integration
+from opentelemetry.ext.psycopg2 import Psycopg2Instrumentor
 from opentelemetry.test.test_base import TestBase
 
 POSTGRES_HOST = os.getenv("POSTGRESQL_HOST ", "localhost")
@@ -35,7 +35,7 @@ class TestFunctionalPsycopg(TestBase):
         cls._connection = None
         cls._cursor = None
         cls._tracer = cls.tracer_provider.get_tracer(__name__)
-        trace_integration(cls.tracer_provider)
+        Psycopg2Instrumentor().instrument(tracer_provider=cls.tracer_provider)
         cls._connection = psycopg2.connect(
             dbname=POSTGRES_DB_NAME,
             user=POSTGRES_USER,
@@ -52,6 +52,7 @@ class TestFunctionalPsycopg(TestBase):
             cls._cursor.close()
         if cls._connection:
             cls._connection.close()
+        Psycopg2Instrumentor().uninstrument()
 
     def validate_spans(self):
         spans = self.memory_exporter.get_finished_spans()

--- a/ext/opentelemetry-ext-grpc/src/opentelemetry/ext/grpc/grpcext/_interceptor.py
+++ b/ext/opentelemetry-ext-grpc/src/opentelemetry/ext/grpc/grpcext/_interceptor.py
@@ -164,6 +164,7 @@ class _InterceptorStreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
         )
 
 
+# pylint: disable=abstract-method
 class _InterceptorChannel(grpc.Channel):
     def __init__(self, channel, interceptor):
         self._channel = channel

--- a/ext/opentelemetry-ext-grpc/src/opentelemetry/ext/grpc/grpcext/_interceptor.py
+++ b/ext/opentelemetry-ext-grpc/src/opentelemetry/ext/grpc/grpcext/_interceptor.py
@@ -164,7 +164,6 @@ class _InterceptorStreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
         )
 
 
-# pylint: disable=abstract-method
 class _InterceptorChannel(grpc.Channel):
     def __init__(self, channel, interceptor):
         self._channel = channel

--- a/ext/opentelemetry-ext-psycopg2/CHANGELOG.md
+++ b/ext/opentelemetry-ext-psycopg2/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Implement instrumentor interface, enabling auto-instrumentation ([#694]https://github.com/open-telemetry/opentelemetry-python/pull/694)
+
 ## 0.4a0
 
 Released 2020-02-21

--- a/ext/opentelemetry-ext-psycopg2/setup.cfg
+++ b/ext/opentelemetry-ext-psycopg2/setup.cfg
@@ -41,8 +41,18 @@ package_dir=
 packages=find_namespace:
 install_requires =
     opentelemetry-api == 0.8.dev0
+    opentelemetry-ext-dbapi == 0.8.dev0
+    opentelemetry-auto-instrumentation == 0.8.dev0
     psycopg2-binary >= 2.7.3.1
     wrapt >= 1.0.0, < 2.0.0
 
+[options.extras_require]
+test =
+    opentelemetry-test == 0.8.dev0
+
 [options.packages.find]
 where = src
+
+[options.entry_points]
+opentelemetry_instrumentor =
+    psycopg2 = opentelemetry.ext.psycopg2:Psycopg2Instrumentor

--- a/ext/opentelemetry-ext-psycopg2/tests/test_psycopg2_integration.py
+++ b/ext/opentelemetry-ext-psycopg2/tests/test_psycopg2_integration.py
@@ -12,17 +12,105 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 from unittest import mock
 
 import psycopg2
 
-from opentelemetry.ext.psycopg2 import trace_integration
+import opentelemetry.ext.psycopg2
+from opentelemetry.ext.psycopg2 import Psycopg2Instrumentor
+from opentelemetry.sdk import resources
+from opentelemetry.test.test_base import TestBase
 
 
-class TestPostgresqlIntegration(unittest.TestCase):
-    def test_trace_integration(self):
-        with mock.patch("psycopg2.connect"):
-            trace_integration()
-            cnx = psycopg2.connect(database="test")
-            self.assertIsNotNone(cnx.cursor_factory)
+class TestPostgresqlIntegration(TestBase):
+    def tearDown(self):
+        super().tearDown()
+        with self.disable_logging():
+            Psycopg2Instrumentor().uninstrument()
+
+    @mock.patch("psycopg2.connect")
+    # pylint: disable=unused-argument
+    def test_instrumentor(self, mock_connect):
+        Psycopg2Instrumentor().instrument()
+
+        cnx = psycopg2.connect(database="test")
+
+        cursor = cnx.cursor()
+
+        query = "SELECT * FROM test"
+        cursor.execute(query)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
+        # Check version and name in span's instrumentation info
+        self.check_span_instrumentation_info(span, opentelemetry.ext.psycopg2)
+
+        # check that no spans are generated after uninstrument
+        Psycopg2Instrumentor().uninstrument()
+
+        cnx = psycopg2.connect(database="test")
+        cursor = cnx.cursor()
+        query = "SELECT * FROM test"
+        cursor.execute(query)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+
+    @mock.patch("psycopg2.connect")
+    # pylint: disable=unused-argument
+    def test_custom_tracer_provider(self, mock_connect):
+        resource = resources.Resource.create({})
+        result = self.create_tracer_provider(resource=resource)
+        tracer_provider, exporter = result
+
+        Psycopg2Instrumentor().instrument(tracer_provider=tracer_provider)
+
+        cnx = psycopg2.connect(database="test")
+        cursor = cnx.cursor()
+        query = "SELECT * FROM test"
+        cursor.execute(query)
+
+        spans_list = exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+        span = spans_list[0]
+
+        self.assertIs(span.resource, resource)
+
+    @mock.patch("psycopg2.connect")
+    # pylint: disable=unused-argument
+    def test_instrument_connection(self, mock_connect):
+        cnx = psycopg2.connect(database="test")
+        query = "SELECT * FROM test"
+        cursor = cnx.cursor()
+        cursor.execute(query)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 0)
+
+        cnx = Psycopg2Instrumentor().instrument_connection(cnx)
+        cursor = cnx.cursor()
+        cursor.execute(query)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+
+    @mock.patch("psycopg2.connect")
+    # pylint: disable=unused-argument
+    def test_uninstrument_connection(self, mock_connect):
+        Psycopg2Instrumentor().instrument()
+        cnx = psycopg2.connect(database="test")
+        query = "SELECT * FROM test"
+        cursor = cnx.cursor()
+        cursor.execute(query)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)
+
+        cnx = Psycopg2Instrumentor().uninstrument_connection(cnx)
+        cursor = cnx.cursor()
+        cursor.execute(query)
+
+        spans_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans_list), 1)

--- a/tox.ini
+++ b/tox.ini
@@ -207,8 +207,9 @@ commands_pre =
   pymongo: pip install {toxinidir}/opentelemetry-auto-instrumentation
   pymongo: pip install {toxinidir}/ext/opentelemetry-ext-pymongo[test]
 
+  psycopg2: pip install {toxinidir}/opentelemetry-auto-instrumentation
   psycopg2: pip install {toxinidir}/ext/opentelemetry-ext-dbapi
-  psycopg2: pip install {toxinidir}/ext/opentelemetry-ext-psycopg2
+  psycopg2: pip install {toxinidir}/ext/opentelemetry-ext-psycopg2[test]
 
   pymysql: pip install {toxinidir}/opentelemetry-auto-instrumentation
   pymysql: pip install {toxinidir}/ext/opentelemetry-ext-dbapi


### PR DESCRIPTION
1. Implemented BaseInstrumentor interface to enable auto-instrumentation
2. Added integration tests (same tests as other db integrations)

Since the psycopg2 connection object can't have properties added to it (for example, ```self._db_api_integration = db_api_integration``` throws an error), I instead closed these properties around the tracing wrappers.

Resolves #633 