### PR TITLE
Fixing the serialization of a tuple element by coercing it into a string

### DIFF
--- a/ext/opentelemetry-ext-jaeger/CHANGELOG.md
+++ b/ext/opentelemetry-ext-jaeger/CHANGELOG.md
@@ -8,6 +8,8 @@ Released 2020-05-27
 
 - Transform resource to tags when exporting
   ([#645](https://github.com/open-telemetry/opentelemetry-python/pull/645))
+- ext/boto: Could not serialize attribute aws.region to tag when exporting via jaeger
+  ([#865](https://github.com/open-telemetry/opentelemetry-python/pull/865))
 
 ## 0.6b0
 

--- a/ext/opentelemetry-ext-jaeger/CHANGELOG.md
+++ b/ext/opentelemetry-ext-jaeger/CHANGELOG.md
@@ -9,6 +9,8 @@ Released 2020-05-27
 - Transform resource to tags when exporting
   ([#645](https://github.com/open-telemetry/opentelemetry-python/pull/645))
 - ext/boto: Could not serialize attribute aws.region to tag when exporting via jaeger
+  Serialize tuple type values by coercing them into a string, since Jaeger does not
+  support tuple types.
   ([#865](https://github.com/open-telemetry/opentelemetry-python/pull/865))
 
 ## 0.6b0

--- a/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
+++ b/ext/opentelemetry-ext-jaeger/src/opentelemetry/ext/jaeger/__init__.py
@@ -314,6 +314,8 @@ def _convert_attribute_to_tag(key, attr):
         return jaeger.Tag(key=key, vLong=attr, vType=jaeger.TagType.LONG)
     if isinstance(attr, float):
         return jaeger.Tag(key=key, vDouble=attr, vType=jaeger.TagType.DOUBLE)
+    if isinstance(attr, tuple):
+        return jaeger.Tag(key=key, vStr=str(attr), vType=jaeger.TagType.STRING)
     logger.warning("Could not serialize attribute %s:%r to tag", key, attr)
     return None
 

--- a/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
+++ b/ext/opentelemetry-ext-jaeger/tests/test_jaeger_exporter.py
@@ -200,6 +200,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
         otel_spans[0].set_attribute("key_bool", False)
         otel_spans[0].set_attribute("key_string", "hello_world")
         otel_spans[0].set_attribute("key_float", 111.22)
+        otel_spans[0].set_attribute("key_tuple", ("tuple_element",))
         otel_spans[0].resource = Resource(
             labels={"key_resource": "some_resource"}
         )
@@ -240,6 +241,11 @@ class TestJaegerSpanExporter(unittest.TestCase):
                         key="key_float",
                         vType=jaeger.TagType.DOUBLE,
                         vDouble=111.22,
+                    ),
+                    jaeger.Tag(
+                        key="key_tuple",
+                        vType=jaeger.TagType.STRING,
+                        vStr="('tuple_element',)",
                     ),
                     jaeger.Tag(
                         key="key_resource",


### PR DESCRIPTION
Fixes #818 

This PR aims at fix the serialization of tuple type values by coercing them into a string.

Tests make sure that this type is handled correctly. The current test is enhanced to include tuple type as well.