### PR TITLE
Add unique identifier to Cloud Monitoring exporter

### DIFF
--- a/docs/examples/cloud_monitoring/README.rst
+++ b/docs/examples/cloud_monitoring/README.rst
@@ -42,7 +42,7 @@ Troubleshooting
 
 Currently, Cloud Monitoring allows one write every 10 seconds for any unique tuple (metric_name, metric_label_value_1, metric_label_value_2, ...). The exporter should rate limit on its own but issues arise if:
 
-    * You are restarting the server more then once every 10 seconds.
+    * You are restarting the server more than once every 10 seconds.
     * You have a multiple exporters (possibly on different threads) writing to the same tuple.
 
-For both cases, you can pass ``add_unique_identifier=True`` to the CloudMonitoringMetricsExporter constructor. This adds a UUID label_value, making the tuple unique again. For the first case, you can also choose to just wait longer then 10 seconds between restarts.
+For both cases, you can pass ``add_unique_identifier=True`` to the CloudMonitoringMetricsExporter constructor. This adds a UUID label_value, making the tuple unique again. For the first case, you can also choose to just wait longer than 10 seconds between restarts.

--- a/docs/examples/cloud_monitoring/README.rst
+++ b/docs/examples/cloud_monitoring/README.rst
@@ -33,3 +33,14 @@ After running the example:
     * Go to the `Cloud Monitoring Metrics Explorer page <https://console.cloud.google.com/monitoring/metrics-explorer>`_.
     * In "Find resource type and metric" enter "OpenTelemetry/request_counter".
     * You can filter by labels and change the graphical output here as well.
+
+Troubleshooting
+--------------------------
+
+``One or more points were written more frequently than the maximum sampling period configured for the metric``
+##############################################################################################################
+
+Currently, Cloud Monitoring allows one write per second for any unique tuple (metric_name, metric_label_value_1, metric_label_value_2, ...). The exporter should rate limit on its own but issues arise if:
+
+    * You are restarting the server more then once every 10 seconds. Either wait longer or ignore the errors.
+    * You have a multiple exporters (possibly on different threads) writing to the same tuple. You need to add ``add_unique_identifier=True`` to the CloudMonitoringMetricsExporter constructor. This adds a UUID label_value, making the tuple unique again.

--- a/docs/examples/cloud_monitoring/README.rst
+++ b/docs/examples/cloud_monitoring/README.rst
@@ -40,7 +40,9 @@ Troubleshooting
 ``One or more points were written more frequently than the maximum sampling period configured for the metric``
 ##############################################################################################################
 
-Currently, Cloud Monitoring allows one write per second for any unique tuple (metric_name, metric_label_value_1, metric_label_value_2, ...). The exporter should rate limit on its own but issues arise if:
+Currently, Cloud Monitoring allows one write every 10 seconds for any unique tuple (metric_name, metric_label_value_1, metric_label_value_2, ...). The exporter should rate limit on its own but issues arise if:
 
-    * You are restarting the server more then once every 10 seconds. Either wait longer or ignore the errors.
-    * You have a multiple exporters (possibly on different threads) writing to the same tuple. You need to add ``add_unique_identifier=True`` to the CloudMonitoringMetricsExporter constructor. This adds a UUID label_value, making the tuple unique again.
+    * You are restarting the server more then once every 10 seconds.
+    * You have a multiple exporters (possibly on different threads) writing to the same tuple.
+
+For both cases, you can pass ``add_unique_identifier=True`` to the CloudMonitoringMetricsExporter constructor. This adds a UUID label_value, making the tuple unique again. For the first case, you can also choose to just wait longer then 10 seconds between restarts.

--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -6,7 +6,6 @@ from google.api.label_pb2 import LabelDescriptor
 from google.api.metric_pb2 import MetricDescriptor
 from google.cloud.monitoring_v3 import MetricServiceClient
 from google.cloud.monitoring_v3.proto.metric_pb2 import TimeSeries
-
 from opentelemetry.sdk.metrics.export import (
     MetricRecord,
     MetricsExporter,
@@ -24,7 +23,20 @@ WRITE_INTERVAL = 10
 class CloudMonitoringMetricsExporter(MetricsExporter):
     """ Implementation of Metrics Exporter to Google Cloud Monitoring"""
 
-    def __init__(self, project_id=None, client=None):
+    def __init__(
+        self, project_id=None, client=None, add_unique_identifier=False
+    ):
+        """ You can manually pass in project_id and client, or else the
+        Exporter will take that informations from Application Default
+        Credentials.
+
+        :param project_id: project id of your Google Cloud project
+        :param client: Client to upload metrics to Google Cloud Monitoring
+        :param add_unique_identifier: Add an identifier to each exporter metric.
+        This must be used when there exist two (or more) exporters that may 
+        export to the same metric name within WRITE_INTERVAL seconds of each
+        other
+        """
         self.client = client or MetricServiceClient()
         if not project_id:
             _, self.project_id = google.auth.default()

--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -33,10 +33,10 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
     Args:
         project_id: project id of your Google Cloud project.
         client: Client to upload metrics to Google Cloud Monitoring.
-        add_unique_identifier: Add an identifier to each exporter metric.
-        This must be used when there exist two (or more) exporters that may
-        export to the same metric name within WRITE_INTERVAL seconds of each
-        other.
+        add_unique_identifier: Add an identifier to each exporter metric. This
+            must be used when there exist two (or more) exporters that may
+            export to the same metric name within WRITE_INTERVAL seconds of
+            each other.
     """
 
     def __init__(

--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -32,12 +32,12 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
         Exporter will take that information from Application Default
         Credentials.
 
-        :param project_id: project id of your Google Cloud project
-        :param client: Client to upload metrics to Google Cloud Monitoring
+        :param project_id: project id of your Google Cloud project.
+        :param client: Client to upload metrics to Google Cloud Monitoring.
         :param add_unique_identifier: Add an identifier to each exporter metric.
         This must be used when there exist two (or more) exporters that may
         export to the same metric name within WRITE_INTERVAL seconds of each
-        other
+        other.
         """
         self.client = client or MetricServiceClient()
         if not project_id:

--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -18,6 +18,7 @@ from opentelemetry.sdk.metrics.export.aggregate import SumAggregator
 logger = logging.getLogger(__name__)
 MAX_BATCH_WRITE = 200
 WRITE_INTERVAL = 10
+UNIQUE_IDENTIFIER_KEY = "opentelemetry_id"
 
 
 # pylint is unable to resolve members of protobuf objects
@@ -121,7 +122,7 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
 
         if self.unique_identifier:
             descriptor["labels"].append(
-                LabelDescriptor(key="opentelemetry_id", value_type="STRING")
+                LabelDescriptor(key=UNIQUE_IDENTIFIER_KEY, value_type="STRING")
             )
 
         if isinstance(record.aggregator, SumAggregator):
@@ -170,7 +171,7 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
 
             if self.unique_identifier:
                 series.metric.labels[
-                    "opentelemetry_id"
+                    UNIQUE_IDENTIFIER_KEY
                 ] = self.unique_identifier
 
             point = series.points.add()

--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -7,6 +7,7 @@ from google.api.label_pb2 import LabelDescriptor
 from google.api.metric_pb2 import MetricDescriptor
 from google.cloud.monitoring_v3 import MetricServiceClient
 from google.cloud.monitoring_v3.proto.metric_pb2 import TimeSeries
+
 from opentelemetry.sdk.metrics.export import (
     MetricRecord,
     MetricsExporter,
@@ -113,6 +114,12 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
                 logger.warning(
                     "Label value %s is not a string, bool or integer", value
                 )
+
+        if self.unique_identifier:
+            descriptor["labels"].append(
+                LabelDescriptor(key="opentelemetry_uuid", value_type="STRING")
+            )
+
         if isinstance(record.aggregator, SumAggregator):
             descriptor["metric_kind"] = MetricDescriptor.MetricKind.GAUGE
         else:

--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -29,7 +29,7 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
         self, project_id=None, client=None, add_unique_identifier=False
     ):
         """ You can manually pass in project_id and client, or else the
-        Exporter will take that informations from Application Default
+        Exporter will take that information from Application Default
         Credentials.
 
         :param project_id: project id of your Google Cloud project

--- a/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
@@ -21,6 +21,7 @@ from google.cloud.monitoring_v3.proto.metric_pb2 import TimeSeries
 
 from opentelemetry.exporter.cloud_monitoring import (
     MAX_BATCH_WRITE,
+    UNIQUE_IDENTIFIER_KEY,
     WRITE_INTERVAL,
     CloudMonitoringMetricsExporter,
 )
@@ -313,7 +314,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                 "description": "description",
                 "labels": [
                     LabelDescriptor(
-                        key="opentelemetry_id", value_type="STRING"
+                        key=UNIQUE_IDENTIFIER_KEY, value_type="STRING"
                     ),
                 ],
                 "metric_kind": "GAUGE",
@@ -331,11 +332,13 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
             first_call,
             second_call,
         ) = client.create_metric_descriptor.call_args_list
-        self.assertEqual(first_call[0][1].labels[0].key, "opentelemetry_id")
-        self.assertEqual(second_call[0][1].labels[0].key, "opentelemetry_id")
+        self.assertEqual(first_call[0][1].labels[0].key, UNIQUE_IDENTIFIER_KEY)
+        self.assertEqual(
+            second_call[0][1].labels[0].key, UNIQUE_IDENTIFIER_KEY
+        )
 
         first_call, second_call = client.create_time_series.call_args_list
         self.assertNotEqual(
-            first_call[0][1][0].metric.labels["opentelemetry_id"],
-            second_call[0][1][0].metric.labels["opentelemetry_id"],
+            first_call[0][1][0].metric.labels[UNIQUE_IDENTIFIER_KEY],
+            second_call[0][1][0].metric.labels[UNIQUE_IDENTIFIER_KEY],
         )

--- a/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
@@ -311,7 +311,11 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                 "type": "custom.googleapis.com/OpenTelemetry/name",
                 "display_name": "name",
                 "description": "description",
-                "labels": [],
+                "labels": [
+                    LabelDescriptor(
+                        key="opentelemetry_uuid", value_type="STRING"
+                    ),
+                ],
                 "metric_kind": "GAUGE",
                 "value_type": "DOUBLE",
             }
@@ -322,6 +326,13 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         metric_record = MetricRecord(MockMetric(), (), sum_agg_one,)
         exporter1.export([metric_record])
         exporter2.export([metric_record])
+
+        (
+            first_call,
+            second_call,
+        ) = client.create_metric_descriptor.call_args_list
+        self.assertEqual(first_call[0][1].labels[0].key, "opentelemetry_uuid")
+        self.assertEqual(second_call[0][1].labels[0].key, "opentelemetry_uuid")
 
         first_call, second_call = client.create_time_series.call_args_list
         self.assertNotEqual(

--- a/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
@@ -318,8 +318,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         )
 
         sum_agg_one = SumAggregator()
-        sum_agg_one.checkpoint = 1
-        sum_agg_one.last_update_timestamp = (WRITE_INTERVAL + 1) * 1e9
+        sum_agg_one.update(1)
         metric_record = MetricRecord(MockMetric(), (), sum_agg_one,)
         exporter1.export([metric_record])
         exporter2.export([metric_record])

--- a/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
@@ -313,7 +313,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
                 "description": "description",
                 "labels": [
                     LabelDescriptor(
-                        key="opentelemetry_uuid", value_type="STRING"
+                        key="opentelemetry_id", value_type="STRING"
                     ),
                 ],
                 "metric_kind": "GAUGE",
@@ -331,11 +331,11 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
             first_call,
             second_call,
         ) = client.create_metric_descriptor.call_args_list
-        self.assertEqual(first_call[0][1].labels[0].key, "opentelemetry_uuid")
-        self.assertEqual(second_call[0][1].labels[0].key, "opentelemetry_uuid")
+        self.assertEqual(first_call[0][1].labels[0].key, "opentelemetry_id")
+        self.assertEqual(second_call[0][1].labels[0].key, "opentelemetry_id")
 
         first_call, second_call = client.create_time_series.call_args_list
         self.assertNotEqual(
-            first_call[0][1][0].metric.labels["opentelemetry_uuid"],
-            second_call[0][1][0].metric.labels["opentelemetry_uuid"],
+            first_call[0][1][0].metric.labels["opentelemetry_id"],
+            second_call[0][1][0].metric.labels["opentelemetry_id"],
         )


### PR DESCRIPTION
Cloud Monitoring allows one update every 10 seconds for a unique tuple (metric_name, metric_label_value_1, metric_label_value_2 ...). To respect this, the exporter has an in memory map of when it last exported each tuple. There are two ways this can be broken.

1. A user restarts the server more then once every 10 seconds. The in memory map will be deleted between restarts.
2. A user has a multithreaded server or multiple servers.

For both cases, a fix has been suggested in the troubleshooting docs. For the second, the ability to add a unique identifier as a label_value has been added. Thanks to @cnnradams for bringing up this issue :)