### PR TITLE
deep copy empty attributes

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -10,6 +10,8 @@
   ([#724](https://github.com/open-telemetry/opentelemetry-python/pull/724))
 - bugfix: Fix error message
   ([#729](https://github.com/open-telemetry/opentelemetry-python/pull/729))
+- deep copy empty attributes
+  ([#714](https://github.com/open-telemetry/opentelemetry-python/pull/714))
 
 ## 0.7b1
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -253,7 +253,6 @@ class Span(trace_api.Span):
     """
 
     # Initialize these lazily assuming most spans won't have them.
-    _empty_attributes = BoundedDict(MAX_NUM_ATTRIBUTES)
     _empty_events = BoundedList(MAX_NUM_EVENTS)
     _empty_links = BoundedList(MAX_NUM_LINKS)
 
@@ -289,7 +288,7 @@ class Span(trace_api.Span):
 
         self._filter_attribute_values(attributes)
         if not attributes:
-            self.attributes = Span._empty_attributes
+            self.attributes = BoundedDict(MAX_NUM_ATTRIBUTES)
         else:
             self.attributes = BoundedDict.from_map(
                 MAX_NUM_ATTRIBUTES, attributes
@@ -407,9 +406,6 @@ class Span(trace_api.Span):
             if not self.is_recording_events():
                 return
             has_ended = self.end_time is not None
-            if not has_ended:
-                if self.attributes is Span._empty_attributes:
-                    self.attributes = BoundedDict(MAX_NUM_ATTRIBUTES)
         if has_ended:
             logger.warning("Setting attribute on ended span.")
             return
@@ -458,7 +454,7 @@ class Span(trace_api.Span):
     ) -> None:
         self._filter_attribute_values(attributes)
         if not attributes:
-            attributes = Span._empty_attributes
+            attributes = BoundedDict(MAX_NUM_ATTRIBUTES)
         self._add_event(
             Event(
                 name=name,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -252,10 +252,6 @@ class Span(trace_api.Span):
             this `Span`.
     """
 
-    # Initialize these lazily assuming most spans won't have them.
-    _empty_events = BoundedList(MAX_NUM_EVENTS)
-    _empty_links = BoundedList(MAX_NUM_LINKS)
-
     def __init__(
         self,
         name: str,
@@ -295,7 +291,7 @@ class Span(trace_api.Span):
             )
 
         if events is None:
-            self.events = Span._empty_events
+            self.events = BoundedList(MAX_NUM_EVENTS)
         else:
             self.events = BoundedList(MAX_NUM_EVENTS)
             for event in events:
@@ -303,7 +299,7 @@ class Span(trace_api.Span):
                 self.events.append(event)
 
         if links is None:
-            self.links = Span._empty_links
+            self.links = BoundedList(MAX_NUM_LINKS)
         else:
             self.links = BoundedList.from_seq(MAX_NUM_LINKS, links)
 
@@ -438,9 +434,7 @@ class Span(trace_api.Span):
             if not self.is_recording_events():
                 return
             has_ended = self.end_time is not None
-            if not has_ended:
-                if self.events is Span._empty_events:
-                    self.events = BoundedList(MAX_NUM_EVENTS)
+
         if has_ended:
             logger.warning("Calling add_event() on an ended span.")
             return

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -284,22 +284,20 @@ class Span(trace_api.Span):
 
         self._filter_attribute_values(attributes)
         if not attributes:
-            self.attributes = BoundedDict(MAX_NUM_ATTRIBUTES)
+            self.attributes = self._new_attributes()
         else:
             self.attributes = BoundedDict.from_map(
                 MAX_NUM_ATTRIBUTES, attributes
             )
 
-        if events is None:
-            self.events = BoundedList(MAX_NUM_EVENTS)
-        else:
-            self.events = BoundedList(MAX_NUM_EVENTS)
+        self.events = self._new_events()
+        if events:
             for event in events:
                 self._filter_attribute_values(event.attributes)
                 self.events.append(event)
 
         if links is None:
-            self.links = BoundedList(MAX_NUM_LINKS)
+            self.links = self._new_links()
         else:
             self.links = BoundedList.from_seq(MAX_NUM_LINKS, links)
 
@@ -319,6 +317,18 @@ class Span(trace_api.Span):
         return '{}(name="{}", context={})'.format(
             type(self).__name__, self.name, self.context
         )
+
+    @staticmethod
+    def _new_attributes():
+        return BoundedDict(MAX_NUM_ATTRIBUTES)
+
+    @staticmethod
+    def _new_events():
+        return BoundedList(MAX_NUM_EVENTS)
+
+    @staticmethod
+    def _new_links():
+        return BoundedList(MAX_NUM_LINKS)
 
     @staticmethod
     def _format_context(context):
@@ -448,7 +458,7 @@ class Span(trace_api.Span):
     ) -> None:
         self._filter_attribute_values(attributes)
         if not attributes:
-            attributes = BoundedDict(MAX_NUM_ATTRIBUTES)
+            attributes = self._new_attributes()
         self._add_event(
             Event(
                 name=name,


### PR DESCRIPTION
Addresses https://github.com/open-telemetry/opentelemetry-python/issues/713. Previously it was possible for a user (acting against the api) to mutate a default variable. Deepcopying solves this issue.