### PR TITLE
Added a warning log when the existing TracerProvider and MeterProvider are overridden

### DIFF
--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -16,6 +16,8 @@ Released 2020-06-10
   ([#764](https://github.com/open-telemetry/opentelemetry-python/pull/764))
 - Add SumObserver and UpDownSumObserver in metrics
   ([#789](https://github.com/open-telemetry/opentelemetry-python/pull/789))
+- Log a warning when replacing the global Tracer/Meter provider
+  ([#856](https://github.com/open-telemetry/opentelemetry-python/pull/856))
 
 ## 0.8b0
 

--- a/opentelemetry-api/src/opentelemetry/metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/__init__.py
@@ -460,6 +460,10 @@ def get_meter(
 def set_meter_provider(meter_provider: MeterProvider) -> None:
     """Sets the current global :class:`~.MeterProvider` object."""
     global _METER_PROVIDER  # pylint: disable=global-statement
+
+    if _METER_PROVIDER is not None:
+        logger.warning("Overriding current MeterProvider")
+
     _METER_PROVIDER = meter_provider
 
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -463,6 +463,10 @@ def get_tracer(
 def set_tracer_provider(tracer_provider: TracerProvider) -> None:
     """Sets the current global :class:`~.TracerProvider` object."""
     global _TRACER_PROVIDER  # pylint: disable=global-statement
+
+    if _TRACER_PROVIDER is not None:
+        logger.warning("Overriding current TracerProvider")
+
     _TRACER_PROVIDER = tracer_provider
 
 

--- a/opentelemetry-api/tests/metrics/test_globals.py
+++ b/opentelemetry-api/tests/metrics/test_globals.py
@@ -1,3 +1,4 @@
+# type:ignore
 import unittest
 from logging import WARNING
 

--- a/opentelemetry-api/tests/metrics/test_globals.py
+++ b/opentelemetry-api/tests/metrics/test_globals.py
@@ -1,0 +1,20 @@
+import unittest
+from logging import WARNING
+
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+
+
+class TestGlobals(unittest.TestCase):
+    def test_meter_provider_override_warning(self):
+        """metrics.set_meter_provider should throw a warning when overridden"""
+        metrics.set_meter_provider(MeterProvider())
+        with self.assertLogs(level=WARNING) as test:
+            metrics.set_meter_provider(MeterProvider())
+            self.assertEqual(
+                test.output,
+                [
+                    "WARNING:opentelemetry.metrics:Overriding current "
+                    "MeterProvider"
+                ],
+            )

--- a/opentelemetry-api/tests/metrics/test_globals.py
+++ b/opentelemetry-api/tests/metrics/test_globals.py
@@ -15,7 +15,9 @@ class TestGlobals(unittest.TestCase):
             self.assertEqual(
                 test.output,
                 [
-                    "WARNING:opentelemetry.metrics:Overriding current "
-                    "MeterProvider"
+                    (
+                        "WARNING:opentelemetry.metrics:Overriding current "
+                        "MeterProvider"
+                    )
                 ],
             )

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -3,8 +3,7 @@ from logging import WARNING
 from unittest.mock import patch
 
 from opentelemetry import context, trace
-from opentelemetry.sdk.trace import TracerProvider
-
+from opentelemetry.sdk.trace import TracerProvider  # type:ignore
 
 class TestGlobals(unittest.TestCase):
     def setUp(self):

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -1,7 +1,9 @@
 import unittest
+from logging import WARNING
 from unittest.mock import patch
 
 from opentelemetry import context, trace
+from opentelemetry.sdk.trace import TracerProvider
 
 
 class TestGlobals(unittest.TestCase):
@@ -19,6 +21,19 @@ class TestGlobals(unittest.TestCase):
         mock_provider = unittest.mock.Mock()
         trace.get_tracer("foo", "var", mock_provider)
         mock_provider.get_tracer.assert_called_with("foo", "var")
+
+    def test_tracer_provider_override_warning(self):
+        """trace.set_tracer_provider should throw a warning when overridden"""
+        trace.set_tracer_provider(TracerProvider())
+        with self.assertLogs(level=WARNING) as test:
+            trace.set_tracer_provider(TracerProvider())
+            self.assertEqual(
+                test.output,
+                [
+                    "WARNING:opentelemetry.trace:Overriding current "
+                    "TracerProvider"
+                ],
+            )
 
 
 class TestTracer(unittest.TestCase):

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from opentelemetry import context, trace
 from opentelemetry.sdk.trace import TracerProvider  # type:ignore
 
+
 class TestGlobals(unittest.TestCase):
     def setUp(self):
         self._patcher = patch("opentelemetry.trace._TRACER_PROVIDER")

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -30,8 +30,10 @@ class TestGlobals(unittest.TestCase):
             self.assertEqual(
                 test.output,
                 [
-                    "WARNING:opentelemetry.trace:Overriding current "
-                    "TracerProvider"
+                    (
+                        "WARNING:opentelemetry.trace:Overriding current "
+                        "TracerProvider"
+                    )
                 ],
             )
 


### PR DESCRIPTION
Fixes #840

This PR aims at providing a simple warning message when the TracerProvider and MeterProvider are overridden. Any value other than `None` in the globals is considered a set and warnings are thrown on all subsequent set to these variables.

Tests make sure that the relevant log messages are generated when TracerProvider and MeterProvider are overridden.