### PR TITLE
feat(datadog): set sampling rate

### DIFF
--- a/ext/opentelemetry-ext-datadog/src/opentelemetry/ext/datadog/constants.py
+++ b/ext/opentelemetry-ext-datadog/src/opentelemetry/ext/datadog/constants.py
@@ -2,3 +2,5 @@ DD_ORIGIN = "_dd_origin"
 AUTO_REJECT = 0
 AUTO_KEEP = 1
 USER_KEEP = 2
+SAMPLE_RATE_METRIC_KEY = "_sample_rate"
+SAMPLING_PRIORITY_KEY = "_sampling_priority_v1"

--- a/ext/opentelemetry-ext-datadog/src/opentelemetry/ext/datadog/exporter.py
+++ b/ext/opentelemetry-ext-datadog/src/opentelemetry/ext/datadog/exporter.py
@@ -137,7 +137,7 @@ class DatadogSpanExporter(SpanExporter):
                 datadog_span.set_tag(DD_ORIGIN, origin)
 
             sampling_rate = _get_sampling_rate(span)
-            if sampling_rate:
+            if sampling_rate is not None:
                 datadog_span.set_metric(SAMPLE_RATE_METRIC_KEY, sampling_rate)
 
             # span events and span links are not supported


### PR DESCRIPTION
Set the sampling rate in the Datadog exported span if span was sampled with the `ProbabilitySampler`.