### PR TITLE
Move "config" out from Meter into MeterProvider

### DIFF
--- a/docs/examples/basic_meter/basic_metrics.py
+++ b/docs/examples/basic_meter/basic_metrics.py
@@ -30,30 +30,14 @@ from opentelemetry.sdk.metrics.export.controller import PushController
 
 stateful = True
 
-
-def usage(argv):
-    print("usage:")
-    print("{} [mode]".format(argv[0]))
-    print("mode: stateful (default) or stateless")
-
-
-if len(sys.argv) >= 2:
-    batcher_mode = sys.argv[1]
-    if batcher_mode not in ("stateful", "stateless"):
-        print("bad mode specified.")
-        usage(sys.argv)
-        sys.exit(1)
-    stateful = batcher_mode == "stateful"
-
 print(
     "Starting example, values will be printed to the console every 5 seconds."
 )
 
-
 # Stateful determines whether how metrics are collected: if true, metrics
 # accumulate over the process lifetime. If false, metrics are reset at the
 # beginning of each collection interval.
-metrics.set_meter_provider(MeterProvider(batcher_mode == "stateful"))
+metrics.set_meter_provider(MeterProvider(stateful))
 # The Meter is responsible for creating and recording metrics. Each meter has a
 # unique name, which we set as the module's name here.
 meter = metrics.get_meter(__name__)

--- a/docs/examples/basic_meter/basic_metrics.py
+++ b/docs/examples/basic_meter/basic_metrics.py
@@ -50,13 +50,13 @@ print(
 )
 
 
+# Stateful determines whether how metrics are collected: if true, metrics
+# accumulate over the process lifetime. If false, metrics are reset at the
+# beginning of each collection interval.
+metrics.set_meter_provider(MeterProvider(batcher_mode == "stateful"))
 # The Meter is responsible for creating and recording metrics. Each meter has a
-# unique name, which we set as the module's name here. The second argument
-# determines whether how metrics are collected: if true, metrics accumulate
-# over the process lifetime. If false, metrics are reset at the beginning of
-# each collection interval.
-metrics.set_meter_provider(MeterProvider())
-meter = metrics.get_meter(__name__, batcher_mode == "stateful")
+# unique name, which we set as the module's name here.
+meter = metrics.get_meter(__name__)
 
 # Exporter to export metrics to the console
 exporter = ConsoleMetricsExporter()

--- a/docs/examples/basic_meter/observer.py
+++ b/docs/examples/basic_meter/observer.py
@@ -24,13 +24,10 @@ from opentelemetry.sdk.metrics.export import ConsoleMetricsExporter
 from opentelemetry.sdk.metrics.export.batcher import UngroupedBatcher
 from opentelemetry.sdk.metrics.export.controller import PushController
 
-# Configure a stateful batcher
-batcher = UngroupedBatcher(stateful=True)
 metrics.set_meter_provider(MeterProvider())
 meter = metrics.get_meter(__name__)
 exporter = ConsoleMetricsExporter()
 controller = PushController(meter=meter, exporter=exporter, interval=2)
-
 
 # Callback to gather cpu usage
 def get_cpu_usage_callback(observer):

--- a/docs/examples/basic_meter/observer.py
+++ b/docs/examples/basic_meter/observer.py
@@ -29,6 +29,7 @@ meter = metrics.get_meter(__name__)
 exporter = ConsoleMetricsExporter()
 controller = PushController(meter=meter, exporter=exporter, interval=2)
 
+
 # Callback to gather cpu usage
 def get_cpu_usage_callback(observer):
     for (number, percent) in enumerate(psutil.cpu_percent(percpu=True)):

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Move stateful from Meter to MeterProvider
+  ([#751](https://github.com/open-telemetry/opentelemetry-python/pull/751))
+
 ## 0.8b0
 
 Released 2020-05-27

--- a/opentelemetry-api/src/opentelemetry/metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/__init__.py
@@ -32,7 +32,7 @@ See the `metrics api`_ spec for terminology and context clarification.
 """
 import abc
 from logging import getLogger
-from typing import Callable, Dict, Sequence, Tuple, Type, TypeVar
+from typing import Callable, Dict, Optional, Sequence, Tuple, Type, TypeVar
 
 from opentelemetry.util import _load_provider
 
@@ -244,7 +244,6 @@ class DefaultMeterProvider(MeterProvider):
     def get_meter(
         self,
         instrumenting_module_name: str,
-        stateful: bool = True,
         instrumenting_library_version: str = "",
     ) -> "Meter":
         # pylint:disable=no-self-use,unused-argument
@@ -387,15 +386,19 @@ _METER_PROVIDER = None
 
 def get_meter(
     instrumenting_module_name: str,
-    stateful: bool = True,
     instrumenting_library_version: str = "",
+    meter_provider: Optional[MeterProvider] = None,
 ) -> "Meter":
     """Returns a `Meter` for use by the given instrumentation library.
     This function is a convenience wrapper for
     opentelemetry.metrics.get_meter_provider().get_meter
+
+    If meter_provider is ommited the current configured one is used.
     """
-    return get_meter_provider().get_meter(
-        instrumenting_module_name, stateful, instrumenting_library_version
+    if meter_provider is None:
+        meter_provider = get_meter_provider()
+    return meter_provider.get_meter(
+        instrumenting_module_name, instrumenting_library_version
     )
 
 

--- a/opentelemetry-api/src/opentelemetry/metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/__init__.py
@@ -393,7 +393,7 @@ def get_meter(
     This function is a convenience wrapper for
     opentelemetry.metrics.get_meter_provider().get_meter
 
-    If meter_provider is ommited the current configured one is used.
+    If meter_provider is omitted the current configured one is used.
     """
     if meter_provider is None:
         meter_provider = get_meter_provider()

--- a/opentelemetry-api/src/opentelemetry/metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/__init__.py
@@ -206,7 +206,6 @@ class MeterProvider(abc.ABC):
     def get_meter(
         self,
         instrumenting_module_name: str,
-        stateful: bool = True,
         instrumenting_library_version: str = "",
     ) -> "Meter":
         """Returns a `Meter` for use by the given instrumentation library.
@@ -222,12 +221,6 @@ class MeterProvider(abc.ABC):
                 instrumented but the name of the module doing the instrumentation.
                 E.g., instead of ``"requests"``, use
                 ``"opentelemetry.ext.requests"``.
-
-            stateful: True/False to indicate whether the meter will be
-                    stateful. True indicates the meter computes checkpoints
-                    from over the process lifetime. False indicates the meter
-                    computes checkpoints which describe the updates of a single
-                    collection period (deltas).
 
             instrumenting_library_version: Optional. The version string of the
                 instrumenting library.  Usually this should be the same as

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Move stateful from Meter to MeterProvider
+- Move stateful & resource from Meter to MeterProvider
   ([#751](https://github.com/open-telemetry/opentelemetry-python/pull/751))
 - Rename Measure to ValueRecorder in metrics
   ([#761](https://github.com/open-telemetry/opentelemetry-python/pull/761))

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Move stateful from Meter to MeterProvider
+  ([#751](https://github.com/open-telemetry/opentelemetry-python/pull/751))
+
 ## 0.8b0
 
 Released 2020-05-27

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -270,22 +270,21 @@ class Meter(metrics_api.Meter):
     """See `opentelemetry.metrics.Meter`.
 
     Args:
+        source: The `MeterProvider` that created this meter.
         instrumentation_info: The `InstrumentationInfo` for this meter.
-        stateful: Indicates whether the meter is stateful.
     """
 
     def __init__(
         self,
+        source: "MeterProvider",
         instrumentation_info: "InstrumentationInfo",
-        stateful: bool,
-        resource: Resource = Resource.create_empty(),
     ):
         self.instrumentation_info = instrumentation_info
+        self.batcher = UngroupedBatcher(source.stateful)
+        self.resource = source.resource
         self.metrics = set()
         self.observers = set()
-        self.batcher = UngroupedBatcher(stateful)
         self.observers_lock = threading.Lock()
-        self.resource = resource
 
     def collect(self) -> None:
         """Collects all the metrics created with this `Meter` for export.
@@ -398,21 +397,30 @@ class Meter(metrics_api.Meter):
 
 
 class MeterProvider(metrics_api.MeterProvider):
-    def __init__(self, resource: Resource = Resource.create_empty()):
+    """See `opentelemetry.metrics.MeterProvider`.
+
+    Args:
+        stateful: Indicates whether meters created are going to be stateful
+        resource: Resource for this MeterProvider
+    """
+    def __init__(
+        self,
+        stateful=True,
+        resource: Resource = Resource.create_empty()
+    ):
+        self.stateful = stateful
         self.resource = resource
 
     def get_meter(
         self,
         instrumenting_module_name: str,
-        stateful=True,
         instrumenting_library_version: str = "",
     ) -> "metrics_api.Meter":
         if not instrumenting_module_name:  # Reject empty strings too.
             raise ValueError("get_meter called with missing module name.")
         return Meter(
+            self,
             InstrumentationInfo(
                 instrumenting_module_name, instrumenting_library_version
             ),
-            stateful=stateful,
-            resource=self.resource,
         )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -405,7 +405,9 @@ class MeterProvider(metrics_api.MeterProvider):
     """
 
     def __init__(
-        self, stateful=True, resource: Resource = Resource.create_empty()
+        self,
+        stateful=True,
+        resource: Resource = Resource.create_empty(),
     ):
         self.stateful = stateful
         self.resource = resource

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -405,9 +405,7 @@ class MeterProvider(metrics_api.MeterProvider):
     """
 
     def __init__(
-        self,
-        stateful=True,
-        resource: Resource = Resource.create_empty(),
+        self, stateful=True, resource: Resource = Resource.create_empty(),
     ):
         self.stateful = stateful
         self.resource = resource

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -403,10 +403,9 @@ class MeterProvider(metrics_api.MeterProvider):
         stateful: Indicates whether meters created are going to be stateful
         resource: Resource for this MeterProvider
     """
+
     def __init__(
-        self,
-        stateful=True,
-        resource: Resource = Resource.create_empty()
+        self, stateful=True, resource: Resource = Resource.create_empty()
     ):
         self.stateful = stateful
         self.resource = resource

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -21,6 +21,11 @@ from opentelemetry.sdk.metrics import export
 
 
 class TestMeterProvider(unittest.TestCase):
+    def test_stateful(self):
+        meter_provider = metrics.MeterProvider(stateful=False)
+        meter = meter_provider.get_meter(__name__)
+        self.assertIs(meter.batcher.stateful, False)
+
     def test_resource(self):
         resource = resources.Resource.create({})
         meter_provider = metrics.MeterProvider(resource=resource)


### PR DESCRIPTION
Part of [#750]
Similar to how `Tracer` has a [reference](https://github.com/open-telemetry/opentelemetry-python/blob/master/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L590) to `TracerProvider` and [configuration](https://github.com/open-telemetry/opentelemetry-python/blob/master/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L727) are done through the `TracerProvider` and passed along to each `Tracer` created for it. Apply similar logic for `stateful` for `MeterProvider` and `Meter`. 

The purpose of this in terms of SDK design is to move a lot of the configuration to one central place (MeterProvider), instead of giving responsibility to other components. The next logical step would be to move PushController as part of the MeterProvider and have MeterProvider control the config [Dot Net](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/samples/Exporters/Console/TestPrometheus.cs#L60) is doing something like this). Another option is introduce a new "Pipeline" concept, in which we register each component to a `Pipeline` and that will be the path of logic that metrics will take. [Go](https://github.com/open-telemetry/opentelemetry-go/blob/master/example/prometheus/main.go#L35) is doing something like this. Any suggestions not related to this PR please discuss in [#750].