### PR TITLE
Rename Observer to ValueObserver

### DIFF
--- a/docs/examples/basic_meter/observer.py
+++ b/docs/examples/basic_meter/observer.py
@@ -19,7 +19,7 @@ asynchronous metrics data.
 import psutil
 
 from opentelemetry import metrics
-from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics import MeterProvider, ValueObserver
 from opentelemetry.sdk.metrics.export import ConsoleMetricsExporter
 from opentelemetry.sdk.metrics.export.batcher import UngroupedBatcher
 from opentelemetry.sdk.metrics.export.controller import PushController
@@ -45,6 +45,7 @@ meter.register_observer(
     description="per-cpu usage",
     unit="1",
     value_type=float,
+    observer_type=ValueObserver,
     label_keys=("cpu_number",),
 )
 

--- a/ext/opentelemetry-ext-opencensusexporter/src/opentelemetry/ext/opencensusexporter/metrics_exporter/__init__.py
+++ b/ext/opentelemetry-ext-opencensusexporter/src/opentelemetry/ext/opencensusexporter/metrics_exporter/__init__.py
@@ -114,10 +114,10 @@ def translate_to_collector(
             )
 
         metric_descriptor = metrics_pb2.MetricDescriptor(
-            name=metric_record.metric.name,
-            description=metric_record.metric.description,
-            unit=metric_record.metric.unit,
-            type=get_collector_metric_type(metric_record.metric),
+            name=metric_record.instrument.name,
+            description=metric_record.instrument.description,
+            unit=metric_record.instrument.unit,
+            type=get_collector_metric_type(metric_record.instrument),
             label_keys=label_keys,
         )
 
@@ -151,14 +151,14 @@ def get_collector_point(metric_record: MetricRecord) -> metrics_pb2.Point:
             metric_record.aggregator.last_update_timestamp
         )
     )
-    if metric_record.metric.value_type == int:
+    if metric_record.instrument.value_type == int:
         point.int64_value = metric_record.aggregator.checkpoint
-    elif metric_record.metric.value_type == float:
+    elif metric_record.instrument.value_type == float:
         point.double_value = metric_record.aggregator.checkpoint
     else:
         raise TypeError(
             "Unsupported metric type: {}".format(
-                metric_record.metric.value_type
+                metric_record.instrument.value_type
             )
         )
     return point

--- a/ext/opentelemetry-ext-opencensusexporter/tests/test_otcollector_metrics_exporter.py
+++ b/ext/opentelemetry-ext-opencensusexporter/tests/test_otcollector_metrics_exporter.py
@@ -92,7 +92,7 @@ class TestCollectorMetricsExporter(unittest.TestCase):
             "testName", "testDescription", "unit", float, Measure
         )
         result = metrics_exporter.get_collector_point(
-            MetricRecord(aggregator, self._key_labels, int_counter)
+            MetricRecord(int_counter, self._key_labels, aggregator)
         )
         self.assertIsInstance(result, metrics_pb2.Point)
         self.assertIsInstance(result.timestamp, Timestamp)
@@ -100,13 +100,13 @@ class TestCollectorMetricsExporter(unittest.TestCase):
         aggregator.update(123.5)
         aggregator.take_checkpoint()
         result = metrics_exporter.get_collector_point(
-            MetricRecord(aggregator, self._key_labels, float_counter)
+            MetricRecord(float_counter, self._key_labels, aggregator)
         )
         self.assertEqual(result.double_value, 123.5)
         self.assertRaises(
             TypeError,
             metrics_exporter.get_collector_point(
-                MetricRecord(aggregator, self._key_labels, measure)
+                MetricRecord(measure, self._key_labels, aggregator)
             ),
         )
 
@@ -122,7 +122,7 @@ class TestCollectorMetricsExporter(unittest.TestCase):
             "testname", "testdesc", "unit", int, Counter, ["environment"]
         )
         record = MetricRecord(
-            aggregate.CounterAggregator(), self._key_labels, test_metric
+            test_metric, self._key_labels, aggregate.CounterAggregator(),
         )
 
         result = collector_exporter.export([record])
@@ -147,7 +147,7 @@ class TestCollectorMetricsExporter(unittest.TestCase):
         aggregator = aggregate.CounterAggregator()
         aggregator.update(123)
         aggregator.take_checkpoint()
-        record = MetricRecord(aggregator, self._key_labels, test_metric)
+        record = MetricRecord(test_metric, self._key_labels, aggregator,)
         output_metrics = metrics_exporter.translate_to_collector([record])
         self.assertEqual(len(output_metrics), 1)
         self.assertIsInstance(output_metrics[0], metrics_pb2.Metric)

--- a/ext/opentelemetry-ext-prometheus/src/opentelemetry/ext/prometheus/__init__.py
+++ b/ext/opentelemetry-ext-prometheus/src/opentelemetry/ext/prometheus/__init__.py
@@ -152,22 +152,22 @@ class CustomCollector:
         metric_name = ""
         if self._prefix != "":
             metric_name = self._prefix + "_"
-        metric_name += self._sanitize(metric_record.metric.name)
+        metric_name += self._sanitize(metric_record.instrument.name)
 
-        if isinstance(metric_record.metric, Counter):
+        if isinstance(metric_record.instrument, Counter):
             prometheus_metric = CounterMetricFamily(
                 name=metric_name,
-                documentation=metric_record.metric.description,
+                documentation=metric_record.instrument.description,
                 labels=label_keys,
             )
             prometheus_metric.add_metric(
                 labels=label_values, value=metric_record.aggregator.checkpoint
             )
         # TODO: Add support for histograms when supported in OT
-        elif isinstance(metric_record.metric, ValueRecorder):
+        elif isinstance(metric_record.instrument, ValueRecorder):
             prometheus_metric = UnknownMetricFamily(
                 name=metric_name,
-                documentation=metric_record.metric.description,
+                documentation=metric_record.instrument.description,
                 labels=label_keys,
             )
             prometheus_metric.add_metric(
@@ -176,7 +176,7 @@ class CustomCollector:
 
         else:
             logger.warning(
-                "Unsupported metric type. %s", type(metric_record.metric)
+                "Unsupported metric type. %s", type(metric_record.instrument)
             )
         return prometheus_metric
 

--- a/ext/opentelemetry-ext-prometheus/tests/test_prometheus_exporter.py
+++ b/ext/opentelemetry-ext-prometheus/tests/test_prometheus_exporter.py
@@ -90,7 +90,7 @@ class TestPrometheusMetricExporter(unittest.TestCase):
         aggregator = CounterAggregator()
         aggregator.update(123)
         aggregator.take_checkpoint()
-        record = MetricRecord(metric, key_labels, aggregator, key_labels)
+        record = MetricRecord(metric, key_labels, aggregator)
         collector = CustomCollector("testprefix")
         collector.add_metrics_data([record])
 

--- a/ext/opentelemetry-ext-prometheus/tests/test_prometheus_exporter.py
+++ b/ext/opentelemetry-ext-prometheus/tests/test_prometheus_exporter.py
@@ -67,7 +67,7 @@ class TestPrometheusMetricExporter(unittest.TestCase):
     def test_export(self):
         with self._registry_register_patch:
             record = MetricRecord(
-                CounterAggregator(), self._labels_key, self._test_metric
+                self._test_metric, self._labels_key, CounterAggregator(),
             )
             exporter = PrometheusMetricsExporter()
             result = exporter.export([record])
@@ -90,7 +90,7 @@ class TestPrometheusMetricExporter(unittest.TestCase):
         aggregator = CounterAggregator()
         aggregator.update(123)
         aggregator.take_checkpoint()
-        record = MetricRecord(aggregator, key_labels, metric)
+        record = MetricRecord(metric, key_labels, aggregator, key_labels)
         collector = CustomCollector("testprefix")
         collector.add_metrics_data([record])
 
@@ -118,7 +118,7 @@ class TestPrometheusMetricExporter(unittest.TestCase):
         )
         labels = {"environment": "staging"}
         key_labels = metrics.get_labels_as_key(labels)
-        record = MetricRecord(None, key_labels, metric)
+        record = MetricRecord(metric, key_labels, None)
         collector = CustomCollector("testprefix")
         collector.add_metrics_data([record])
         collector.collect()

--- a/ext/opentelemetry-ext-system-metrics/src/opentelemetry/ext/system_metrics/__init__.py
+++ b/ext/opentelemetry-ext-system-metrics/src/opentelemetry/ext/system_metrics/__init__.py
@@ -58,6 +58,7 @@ import typing
 import psutil
 
 from opentelemetry import metrics
+from opentelemetry.sdk.metrics import ValueObserver
 from opentelemetry.sdk.metrics.export import MetricsExporter
 from opentelemetry.sdk.metrics.export.controller import PushController
 
@@ -106,6 +107,7 @@ class SystemMetrics:
             description="System memory",
             unit="bytes",
             value_type=int,
+            observer_type=ValueObserver,
         )
 
         self.meter.register_observer(
@@ -114,6 +116,7 @@ class SystemMetrics:
             description="System CPU",
             unit="seconds",
             value_type=float,
+            observer_type=ValueObserver,
         )
 
         self.meter.register_observer(
@@ -122,6 +125,7 @@ class SystemMetrics:
             description="System network bytes",
             unit="bytes",
             value_type=int,
+            observer_type=ValueObserver,
         )
 
         self.meter.register_observer(
@@ -130,6 +134,7 @@ class SystemMetrics:
             description="Runtime memory",
             unit="bytes",
             value_type=int,
+            observer_type=ValueObserver,
         )
 
         self.meter.register_observer(
@@ -138,6 +143,7 @@ class SystemMetrics:
             description="Runtime CPU",
             unit="seconds",
             value_type=float,
+            observer_type=ValueObserver,
         )
 
         self.meter.register_observer(
@@ -146,9 +152,10 @@ class SystemMetrics:
             description="Runtime: gc objects",
             unit="objects",
             value_type=int,
+            observer_type=ValueObserver,
         )
 
-    def _get_system_memory(self, observer: metrics.Observer) -> None:
+    def _get_system_memory(self, observer: metrics.ValueObserver) -> None:
         """Observer callback for memory available
 
         Args:
@@ -161,7 +168,7 @@ class SystemMetrics:
                 getattr(system_memory, metric), self._system_memory_labels
             )
 
-    def _get_system_cpu(self, observer: metrics.Observer) -> None:
+    def _get_system_cpu(self, observer: metrics.ValueObserver) -> None:
         """Observer callback for system cpu
 
         Args:
@@ -174,7 +181,7 @@ class SystemMetrics:
                 getattr(cpu_times, _type), self._system_cpu_labels
             )
 
-    def _get_network_bytes(self, observer: metrics.Observer) -> None:
+    def _get_network_bytes(self, observer: metrics.ValueObserver) -> None:
         """Observer callback for network bytes
 
         Args:
@@ -187,7 +194,7 @@ class SystemMetrics:
                 getattr(net_io, _type), self._network_bytes_labels
             )
 
-    def _get_runtime_memory(self, observer: metrics.Observer) -> None:
+    def _get_runtime_memory(self, observer: metrics.ValueObserver) -> None:
         """Observer callback for runtime memory
 
         Args:
@@ -200,7 +207,7 @@ class SystemMetrics:
                 getattr(proc_memory, _type), self._runtime_memory_labels
             )
 
-    def _get_runtime_cpu(self, observer: metrics.Observer) -> None:
+    def _get_runtime_cpu(self, observer: metrics.ValueObserver) -> None:
         """Observer callback for runtime CPU
 
         Args:
@@ -213,7 +220,7 @@ class SystemMetrics:
                 getattr(proc_cpu, _type), self._runtime_cpu_labels
             )
 
-    def _get_runtime_gc_count(self, observer: metrics.Observer) -> None:
+    def _get_runtime_gc_count(self, observer: metrics.ValueObserver) -> None:
         """Observer callback for garbage collection
 
         Args:

--- a/ext/opentelemetry-ext-system-metrics/tests/test_system_metrics.py
+++ b/ext/opentelemetry-ext-system-metrics/tests/test_system_metrics.py
@@ -54,7 +54,7 @@ class TestSystemMetrics(TestBase):
         ):
             if (
                 metric.labels in expected
-                and metric.metric.name == observer_name
+                and metric.instrument.name == observer_name
             ):
                 self.assertEqual(
                     metric.aggregator.checkpoint.last, expected[metric.labels],

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Rename Observer to ValueObserver
+  ([#751](https://github.com/open-telemetry/opentelemetry-python/pull/751))
+
 ## 0.8b0
 
 Released 2020-05-27

--- a/opentelemetry-api/src/opentelemetry/metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/__init__.py
@@ -173,7 +173,6 @@ class Observer(abc.ABC):
     """An observer type metric instrument used to capture a current set of
     values.
 
-
     Observer instruments are asynchronous, a callback is invoked with the
     observer instrument as argument allowing the user to capture multiple
     values per collection interval.
@@ -197,6 +196,18 @@ class DefaultObserver(Observer):
 
         Args:
             value: The value to capture to this observer metric.
+            labels: Labels associated to ``value``.
+        """
+
+
+class ValueObserver(Observer):
+    """No-op implementation of ``ValueObserver``."""
+
+    def observe(self, value: ValueT, labels: Dict[str, str]) -> None:
+        """Captures ``value`` to the valueobserver.
+
+        Args:
+            value: The value to capture to this valueobserver metric.
             labels: Labels associated to ``value``.
         """
 
@@ -251,7 +262,10 @@ class DefaultMeterProvider(MeterProvider):
         return DefaultMeter()
 
 
-MetricT = TypeVar("MetricT", Counter, Measure, Observer)
+MetricT = TypeVar("MetricT", Counter, Measure)
+InstrumentT = TypeVar("InstrumentT", Counter, Measure, Observer)
+# TODO: Will populate with other observers when implemented
+ObserverT = TypeVar("ObserverT", DefaultObserver, ValueObserver)
 ObserverCallbackT = Callable[[Observer], None]
 
 
@@ -302,6 +316,7 @@ class Meter(abc.ABC):
             unit: Unit of the metric values following the UCUM convention
                 (https://unitsofmeasure.org/ucum.html).
             value_type: The type of values being recorded by the metric.
+            observer_type: The type of observer being registered.
             metric_type: The type of metric being created.
             label_keys: The keys for the labels with dynamic values.
             enabled: Whether to report the metric by default.
@@ -316,6 +331,7 @@ class Meter(abc.ABC):
         description: str,
         unit: str,
         value_type: Type[ValueT],
+        observer_type: Type[ObserverT],
         label_keys: Sequence[str] = (),
         enabled: bool = True,
     ) -> "Observer":

--- a/opentelemetry-api/src/opentelemetry/metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/__init__.py
@@ -253,8 +253,7 @@ class DefaultMeterProvider(MeterProvider):
 
 MetricT = TypeVar("MetricT", Counter, ValueRecorder)
 InstrumentT = TypeVar("InstrumentT", Counter, Observer, ValueRecorder)
-# TODO: Will populate with other observers when implemented
-ObserverT = TypeVar("ObserverT", DefaultObserver, ValueObserver)
+ObserverT = TypeVar("ObserverT", bound=Observer)
 ObserverCallbackT = Callable[[Observer], None]
 
 
@@ -305,7 +304,6 @@ class Meter(abc.ABC):
             unit: Unit of the metric values following the UCUM convention
                 (https://unitsofmeasure.org/ucum.html).
             value_type: The type of values being recorded by the metric.
-            observer_type: The type of observer being registered.
             metric_type: The type of metric being created.
             label_keys: The keys for the labels with dynamic values.
             enabled: Whether to report the metric by default.
@@ -334,6 +332,7 @@ class Meter(abc.ABC):
             unit: Unit of the metric values following the UCUM convention
                 (https://unitsofmeasure.org/ucum.html).
             value_type: The type of values being recorded by the metric.
+            observer_type: The type of observer being registered.
             label_keys: The keys for the labels with dynamic values.
             enabled: Whether to report the metric by default.
         Returns: A new ``Observer`` metric instrument.

--- a/opentelemetry-api/src/opentelemetry/metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/__init__.py
@@ -389,6 +389,7 @@ class DefaultMeter(Meter):
         description: str,
         unit: str,
         value_type: Type[ValueT],
+        observer_type: Type[ObserverT],
         label_keys: Sequence[str] = (),
         enabled: bool = True,
     ) -> "Observer":

--- a/opentelemetry-api/tests/test_implementation.py
+++ b/opentelemetry-api/tests/test_implementation.py
@@ -84,7 +84,8 @@ class TestAPIOnlyImplementation(unittest.TestCase):
         meter = metrics.DefaultMeter()
         callback = mock.Mock()
         observer = meter.register_observer(
-            callback, "", "", "", int, metrics.ValueObserver)
+            callback, "", "", "", int, metrics.ValueObserver
+        )
         self.assertIsInstance(observer, metrics.DefaultObserver)
 
     def test_unregister_observer(self):

--- a/opentelemetry-api/tests/test_implementation.py
+++ b/opentelemetry-api/tests/test_implementation.py
@@ -83,7 +83,8 @@ class TestAPIOnlyImplementation(unittest.TestCase):
     def test_register_observer(self):
         meter = metrics.DefaultMeter()
         callback = mock.Mock()
-        observer = meter.register_observer(callback, "", "", "", int, (), True)
+        observer = meter.register_observer(
+            callback, "", "", "", int, metrics.ValueObserver)
         self.assertIsInstance(observer, metrics.DefaultObserver)
 
     def test_unregister_observer(self):

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Rename Observer to ValueObserver
+  ([#751](https://github.com/open-telemetry/opentelemetry-python/pull/751))
+
 ## 0.8b0
 
 Released 2020-05-27

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -393,7 +393,7 @@ class Meter(metrics_api.Meter):
             self.observers.add(ob)
         return ob
 
-    def unregister_observer(self, observer: "Observer") -> None:
+    def unregister_observer(self, observer: metrics_api.ObserverT) -> None:
         with self.observers_lock:
             self.observers.remove(observer)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -190,8 +190,8 @@ class Measure(Metric, metrics_api.Measure):
     UPDATE_FUNCTION = record
 
 
-class Observer(metrics_api.Observer):
-    """See `opentelemetry.metrics.Observer`."""
+class ValueObserver(metrics_api.ValueObserver):
+    """See `opentelemetry.metrics.ValueObserver`."""
 
     def __init__(
         self,
@@ -257,7 +257,7 @@ class Record:
 
     def __init__(
         self,
-        metric: metrics_api.MetricT,
+        instrument: metrics_api.InstrumentT,
         labels: Dict[str, str],
         aggregator: Aggregator,
     ):
@@ -375,10 +375,11 @@ class Meter(metrics_api.Meter):
         description: str,
         unit: str,
         value_type: Type[metrics_api.ValueT],
+        observer_type = Type[metrics_api.ObserverT],
         label_keys: Sequence[str] = (),
         enabled: bool = True,
-    ) -> metrics_api.Observer:
-        ob = Observer(
+    ) -> metrics_api.ObserverT:
+        ob = observer_type(
             callback,
             name,
             description,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -378,7 +378,7 @@ class Meter(metrics_api.Meter):
         observer_type=Type[metrics_api.ObserverT],
         label_keys: Sequence[str] = (),
         enabled: bool = True,
-    ) -> metrics_api.ObserverT:
+    ) -> metrics_api.Observer:
         ob = observer_type(
             callback,
             name,
@@ -393,7 +393,7 @@ class Meter(metrics_api.Meter):
             self.observers.add(ob)
         return ob
 
-    def unregister_observer(self, observer: metrics_api.ObserverT) -> None:
+    def unregister_observer(self, observer: metrics_api.Observer) -> None:
         with self.observers_lock:
             self.observers.remove(observer)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -261,7 +261,7 @@ class Record:
         labels: Dict[str, str],
         aggregator: Aggregator,
     ):
-        self.metric = metric
+        self.instrument = instrument
         self.labels = labels
         self.aggregator = aggregator
 
@@ -375,7 +375,7 @@ class Meter(metrics_api.Meter):
         description: str,
         unit: str,
         value_type: Type[metrics_api.ValueT],
-        observer_type = Type[metrics_api.ObserverT],
+        observer_type=Type[metrics_api.ObserverT],
         label_keys: Sequence[str] = (),
         enabled: bool = True,
     ) -> metrics_api.ObserverT:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
@@ -79,7 +79,7 @@ class ConsoleMetricsExporter(MetricsExporter):
             print(
                 '{}(data="{}", labels="{}", value={})'.format(
                     type(self).__name__,
-                    record.metric,
+                    record.instrument,
                     record.labels,
                     record.aggregator.checkpoint,
                 )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
@@ -27,13 +27,13 @@ class MetricsExportResult(Enum):
 class MetricRecord:
     def __init__(
         self,
-        aggregator: Aggregator,
+        instrument: metrics_api.InstrumentT,
         labels: Tuple[Tuple[str, str]],
-        metric: metrics_api.MetricT,
+        aggregator: Aggregator,
     ):
-        self.aggregator = aggregator
+        self.instrument = instrument
         self.labels = labels
-        self.metric = metric
+        self.aggregator = aggregator
 
 
 class MetricsExporter:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
@@ -125,7 +125,7 @@ class MinMaxSumCountAggregator(Aggregator):
             )
 
 
-class ObserverAggregator(Aggregator):
+class ValueObserverAggregator(Aggregator):
     """Same as MinMaxSumCount but also with last value."""
 
     _TYPE = namedtuple("minmaxsumcountlast", "min max sum count last")

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
@@ -63,8 +63,8 @@ class Batcher(abc.ABC):
         data in all of the aggregators in this batcher.
         """
         metric_records = []
-        for (metric, labels), aggregator in self._batch_map.items():
-            metric_records.append(MetricRecord(aggregator, labels, metric))
+        for (instrument, labels), aggregator in self._batch_map.items():
+            metric_records.append(MetricRecord(aggregator, labels, instrument))
         return metric_records
 
     def finished_collection(self):
@@ -90,7 +90,7 @@ class UngroupedBatcher(Batcher):
     def process(self, record):
         # Checkpoints the current aggregator value to be collected for export
         record.aggregator.take_checkpoint()
-        batch_key = (record.metric, record.labels)
+        batch_key = (record.instrument, record.labels)
         batch_value = self._batch_map.get(batch_key)
         aggregator = record.aggregator
         if batch_value:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
@@ -41,17 +41,17 @@ class Batcher(abc.ABC):
         # (deltas)
         self.stateful = stateful
 
-    def aggregator_for(self, metric_type: Type[MetricT]) -> Aggregator:
-        """Returns an aggregator based on metric type.
+    def aggregator_for(self, instrument_type: Type[InstrumentT]) -> Aggregator:
+        """Returns an aggregator based on metric instrument type.
 
         Aggregators keep track of and updates values when metrics get updated.
         """
         # pylint:disable=R0201
-        if issubclass(metric_type, Counter):
+        if issubclass(instrument_type, Counter):
             return CounterAggregator()
-        if issubclass(metric_type, Measure):
+        if issubclass(instrument_type, Measure):
             return MinMaxSumCountAggregator()
-        if issubclass(metric_type, ValueObserver):
+        if issubclass(instrument_type, ValueObserver):
             return ValueObserverAggregator()
         # TODO: Add other aggregators
         return CounterAggregator()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
@@ -15,7 +15,7 @@
 import abc
 from typing import Sequence, Type
 
-from opentelemetry.metrics import Counter, Measure, InstrumentT, ValueObserver
+from opentelemetry.metrics import Counter, InstrumentT, Measure, ValueObserver
 from opentelemetry.sdk.metrics.export import MetricRecord
 from opentelemetry.sdk.metrics.export.aggregate import (
     Aggregator,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
@@ -64,7 +64,7 @@ class Batcher(abc.ABC):
         """
         metric_records = []
         for (instrument, labels), aggregator in self._batch_map.items():
-            metric_records.append(MetricRecord(aggregator, labels, instrument))
+            metric_records.append(MetricRecord(instrument, labels, aggregator))
         return metric_records
 
     def finished_collection(self):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
@@ -101,6 +101,6 @@ class UngroupedBatcher(Batcher):
         if self.stateful:
             # if stateful batcher, create a copy of the aggregator and update
             # it with the current checkpointed value for long-term storage
-            aggregator = self.aggregator_for(record.metric.__class__)
+            aggregator = self.aggregator_for(record.instrument.__class__)
             aggregator.merge(record.aggregator)
         self._batch_map[batch_key] = aggregator

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
@@ -15,7 +15,7 @@
 import abc
 from typing import Sequence, Type
 
-from opentelemetry.metrics import Counter, Measure, MetricT, ValueObserver
+from opentelemetry.metrics import Counter, Measure, InstrumentT, ValueObserver
 from opentelemetry.sdk.metrics.export import MetricRecord
 from opentelemetry.sdk.metrics.export.aggregate import (
     Aggregator,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
@@ -18,8 +18,8 @@ from typing import Sequence, Type
 from opentelemetry.metrics import (
     Counter,
     InstrumentT,
-    ValueRecorder,
     ValueObserver,
+    ValueRecorder,
 )
 from opentelemetry.sdk.metrics.export import MetricRecord
 from opentelemetry.sdk.metrics.export.aggregate import (

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
@@ -15,7 +15,12 @@
 import abc
 from typing import Sequence, Type
 
-from opentelemetry.metrics import Counter, InstrumentT, ValueRecorder, ValueObserver
+from opentelemetry.metrics import (
+    Counter,
+    InstrumentT,
+    ValueRecorder,
+    ValueObserver,
+)
 from opentelemetry.sdk.metrics.export import MetricRecord
 from opentelemetry.sdk.metrics.export.aggregate import (
     Aggregator,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
@@ -15,13 +15,13 @@
 import abc
 from typing import Sequence, Type
 
-from opentelemetry.metrics import Counter, Measure, MetricT, Observer
+from opentelemetry.metrics import Counter, Measure, MetricT, ValueObserver
 from opentelemetry.sdk.metrics.export import MetricRecord
 from opentelemetry.sdk.metrics.export.aggregate import (
     Aggregator,
     CounterAggregator,
     MinMaxSumCountAggregator,
-    ObserverAggregator,
+    ValueObserverAggregator,
 )
 
 
@@ -51,8 +51,8 @@ class Batcher(abc.ABC):
             return CounterAggregator()
         if issubclass(metric_type, Measure):
             return MinMaxSumCountAggregator()
-        if issubclass(metric_type, Observer):
-            return ObserverAggregator()
+        if issubclass(metric_type, ValueObserver):
+            return ValueObserverAggregator()
         # TODO: Add other aggregators
         return CounterAggregator()
 

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -26,7 +26,7 @@ from opentelemetry.sdk.metrics.export import (
 from opentelemetry.sdk.metrics.export.aggregate import (
     CounterAggregator,
     MinMaxSumCountAggregator,
-    ObserverAggregator,
+    ValueObserverAggregator,
 )
 from opentelemetry.sdk.metrics.export.batcher import UngroupedBatcher
 from opentelemetry.sdk.metrics.export.controller import PushController
@@ -432,11 +432,11 @@ class TestMinMaxSumCountAggregator(unittest.TestCase):
             self.assertEqual(checkpoint_total, fut.result())
 
 
-class TestObserverAggregator(unittest.TestCase):
+class TestValueObserverAggregator(unittest.TestCase):
     @mock.patch("opentelemetry.sdk.metrics.export.aggregate.time_ns")
     def test_update(self, time_mock):
         time_mock.return_value = 123
-        observer = ObserverAggregator()
+        observer = ValueObserverAggregator()
         # test current values without any update
         self.assertEqual(observer.mmsc.current, (None, None, None, 0))
         self.assertIsNone(observer.current)
@@ -455,7 +455,7 @@ class TestObserverAggregator(unittest.TestCase):
         self.assertEqual(observer.current, values[-1])
 
     def test_checkpoint(self):
-        observer = ObserverAggregator()
+        observer = ValueObserverAggregator()
 
         # take checkpoint wihtout any update
         observer.take_checkpoint()
@@ -473,15 +473,15 @@ class TestObserverAggregator(unittest.TestCase):
         )
 
     def test_merge(self):
-        observer1 = ObserverAggregator()
-        observer2 = ObserverAggregator()
+        observer1 = ValueObserverAggregator()
+        observer2 = ValueObserverAggregator()
 
         mmsc_checkpoint1 = MinMaxSumCountAggregator._TYPE(3, 150, 101, 3)
         mmsc_checkpoint2 = MinMaxSumCountAggregator._TYPE(1, 33, 44, 2)
 
-        checkpoint1 = ObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
+        checkpoint1 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
 
-        checkpoint2 = ObserverAggregator._TYPE(*(mmsc_checkpoint2 + (27,)))
+        checkpoint2 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint2 + (27,)))
 
         observer1.mmsc.checkpoint = mmsc_checkpoint1
         observer2.mmsc.checkpoint = mmsc_checkpoint2
@@ -507,15 +507,15 @@ class TestObserverAggregator(unittest.TestCase):
         self.assertEqual(observer1.last_update_timestamp, 123)
 
     def test_merge_last_updated(self):
-        observer1 = ObserverAggregator()
-        observer2 = ObserverAggregator()
+        observer1 = ValueObserverAggregator()
+        observer2 = ValueObserverAggregator()
 
         mmsc_checkpoint1 = MinMaxSumCountAggregator._TYPE(3, 150, 101, 3)
         mmsc_checkpoint2 = MinMaxSumCountAggregator._TYPE(1, 33, 44, 2)
 
-        checkpoint1 = ObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
+        checkpoint1 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
 
-        checkpoint2 = ObserverAggregator._TYPE(*(mmsc_checkpoint2 + (27,)))
+        checkpoint2 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint2 + (27,)))
 
         observer1.mmsc.checkpoint = mmsc_checkpoint1
         observer2.mmsc.checkpoint = mmsc_checkpoint2
@@ -541,15 +541,15 @@ class TestObserverAggregator(unittest.TestCase):
         self.assertEqual(observer1.last_update_timestamp, 123)
 
     def test_merge_last_updated_none(self):
-        observer1 = ObserverAggregator()
-        observer2 = ObserverAggregator()
+        observer1 = ValueObserverAggregator()
+        observer2 = ValueObserverAggregator()
 
         mmsc_checkpoint1 = MinMaxSumCountAggregator._TYPE(3, 150, 101, 3)
         mmsc_checkpoint2 = MinMaxSumCountAggregator._TYPE(1, 33, 44, 2)
 
-        checkpoint1 = ObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
+        checkpoint1 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
 
-        checkpoint2 = ObserverAggregator._TYPE(*(mmsc_checkpoint2 + (27,)))
+        checkpoint2 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint2 + (27,)))
 
         observer1.mmsc.checkpoint = mmsc_checkpoint1
         observer2.mmsc.checkpoint = mmsc_checkpoint2
@@ -575,11 +575,11 @@ class TestObserverAggregator(unittest.TestCase):
         self.assertEqual(observer1.last_update_timestamp, 100)
 
     def test_merge_with_empty(self):
-        observer1 = ObserverAggregator()
-        observer2 = ObserverAggregator()
+        observer1 = ValueObserverAggregator()
+        observer2 = ValueObserverAggregator()
 
         mmsc_checkpoint1 = MinMaxSumCountAggregator._TYPE(3, 150, 101, 3)
-        checkpoint1 = ObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
+        checkpoint1 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
 
         observer1.mmsc.checkpoint = mmsc_checkpoint1
         observer1.checkpoint = checkpoint1

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -48,7 +48,7 @@ class TestConsoleMetricsExporter(unittest.TestCase):
         )
         labels = {"environment": "staging"}
         aggregator = CounterAggregator()
-        record = MetricRecord(aggregator, labels, metric)
+        record = MetricRecord(metric, labels, aggregator)
         result = '{}(data="{}", labels="{}", value={})'.format(
             ConsoleMetricsExporter.__name__,
             metric,

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -90,7 +90,7 @@ class TestBatcher(unittest.TestCase):
         batcher._batch_map = _batch_map
         records = batcher.checkpoint_set()
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0].metric, metric)
+        self.assertEqual(records[0].instrument, metric)
         self.assertEqual(records[0].labels, labels)
         self.assertEqual(records[0].aggregator, aggregator)
 

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -479,9 +479,13 @@ class TestValueObserverAggregator(unittest.TestCase):
         mmsc_checkpoint1 = MinMaxSumCountAggregator._TYPE(3, 150, 101, 3)
         mmsc_checkpoint2 = MinMaxSumCountAggregator._TYPE(1, 33, 44, 2)
 
-        checkpoint1 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
+        checkpoint1 = ValueObserverAggregator._TYPE(
+            *(mmsc_checkpoint1 + (23,))
+        )
 
-        checkpoint2 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint2 + (27,)))
+        checkpoint2 = ValueObserverAggregator._TYPE(
+            *(mmsc_checkpoint2 + (27,))
+        )
 
         observer1.mmsc.checkpoint = mmsc_checkpoint1
         observer2.mmsc.checkpoint = mmsc_checkpoint2
@@ -513,9 +517,13 @@ class TestValueObserverAggregator(unittest.TestCase):
         mmsc_checkpoint1 = MinMaxSumCountAggregator._TYPE(3, 150, 101, 3)
         mmsc_checkpoint2 = MinMaxSumCountAggregator._TYPE(1, 33, 44, 2)
 
-        checkpoint1 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
+        checkpoint1 = ValueObserverAggregator._TYPE(
+            *(mmsc_checkpoint1 + (23,))
+        )
 
-        checkpoint2 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint2 + (27,)))
+        checkpoint2 = ValueObserverAggregator._TYPE(
+            *(mmsc_checkpoint2 + (27,))
+        )
 
         observer1.mmsc.checkpoint = mmsc_checkpoint1
         observer2.mmsc.checkpoint = mmsc_checkpoint2
@@ -547,9 +555,13 @@ class TestValueObserverAggregator(unittest.TestCase):
         mmsc_checkpoint1 = MinMaxSumCountAggregator._TYPE(3, 150, 101, 3)
         mmsc_checkpoint2 = MinMaxSumCountAggregator._TYPE(1, 33, 44, 2)
 
-        checkpoint1 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
+        checkpoint1 = ValueObserverAggregator._TYPE(
+            *(mmsc_checkpoint1 + (23,))
+        )
 
-        checkpoint2 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint2 + (27,)))
+        checkpoint2 = ValueObserverAggregator._TYPE(
+            *(mmsc_checkpoint2 + (27,))
+        )
 
         observer1.mmsc.checkpoint = mmsc_checkpoint1
         observer2.mmsc.checkpoint = mmsc_checkpoint2
@@ -579,7 +591,9 @@ class TestValueObserverAggregator(unittest.TestCase):
         observer2 = ValueObserverAggregator()
 
         mmsc_checkpoint1 = MinMaxSumCountAggregator._TYPE(3, 150, 101, 3)
-        checkpoint1 = ValueObserverAggregator._TYPE(*(mmsc_checkpoint1 + (23,)))
+        checkpoint1 = ValueObserverAggregator._TYPE(
+            *(mmsc_checkpoint1 + (23,))
+        )
 
         observer1.mmsc.checkpoint = mmsc_checkpoint1
         observer1.checkpoint = checkpoint1

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -83,7 +83,7 @@ class TestMeter(unittest.TestCase):
             self.assertIsInstance(observer, metrics_api.Observer)
             observer.observe(45, {})
 
-        observer = metrics.Observer(
+        observer = metrics.ValueObserver(
             callback, "name", "desc", "unit", int, meter, (), True
         )
 
@@ -160,7 +160,7 @@ class TestMeter(unittest.TestCase):
         callback = mock.Mock()
 
         observer = meter.register_observer(
-            callback, "name", "desc", "unit", int, (), True
+            callback, "name", "desc", "unit", int, metrics.ValueObserver
         )
 
         self.assertIsInstance(observer, metrics_api.Observer)
@@ -180,7 +180,7 @@ class TestMeter(unittest.TestCase):
         callback = mock.Mock()
 
         observer = meter.register_observer(
-            callback, "name", "desc", "unit", int, (), True
+            callback, "name", "desc", "unit", int, metrics.ValueObserver
         )
 
         meter.unregister_observer(observer)
@@ -283,10 +283,10 @@ class TestMeasure(unittest.TestCase):
         )
 
 
-class TestObserver(unittest.TestCase):
+class TestValueObserver(unittest.TestCase):
     def test_observe(self):
         meter = metrics.MeterProvider().get_meter(__name__)
-        observer = metrics.Observer(
+        observer = metrics.ValueObserver(
             None, "name", "desc", "unit", int, meter, ("key",), True
         )
         labels = {"key": "value"}
@@ -303,7 +303,7 @@ class TestObserver(unittest.TestCase):
 
     def test_observe_disabled(self):
         meter = metrics.MeterProvider().get_meter(__name__)
-        observer = metrics.Observer(
+        observer = metrics.ValueObserver(
             None, "name", "desc", "unit", int, meter, ("key",), False
         )
         labels = {"key": "value"}
@@ -313,7 +313,7 @@ class TestObserver(unittest.TestCase):
     @mock.patch("opentelemetry.sdk.metrics.logger")
     def test_observe_incorrect_type(self, logger_mock):
         meter = metrics.MeterProvider().get_meter(__name__)
-        observer = metrics.Observer(
+        observer = metrics.ValueObserver(
             None, "name", "desc", "unit", int, meter, ("key",), True
         )
         labels = {"key": "value"}
@@ -325,7 +325,7 @@ class TestObserver(unittest.TestCase):
         meter = metrics.MeterProvider().get_meter(__name__)
 
         callback = mock.Mock()
-        observer = metrics.Observer(
+        observer = metrics.ValueObserver(
             callback, "name", "desc", "unit", int, meter, (), True
         )
 
@@ -339,7 +339,7 @@ class TestObserver(unittest.TestCase):
         callback = mock.Mock()
         callback.side_effect = Exception("We have a problem!")
 
-        observer = metrics.Observer(
+        observer = metrics.ValueObserver(
             callback, "name", "desc", "unit", int, meter, (), True
         )
 


### PR DESCRIPTION
Part of [#753].

Name change.

ValueObservers are an API element, so default implementations were made for them in the API.