### PR TITLE
Implement UpDownCounter instrument

### DIFF
--- a/opentelemetry-api/src/opentelemetry/metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/__init__.py
@@ -137,7 +137,28 @@ class Counter(Metric):
         """Increases the value of the counter by ``value``.
 
         Args:
-            value: The value to add to the counter metric.
+            value: The value to add to the counter metric. Should be positive
+                or zero. For a Counter that can decrease, use
+                `UpDownCounter`.
+            labels: Labels to associate with the bound instrument.
+        """
+
+
+class UpDownCounter(Metric):
+    """A counter type metric that expresses the computation of a sum,
+    allowing negative increments."""
+
+    def bind(self, labels: Dict[str, str]) -> "BoundCounter":
+        """Gets a `BoundCounter`."""
+        return BoundCounter()
+
+    def add(self, value: ValueT, labels: Dict[str, str]) -> None:
+        """Increases the value of the counter by ``value``.
+
+        Args:
+            value: The value to add to the counter metric. Can be positive or
+                negative. For a Counter that is never decreasing, use
+                `Counter`.
             labels: Labels to associate with the bound instrument.
         """
 
@@ -244,7 +265,9 @@ class DefaultMeterProvider(MeterProvider):
 
 
 MetricT = TypeVar("MetricT", Counter, ValueRecorder)
-InstrumentT = TypeVar("InstrumentT", Counter, Observer, ValueRecorder)
+InstrumentT = TypeVar(
+    "InstrumentT", Counter, UpDownCounter, Observer, ValueRecorder
+)
 ObserverT = TypeVar("ObserverT", bound=Observer)
 ObserverCallbackT = Callable[[Observer], None]
 

--- a/opentelemetry-api/tests/metrics/test_metrics.py
+++ b/opentelemetry-api/tests/metrics/test_metrics.py
@@ -35,6 +35,16 @@ class TestMetrics(unittest.TestCase):
         counter = metrics.Counter()
         counter.add(1, {})
 
+    def test_updowncounter(self):
+        counter = metrics.UpDownCounter()
+        bound_counter = counter.bind({})
+        self.assertIsInstance(bound_counter, metrics.BoundCounter)
+
+    def test_updowncounter_add(self):
+        counter = metrics.Counter()
+        counter.add(1, {})
+        counter.add(-1, {})
+
     def test_valuerecorder(self):
         valuerecorder = metrics.ValueRecorder()
         bound_valuerecorder = valuerecorder.bind({})

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -174,6 +174,21 @@ class Counter(Metric, metrics_api.Counter):
     UPDATE_FUNCTION = add
 
 
+class UpDownCounter(Metric, metrics_api.UpDownCounter):
+    """See `opentelemetry.metrics.UpDownCounter`.
+    """
+
+    BOUND_INSTR_TYPE = BoundCounter
+
+    def add(self, value: metrics_api.ValueT, labels: Dict[str, str]) -> None:
+        """See `opentelemetry.metrics.UpDownCounter.add`."""
+        bound_intrument = self.bind(labels)
+        bound_intrument.add(value)
+        bound_intrument.release()
+
+    UPDATE_FUNCTION = add
+
+
 class ValueRecorder(Metric, metrics_api.ValueRecorder):
     """See `opentelemetry.metrics.ValueRecorder`."""
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
@@ -18,6 +18,7 @@ from typing import Sequence, Type
 from opentelemetry.metrics import (
     Counter,
     InstrumentT,
+    UpDownCounter,
     ValueObserver,
     ValueRecorder,
 )
@@ -52,7 +53,7 @@ class Batcher(abc.ABC):
         Aggregators keep track of and updates values when metrics get updated.
         """
         # pylint:disable=R0201
-        if issubclass(instrument_type, Counter):
+        if issubclass(instrument_type, (Counter, UpDownCounter)):
             return CounterAggregator()
         if issubclass(instrument_type, ValueRecorder):
             return MinMaxSumCountAggregator()

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -69,6 +69,15 @@ class TestBatcher(unittest.TestCase):
             )
         )
 
+    def test_aggregator_for_updowncounter(self):
+        batcher = UngroupedBatcher(True)
+        self.assertTrue(
+            isinstance(
+                batcher.aggregator_for(metrics.UpDownCounter),
+                CounterAggregator,
+            )
+        )
+
     # TODO: Add other aggregator tests
 
     def test_checkpoint_set(self):

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -150,6 +150,15 @@ class TestMeter(unittest.TestCase):
         self.assertEqual(counter.name, "name")
         self.assertIs(counter.meter.resource, resource)
 
+    def test_create_updowncounter(self):
+        meter = metrics.MeterProvider().get_meter(__name__)
+        updowncounter = meter.create_metric(
+            "name", "desc", "unit", float, metrics.UpDownCounter, ()
+        )
+        self.assertIsInstance(updowncounter, metrics.UpDownCounter)
+        self.assertEqual(updowncounter.value_type, float)
+        self.assertEqual(updowncounter.name, "name")
+
     def test_create_valuerecorder(self):
         meter = metrics.MeterProvider().get_meter(__name__)
         valuerecorder = meter.create_metric(
@@ -271,6 +280,24 @@ class TestCounter(unittest.TestCase):
         metric.add(3, labels)
         metric.add(2, labels)
         self.assertEqual(bound_counter.aggregator.current, 5)
+
+
+class TestUpDownCounter(unittest.TestCase):
+    def test_add(self):
+        meter = metrics.MeterProvider().get_meter(__name__)
+        metric = metrics.UpDownCounter(
+            "name", "desc", "unit", int, meter, ("key",)
+        )
+        labels = {"key": "value"}
+        bound_counter = metric.bind(labels)
+        metric.add(3, labels)
+        metric.add(2, labels)
+        self.assertEqual(bound_counter.aggregator.current, 5)
+
+        metric.add(0, labels)
+        metric.add(-3, labels)
+        metric.add(-1, labels)
+        self.assertEqual(bound_counter.aggregator.current, 1)
 
 
 class TestValueRecorder(unittest.TestCase):


### PR DESCRIPTION
Closes #754. Very similar to `Counter`, I just copied the classes and renamed.

Things that could be implemented differently:
- `UpDownCounter` could subclass `Counter`, but I think that is a confusing way to do it.
- Instead of using `BoundCounter`, I could copy it to a new class `BoundUpDownCounter`.
- Instead of using `CounterAggregator`, I could create a `UpDownCounterAggregator`. I think it would make more sense to rename `CounterAggregator` -> `SumAggregator` and use it in both. Then `SumAggregator` can be used in the views API.

Let me know what you think!