### PR TITLE
Return INVALID_SPAN on get_current_span instead of None

### DIFF
--- a/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/cloud_trace_propagator.py
+++ b/ext/opentelemetry-exporter-cloud-trace/src/opentelemetry/exporter/cloud_trace/cloud_trace_propagator.py
@@ -77,8 +77,6 @@ class CloudTraceFormatPropagator(httptextformat.HTTPTextFormat):
         context: typing.Optional[Context] = None,
     ) -> None:
         span = trace.get_current_span(context)
-        if span is None:
-            return
         span_context = span.get_context()
         if span_context == trace.INVALID_SPAN_CONTEXT:
             return

--- a/ext/opentelemetry-ext-datadog/src/opentelemetry/ext/datadog/propagator.py
+++ b/ext/opentelemetry-ext-datadog/src/opentelemetry/ext/datadog/propagator.py
@@ -86,6 +86,9 @@ class DatadogFormat(HTTPTextFormat):
         context: typing.Optional[Context] = None,
     ) -> None:
         span = get_current_span(context)
+        span_context = span.get_context()
+        if span_context == trace.INVALID_SPAN_CONTEXT:
+            return
         sampled = (trace.TraceFlags.SAMPLED & span.context.trace_flags) != 0
         set_in_carrier(
             carrier, self.TRACE_ID_KEY, format_trace_id(span.context.trace_id),

--- a/ext/opentelemetry-ext-grpc/tests/test_server_interceptor.py
+++ b/ext/opentelemetry-ext-grpc/tests/test_server_interceptor.py
@@ -118,8 +118,8 @@ class TestOpenTelemetryServerInterceptor(TestBase):
             server.stop(None)
         active_span_after_call = trace.get_current_span()
 
-        self.assertIsNone(active_span_before_call)
-        self.assertIsNone(active_span_after_call)
+        self.assertEqual(active_span_before_call, trace.INVALID_SPAN)
+        self.assertEqual(active_span_after_call, trace.INVALID_SPAN)
         self.assertIsInstance(active_span_in_handler, trace_sdk.Span)
         self.assertIsNone(active_span_in_handler.parent)
 

--- a/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
+++ b/ext/opentelemetry-ext-opentracing-shim/src/opentelemetry/ext/opentracing_shim/__init__.py
@@ -470,7 +470,7 @@ class ScopeManagerShim(opentracing.ScopeManager):
         """
 
         span = trace_api.get_current_span()
-        if span is None:
+        if span.get_context() == trace_api.INVALID_SPAN_CONTEXT:
             return None
 
         span_context = SpanContextShim(span.get_context())

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Return INVALID_SPAN if no TracerProvider set for get_current_span
+  ([#751](https://github.com/open-telemetry/opentelemetry-python/pull/751))
+
 ## 0.9b0
 
 Released 2020-06-10

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/__init__.py
@@ -34,7 +34,7 @@ def set_span_in_context(
     return ctx
 
 
-def get_current_span(context: Optional[Context] = None) -> Optional[Span]:
+def get_current_span(context: Optional[Context] = None) -> Span:
     """Retrieve the current span.
 
     Args:

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/__init__.py
@@ -42,11 +42,9 @@ def get_current_span(context: Optional[Context] = None) -> Optional[Span]:
             default current context is used instead.
 
     Returns:
-        The Span set in the context if it exists. None otherwise.
+        The Span set in the context if it exists. INVALID_SPAN otherwise.
     """
     span = get_value(SPAN_KEY, context=context)
-    if span is None:
-        return None
-    if not isinstance(span, Span):
+    if span is None or not isinstance(span, Span):
         return INVALID_SPAN
     return span

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontexthttptextformat.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontexthttptextformat.py
@@ -120,9 +120,6 @@ class TraceContextHTTPTextFormat(httptextformat.HTTPTextFormat):
         See `opentelemetry.trace.propagation.httptextformat.HTTPTextFormat.inject`
         """
         span = trace.get_current_span(context)
-        if span is None:
-            return
-        span_context = span.get_context()
         if span_context == trace.INVALID_SPAN_CONTEXT:
             return
         traceparent_string = "00-{:032x}-{:016x}-{:02x}".format(

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontexthttptextformat.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontexthttptextformat.py
@@ -120,6 +120,7 @@ class TraceContextHTTPTextFormat(httptextformat.HTTPTextFormat):
         See `opentelemetry.trace.propagation.httptextformat.HTTPTextFormat.inject`
         """
         span = trace.get_current_span(context)
+        span_context = span.get_context()
         if span_context == trace.INVALID_SPAN_CONTEXT:
             return
         traceparent_string = "00-{:032x}-{:016x}-{:02x}".format(

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -46,7 +46,7 @@ class TestTracer(unittest.TestCase):
         """DefaultTracer's start_span will also
         be retrievable via get_current_span
         """
-        self.assertIs(trace.get_current_span(), None)
+        self.assertEqual(trace.get_current_span(), trace.INVALID_SPAN)
         span = trace.DefaultSpan(trace.INVALID_SPAN_CONTEXT)
         ctx = trace.set_span_in_context(span)
         token = context.attach(ctx)
@@ -54,4 +54,4 @@ class TestTracer(unittest.TestCase):
             self.assertIs(trace.get_current_span(), span)
         finally:
             context.detach(token)
-        self.assertIs(trace.get_current_span(), None)
+        self.assertEqual(trace.get_current_span(), trace.INVALID_SPAN)

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -33,3 +33,9 @@ class TestTracer(unittest.TestCase):
         span = trace.DefaultSpan(trace.INVALID_SPAN_CONTEXT)
         with self.tracer.use_span(span):
             pass
+
+    def test_get_current_span(self):
+        with self.tracer.start_as_current_span('test') as span:
+            trace.get_current_span().set_attribute("test", "test")
+            self.assertEqual(span, trace.INVALID_SPAN)
+            self.assertFalse(hasattr('span', 'attributes'))

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -35,7 +35,7 @@ class TestTracer(unittest.TestCase):
             pass
 
     def test_get_current_span(self):
-        with self.tracer.start_as_current_span('test') as span:
+        with self.tracer.start_as_current_span("test") as span:
             trace.get_current_span().set_attribute("test", "test")
             self.assertEqual(span, trace.INVALID_SPAN)
-            self.assertFalse(hasattr('span', 'attributes'))
+            self.assertFalse(hasattr("span", "attributes"))

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
@@ -123,7 +123,7 @@ class B3Format(HTTPTextFormat):
     ) -> None:
         span = trace.get_current_span(context=context)
 
-        if span is None:
+        if span.get_context() == trace.INVALID_SPAN_CONTEXT:
             return
 
         sampled = (trace.TraceFlags.SAMPLED & span.context.trace_flags) != 0

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -225,7 +225,7 @@ class TestSpanCreation(unittest.TestCase):
     def test_start_span_implicit(self):
         tracer = new_tracer()
 
-        self.assertIsNone(trace_api.get_current_span())
+        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
 
         root = tracer.start_span("root")
         self.assertIsNotNone(root.start_time)
@@ -264,7 +264,7 @@ class TestSpanCreation(unittest.TestCase):
 
             self.assertIsNotNone(child.end_time)
 
-        self.assertIsNone(trace_api.get_current_span())
+        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
         self.assertIsNotNone(root.end_time)
 
     def test_start_span_explicit(self):
@@ -277,7 +277,7 @@ class TestSpanCreation(unittest.TestCase):
             trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         )
 
-        self.assertIsNone(trace_api.get_current_span())
+        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
 
         root = tracer.start_span("root")
         self.assertIsNotNone(root.start_time)
@@ -320,7 +320,7 @@ class TestSpanCreation(unittest.TestCase):
     def test_start_as_current_span_implicit(self):
         tracer = new_tracer()
 
-        self.assertIsNone(trace_api.get_current_span())
+        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
 
         with tracer.start_as_current_span("root") as root:
             self.assertIs(trace_api.get_current_span(), root)
@@ -334,7 +334,7 @@ class TestSpanCreation(unittest.TestCase):
             self.assertIs(trace_api.get_current_span(), root)
             self.assertIsNotNone(child.end_time)
 
-        self.assertIsNone(trace_api.get_current_span())
+        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
         self.assertIsNotNone(root.end_time)
 
     def test_start_as_current_span_explicit(self):
@@ -346,7 +346,7 @@ class TestSpanCreation(unittest.TestCase):
             is_remote=False,
         )
 
-        self.assertIsNone(trace_api.get_current_span())
+        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
 
         # Test with the implicit root span
         with tracer.start_as_current_span("root") as root:
@@ -552,7 +552,7 @@ class TestSpan(unittest.TestCase):
             self.assertEqual(root.attributes["attr-in-both"], "decision-attr")
 
     def test_events(self):
-        self.assertIsNone(trace_api.get_current_span())
+        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
 
         with self.tracer.start_as_current_span("root") as root:
             # only event name
@@ -608,7 +608,7 @@ class TestSpan(unittest.TestCase):
             self.assertEqual(root.events[4].timestamp, now)
 
     def test_invalid_event_attributes(self):
-        self.assertIsNone(trace_api.get_current_span())
+        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
 
         with self.tracer.start_as_current_span("root") as root:
             root.add_event("event0", {"attr1": True, "attr2": ["hi", False]})


### PR DESCRIPTION
Solves https://github.com/open-telemetry/opentelemetry-python/issues/881

If TracerProvider is not set, context is never set with current span if the span is used. `get_current_span` will return None if a current span is not found in this case, which will crash applications that use it without configuring  a TracerProvider. We essentially want to have a "no-op" behaviour in this case instead of crashing.