### PR TITLE
add changelog for cloud exporters

### DIFF
--- a/ext/opentelemetry-exporter-cloud-monitoring/CHANGELOG.md
+++ b/ext/opentelemetry-exporter-cloud-monitoring/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## 0.10b0
-
-Released 2020-06-23
-
 - Add ability for exporter to add unique identifier 
   ([#841](https://github.com/open-telemetry/opentelemetry-python/pull/841))
 - Added tests to tox coverage files

--- a/ext/opentelemetry-exporter-cloud-monitoring/CHANGELOG.md
+++ b/ext/opentelemetry-exporter-cloud-monitoring/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## Unreleased
+
+## 0.10b0
+
+Released 2020-06-23
+
+- Add ability for exporter to add unique identifier 
+  ([#841](https://github.com/open-telemetry/opentelemetry-python/pull/841))
+- Added tests to tox coverage files
+  ([#804](https://github.com/open-telemetry/opentelemetry-python/pull/804))
+
+## 0.9b0
+
+Released 2020-06-10
+
+- Initial release

--- a/ext/opentelemetry-exporter-cloud-trace/CHANGELOG.md
+++ b/ext/opentelemetry-exporter-cloud-trace/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## Unreleased
+
+## 0.10b0
+
+Released 2020-06-23
+
+- Add g.co/agent label for Google internal metrics tracking
+  ([#833](https://github.com/open-telemetry/opentelemetry-python/pull/833))
+- Adding trouble-shooting tips
+  ([#827](https://github.com/open-telemetry/opentelemetry-python/pull/827))
+- Added Cloud Trace context propagation
+  ([#819](https://github.com/open-telemetry/opentelemetry-python/pull/819))
+- Added tests to tox coverage files
+  ([#804](https://github.com/open-telemetry/opentelemetry-python/pull/804))
+
+## 0.9b0
+
+Released 2020-06-10
+
+- Initial release

--- a/ext/opentelemetry-exporter-cloud-trace/CHANGELOG.md
+++ b/ext/opentelemetry-exporter-cloud-trace/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## 0.10b0
-
-Released 2020-06-23
-
 - Add g.co/agent label for Google internal metrics tracking
   ([#833](https://github.com/open-telemetry/opentelemetry-python/pull/833))
 - Adding trouble-shooting tips


### PR DESCRIPTION
Adding changelog for features for Cloud Trace and Cloud Monitoring exporter that have been added since initial release.