### PR TITLE
Fix API/SDK dependencies in datadog exporter

### DIFF
--- a/ext/opentelemetry-ext-datadog/setup.cfg
+++ b/ext/opentelemetry-ext-datadog/setup.cfg
@@ -40,8 +40,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     ddtrace>=0.34.0
-    opentelemetry-api==0.10.dev0
-    opentelemetry-sdk==0.10.dev0
+    opentelemetry-api==0.11.dev0
+    opentelemetry-sdk==0.11.dev0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
datadog exporter was still referencing API and SDK in version `0.10.dev0` instead of the current version