### PR TITLE
Converted resource to hold Resource attribute than a string

### DIFF
--- a/ext/opentelemetry-ext-boto/CHANGELOG.md
+++ b/ext/opentelemetry-ext-boto/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+## 0.11b0
+- ext/boto and ext/botocore: fails to export spans via jaeger
+([#866](https://github.com/open-telemetry/opentelemetry-python/pull/866))
+
 ## 0.9b0
 
 Released 2020-06-10
 
 - Initial release
+

--- a/ext/opentelemetry-ext-boto/CHANGELOG.md
+++ b/ext/opentelemetry-ext-boto/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-## 0.11b0
 - ext/boto and ext/botocore: fails to export spans via jaeger
 ([#866](https://github.com/open-telemetry/opentelemetry-python/pull/866))
 

--- a/ext/opentelemetry-ext-boto/src/opentelemetry/ext/boto/__init__.py
+++ b/ext/opentelemetry-ext-boto/src/opentelemetry/ext/boto/__init__.py
@@ -52,7 +52,6 @@ from wrapt import ObjectProxy, wrap_function_wrapper
 
 from opentelemetry.ext.boto.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.sdk.trace import Resource
 from opentelemetry.trace import SpanKind, get_tracer
 
 logger = logging.getLogger(__name__)
@@ -124,14 +123,9 @@ class BotoInstrumentor(BaseInstrumentor):
         ) as span:
             if args:
                 http_method = args[0]
-                span.resource = Resource(
-                    labels={
-                        "endpoint": endpoint_name,
-                        "http_method": http_method.lower(),
-                    }
-                )
+                span.resource = "%s.%s" % (endpoint_name, http_method.lower())
             else:
-                span.resource = Resource(labels={"endpoint": endpoint_name})
+                span.resource = endpoint_name
 
             add_span_arg_tags(
                 span, endpoint_name, args, args_name, traced_args,

--- a/ext/opentelemetry-ext-boto/src/opentelemetry/ext/boto/__init__.py
+++ b/ext/opentelemetry-ext-boto/src/opentelemetry/ext/boto/__init__.py
@@ -52,6 +52,7 @@ from wrapt import ObjectProxy, wrap_function_wrapper
 
 from opentelemetry.ext.boto.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.sdk.trace import Resource
 from opentelemetry.trace import SpanKind, get_tracer
 
 logger = logging.getLogger(__name__)
@@ -123,9 +124,14 @@ class BotoInstrumentor(BaseInstrumentor):
         ) as span:
             if args:
                 http_method = args[0]
-                span.resource = "%s.%s" % (endpoint_name, http_method.lower())
+                span.resource = Resource(
+                    labels={
+                        "endpoint": endpoint_name,
+                        "http_method": http_method.lower(),
+                    }
+                )
             else:
-                span.resource = endpoint_name
+                span.resource = Resource(labels={"endpoint": endpoint_name})
 
             add_span_arg_tags(
                 span, endpoint_name, args, args_name, traced_args,

--- a/ext/opentelemetry-ext-boto/tests/test_boto_instrumentation.py
+++ b/ext/opentelemetry-ext-boto/tests/test_boto_instrumentation.py
@@ -27,7 +27,6 @@ from moto import (  # pylint: disable=import-error
 )
 
 from opentelemetry.ext.boto import BotoInstrumentor
-from opentelemetry.sdk.resources import Resource
 from opentelemetry.test.test_base import TestBase
 
 
@@ -70,12 +69,7 @@ class TestBotoInstrumentor(TestBase):
         span = spans[1]
         self.assertEqual(span.attributes["aws.operation"], "RunInstances")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(
-            span.resource,
-            Resource(
-                labels={"endpoint": "ec2", "http_method": "runinstances"}
-            ),
-        )
+        self.assertEqual(span.resource, "ec2.runinstances")
         self.assertEqual(span.attributes["http.method"], "POST")
         self.assertEqual(span.attributes["aws.region"], "us-west-2")
         self.assertEqual(span.name, "ec2.command")
@@ -129,10 +123,7 @@ class TestBotoInstrumentor(TestBase):
         self.assertEqual(len(spans), 3)
         span = spans[2]
         assert_span_http_status_code(span, 200)
-        self.assertEqual(
-            span.resource,
-            Resource(labels={"endpoint": "s3", "http_method": "head"}),
-        )
+        self.assertEqual(span.resource, "s3.head")
         self.assertEqual(span.attributes["http.method"], "HEAD")
         self.assertEqual(span.attributes["aws.operation"], "head_bucket")
         self.assertEqual(span.name, "s3.command")
@@ -144,10 +135,7 @@ class TestBotoInstrumentor(TestBase):
             spans = self.memory_exporter.get_finished_spans()
             assert spans
             span = spans[2]
-            self.assertEqual(
-                span.resource,
-                Resource(labels={"endpoint": "s3", "http_method": "head"}),
-            )
+            self.assertEqual(span.resource, "s3.head")
 
     @mock_s3_deprecated
     def test_s3_put(self):
@@ -164,24 +152,15 @@ class TestBotoInstrumentor(TestBase):
         self.assertEqual(len(spans), 3)
         self.assertEqual(spans[0].attributes["aws.operation"], "create_bucket")
         assert_span_http_status_code(spans[0], 200)
-        self.assertEqual(
-            spans[0].resource,
-            Resource(labels={"endpoint": "s3", "http_method": "put"}),
-        )
+        self.assertEqual(spans[0].resource, "s3.put")
         # get bucket
         self.assertEqual(spans[1].attributes["aws.operation"], "head_bucket")
-        self.assertEqual(
-            spans[1].resource,
-            Resource(labels={"endpoint": "s3", "http_method": "head"}),
-        )
+        self.assertEqual(spans[1].resource, "s3.head")
         # put object
         self.assertEqual(
             spans[2].attributes["aws.operation"], "_send_file_internal"
         )
-        self.assertEqual(
-            spans[2].resource,
-            Resource(labels={"endpoint": "s3", "http_method": "put"}),
-        )
+        self.assertEqual(spans[2].resource, "s3.put")
 
     @mock_lambda_deprecated
     def test_unpatch(self):
@@ -221,10 +200,7 @@ class TestBotoInstrumentor(TestBase):
         self.assertEqual(len(spans), 2)
         span = spans[0]
         assert_span_http_status_code(span, 200)
-        self.assertEqual(
-            span.resource,
-            Resource(labels={"endpoint": "lambda", "http_method": "get"}),
-        )
+        self.assertEqual(span.resource, "lambda.get")
         self.assertEqual(span.attributes["http.method"], "GET")
         self.assertEqual(span.attributes["aws.region"], "us-east-2")
         self.assertEqual(span.attributes["aws.operation"], "list_functions")
@@ -238,12 +214,7 @@ class TestBotoInstrumentor(TestBase):
         spans = self.memory_exporter.get_finished_spans()
         assert spans
         span = spans[0]
-        self.assertEqual(
-            span.resource,
-            Resource(
-                labels={"endpoint": "sts", "http_method": "getfederationtoken"}
-            ),
-        )
+        self.assertEqual(span.resource, "sts.getfederationtoken")
         self.assertEqual(span.attributes["aws.region"], "us-west-2")
         self.assertEqual(
             span.attributes["aws.operation"], "GetFederationToken"
@@ -267,7 +238,5 @@ class TestBotoInstrumentor(TestBase):
         spans = self.memory_exporter.get_finished_spans()
         assert spans
         span = spans[0]
-        self.assertEqual(
-            span.resource, Resource(labels={"endpoint": "elasticcache"})
-        )
+        self.assertEqual(span.resource, "elasticache")
         self.assertEqual(span.attributes["aws.region"], "us-west-2")

--- a/ext/opentelemetry-ext-boto/tests/test_boto_instrumentation.py
+++ b/ext/opentelemetry-ext-boto/tests/test_boto_instrumentation.py
@@ -27,6 +27,7 @@ from moto import (  # pylint: disable=import-error
 )
 
 from opentelemetry.ext.boto import BotoInstrumentor
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.test.test_base import TestBase
 
 
@@ -69,7 +70,12 @@ class TestBotoInstrumentor(TestBase):
         span = spans[1]
         self.assertEqual(span.attributes["aws.operation"], "RunInstances")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(span.resource, "ec2.runinstances")
+        self.assertEqual(
+            span.resource,
+            Resource(
+                labels={"endpoint": "ec2", "http_method": "runinstances"}
+            ),
+        )
         self.assertEqual(span.attributes["http.method"], "POST")
         self.assertEqual(span.attributes["aws.region"], "us-west-2")
         self.assertEqual(span.name, "ec2.command")
@@ -123,7 +129,10 @@ class TestBotoInstrumentor(TestBase):
         self.assertEqual(len(spans), 3)
         span = spans[2]
         assert_span_http_status_code(span, 200)
-        self.assertEqual(span.resource, "s3.head")
+        self.assertEqual(
+            span.resource,
+            Resource(labels={"endpoint": "s3", "http_method": "head"}),
+        )
         self.assertEqual(span.attributes["http.method"], "HEAD")
         self.assertEqual(span.attributes["aws.operation"], "head_bucket")
         self.assertEqual(span.name, "s3.command")
@@ -135,7 +144,10 @@ class TestBotoInstrumentor(TestBase):
             spans = self.memory_exporter.get_finished_spans()
             assert spans
             span = spans[2]
-            self.assertEqual(span.resource, "s3.head")
+            self.assertEqual(
+                span.resource,
+                Resource(labels={"endpoint": "s3", "http_method": "head"}),
+            )
 
     @mock_s3_deprecated
     def test_s3_put(self):
@@ -152,15 +164,24 @@ class TestBotoInstrumentor(TestBase):
         self.assertEqual(len(spans), 3)
         self.assertEqual(spans[0].attributes["aws.operation"], "create_bucket")
         assert_span_http_status_code(spans[0], 200)
-        self.assertEqual(spans[0].resource, "s3.put")
+        self.assertEqual(
+            spans[0].resource,
+            Resource(labels={"endpoint": "s3", "http_method": "put"}),
+        )
         # get bucket
         self.assertEqual(spans[1].attributes["aws.operation"], "head_bucket")
-        self.assertEqual(spans[1].resource, "s3.head")
+        self.assertEqual(
+            spans[1].resource,
+            Resource(labels={"endpoint": "s3", "http_method": "head"}),
+        )
         # put object
         self.assertEqual(
             spans[2].attributes["aws.operation"], "_send_file_internal"
         )
-        self.assertEqual(spans[2].resource, "s3.put")
+        self.assertEqual(
+            spans[2].resource,
+            Resource(labels={"endpoint": "s3", "http_method": "put"}),
+        )
 
     @mock_lambda_deprecated
     def test_unpatch(self):
@@ -200,7 +221,10 @@ class TestBotoInstrumentor(TestBase):
         self.assertEqual(len(spans), 2)
         span = spans[0]
         assert_span_http_status_code(span, 200)
-        self.assertEqual(span.resource, "lambda.get")
+        self.assertEqual(
+            span.resource,
+            Resource(labels={"endpoint": "lambda", "http_method": "get"}),
+        )
         self.assertEqual(span.attributes["http.method"], "GET")
         self.assertEqual(span.attributes["aws.region"], "us-east-2")
         self.assertEqual(span.attributes["aws.operation"], "list_functions")
@@ -214,7 +238,12 @@ class TestBotoInstrumentor(TestBase):
         spans = self.memory_exporter.get_finished_spans()
         assert spans
         span = spans[0]
-        self.assertEqual(span.resource, "sts.getfederationtoken")
+        self.assertEqual(
+            span.resource,
+            Resource(
+                labels={"endpoint": "sts", "http_method": "getfederationtoken"}
+            ),
+        )
         self.assertEqual(span.attributes["aws.region"], "us-west-2")
         self.assertEqual(
             span.attributes["aws.operation"], "GetFederationToken"
@@ -238,5 +267,7 @@ class TestBotoInstrumentor(TestBase):
         spans = self.memory_exporter.get_finished_spans()
         assert spans
         span = spans[0]
-        self.assertEqual(span.resource, "elasticache")
+        self.assertEqual(
+            span.resource, Resource(labels={"endpoint": "elasticcache"})
+        )
         self.assertEqual(span.attributes["aws.region"], "us-west-2")

--- a/ext/opentelemetry-ext-botocore/CHANGELOG.md
+++ b/ext/opentelemetry-ext-botocore/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.11b0
+- ext/boto and ext/botocore: fails to export spans via jaeger
+([#866](https://github.com/open-telemetry/opentelemetry-python/pull/866))
+
 ## 0.9b0
 
 Released 2020-06-10

--- a/ext/opentelemetry-ext-botocore/CHANGELOG.md
+++ b/ext/opentelemetry-ext-botocore/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-## 0.11b0
 - ext/boto and ext/botocore: fails to export spans via jaeger
 ([#866](https://github.com/open-telemetry/opentelemetry-python/pull/866))
 

--- a/ext/opentelemetry-ext-botocore/src/opentelemetry/ext/botocore/__init__.py
+++ b/ext/opentelemetry-ext-botocore/src/opentelemetry/ext/botocore/__init__.py
@@ -58,7 +58,6 @@ from wrapt import ObjectProxy, wrap_function_wrapper
 
 from opentelemetry.ext.botocore.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.sdk.trace import Resource
 from opentelemetry.trace import SpanKind, get_tracer
 
 logger = logging.getLogger(__name__)
@@ -99,15 +98,10 @@ class BotocoreInstrumentor(BaseInstrumentor):
             operation = None
             if args:
                 operation = args[0]
-                span.resource = Resource(
-                    labels={
-                        "endpoint": endpoint_name,
-                        "operation": operation.lower(),
-                    }
-                )
+                span.resource = "%s.%s" % (endpoint_name, operation.lower())
 
             else:
-                span.resource = Resource(labels={"endpoint": endpoint_name})
+                span.resource = endpoint_name
 
             add_span_arg_tags(
                 span,

--- a/ext/opentelemetry-ext-botocore/src/opentelemetry/ext/botocore/__init__.py
+++ b/ext/opentelemetry-ext-botocore/src/opentelemetry/ext/botocore/__init__.py
@@ -58,6 +58,7 @@ from wrapt import ObjectProxy, wrap_function_wrapper
 
 from opentelemetry.ext.botocore.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.sdk.trace import Resource
 from opentelemetry.trace import SpanKind, get_tracer
 
 logger = logging.getLogger(__name__)
@@ -98,10 +99,15 @@ class BotocoreInstrumentor(BaseInstrumentor):
             operation = None
             if args:
                 operation = args[0]
-                span.resource = "%s.%s" % (endpoint_name, operation.lower())
+                span.resource = Resource(
+                    labels={
+                        "endpoint": endpoint_name,
+                        "operation": operation.lower(),
+                    }
+                )
 
             else:
-                span.resource = endpoint_name
+                span.resource = Resource(labels={"endpoint": endpoint_name})
 
             add_span_arg_tags(
                 span,

--- a/ext/opentelemetry-ext-botocore/tests/test_botocore_instrumentation.py
+++ b/ext/opentelemetry-ext-botocore/tests/test_botocore_instrumentation.py
@@ -10,6 +10,7 @@ from moto import (  # pylint: disable=import-error
 )
 
 from opentelemetry.ext.botocore import BotocoreInstrumentor
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.test.test_base import TestBase
 
 
@@ -49,7 +50,12 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(span.attributes["aws.region"], "us-west-2")
         self.assertEqual(span.attributes["aws.operation"], "DescribeInstances")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(span.resource, "ec2.describeinstances")
+        self.assertEqual(
+            span.resource,
+            Resource(
+                labels={"endpoint": "ec2", "operation": "describeinstances"}
+            ),
+        )
         self.assertEqual(span.name, "ec2.command")
 
     @mock_ec2
@@ -73,7 +79,10 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(len(spans), 2)
         self.assertEqual(span.attributes["aws.operation"], "ListBuckets")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(span.resource, "s3.listbuckets")
+        self.assertEqual(
+            span.resource,
+            Resource(labels={"endpoint": "s3", "operation": "listbuckets"}),
+        )
 
         # testing for span error
         self.memory_exporter.get_finished_spans()
@@ -82,7 +91,10 @@ class TestBotocoreInstrumentor(TestBase):
         spans = self.memory_exporter.get_finished_spans()
         assert spans
         span = spans[2]
-        self.assertEqual(span.resource, "s3.listobjects")
+        self.assertEqual(
+            span.resource,
+            Resource(labels={"endpoint": "s3", "operation": "listobjects"}),
+        )
 
     @mock_s3
     def test_s3_put(self):
@@ -97,9 +109,15 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(len(spans), 2)
         self.assertEqual(span.attributes["aws.operation"], "CreateBucket")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(span.resource, "s3.createbucket")
+        self.assertEqual(
+            span.resource,
+            Resource(labels={"endpoint": "s3", "operation": "createbucket"}),
+        )
         self.assertEqual(spans[1].attributes["aws.operation"], "PutObject")
-        self.assertEqual(spans[1].resource, "s3.putobject")
+        self.assertEqual(
+            spans[1].resource,
+            Resource(labels={"endpoint": "s3", "operation": "putobject"}),
+        )
         self.assertEqual(spans[1].attributes["params.Key"], str(params["Key"]))
         self.assertEqual(
             spans[1].attributes["params.Bucket"], str(params["Bucket"])
@@ -119,7 +137,10 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(span.attributes["aws.region"], "us-east-1")
         self.assertEqual(span.attributes["aws.operation"], "ListQueues")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(span.resource, "sqs.listqueues")
+        self.assertEqual(
+            span.resource,
+            Resource(labels={"endpoint": "sqs", "operation": "listqueues"}),
+        )
 
     @mock_kinesis
     def test_kinesis_client(self):
@@ -136,7 +157,12 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(span.attributes["aws.region"], "us-east-1")
         self.assertEqual(span.attributes["aws.operation"], "ListStreams")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(span.resource, "kinesis.liststreams")
+        self.assertEqual(
+            span.resource,
+            Resource(
+                labels={"endpoint": "kinesis", "operation": "liststreams"}
+            ),
+        )
 
     @mock_kinesis
     def test_unpatch(self):
@@ -176,7 +202,12 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(span.attributes["aws.region"], "us-east-1")
         self.assertEqual(span.attributes["aws.operation"], "ListFunctions")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(span.resource, "lambda.listfunctions")
+        self.assertEqual(
+            span.resource,
+            Resource(
+                labels={"endpoint": "lambda", "operation": "listfunctions"}
+            ),
+        )
 
     @mock_kms
     def test_kms_client(self):
@@ -191,7 +222,10 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(span.attributes["aws.region"], "us-east-1")
         self.assertEqual(span.attributes["aws.operation"], "ListKeys")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(span.resource, "kms.listkeys")
+        self.assertEqual(
+            span.resource,
+            Resource(labels={"endpoint": "kms", "operation": "listkeys"}),
+        )
 
         # checking for protection on sts against security leak
         self.assertTrue("params" not in span.attributes.keys())

--- a/ext/opentelemetry-ext-botocore/tests/test_botocore_instrumentation.py
+++ b/ext/opentelemetry-ext-botocore/tests/test_botocore_instrumentation.py
@@ -10,7 +10,6 @@ from moto import (  # pylint: disable=import-error
 )
 
 from opentelemetry.ext.botocore import BotocoreInstrumentor
-from opentelemetry.sdk.resources import Resource
 from opentelemetry.test.test_base import TestBase
 
 
@@ -50,12 +49,7 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(span.attributes["aws.region"], "us-west-2")
         self.assertEqual(span.attributes["aws.operation"], "DescribeInstances")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(
-            span.resource,
-            Resource(
-                labels={"endpoint": "ec2", "operation": "describeinstances"}
-            ),
-        )
+        self.assertEqual(span.resource, "ec2.describeinstances")
         self.assertEqual(span.name, "ec2.command")
 
     @mock_ec2
@@ -79,10 +73,7 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(len(spans), 2)
         self.assertEqual(span.attributes["aws.operation"], "ListBuckets")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(
-            span.resource,
-            Resource(labels={"endpoint": "s3", "operation": "listbuckets"}),
-        )
+        self.assertEqual(span.resource, "s3.listbuckets")
 
         # testing for span error
         self.memory_exporter.get_finished_spans()
@@ -91,10 +82,7 @@ class TestBotocoreInstrumentor(TestBase):
         spans = self.memory_exporter.get_finished_spans()
         assert spans
         span = spans[2]
-        self.assertEqual(
-            span.resource,
-            Resource(labels={"endpoint": "s3", "operation": "listobjects"}),
-        )
+        self.assertEqual(span.resource, "s3.listobjects")
 
     @mock_s3
     def test_s3_put(self):
@@ -109,15 +97,9 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(len(spans), 2)
         self.assertEqual(span.attributes["aws.operation"], "CreateBucket")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(
-            span.resource,
-            Resource(labels={"endpoint": "s3", "operation": "createbucket"}),
-        )
+        self.assertEqual(span.resource, "s3.createbucket")
         self.assertEqual(spans[1].attributes["aws.operation"], "PutObject")
-        self.assertEqual(
-            spans[1].resource,
-            Resource(labels={"endpoint": "s3", "operation": "putobject"}),
-        )
+        self.assertEqual(spans[1].resource, "s3.putobject")
         self.assertEqual(spans[1].attributes["params.Key"], str(params["Key"]))
         self.assertEqual(
             spans[1].attributes["params.Bucket"], str(params["Bucket"])
@@ -137,10 +119,7 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(span.attributes["aws.region"], "us-east-1")
         self.assertEqual(span.attributes["aws.operation"], "ListQueues")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(
-            span.resource,
-            Resource(labels={"endpoint": "sqs", "operation": "listqueues"}),
-        )
+        self.assertEqual(span.resource, "sqs.listqueues")
 
     @mock_kinesis
     def test_kinesis_client(self):
@@ -157,12 +136,7 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(span.attributes["aws.region"], "us-east-1")
         self.assertEqual(span.attributes["aws.operation"], "ListStreams")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(
-            span.resource,
-            Resource(
-                labels={"endpoint": "kinesis", "operation": "liststreams"}
-            ),
-        )
+        self.assertEqual(span.resource, "kinesis.liststreams")
 
     @mock_kinesis
     def test_unpatch(self):
@@ -202,12 +176,7 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(span.attributes["aws.region"], "us-east-1")
         self.assertEqual(span.attributes["aws.operation"], "ListFunctions")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(
-            span.resource,
-            Resource(
-                labels={"endpoint": "lambda", "operation": "listfunctions"}
-            ),
-        )
+        self.assertEqual(span.resource, "lambda.listfunctions")
 
     @mock_kms
     def test_kms_client(self):
@@ -222,10 +191,7 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertEqual(span.attributes["aws.region"], "us-east-1")
         self.assertEqual(span.attributes["aws.operation"], "ListKeys")
         assert_span_http_status_code(span, 200)
-        self.assertEqual(
-            span.resource,
-            Resource(labels={"endpoint": "kms", "operation": "listkeys"}),
-        )
+        self.assertEqual(span.resource, "kms.listkeys")
 
         # checking for protection on sts against security leak
         self.assertTrue("params" not in span.attributes.keys())


### PR DESCRIPTION
Fixes #817 

This PR aims to fix the issue of having the resource attribute in boto and botocore as `string` which fails when exported to Jaeger or zipkin.

Tests are fixed to reflect these changes by converting resource from `string` to `Resource`