### PR TITLE
fix: new version of grpc causes lint issues

### DIFF
--- a/ext/opentelemetry-ext-grpc/src/opentelemetry/ext/grpc/grpcext/_interceptor.py
+++ b/ext/opentelemetry-ext-grpc/src/opentelemetry/ext/grpc/grpcext/_interceptor.py
@@ -230,6 +230,14 @@ class _InterceptorChannel(grpc.Channel):
             )
         self._channel.close()
 
+    def __enter__(self):
+        """Enters the runtime context related to the channel object."""
+        raise NotImplementedError()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exits the runtime context related to the channel object."""
+        raise NotImplementedError()
+
 
 def intercept_channel(channel, *interceptors):
     result = channel


### PR DESCRIPTION
This addresses the linting problems caused by a newer version of grpc:

```
************ Module _interceptor

ext/opentelemetry-ext-grpc/src/opentelemetry/ext/grpc/grpcext/_interceptor.py:167:0: W0223: Method '__enter__' is abstract in class 'Channel' but is not overridden (abstract-method)

ext/opentelemetry-ext-grpc/src/opentelemetry/ext/grpc/grpcext/_interceptor.py:167:0: W0223: Method '__exit__' is abstract in class 'Channel' but is not overridden (abstract-method)
```