### PR TITLE
Updating datadog dependencies to 0.10b0

### DIFF
--- a/ext/opentelemetry-ext-datadog/setup.cfg
+++ b/ext/opentelemetry-ext-datadog/setup.cfg
@@ -40,8 +40,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     ddtrace>=0.34.0
-    opentelemetry-api==0.10.dev0
-    opentelemetry-sdk==0.10.dev0
+    opentelemetry-api == 0.10b0
+    opentelemetry-sdk == 0.10b0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
eachdist.py release did not catch the version specifiers
in ext-datadog's setup.cfg.

I would also like to release this fix to 0.10b0, which raises an interesting question: how should we go about doing that?

I see two options:

1. delete old 0.10b0 for ext-datadog, and re-release it.
2. update version of ext-datadog to 0.10b1, and release that.

* pro for 1: no need to wrestle with upping all versions at the same time.
* pro for 2: doesn't replace an existing package that was uploaded. This break an expectation around package contents not changing between versions. Although right now, ext-datadog is unusable anyway (0.10dev0 doesn't really exist in pypi)

Thoughts?