### PR TITLE
Fix auto instrumentation entry point for mysql

### DIFF
--- a/ext/opentelemetry-ext-mysql/CHANGELOG.md
+++ b/ext/opentelemetry-ext-mysql/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- bugfix: Fix auto-instrumentation entry point for mysql
+  ([#858](https://github.com/open-telemetry/opentelemetry-python/pull/858))
+
 ## 0.7b1
 
 Released 2020-05-12

--- a/ext/opentelemetry-ext-mysql/setup.cfg
+++ b/ext/opentelemetry-ext-mysql/setup.cfg
@@ -55,4 +55,4 @@ where = src
 
 [options.entry_points]
 opentelemetry_instrumentor =
-    mysql = opentelemetry.ext.pymysql:MySQLInstrumentor
+    mysql = opentelemetry.ext.mysql:MySQLInstrumentor


### PR DESCRIPTION
entry point for the `mysql` instrumentation pointed to `pymysql` instrumentation which caused loading of the instrumentation to fail since it does not exist.