### PR TITLE
Strip letters

### DIFF
--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/__init__.py
@@ -291,6 +291,10 @@ def _extract_events(events: Sequence[Event]) -> ProtoSpan.TimeEvents:
     )
 
 
+def _strip_characters(ot_version):
+    return "".join(filter(lambda x: x.isdigit() or x == ".", ot_version))
+
+
 def _extract_attributes(
     attrs: types.Attributes,
     num_attrs_limit: int,
@@ -310,8 +314,10 @@ def _extract_attributes(
     if add_agent_attr:
         attributes_dict["g.co/agent"] = _format_attribute_value(
             "opentelemetry-python {}; google-cloud-trace-exporter {}".format(
-                pkg_resources.get_distribution("opentelemetry-sdk").version,
-                cloud_trace_version,
+                _strip_characters(
+                    pkg_resources.get_distribution("opentelemetry-sdk").version
+                ),
+                _strip_characters(cloud_trace_version),
             )
         )
     return ProtoSpan.Attributes(

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
@@ -421,5 +421,7 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
 
     def test_strip_characters(self):
         self.assertEqual("0.10.0", _strip_characters("0.10.0b"))
-        self.assertEqual("0.10.0", _strip_characters("0.10.0"))
-        self.assertEqual("0.10.0", _strip_characters("0.10.0beta"))
+        self.assertEqual("1.20.5", _strip_characters("1.20.5"))
+        self.assertEqual("3.1.0", _strip_characters("3.1.0beta"))
+        self.assertEqual("4.2.0", _strip_characters("4b.2rc.0a"))
+        self.assertEqual("6.20.15", _strip_characters("b6.20.15"))

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
@@ -418,3 +418,8 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
             ),
             MAX_EVENT_ATTRS,
         )
+
+    def test_strip_characters(self):
+        self.assertEqual("0.10.0", _strip_characters("0.10.0b"))
+        self.assertEqual("0.10.0", _strip_characters("0.10.0"))
+        self.assertEqual("0.10.0", _strip_characters("0.10.0beta"))

--- a/ext/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
+++ b/ext/opentelemetry-exporter-cloud-trace/tests/test_cloud_trace_exporter.py
@@ -32,6 +32,7 @@ from opentelemetry.exporter.cloud_trace import (
     _extract_links,
     _extract_status,
     _format_attribute_value,
+    _strip_characters,
     _truncate_str,
 )
 from opentelemetry.exporter.cloud_trace.version import (
@@ -117,10 +118,12 @@ class TestCloudTraceSpanExporter(unittest.TestCase):
                 attribute_map={
                     "g.co/agent": _format_attribute_value(
                         "opentelemetry-python {}; google-cloud-trace-exporter {}".format(
-                            pkg_resources.get_distribution(
-                                "opentelemetry-sdk"
-                            ).version,
-                            cloud_trace_version,
+                            _strip_characters(
+                                pkg_resources.get_distribution(
+                                    "opentelemetry-sdk"
+                                ).version
+                            ),
+                            _strip_characters(cloud_trace_version),
                         )
                     )
                 }


### PR DESCRIPTION
Google cloud trace exporter exports an additional label with all spans of the form

g.co/agent: "opentelemetry-python <ot_version>; google-cloud-trace-exporter <exporter_version>"

Currently, <ot_version> and <exporter_version> can have values "0.10.0b". The "b" makes it difficult for internal metrics at Google, so this PR removes those non numeric characters.