### PR TITLE
fix typo in BatchExportSpanProcessor value error

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -120,7 +120,7 @@ class BatchExportSpanProcessor(SpanProcessor):
 
         if max_export_batch_size > max_queue_size:
             raise ValueError(
-                "max_export_batch_size must be less than and equal to max_queue_size."
+                "max_export_batch_size must be less than or equal to max_queue_size."
             )
 
         self.span_exporter = span_exporter


### PR DESCRIPTION
This is a small typo I noticed while going through the codebase. Not sure if this was ever an issue but this error message could be slightly confusing if someone ever saw it as it contains an impossible condition!