### PR TITLE
Flush metrics on exit

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/controller.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/controller.py
@@ -44,6 +44,7 @@ class PushController(threading.Thread):
 
     def shutdown(self):
         self.finished.set()
+        # Run one more collection pass to flush metrics batched in the meter
         self.tick()
         self.exporter.shutdown()
         if self._atexit_handler is not None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/controller.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/controller.py
@@ -44,6 +44,7 @@ class PushController(threading.Thread):
 
     def shutdown(self):
         self.finished.set()
+        self.tick()
         self.exporter.shutdown()
         if self._atexit_handler is not None:
             atexit.unregister(self._atexit_handler)

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -601,6 +601,10 @@ class TestController(unittest.TestCase):
         self.assertTrue(controller.finished.isSet())
         exporter.shutdown.assert_any_call()
 
+        # shutdown should flush the meter
+        meter.collect.assert_called_once()
+        exporter.export.assert_called_once()
+
     def test_push_controller_suppress_instrumentation(self):
         meter = mock.Mock()
         exporter = mock.Mock()

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -597,13 +597,14 @@ class TestController(unittest.TestCase):
         controller = PushController(meter, exporter, 5.0)
         meter.collect.assert_not_called()
         exporter.export.assert_not_called()
+
         controller.shutdown()
         self.assertTrue(controller.finished.isSet())
         exporter.shutdown.assert_any_call()
 
         # shutdown should flush the meter
-        meter.collect.assert_called_once()
-        exporter.export.assert_called_once()
+        self.assertEqual(meter.collect.call_count, 1)
+        self.assertEqual(exporter.export.call_count, 1)
 
     def test_push_controller_suppress_instrumentation(self):
         meter = mock.Mock()


### PR DESCRIPTION
For #664, in PushController before exit, flush the meter by calling `tick()`.

Metrics are batched in the `meter` and flushed each `tick()` of the PushController. The fix is to additionally call `tick()` before exiting.