### PR TITLE
Typing fixes #768, upgrade mypy to 0.770

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ pylint==2.4.4
 flake8==3.7.9
 isort~=4.3
 black>=19.3b0,==19.*
-mypy==0.740
+mypy==0.770
 sphinx~=2.1
 sphinx-rtd-theme~=0.4
 sphinx-autodoc-typehints~=1.10.2

--- a/ext/opentelemetry-ext-boto/src/opentelemetry/ext/boto/__init__.py
+++ b/ext/opentelemetry-ext-boto/src/opentelemetry/ext/boto/__init__.py
@@ -47,9 +47,9 @@ API
 import logging
 from inspect import currentframe
 
-from boto.connection import AWSAuthConnection, AWSQueryConnection
 from wrapt import ObjectProxy, wrap_function_wrapper
 
+from boto.connection import AWSAuthConnection, AWSQueryConnection
 from opentelemetry.auto_instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.ext.boto.version import __version__
 from opentelemetry.trace import SpanKind, get_tracer

--- a/ext/opentelemetry-ext-boto/src/opentelemetry/ext/boto/__init__.py
+++ b/ext/opentelemetry-ext-boto/src/opentelemetry/ext/boto/__init__.py
@@ -47,9 +47,9 @@ API
 import logging
 from inspect import currentframe
 
+from boto.connection import AWSAuthConnection, AWSQueryConnection
 from wrapt import ObjectProxy, wrap_function_wrapper
 
-from boto.connection import AWSAuthConnection, AWSQueryConnection
 from opentelemetry.auto_instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.ext.boto.version import __version__
 from opentelemetry.trace import SpanKind, get_tracer

--- a/ext/opentelemetry-ext-boto/tests/test_boto_instrumentation.py
+++ b/ext/opentelemetry-ext-boto/tests/test_boto_instrumentation.py
@@ -19,6 +19,7 @@ import boto.ec2
 import boto.elasticache
 import boto.s3
 import boto.sts
+
 from moto import (  # pylint: disable=import-error
     mock_ec2_deprecated,
     mock_lambda_deprecated,

--- a/ext/opentelemetry-ext-boto/tests/test_boto_instrumentation.py
+++ b/ext/opentelemetry-ext-boto/tests/test_boto_instrumentation.py
@@ -19,7 +19,6 @@ import boto.ec2
 import boto.elasticache
 import boto.s3
 import boto.sts
-
 from moto import (  # pylint: disable=import-error
     mock_ec2_deprecated,
     mock_lambda_deprecated,

--- a/opentelemetry-api/src/opentelemetry/configuration/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/configuration/__init__.py
@@ -95,6 +95,7 @@ from re import fullmatch
 from typing import Dict, Optional, Type, TypeVar, Union
 
 ConfigValue = Union[str, bool, int, float]
+_T = TypeVar("_T", ConfigValue, Optional[ConfigValue])
 
 
 class Configuration:
@@ -148,7 +149,7 @@ class Configuration:
         else:
             raise AttributeError(key)
 
-    def get(self, name: str, default: ConfigValue) -> ConfigValue:
+    def get(self, name: str, default: _T) -> _T:
         val = self._config_map.get(name, default)
         return val
 

--- a/opentelemetry-api/src/opentelemetry/configuration/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/configuration/__init__.py
@@ -92,7 +92,7 @@ to override this value instead of changing it.
 
 from os import environ
 from re import fullmatch
-from typing import Union, Type, Optional, Dict, TypeVar
+from typing import Dict, Optional, Type, TypeVar, Union
 
 ConfigValue = Union[str, bool, int, float]
 

--- a/opentelemetry-api/src/opentelemetry/configuration/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/configuration/__init__.py
@@ -92,15 +92,15 @@ to override this value instead of changing it.
 
 from os import environ
 from re import fullmatch
-from typing import Dict, Optional, Type, TypeVar, Union
+from typing import Dict, Optional, Type, TypeVar, Union, ClassVar
 
 ConfigValue = Union[str, bool, int, float]
 _T = TypeVar("_T", ConfigValue, Optional[ConfigValue])
 
 
 class Configuration:
-    _instance = None  # type: Optional["Configuration"]
-    _config_map = {}  # type: Dict[str, ConfigValue]
+    _instance = None  # type: ClassVar[Optional[Configuration]]
+    _config_map = {}  # type: ClassVar[Dict[str, ConfigValue]]
 
     def __new__(cls) -> "Configuration":
         if cls._instance is not None:

--- a/opentelemetry-api/src/opentelemetry/configuration/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/configuration/__init__.py
@@ -150,7 +150,7 @@ class Configuration:
             raise AttributeError(key)
 
     def get(self, name: str, default: _T) -> _T:
-        """Use this typed method for dynamic access instead of `getattr()`"""
+        """Use this typed method for dynamic access instead of `getattr`"""
         val = self._config_map.get(name, default)
         return val
 

--- a/opentelemetry-api/src/opentelemetry/configuration/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/configuration/__init__.py
@@ -150,6 +150,7 @@ class Configuration:
             raise AttributeError(key)
 
     def get(self, name: str, default: _T) -> _T:
+        """Use this typed method for dynamic access instead of `getattr()`"""
         val = self._config_map.get(name, default)
         return val
 

--- a/opentelemetry-api/src/opentelemetry/configuration/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/configuration/__init__.py
@@ -92,7 +92,7 @@ to override this value instead of changing it.
 
 from os import environ
 from re import fullmatch
-from typing import Dict, Optional, Type, TypeVar, Union, ClassVar
+from typing import ClassVar, Dict, Optional, TypeVar, Union
 
 ConfigValue = Union[str, bool, int, float]
 _T = TypeVar("_T", ConfigValue, Optional[ConfigValue])

--- a/opentelemetry-api/src/opentelemetry/configuration/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/configuration/__init__.py
@@ -99,8 +99,8 @@ _T = TypeVar("_T", ConfigValue, Optional[ConfigValue])
 
 
 class Configuration:
-    _instance: Optional["Configuration"] = None
-    _config_map: Dict[str, ConfigValue]
+    _instance = None  # type: Optional["Configuration"]
+    _config_map = {}  # type: Dict[str, ConfigValue]
 
     def __new__(cls) -> "Configuration":
         if cls._instance is not None:
@@ -108,7 +108,6 @@ class Configuration:
         else:
 
             instance = super().__new__(cls)
-            instance._config_map = {}
             for key, value_str in environ.items():
 
                 match = fullmatch(
@@ -150,7 +149,10 @@ class Configuration:
             raise AttributeError(key)
 
     def get(self, name: str, default: _T) -> _T:
-        """Use this typed method for dynamic access instead of `getattr`"""
+        """Use this typed method for dynamic access instead of `getattr`
+
+        :rtype: str or bool or int or float or None
+        """
         val = self._config_map.get(name, default)
         return val
 

--- a/opentelemetry-api/src/opentelemetry/configuration/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/configuration/__init__.py
@@ -117,7 +117,7 @@ class Configuration:
                 if match is not None:
 
                     key = match.group(1)
-                    value: ConfigValue = value_str
+                    value = value_str  # type: ConfigValue
 
                     if value_str == "True":
                         value = True

--- a/opentelemetry-api/src/opentelemetry/metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/__init__.py
@@ -34,7 +34,7 @@ import abc
 from logging import getLogger
 from typing import Callable, Dict, Sequence, Tuple, Type, TypeVar
 
-from opentelemetry.util import _load_provider
+from opentelemetry.util import _load_meter_provider
 
 logger = getLogger(__name__)
 ValueT = TypeVar("ValueT", int, float)
@@ -410,6 +410,6 @@ def get_meter_provider() -> MeterProvider:
     global _METER_PROVIDER  # pylint: disable=global-statement
 
     if _METER_PROVIDER is None:
-        _METER_PROVIDER = _load_provider("meter_provider")
+        _METER_PROVIDER = _load_meter_provider("meter_provider")
 
     return _METER_PROVIDER

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -78,7 +78,7 @@ from contextlib import contextmanager
 from logging import getLogger
 
 from opentelemetry.trace.status import Status
-from opentelemetry.util import _load_provider, types
+from opentelemetry.util import _load_trace_provider, types
 
 logger = getLogger(__name__)
 
@@ -706,6 +706,6 @@ def get_tracer_provider() -> TracerProvider:
     global _TRACER_PROVIDER  # pylint: disable=global-statement
 
     if _TRACER_PROVIDER is None:
-        _TRACER_PROVIDER = _load_provider("tracer_provider")
+        _TRACER_PROVIDER = _load_trace_provider("tracer_provider")
 
     return _TRACER_PROVIDER

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -14,11 +14,17 @@
 import re
 import time
 from logging import getLogger
-from typing import Sequence, Union
+from typing import Sequence, Union, cast, TYPE_CHECKING
 
 from pkg_resources import iter_entry_points
 
-from opentelemetry.configuration import Configuration  # type: ignore
+from opentelemetry.configuration import Configuration
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import TracerProvider
+    from opentelemetry.metrics import MeterProvider
+
+Provider = Union["TracerProvider", "MeterProvider"]
 
 logger = getLogger(__name__)
 
@@ -34,23 +40,31 @@ except AttributeError:
         return int(time.time() * 1e9)
 
 
-def _load_provider(
-    provider: str,
-) -> Union["TracerProvider", "MeterProvider"]:  # type: ignore
+def _load_provider(provider: str) -> Provider:
     try:
-        return next(  # type: ignore
+        entry_point = next(
             iter_entry_points(
                 "opentelemetry_{}".format(provider),
-                name=getattr(
-                    Configuration(),  # type: ignore
-                    provider,
-                    "default_{}".format(provider),
+                name=cast(
+                    str,
+                    Configuration().get(
+                        provider, "default_{}".format(provider),
+                    ),
                 ),
             )
-        ).load()()
+        )
+        return cast(Provider, entry_point.load()(),)
     except Exception:  # pylint: disable=broad-except
         logger.error("Failed to load configured provider %s", provider)
         raise
+
+
+def _load_meter_provider(provider: str) -> "MeterProvider":
+    return cast("MeterProvider", _load_provider(provider))
+
+
+def _load_trace_provider(provider: str) -> "TracerProvider":
+    return cast("TracerProvider", _load_provider(provider))
 
 
 # Pattern for matching up until the first '/' after the 'https://' part.

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -14,7 +14,7 @@
 import re
 import time
 from logging import getLogger
-from typing import Sequence, Union, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence, Union, cast
 
 from pkg_resources import iter_entry_points
 

--- a/opentelemetry-api/tests/configuration/test_configuration.py
+++ b/opentelemetry-api/tests/configuration/test_configuration.py
@@ -16,16 +16,16 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from opentelemetry.configuration import Configuration  # type: ignore
+from opentelemetry.configuration import Configuration
 
 
 class TestConfiguration(TestCase):
-    def tearDown(self):
+    def tearDown(self) -> None:
         # This call resets the attributes of the Configuration class so that
         # each test is executed in the same conditions.
         Configuration._reset()
 
-    def test_singleton(self):
+    def test_singleton(self) -> None:
         self.assertIsInstance(Configuration(), Configuration)
         self.assertIs(Configuration(), Configuration())
 

--- a/opentelemetry-api/tests/configuration/test_configuration.py
+++ b/opentelemetry-api/tests/configuration/test_configuration.py
@@ -39,7 +39,7 @@ class TestConfiguration(TestCase):
             "OPENTELEMETRY_PTHON_TRACEX_PROVIDER": "tracex_provider",
         },
     )
-    def test_environment_variables(self):  # type: ignore
+    def test_environment_variables(self):
         self.assertEqual(
             Configuration().METER_PROVIDER, "meter_provider"
         )  # pylint: disable=no-member
@@ -62,16 +62,21 @@ class TestConfiguration(TestCase):
         with self.assertRaises(AttributeError):
             Configuration().TRACER_PROVIDER = "new_tracer_provider"
 
-    def test_slots(self):
+    def test_slots(self) -> None:
         with self.assertRaises(AttributeError):
             Configuration().XYZ = "xyz"  # pylint: disable=assigning-non-slot
 
-    def test_getattr(self):
+    def test_getattr(self) -> None:
+        # literal access
         self.assertIsNone(Configuration().XYZ)
 
-    def test_reset(self):
+        # dynamic access
+        self.assertIsNone(getattr(Configuration(), "XYZ"))
+        self.assertIsNone(Configuration().get("XYZ", None))
+
+    def test_reset(self) -> None:
         environ_patcher = patch.dict(
-            "os.environ",  # type: ignore
+            "os.environ",
             {"OPENTELEMETRY_PYTHON_TRACER_PROVIDER": "tracer_provider"},
         )
 
@@ -96,7 +101,7 @@ class TestConfiguration(TestCase):
             "OPENTELEMETRY_PYTHON_FALSE": "False",
         },
     )
-    def test_boolean(self):
+    def test_boolean(self) -> None:
         self.assertIsInstance(
             Configuration().TRUE, bool
         )  # pylint: disable=no-member
@@ -114,7 +119,7 @@ class TestConfiguration(TestCase):
             "OPENTELEMETRY_PYTHON_NON_INTEGER": "-12z3",
         },
     )
-    def test_integer(self):
+    def test_integer(self) -> None:
         self.assertEqual(
             Configuration().POSITIVE_INTEGER, 123
         )  # pylint: disable=no-member
@@ -133,7 +138,7 @@ class TestConfiguration(TestCase):
             "OPENTELEMETRY_PYTHON_NON_FLOAT": "-12z3.123",
         },
     )
-    def test_float(self):
+    def test_float(self) -> None:
         self.assertEqual(
             Configuration().POSITIVE_FLOAT, 123.123
         )  # pylint: disable=no-member


### PR DESCRIPTION
Closes #768. Removes 8 type ignores across api.

- Removed file-wide `type: ignore` in `opentelemetry-api/src/opentelemetry/configuration/__init__.py`
  * Previously, each config from environment variables was stored directly on the class as `cls._{key}` and a property descriptor was added at `cls.{key}` to access it (read-only). I switched this to just store each value in a dict and instead allow access by overriding `__getattr__()`, which is a little simpler and easier to add typing to directly on the method declaration.
  * This preserves the same semantics and adds typing
- Instead of using `getattr()`, just call `Configuration().get()` which is typed.
- Added `_load_trace_provider()`/`_load_meter_provider()` to keep all the casting in the utils
- Added `opentelemetry-api/src/opentelemetry/__init__.pyi` (that's **`pyi`**)
  * `opentelemetry` directory is a namespace package and shouldn't have an `__init__.py`. However, mypy was seeing everything in `opentelemetry-api/src/opentelemetry/metrics/__init__.py` as if it was the package `metrics` and not `opentelemetry.metrics`.
  * [Adding `__init__.pyi` lets mypy know `opentelemetry` is a package without losing the namespace package behavior](https://github.com/python/mypy/issues/6989#issuecomment-502156258).
- Upgraded mypy 0.770

Note, tox has a bug where it doesn't detect that the requirements file was updated. To get the new mypy version, force tox to recreate its venvs: `tox --recreate`