### PR TITLE
Fix for byte type attributes crashing spans	

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -424,6 +424,8 @@ class Span(trace_api.Span):
             # Freeze mutable sequences defensively
             if isinstance(value, MutableSequence):
                 value = tuple(value)
+            if isinstance(value, bytes):
+                value = value.decode()
             with self._lock:
                 self.attributes[key] = value
 


### PR DESCRIPTION
This pull request addresses the behavior when setting byte type attributes in a span. When a byte type attribute is set, the exporter fails to convert the span to a JSON structure because the byte type is not JSON serializable, and the exporter crashes. This change decodes byte type attributes before adding them to the attributes dictionary.