### PR TITLE
Resources prototype

### DIFF
--- a/docs/examples/basic_tracer/README.rst
+++ b/docs/examples/basic_tracer/README.rst
@@ -7,7 +7,7 @@ There are two different examples:
 
 * basic_trace: Shows how to configure a SpanProcessor and Exporter, and how to create a tracer and span.
 
-* resources: Shows how to add resource information to a Provider. Note that this must be run on a GCP instance.
+* resources: Shows how to add resource information to a Provider. Note that this must be run on a Google Compute Engine instance.
 
 The source files of these examples are available :scm_web:`here <docs/examples/basic_tracer/>`.
 

--- a/docs/examples/basic_tracer/README.rst
+++ b/docs/examples/basic_tracer/README.rst
@@ -1,0 +1,37 @@
+Basic Trace
+===========
+
+These examples show how to use OpenTelemetry create and export Spans.
+
+There are two different examples:
+
+* basic_trace: Shows to how to configure a SpanProcessor and Exporter, and how to create a tracer and span.
+
+* resources: Shows how to add resource information to a Provider. Note that this must be run on a GCP instance.
+
+The source files of these examples are available :scm_web:`here <docs/examples/basic_tracer/>`.
+
+Installation
+------------
+
+.. code-block:: sh
+
+    pip install opentelemetry-api
+    pip install opentelemetry-sdk
+
+Run the Example
+---------------
+
+.. code-block:: sh
+
+    python <example_name>.py
+
+The output will be shown in the console.
+
+Useful links
+------------
+
+- OpenTelemetry_
+- :doc:`../../api/trace`
+
+.. _OpenTelemetry: https://github.com/open-telemetry/opentelemetry-python/

--- a/docs/examples/basic_tracer/README.rst
+++ b/docs/examples/basic_tracer/README.rst
@@ -1,11 +1,11 @@
 Basic Trace
 ===========
 
-These examples show how to use OpenTelemetry create and export Spans.
+These examples show how to use OpenTelemetry to create and export Spans.
 
 There are two different examples:
 
-* basic_trace: Shows to how to configure a SpanProcessor and Exporter, and how to create a tracer and span.
+* basic_trace: Shows how to configure a SpanProcessor and Exporter, and how to create a tracer and span.
 
 * resources: Shows how to add resource information to a Provider. Note that this must be run on a GCP instance.
 

--- a/docs/examples/basic_tracer/basic_trace.py
+++ b/docs/examples/basic_tracer/basic_trace.py
@@ -1,0 +1,15 @@
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    ConsoleSpanExporter,
+    SimpleExportSpanProcessor,
+)
+
+trace.set_tracer_provider(TracerProvider())
+
+trace.get_tracer_provider().add_span_processor(
+    SimpleExportSpanProcessor(ConsoleSpanExporter())
+)
+tracer = trace.get_tracer(__name__)
+with tracer.start_as_current_span("foo"):
+    print("Hello world!")

--- a/docs/examples/basic_tracer/basic_trace.py
+++ b/docs/examples/basic_tracer/basic_trace.py
@@ -6,7 +6,6 @@ from opentelemetry.sdk.trace.export import (
 )
 
 trace.set_tracer_provider(TracerProvider())
-
 trace.get_tracer_provider().add_span_processor(
     SimpleExportSpanProcessor(ConsoleSpanExporter())
 )

--- a/docs/examples/basic_tracer/resources.py
+++ b/docs/examples/basic_tracer/resources.py
@@ -1,0 +1,19 @@
+from opentelemetry import trace
+from opentelemetry.sdk.resources import get_aggregated_resources
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    ConsoleSpanExporter,
+    SimpleExportSpanProcessor,
+)
+from opentelemetry.tools.resource_detector import GoogleCloudResourceDetector
+
+resources = get_aggregated_resources([GoogleCloudResourceDetector()])
+
+trace.set_tracer_provider(TracerProvider(resource=resources))
+
+trace.get_tracer_provider().add_span_processor(
+    SimpleExportSpanProcessor(ConsoleSpanExporter())
+)
+tracer = trace.get_tracer(__name__)
+with tracer.start_as_current_span("foo"):
+    print("Hello world!")

--- a/ext/opentelemetry-exporter-cloud-monitoring/CHANGELOG.md
+++ b/ext/opentelemetry-exporter-cloud-monitoring/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add support for resources
+  ([#853](https://github.com/open-telemetry/opentelemetry-python/pull/853))
+
 ## Version 0.10b0
 
 Released 2020-06-23

--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -67,9 +67,9 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
             series: ProtoBuf TimeSeries
         """
         monitored = None
-        if "gcp_instance" in resource.labels:
+        if "gce_instance" in resource.labels:
             monitored = MonitoredResource(
-                type="gcp_instance", labels=resource.labels["gcp_instance"]
+                type="gce_instance", labels=resource.labels["gce_instance"]
             )
         return TimeSeries(resource=monitored)
 

--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -64,7 +64,7 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
 
         See
         https://cloud.google.com/monitoring/custom-metrics/creating-metrics#custom-metric-resources
-        for acceptable types
+        for supported types
         Args:
             series: ProtoBuf TimeSeries
         """

--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -62,7 +62,9 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
     def _get_monitored_resource(resource: Resource) -> TimeSeries:
         """Add Google resource specific information (e.g. instance id, region).
 
-        See https://cloud.google.com/monitoring/custom-metrics/creating-metrics#custom-metric-resources for acceptable types
+        See
+        https://cloud.google.com/monitoring/custom-metrics/creating-metrics#custom-metric-resources
+        for acceptable types
         Args:
             series: ProtoBuf TimeSeries
         """

--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -171,7 +171,6 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
             metric_descriptor = self._get_metric_descriptor(record)
             if not metric_descriptor:
                 continue
-
             series = TimeSeries(
                 resource=self._get_monitored_resource(
                     record.instrument.meter.resource

--- a/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
@@ -46,12 +46,12 @@ class MockMetric:
         name="name",
         description="description",
         value_type=int,
-        meter=MockMeter(),
+        meter=None,
     ):
         self.name = name
         self.description = description
         self.value_type = value_type
-        self.meter = meter
+        self.meter = meter or MockMeter()
 
 
 # pylint: disable=protected-access

--- a/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
@@ -27,10 +27,16 @@ from opentelemetry.exporter.cloud_monitoring import (
 )
 from opentelemetry.sdk.metrics.export import MetricRecord
 from opentelemetry.sdk.metrics.export.aggregate import SumAggregator
+from opentelemetry.sdk.resources import Resource
 
 
 class UnsupportedAggregator:
     pass
+
+
+class MockMeter:
+    def __init__(self):
+        self.resource = Resource.create_empty()
 
 
 class MockMetric:
@@ -38,6 +44,7 @@ class MockMetric:
         self.name = name
         self.description = description
         self.value_type = value_type
+        self.meter = MockMeter()
 
 
 # pylint: disable=protected-access

--- a/ext/opentelemetry-exporter-cloud-trace/CHANGELOG.md
+++ b/ext/opentelemetry-exporter-cloud-trace/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add support for resources and resource detector
+  ([#853](https://github.com/open-telemetry/opentelemetry-python/pull/853))
+
 ## Version 0.10b0
 
 Released 2020-06-23

--- a/ext/opentelemetry-exporter-cloud-trace/setup.cfg
+++ b/ext/opentelemetry-exporter-cloud-trace/setup.cfg
@@ -39,6 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
+    requests
     opentelemetry-api
     opentelemetry-sdk
     google-cloud-trace

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -301,6 +301,7 @@ def _extract_events(events: Sequence[Event]) -> ProtoSpan.TimeEvents:
 def _strip_characters(ot_version):
     return "".join(filter(lambda x: x.isdigit() or x == ".", ot_version))
 
+
 OT_RESOURCE_LABEL_TO_GCP = {
     "gce_instance": {
         "cloud.account.id": "project_id",

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -312,18 +312,19 @@ OT_RESOURCE_LABEL_TO_GCP = {
 
 
 def _extract_resources(resource: Resource) -> Dict[str, str]:
-    resources_dist = {}
-    if resource.labels.get("cloud.provider") == "gcp":
-        resource_type = resource.labels["gcp.resource_type"]
-        if resource_type not in OT_RESOURCE_LABEL_TO_GCP:
-            return {}
+    if resource.labels.get("cloud.provider") != "gcp":
+        return {}
+    resource_type = resource.labels["gcp.resource_type"]
+    if resource_type not in OT_RESOURCE_LABEL_TO_GCP:
+        return {}
+    return {
+        "g.co/r/{}/{}".format(resource_type, gcp_resource_key,): str(
+            resource.labels[ot_resource_key]
+        )
         for ot_resource_key, gcp_resource_key in OT_RESOURCE_LABEL_TO_GCP[
             resource_type
-        ].items():
-            resources_dist[
-                "g.co/r/{}/{}".format(resource_type, gcp_resource_key,)
-            ] = str(resource.labels[ot_resource_key])
-    return resources_dist
+        ].items()
+    }
 
 
 def _extract_attributes(

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -313,15 +313,16 @@ OT_RESOURCE_LABEL_TO_GCP = {
 
 def _extract_resources(resource: Resource) -> Dict[str, str]:
     resources_dist = {}
-    for resource_type, resource_labels in resource.labels.items():
+    if resource.labels.get("cloud.provider") == "gcp":
+        resource_type = resource.labels["gcp.resource_type"]
         if resource_type not in OT_RESOURCE_LABEL_TO_GCP:
-            continue
+            return {}
         for ot_resource_key, gcp_resource_key in OT_RESOURCE_LABEL_TO_GCP[
             resource_type
         ].items():
             resources_dist[
                 "g.co/r/{}/{}".format(resource_type, gcp_resource_key,)
-            ] = str(resource_labels[ot_resource_key])
+            ] = str(resource.labels[ot_resource_key])
     return resources_dist
 
 

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -107,7 +107,6 @@ class CloudTraceSpanExporter(SpanExporter):
             # pylint: disable=broad-except
             except Exception as ex:
                 logger.error("Error when creating span %s", span, exc_info=ex)
-
         try:
             self.client.batch_write_spans(
                 "projects/{}".format(self.project_id), cloud_trace_spans,
@@ -151,8 +150,8 @@ class CloudTraceSpanExporter(SpanExporter):
                     MAX_SPAN_ATTRS,
                 )
 
-            # Span does not support a MonitoredResource object. We put in the
-            # information into the labels instead.
+            # Span does not support a MonitoredResource object. We put the
+            # information into labels instead.
             resources_and_attrs = _extract_resources(span.resource)
             resources_and_attrs.update(span.attributes)
 

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
@@ -31,7 +31,7 @@ def get_gce_resources():
     return gce_resources
 
 
-_RESOURCE_TYPE_TO_FINDER = {"gce_instance": get_gce_resources}
+_RESOURCE_FINDERS = {get_gce_resources}
 
 
 class GoogleCloudResourceDetector(ResourceDetector):
@@ -43,11 +43,7 @@ class GoogleCloudResourceDetector(ResourceDetector):
     def detect(self) -> "Resource":
         if not self.cached:
             self.cached = True
-            for (
-                resource_type,
-                resource_finder,
-            ) in _RESOURCE_TYPE_TO_FINDER.items():
+            for resource_finder in _RESOURCE_FINDERS:
                 found_resources = resource_finder()
-                if found_resources:
-                    self.gcp_resources[resource_type] = found_resources
+                self.gcp_resources.update(found_resources)
         return Resource(self.gcp_resources)

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
@@ -1,0 +1,69 @@
+import requests
+
+from opentelemetry.sdk.resources import Resource, ResourceDetector
+
+_GCP_METADATA_URI = "http://metadata.google.internal/computeMetadata/v1/"
+_GCP_METADATA_URI_HEADER = {"Metadata-Flavor": "Google"}
+
+# GCE common attributes
+# See: https://cloud.google.com/compute/docs/storing-retrieving-metadata
+_GCE_ATTRIBUTES = {
+    "project_id": "project/project-id",
+    "instance_id": "instance/id",
+    "zone": "instance/zone",
+}
+
+_ATTRIBUTE_URI_TRANSFORMATIONS = {
+    "instance/zone": lambda v: v.split("/")[-1] if "/" in v else v
+}
+
+_GCP_METADATA_MAP = {}
+
+
+class GoogleCloudResourceDetector(ResourceDetector):
+    def __init__(self, crash_on_error=False):
+        super().__init__(crash_on_error)
+        self.scraped = False
+
+    def _scrape_attributes(self) -> None:
+        instance_id = self.get_attribute("instance/id")
+        if instance_id is not None:
+            _GCP_METADATA_MAP["instance_id"] = instance_id
+
+            for attribute_key, attribute_uri in _GCE_ATTRIBUTES.items():
+                if attribute_key in _GCP_METADATA_MAP:
+                    continue
+                _GCP_METADATA_MAP[attribute_key] = self.get_attribute(
+                    attribute_uri
+                )
+
+    @staticmethod
+    def get_attribute(attribute_uri: str) -> str:
+        """Fetch the requested instance metadata entry.
+
+        :param attribute_uri: attribute_uri: attribute name relative to the
+        computeMetadata/v1 prefix
+        :return:  The value read from the metadata service or None
+        """
+        attribute_value = requests.get(
+            _GCP_METADATA_URI + attribute_uri, headers=_GCP_METADATA_URI_HEADER
+        ).content
+
+        if attribute_value is not None and isinstance(attribute_value, bytes):
+            # At least in python3, the response is ISO-8859-1 encoded bytes
+            attribute_value = attribute_value.decode("ISO-8859-1")
+
+        if attribute_uri in _ATTRIBUTE_URI_TRANSFORMATIONS:
+            attribute_value = _ATTRIBUTE_URI_TRANSFORMATIONS[attribute_uri](
+                attribute_value
+            )
+
+        return attribute_value
+
+    def detect(self) -> "Resource":
+        if not self.scraped:
+            self._scrape_attributes()
+            self.scraped = True
+        if _GCE_ATTRIBUTES:
+            return Resource({"gcp_instance": _GCP_METADATA_MAP})
+        return Resource.create_empty()

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
@@ -2,68 +2,92 @@ import requests
 
 from opentelemetry.sdk.resources import Resource, ResourceDetector
 
-_GCP_METADATA_URI = "http://metadata.google.internal/computeMetadata/v1/"
-_GCP_METADATA_URI_HEADER = {"Metadata-Flavor": "Google"}
-
-# GCE common attributes
-# See: https://cloud.google.com/compute/docs/storing-retrieving-metadata
-_GCE_ATTRIBUTES = {
-    "project_id": "project/project-id",
-    "instance_id": "instance/id",
-    "zone": "instance/zone",
-}
-
-_ATTRIBUTE_URI_TRANSFORMATIONS = {
-    "instance/zone": lambda v: v.split("/")[-1] if "/" in v else v
-}
-
-_GCP_METADATA_MAP = {}
+_GCP_METADATA_URL_HEADER = {"Metadata-Flavor": "Google"}
 
 
-class GoogleCloudResourceDetector(ResourceDetector):
-    def __init__(self, crash_on_error=False):
-        super().__init__(crash_on_error)
-        self.scraped = False
+class GoogleResourceFinder:
+    def __init__(self, base_url, url_post_process=None):
+        self.base_url = base_url
+        self.url_post_process = url_post_process or {}
 
-    def _scrape_attributes(self) -> None:
-        instance_id = self.get_attribute("instance/id")
-        if instance_id is not None:
-            _GCP_METADATA_MAP["instance_id"] = instance_id
-
-            for attribute_key, attribute_uri in _GCE_ATTRIBUTES.items():
-                if attribute_key in _GCP_METADATA_MAP:
-                    continue
-                _GCP_METADATA_MAP[attribute_key] = self.get_attribute(
-                    attribute_uri
-                )
-
-    @staticmethod
-    def get_attribute(attribute_uri: str) -> str:
+    def get_attribute(self, attribute_url: str) -> str:
         """Fetch the requested instance metadata entry.
 
-        :param attribute_uri: attribute_uri: attribute name relative to the
-        computeMetadata/v1 prefix
+        :param attribute_url: attribute name relative to the computeMetadata/v1 prefix
         :return:  The value read from the metadata service or None
         """
         attribute_value = requests.get(
-            _GCP_METADATA_URI + attribute_uri, headers=_GCP_METADATA_URI_HEADER
-        ).content
+            self.base_url + attribute_url, headers=_GCP_METADATA_URL_HEADER
+        ).text
 
-        if attribute_value is not None and isinstance(attribute_value, bytes):
-            # At least in python3, the response is ISO-8859-1 encoded bytes
-            attribute_value = attribute_value.decode("ISO-8859-1")
-
-        if attribute_uri in _ATTRIBUTE_URI_TRANSFORMATIONS:
-            attribute_value = _ATTRIBUTE_URI_TRANSFORMATIONS[attribute_uri](
+        if attribute_url in self.url_post_process:
+            attribute_value = self.url_post_process[attribute_url](
                 attribute_value
             )
 
         return attribute_value
 
+    def get_resources(self):
+        pass
+
+
+class GCEResourceFinder(GoogleResourceFinder):
+    """ Resource finder for common GCE attributes
+
+    See: https://cloud.google.com/compute/docs/storing-retrieving-metadata
+    """
+
+    def __init__(self):
+        super().__init__(
+            "http://metadata.google.internal/computeMetadata/v1/",
+            {
+                # e.g. 'projects/233510669893/zones/us-east1-d' -> 'us-east1-d'
+                "instance/zone": lambda v: v.split("/")[-1]
+                if "/" in v
+                else v
+            },
+        )
+        self.attribute_key_to_url = {
+            "cloud.account.id": "project/project-id",
+            "host.id": "instance/id",
+            "cloud.zone": "instance/zone",
+        }
+
+    def get_resources(self):
+        # If we are currently not in a GCE instance this call will throw
+        try:
+            instance_id = self.get_attribute("instance/id")
+        # pylint: disable=broad-except
+        except Exception:
+            instance_id = None
+        if instance_id is None:
+            return {}
+
+        gce_resources = {"host.id": instance_id, "cloud.provider": "gcp"}
+        for attribute_key, attribute_url in self.attribute_key_to_url.items():
+            if attribute_key in gce_resources:
+                continue
+            gce_resources[attribute_key] = self.get_attribute(attribute_url)
+        return gce_resources
+
+
+_RESOURCE_TYPE_TO_FINDER = {"gce_instance": GCEResourceFinder}
+
+
+class GoogleCloudResourceDetector(ResourceDetector):
+    def __init__(self, raise_on_error=False):
+        super().__init__(raise_on_error)
+        self.cached = False
+        self.gcp_resources = {}
+
     def detect(self) -> "Resource":
-        if not self.scraped:
-            self._scrape_attributes()
-            self.scraped = True
-        if _GCE_ATTRIBUTES:
-            return Resource({"gce_instance": _GCP_METADATA_MAP})
-        return Resource.create_empty()
+        if not self.cached:
+            self.cached = True
+            for (
+                resource_type,
+                resource_finder,
+            ) in _RESOURCE_TYPE_TO_FINDER.items():
+                found_resources = resource_finder().get_resources()
+                if found_resources:
+                    self.gcp_resources[resource_type] = found_resources
+        return Resource(self.gcp_resources)

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
@@ -1,6 +1,6 @@
 import requests
 
-from opentelemetry.context import attach, set_value
+from opentelemetry.context import attach, detach, set_value
 from opentelemetry.sdk.resources import Resource, ResourceDetector
 
 _GCP_METADATA_URL = (
@@ -14,10 +14,11 @@ def get_gce_resources():
 
         See: https://cloud.google.com/compute/docs/storing-retrieving-metadata
     """
-    attach(set_value("suppress_instrumentation", True))
+    token = attach(set_value("suppress_instrumentation", True))
     all_metadata = requests.get(
         _GCP_METADATA_URL, headers=_GCP_METADATA_URL_HEADER
     ).json()
+    detach(token)
     gce_resources = {
         "host.id": all_metadata["instance"]["id"],
         "cloud.account.id": all_metadata["project"]["projectId"],

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
@@ -65,5 +65,5 @@ class GoogleCloudResourceDetector(ResourceDetector):
             self._scrape_attributes()
             self.scraped = True
         if _GCE_ATTRIBUTES:
-            return Resource({"gcp_instance": _GCP_METADATA_MAP})
+            return Resource({"gce_instance": _GCP_METADATA_MAP})
         return Resource.create_empty()

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
@@ -13,8 +13,8 @@ class GoogleResourceFinder:
     def get_attribute(self, attribute_url: str) -> str:
         """Fetch the requested instance metadata entry.
 
-        :param attribute_url: attribute name relative to the computeMetadata/v1 prefix
-        :return:  The value read from the metadata service or None
+        :param attribute_url: suffix of the complete url
+        :return:  The value read from the metadata service
         """
         attribute_value = requests.get(
             self.base_url + attribute_url, headers=_GCP_METADATA_URL_HEADER

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
@@ -13,14 +13,9 @@ def get_gce_resources():
 
         See: https://cloud.google.com/compute/docs/storing-retrieving-metadata
     """
-    # This call will throw if we aren't currently in a GCE instance
-    try:
-        all_metadata = requests.get(
-            _GCP_METADATA_URL, headers=_GCP_METADATA_URL_HEADER
-        ).json()
-    # pylint: disable=broad-except
-    except Exception:
-        return {}
+    all_metadata = requests.get(
+        _GCP_METADATA_URL, headers=_GCP_METADATA_URL_HEADER
+    ).json()
     gce_resources = {
         "host.id": all_metadata["instance"]["id"],
         "cloud.account.id": all_metadata["project"]["projectId"],

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
@@ -31,7 +31,7 @@ def get_gce_resources():
     return gce_resources
 
 
-_RESOURCE_FINDERS = {get_gce_resources}
+_RESOURCE_FINDERS = [get_gce_resources]
 
 
 class GoogleCloudResourceDetector(ResourceDetector):

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
@@ -1,9 +1,10 @@
 import requests
 
+from opentelemetry.context import attach, set_value
 from opentelemetry.sdk.resources import Resource, ResourceDetector
 
 _GCP_METADATA_URL = (
-    "http://metadata.google.internal/computeMetadata/v1?recursive=true"
+    "http://metadata.google.internal/computeMetadata/v1/?recursive=true"
 )
 _GCP_METADATA_URL_HEADER = {"Metadata-Flavor": "Google"}
 
@@ -13,6 +14,7 @@ def get_gce_resources():
 
         See: https://cloud.google.com/compute/docs/storing-retrieving-metadata
     """
+    attach(set_value("suppress_instrumentation", True))
     all_metadata = requests.get(
         _GCP_METADATA_URL, headers=_GCP_METADATA_URL_HEADER
     ).json()

--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/tools/resource_detector.py
@@ -2,7 +2,7 @@ import requests
 
 from opentelemetry.sdk.resources import Resource, ResourceDetector
 
-_GCE_METADATA_URL = (
+_GCP_METADATA_URL = (
     "http://metadata.google.internal/computeMetadata/v1?recursive=true"
 )
 _GCP_METADATA_URL_HEADER = {"Metadata-Flavor": "Google"}
@@ -16,7 +16,7 @@ def get_gce_resources():
     # This call will throw if we aren't currently in a GCE instance
     try:
         all_metadata = requests.get(
-            _GCE_METADATA_URL, headers=_GCP_METADATA_URL_HEADER
+            _GCP_METADATA_URL, headers=_GCP_METADATA_URL_HEADER
         ).json()
     # pylint: disable=broad-except
     except Exception:

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
@@ -1,4 +1,4 @@
-# Copyright OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
@@ -30,6 +30,7 @@ from opentelemetry.exporter.cloud_trace import (
     _extract_attributes,
     _extract_events,
     _extract_links,
+    _extract_resources,
     _extract_status,
     _format_attribute_value,
     _strip_characters,
@@ -38,6 +39,7 @@ from opentelemetry.exporter.cloud_trace import (
 from opentelemetry.exporter.cloud_trace.version import (
     __version__ as cloud_trace_version,
 )
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Event
 from opentelemetry.sdk.trace.export import Span
 from opentelemetry.trace import Link, SpanContext, SpanKind
@@ -92,6 +94,16 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
     def test_export(self):
         trace_id = "6e0c63257de34c92bf9efcd03927272e"
         span_id = "95bb5edabd45950f"
+        resource_info = Resource(
+            {
+                "gce_instance": {
+                    "cloud.account.id": 123,
+                    "host.id": "host",
+                    "cloud.zone": "US",
+                    "cloud.provider": "gcp",
+                }
+            }
+        )
         span_datas = [
             Span(
                 name="span_name",
@@ -102,6 +114,8 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
                 ),
                 parent=None,
                 kind=SpanKind.INTERNAL,
+                resource=resource_info,
+                attributes={"attr_key": "attr_value"},
             )
         ]
 
@@ -116,6 +130,13 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
             ),
             "attributes": ProtoSpan.Attributes(
                 attribute_map={
+                    "g.co/r/gce_instance/zone": _format_attribute_value("US"),
+                    "g.co/r/gce_instance/instance_id": _format_attribute_value(
+                        "host"
+                    ),
+                    "g.co/r/gce_instance/project_id": _format_attribute_value(
+                        "123"
+                    ),
                     "g.co/agent": _format_attribute_value(
                         "opentelemetry-python {}; google-cloud-trace-exporter {}".format(
                             _strip_characters(
@@ -125,7 +146,8 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
                             ),
                             _strip_characters(cloud_trace_version),
                         )
-                    )
+                    ),
+                    "attr_key": _format_attribute_value("attr_value"),
                 }
             ),
             "links": None,
@@ -283,6 +305,40 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
                 ]
             ),
         )
+
+    def test_extract_resources(self):
+        self.assertEqual(_extract_resources(Resource.create_empty()), {})
+        resource = Resource(
+            labels={
+                "gce_instance": {
+                    "cloud.account.id": 123,
+                    "host.id": "host",
+                    "cloud.zone": "US",
+                    "cloud.provider": "gcp",
+                    "extra_info": "extra",
+                },
+                "not_gcp_resource": "value",
+            }
+        )
+        expected_extract = {
+            "g.co/r/gce_instance/project_id": "123",
+            "g.co/r/gce_instance/instance_id": "host",
+            "g.co/r/gce_instance/zone": "US",
+        }
+        self.assertEqual(_extract_resources(resource), expected_extract)
+
+        resource = Resource(
+            labels={
+                "gce_instance": {
+                    "cloud.account.id": "123",
+                    "host.id": "host",
+                    "extra_info": "extra",
+                },
+                "not_gcp_resource": "value",
+            }
+        )
+        # Should throw when passed a malformed GCP resource dict
+        self.assertRaises(KeyError, _extract_resources, resource)
 
     # pylint:disable=too-many-locals
     def test_truncate(self):

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
@@ -32,19 +32,10 @@ class DummyRequest:
         return json.loads(self.text)
 
 
-# pylint: disable=unused-argument
-def mock_return_resources(url, headers):
-    return DummyRequest(
-        json.dumps(
-            {
-                "instance": {
-                    "id": "instance_id",
-                    "zone": "projects/123/zones/zone",
-                },
-                "project": {"projectId": "project_id"},
-            }
-        )
-    )
+RESOURCES_JSON_STRING = {
+    "instance": {"id": "instance_id", "zone": "projects/123/zones/zone"},
+    "project": {"projectId": "project_id"},
+}
 
 
 class TestGCEResourceFinder(unittest.TestCase):
@@ -55,7 +46,7 @@ class TestGCEResourceFinder(unittest.TestCase):
 
     @mock.patch("opentelemetry.tools.resource_detector.requests.get")
     def test_finding_gce_resources(self, getter):
-        getter.side_effect = mock_return_resources
+        getter.return_value.json.return_value = RESOURCES_JSON_STRING
         found_resources = get_gce_resources()
         self.assertEqual(getter.call_args_list[0][0][0], _GCP_METADATA_URL)
         self.assertEqual(
@@ -74,7 +65,7 @@ class TestGoogleCloudResourceDetector(unittest.TestCase):
     @mock.patch("opentelemetry.tools.resource_detector.requests.get")
     def test_finding_resources(self, getter):
         resource_finder = GoogleCloudResourceDetector()
-        getter.side_effect = mock_return_resources
+        getter.return_value.json.return_value = RESOURCES_JSON_STRING
         found_resources = resource_finder.detect()
         self.assertEqual(getter.call_args_list[0][0][0], _GCP_METADATA_URL)
         self.assertEqual(

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
@@ -1,0 +1,162 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from mock import patch
+
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.tools.resource_detector import (
+    _GCP_METADATA_URL_HEADER,
+    GCEResourceFinder,
+    GoogleCloudResourceDetector,
+    GoogleResourceFinder,
+)
+
+
+class DummyRequest:
+    def __init__(self, text):
+        self.text = text
+
+
+class TestGoogleResourceFinder(unittest.TestCase):
+    def setUp(self):
+        self.base_url = "base_url/"
+        self.attribute_url = "attribute_url"
+
+    @patch("opentelemetry.tools.resource_detector.requests.get")
+    def test_get_attribute(self, getter):
+        resource_finder = GoogleResourceFinder(self.base_url)
+        getter.return_value = DummyRequest("resource_info")
+        found_resource = resource_finder.get_attribute(self.attribute_url)
+        self.assertEqual(found_resource, "resource_info")
+        self.assertEqual(
+            getter.call_args.args[0], self.base_url + self.attribute_url
+        )
+        self.assertEqual(
+            getter.call_args.kwargs["headers"], _GCP_METADATA_URL_HEADER
+        )
+
+        resource_finder = GoogleResourceFinder(
+            self.base_url, {self.attribute_url: lambda x: x + "_suffix"}
+        )
+        getter.return_value = DummyRequest("resource_info")
+        found_resource = resource_finder.get_attribute(self.attribute_url)
+        self.assertEqual(found_resource, "resource_info_suffix")
+
+        getter.return_value = DummyRequest("other_resource_info")
+        found_resource = resource_finder.get_attribute("other_url")
+        self.assertEqual(found_resource, "other_resource_info")
+
+
+# pylint:disable=unused-argument
+def mock_return_resources(url, headers):
+    url_to_resources = {
+        "http://metadata.google.internal/computeMetadata/v1/instance/id": "instance_id",
+        "http://metadata.google.internal/computeMetadata/v1/project/project-id": "project_id",
+        "http://metadata.google.internal/computeMetadata/v1/instance/zone": "zone",
+    }
+    return DummyRequest(url_to_resources[url])
+
+
+class TestGCEResourceFinder(unittest.TestCase):
+    @patch("opentelemetry.tools.resource_detector.requests.get")
+    def test_not_on_gce(self, getter):
+        resource_finder = GCEResourceFinder()
+        getter.side_effect = Exception()
+        self.assertEqual(resource_finder.get_resources(), {})
+
+    @patch("opentelemetry.tools.resource_detector.requests.get")
+    def test_finding_gce_resources(self, getter):
+        resource_finder = GCEResourceFinder()
+        getter.side_effect = mock_return_resources
+        found_resources = resource_finder.get_resources()
+        self.assertEqual(
+            getter.call_args_list[0].args[0],
+            "http://metadata.google.internal/computeMetadata/v1/instance/id",
+        )
+        self.assertEqual(
+            getter.call_args_list[1].args[0],
+            "http://metadata.google.internal/computeMetadata/v1/project/project-id",
+        )
+        self.assertEqual(
+            getter.call_args_list[2].args[0],
+            "http://metadata.google.internal/computeMetadata/v1/instance/zone",
+        )
+        self.assertEqual(
+            found_resources,
+            {
+                "host.id": "instance_id",
+                "cloud.provider": "gcp",
+                "cloud.account.id": "project_id",
+                "cloud.zone": "zone",
+            },
+        )
+
+
+class TestGoogleCloudResourceDetector(unittest.TestCase):
+    @patch("opentelemetry.tools.resource_detector.requests.get")
+    def test_finding_resources(self, getter):
+        resource_finder = GoogleCloudResourceDetector()
+        getter.side_effect = mock_return_resources
+        found_resources = resource_finder.detect()
+        self.assertEqual(
+            getter.call_args_list[0].args[0],
+            "http://metadata.google.internal/computeMetadata/v1/instance/id",
+        )
+        self.assertEqual(
+            getter.call_args_list[1].args[0],
+            "http://metadata.google.internal/computeMetadata/v1/project/project-id",
+        )
+        self.assertEqual(
+            getter.call_args_list[2].args[0],
+            "http://metadata.google.internal/computeMetadata/v1/instance/zone",
+        )
+        self.assertEqual(
+            found_resources,
+            Resource(
+                labels={
+                    "gce_instance": {
+                        "host.id": "instance_id",
+                        "cloud.provider": "gcp",
+                        "cloud.account.id": "project_id",
+                        "cloud.zone": "zone",
+                    }
+                }
+            ),
+        )
+        self.assertEqual(getter.call_count, 3)
+
+        found_resources = resource_finder.detect()
+        self.assertEqual(getter.call_count, 3)
+        self.assertEqual(
+            found_resources,
+            Resource(
+                labels={
+                    "gce_instance": {
+                        "host.id": "instance_id",
+                        "cloud.provider": "gcp",
+                        "cloud.account.id": "project_id",
+                        "cloud.zone": "zone",
+                    }
+                }
+            ),
+        )
+
+    @patch("opentelemetry.tools.resource_detector.requests.get")
+    def test_not_on_gcp(self, getter):
+        resource_finder = GoogleCloudResourceDetector()
+        getter.side_effect = Exception()
+        found_resources = resource_finder.detect()
+        self.assertEqual(found_resources, Resource.create_empty())

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import unittest
 from unittest import mock
 
@@ -22,15 +21,6 @@ from opentelemetry.tools.resource_detector import (
     GoogleCloudResourceDetector,
     get_gce_resources,
 )
-
-
-class DummyRequest:
-    def __init__(self, text):
-        self.text = text
-
-    def json(self):
-        return json.loads(self.text)
-
 
 RESOURCES_JSON_STRING = {
     "instance": {"id": "instance_id", "zone": "projects/123/zones/zone"},

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import unittest
+from unittest import mock
 
-from mock import patch
 
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.tools.resource_detector import (
@@ -35,7 +35,7 @@ class TestGoogleResourceFinder(unittest.TestCase):
         self.base_url = "base_url/"
         self.attribute_url = "attribute_url"
 
-    @patch("opentelemetry.tools.resource_detector.requests.get")
+    @mock.patch("opentelemetry.tools.resource_detector.requests.get")
     def test_get_attribute(self, getter):
         resource_finder = GoogleResourceFinder(self.base_url)
         getter.return_value = DummyRequest("resource_info")
@@ -71,13 +71,13 @@ def mock_return_resources(url, headers):
 
 
 class TestGCEResourceFinder(unittest.TestCase):
-    @patch("opentelemetry.tools.resource_detector.requests.get")
+    @mock.patch("opentelemetry.tools.resource_detector.requests.get")
     def test_not_on_gce(self, getter):
         resource_finder = GCEResourceFinder()
         getter.side_effect = Exception()
         self.assertEqual(resource_finder.get_resources(), {})
 
-    @patch("opentelemetry.tools.resource_detector.requests.get")
+    @mock.patch("opentelemetry.tools.resource_detector.requests.get")
     def test_finding_gce_resources(self, getter):
         resource_finder = GCEResourceFinder()
         getter.side_effect = mock_return_resources
@@ -106,7 +106,7 @@ class TestGCEResourceFinder(unittest.TestCase):
 
 
 class TestGoogleCloudResourceDetector(unittest.TestCase):
-    @patch("opentelemetry.tools.resource_detector.requests.get")
+    @mock.patch("opentelemetry.tools.resource_detector.requests.get")
     def test_finding_resources(self, getter):
         resource_finder = GoogleCloudResourceDetector()
         getter.side_effect = mock_return_resources
@@ -154,7 +154,7 @@ class TestGoogleCloudResourceDetector(unittest.TestCase):
             ),
         )
 
-    @patch("opentelemetry.tools.resource_detector.requests.get")
+    @mock.patch("opentelemetry.tools.resource_detector.requests.get")
     def test_not_on_gcp(self, getter):
         resource_finder = GoogleCloudResourceDetector()
         getter.side_effect = Exception()

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
@@ -81,13 +81,11 @@ class TestGoogleCloudResourceDetector(unittest.TestCase):
             found_resources,
             Resource(
                 labels={
-                    "gce_instance": {
-                        "host.id": "instance_id",
-                        "cloud.provider": "gcp",
-                        "cloud.account.id": "project_id",
-                        "cloud.zone": "zone",
-                        "gcp.resource_type": "gce_instance",
-                    }
+                    "host.id": "instance_id",
+                    "cloud.provider": "gcp",
+                    "cloud.account.id": "project_id",
+                    "cloud.zone": "zone",
+                    "gcp.resource_type": "gce_instance",
                 }
             ),
         )
@@ -99,13 +97,11 @@ class TestGoogleCloudResourceDetector(unittest.TestCase):
             found_resources,
             Resource(
                 labels={
-                    "gce_instance": {
-                        "host.id": "instance_id",
-                        "cloud.provider": "gcp",
-                        "cloud.account.id": "project_id",
-                        "cloud.zone": "zone",
-                        "gcp.resource_type": "gce_instance",
-                    }
+                    "host.id": "instance_id",
+                    "cloud.provider": "gcp",
+                    "cloud.account.id": "project_id",
+                    "cloud.zone": "zone",
+                    "gcp.resource_type": "gce_instance",
                 }
             ),
         )

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
@@ -40,11 +40,6 @@ RESOURCES_JSON_STRING = {
 
 class TestGCEResourceFinder(unittest.TestCase):
     @mock.patch("opentelemetry.tools.resource_detector.requests.get")
-    def test_not_on_gce(self, getter):
-        getter.side_effect = Exception()
-        self.assertEqual(get_gce_resources(), {})
-
-    @mock.patch("opentelemetry.tools.resource_detector.requests.get")
     def test_finding_gce_resources(self, getter):
         getter.return_value.json.return_value = RESOURCES_JSON_STRING
         found_resources = get_gce_resources()
@@ -96,10 +91,3 @@ class TestGoogleCloudResourceDetector(unittest.TestCase):
                 }
             ),
         )
-
-    @mock.patch("opentelemetry.tools.resource_detector.requests.get")
-    def test_not_on_gcp(self, getter):
-        resource_finder = GoogleCloudResourceDetector()
-        getter.side_effect = Exception()
-        found_resources = resource_finder.detect()
-        self.assertEqual(found_resources, Resource.create_empty())

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_gcp_resource_detector.py
@@ -18,7 +18,7 @@ from unittest import mock
 
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.tools.resource_detector import (
-    _GCE_METADATA_URL,
+    _GCP_METADATA_URL,
     GoogleCloudResourceDetector,
     get_gce_resources,
 )
@@ -57,7 +57,7 @@ class TestGCEResourceFinder(unittest.TestCase):
     def test_finding_gce_resources(self, getter):
         getter.side_effect = mock_return_resources
         found_resources = get_gce_resources()
-        self.assertEqual(getter.call_args_list[0][0][0], _GCE_METADATA_URL)
+        self.assertEqual(getter.call_args_list[0][0][0], _GCP_METADATA_URL)
         self.assertEqual(
             found_resources,
             {
@@ -76,7 +76,7 @@ class TestGoogleCloudResourceDetector(unittest.TestCase):
         resource_finder = GoogleCloudResourceDetector()
         getter.side_effect = mock_return_resources
         found_resources = resource_finder.detect()
-        self.assertEqual(getter.call_args_list[0][0][0], _GCE_METADATA_URL)
+        self.assertEqual(getter.call_args_list[0][0][0], _GCP_METADATA_URL)
         self.assertEqual(
             found_resources,
             Resource(

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add support for resources and resource detector
+  ([#853](https://github.com/open-telemetry/opentelemetry-python/pull/853))
+
 ## Version 0.10b0
 
 Released 2020-06-23

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import typing
 from json import dumps
@@ -20,6 +21,7 @@ from opentelemetry.context import attach, detach, set_value
 
 LabelValue = typing.Union[str, bool, int, float]
 Labels = typing.Dict[str, LabelValue]
+logger = logging.getLogger(__name__)
 
 
 class Resource:
@@ -97,6 +99,7 @@ def get_aggregated_resources(
         except Exception as ex:
             if detector.raise_on_error:
                 raise ex
+            logger.warning("Exception in detector %s, ignoring", detector)
             detected_resources = _EMPTY_RESOURCE
         finally:
             final_resource = final_resource.merge(detected_resources)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -101,7 +101,7 @@ def get_aggregated_resources(
     final_resource = initial_resource or _EMPTY_RESOURCE
     detectors = [OTELResourceDetector()] + detectors
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
         futures = [executor.submit(detector.detect) for detector in detectors]
         for detector_ind, future in enumerate(futures):
             detector = detectors[detector_ind]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -72,12 +72,12 @@ class ResourceDetector:
 class OTELResourceDetector:
     # pylint: disable=no-self-use
     def detect(self) -> "Resource":
-        env_resources_items = os.environ["OTEL_RESOURCE"]
+        env_resources_items = os.environ.get("OTEL_RESOURCE")
         env_resource_map = {}
         if env_resources_items:
             for item in env_resources_items.split(","):
                 key, value = item.split("=")
-                env_resource_map[key] = value
+                env_resource_map[key.strip()] = value.strip()
         return Resource(env_resource_map)
 
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -84,11 +84,9 @@ class OTELResourceDetector:
 def get_aggregated_resources(
     detectors: typing.List["ResourceDetector"],
     initial_resource=None,
-    detect_from_env=True,
 ) -> "Resource":
     final_resource = initial_resource or _EMPTY_RESOURCE
-    if detect_from_env:
-        final_resource = final_resource.merge(OTELResourceDetector().detect())
+    final_resource = final_resource.merge(OTELResourceDetector().detect())
     token = attach(set_value("suppress_instrumentation", True))
     for detector in detectors:
         try:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -520,6 +520,7 @@ class Span(trace_api.Span):
         f_span["attributes"] = self._format_attributes(self.attributes)
         f_span["events"] = self._format_events(self.events)
         f_span["links"] = self._format_links(self.links)
+        f_span["resource"] = self.resource.labels
 
         return json.dumps(f_span, indent=indent)
 

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -954,10 +954,11 @@ class TestSpanProcessor(unittest.TestCase):
     "end_time": null,
     "attributes": {},
     "events": [],
-    "links": []
+    "links": [],
+    "resource": {}
 }""",
         )
         self.assertEqual(
             span.to_json(indent=None),
-            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "attributes": {}, "events": [], "links": []}',
+            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "attributes": {}, "events": [], "links": [], "resource": {}}',
         )


### PR DESCRIPTION
Adds Resource Detection for Google  tools like GCE and for environment variable resource detection OTEL_RESOURCE. Follows https://github.com/open-telemetry/oteps/pull/111 (Note at the time of writing this OTEP hasn't been updated after our offline discussion so there's currently some discrepancy). 

Example:
```
import time

from opentelemetry import metrics
from opentelemetry.exporter.cloud_monitoring import (
    CloudMonitoringMetricsExporter,
)
from opentelemetry.sdk.metrics import Counter, MeterProvider
from opentelemetry import trace
from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
from opentelemetry.tools.resource_detector import GoogleCloudResourceDetector
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
from opentelemetry.sdk.resources import Resource, get_aggregated_resources

resources = get_aggregated_resources([GoogleCloudResourceDetector()])

metrics.set_meter_provider(MeterProvider(resource=resources))
meter = metrics.get_meter(__name__)
metrics.get_meter_provider().start_pipeline(
    meter, CloudMonitoringMetricsExporter(), 5
)

requests_counter = meter.create_metric(
    name="request_counter",
    description="number of requests",
    unit="1",
    value_type=int,
    metric_type=Counter,
    label_keys=("environment"),
)

staging_labels = {"environment": "staging"}

for i in range(20):
    requests_counter.add(25, staging_labels)
    time.sleep(10)
```

Tests will be added in the next commit. Doing some manual testing with the code above, it correctly scrapes information when run on a GCE instance and sends it to Monitoring properly.

Addresses issue https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/issues/8