### PR TITLE
Update instrumentors to use span processors

### DIFF
--- a/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/__init__.py
+++ b/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/__init__.py
@@ -67,8 +67,6 @@ class MySQLInstrumentor(BaseInstrumentor):
         """
         tracer_provider = kwargs.get("tracer_provider")
 
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
         dbapi.wrap_connect(
             __name__,
             mysql.connector,

--- a/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/__init__.py
+++ b/ext/opentelemetry-ext-mysql/src/opentelemetry/ext/mysql/__init__.py
@@ -42,14 +42,12 @@ API
 ---
 """
 
-import typing
-
 import mysql.connector
 
 from opentelemetry.ext import dbapi
 from opentelemetry.ext.mysql.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.trace import TracerProvider, get_tracer
+from opentelemetry.trace import get_tracer
 
 
 class MySQLInstrumentor(BaseInstrumentor):
@@ -72,12 +70,14 @@ class MySQLInstrumentor(BaseInstrumentor):
         tracer = get_tracer(__name__, __version__, tracer_provider)
 
         dbapi.wrap_connect(
-            tracer,
+            __name__,
             mysql.connector,
             "connect",
             self._DATABASE_COMPONENT,
             self._DATABASE_TYPE,
             self._CONNECTION_ATTRIBUTES,
+            version=__version__,
+            tracer_provider=tracer_provider,
         )
 
     def _uninstrument(self, **kwargs):

--- a/ext/opentelemetry-ext-psycopg2/src/opentelemetry/ext/psycopg2/__init__.py
+++ b/ext/opentelemetry-ext-psycopg2/src/opentelemetry/ext/psycopg2/__init__.py
@@ -42,15 +42,12 @@ API
 ---
 """
 
-import typing
-
 import psycopg2
-import wrapt
 
 from opentelemetry.ext import dbapi
 from opentelemetry.ext.psycopg2.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.trace import TracerProvider, get_tracer
+from opentelemetry.trace import get_tracer
 
 
 class Psycopg2Instrumentor(BaseInstrumentor):
@@ -71,15 +68,15 @@ class Psycopg2Instrumentor(BaseInstrumentor):
 
         tracer_provider = kwargs.get("tracer_provider")
 
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
         dbapi.wrap_connect(
-            tracer,
+            __name__,
             psycopg2,
             "connect",
             self._DATABASE_COMPONENT,
             self._DATABASE_TYPE,
             self._CONNECTION_ATTRIBUTES,
+            version=__version__,
+            tracer_provider=tracer_provider,
         )
 
     def _uninstrument(self, **kwargs):

--- a/ext/opentelemetry-ext-pymysql/src/opentelemetry/ext/pymysql/__init__.py
+++ b/ext/opentelemetry-ext-pymysql/src/opentelemetry/ext/pymysql/__init__.py
@@ -43,14 +43,11 @@ API
 ---
 """
 
-import typing
-
 import pymysql
 
 from opentelemetry.ext import dbapi
 from opentelemetry.ext.pymysql.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.trace import TracerProvider, get_tracer
 
 
 class PyMySQLInstrumentor(BaseInstrumentor):
@@ -70,15 +67,15 @@ class PyMySQLInstrumentor(BaseInstrumentor):
         """
         tracer_provider = kwargs.get("tracer_provider")
 
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
         dbapi.wrap_connect(
-            tracer,
+            __name__,
             pymysql,
             "connect",
             self._DATABASE_COMPONENT,
             self._DATABASE_TYPE,
             self._CONNECTION_ATTRIBUTES,
+            version=__version__,
+            tracer_provider=tracer_provider,
         )
 
     def _uninstrument(self, **kwargs):
@@ -95,14 +92,14 @@ class PyMySQLInstrumentor(BaseInstrumentor):
         Returns:
             An instrumented connection.
         """
-        tracer = get_tracer(__name__, __version__)
 
         return dbapi.instrument_connection(
-            tracer,
+            __name__,
             connection,
             self._DATABASE_COMPONENT,
             self._DATABASE_TYPE,
             self._CONNECTION_ATTRIBUTES,
+            version=__version__,
         )
 
     def uninstrument_connection(self, connection):

--- a/ext/opentelemetry-ext-requests/src/opentelemetry/ext/requests/__init__.py
+++ b/ext/opentelemetry-ext-requests/src/opentelemetry/ext/requests/__init__.py
@@ -90,9 +90,7 @@ def _instrument(tracer_provider=None, span_callback=None):
 
         with get_tracer(
             __name__, __version__, tracer_provider
-        ).start_as_current_span(
-            span_name, kind=SpanKind.CLIENT
-        ) as span:
+        ).start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
             span.set_attribute("component", "http")
             span.set_attribute("http.method", method.upper())
             span.set_attribute("http.url", url)

--- a/ext/opentelemetry-ext-requests/src/opentelemetry/ext/requests/__init__.py
+++ b/ext/opentelemetry-ext-requests/src/opentelemetry/ext/requests/__init__.py
@@ -24,7 +24,8 @@ Usage
     import requests
     import opentelemetry.ext.requests
 
-    # You can optionally pass a custom TracerProvider to RequestInstrumentor.instrument()
+    # You can optionally pass a custom TracerProvider to
+    RequestInstrumentor.instrument()
     opentelemetry.ext.requests.RequestsInstrumentor().instrument()
     response = requests.get(url="https://www.example.org/")
 
@@ -49,7 +50,7 @@ from requests import Timeout, URLRequired
 from requests.exceptions import InvalidSchema, InvalidURL, MissingSchema
 from requests.sessions import Session
 
-from opentelemetry import context, propagators, trace
+from opentelemetry import context, propagators
 from opentelemetry.ext.requests.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import http_status_to_canonical_code
@@ -72,8 +73,6 @@ def _instrument(tracer_provider=None, span_callback=None):
 
     wrapped = Session.request
 
-    tracer = trace.get_tracer(__name__, __version__, tracer_provider)
-
     @functools.wraps(wrapped)
     def instrumented_request(self, method, url, *args, **kwargs):
         if context.get_value("suppress_instrumentation"):
@@ -89,7 +88,9 @@ def _instrument(tracer_provider=None, span_callback=None):
 
         exception = None
 
-        with tracer.start_as_current_span(
+        with get_tracer(
+            __name__, __version__, tracer_provider
+        ).start_as_current_span(
             span_name, kind=SpanKind.CLIENT
         ) as span:
             span.set_attribute("component", "http")

--- a/ext/opentelemetry-ext-sqlite3/src/opentelemetry/ext/sqlite3/__init__.py
+++ b/ext/opentelemetry-ext-sqlite3/src/opentelemetry/ext/sqlite3/__init__.py
@@ -43,12 +43,11 @@ API
 """
 
 import sqlite3
-import typing
 
 from opentelemetry.ext import dbapi
 from opentelemetry.ext.sqlite3.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.trace import TracerProvider, get_tracer
+from opentelemetry.trace import get_tracer
 
 
 class SQLite3Instrumentor(BaseInstrumentor):
@@ -64,15 +63,15 @@ class SQLite3Instrumentor(BaseInstrumentor):
         """
         tracer_provider = kwargs.get("tracer_provider")
 
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
         dbapi.wrap_connect(
-            tracer,
+            __name__,
             sqlite3,
             "connect",
             self._DATABASE_COMPONENT,
             self._DATABASE_TYPE,
             self._CONNECTION_ATTRIBUTES,
+            version=__version__,
+            tracer_provider=tracer_provider,
         )
 
     def _uninstrument(self, **kwargs):

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -48,7 +48,7 @@ def _load_provider(provider: str) -> Provider:
                 name=cast(
                     str,
                     Configuration().get(
-                        provider, "default_{}".format(provider),
+                        provider.upper(), "default_{}".format(provider),
                     ),
                 ),
             )


### PR DESCRIPTION
Fixes #832 

This can be implemented as a fix right now, but the issue highlights a more pressing matter, the fact that there is an overlap between configuration in the standard sense (the kind that uses `Configuration`) and the kind that is implemented by the end user as application code.