### PR TITLE
bump datadog to 0.10b1

### DIFF
--- a/ext/opentelemetry-ext-datadog/src/opentelemetry/ext/datadog/version.py
+++ b/ext/opentelemetry-ext-datadog/src/opentelemetry/ext/datadog/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.10b0"
+__version__ = "0.10b1"


### PR DESCRIPTION
pypi.io does not allow re-uploading of a version, even if it is deleted. As such, bumping an incremental version of ext-datadog to publish a version with fixed dependency versions.