### PR TITLE
Handle statefulness in Cloud Monitoring exporter

### DIFF
--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -226,8 +226,10 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
             # Cloud Monitoring API allows, for any combination of labels and
             # metric name, one update per WRITE_INTERVAL seconds
             updated_key = (metric_descriptor.type, record.labels)
-            last_updated_time, _ = self._last_updated.get(updated_key, (0, 0))
-            if seconds <= last_updated_time + WRITE_INTERVAL:
+            last_updated_time_seconds, _ = self._last_updated.get(
+                updated_key, (0, 0)
+            )
+            if seconds <= last_updated_time_seconds + WRITE_INTERVAL:
                 continue
 
             if (
@@ -250,6 +252,8 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
                     point.interval.start_time.seconds = int(
                         self._last_updated[updated_key][0]
                     )
+
+                    # need +1ms to avoid losing data due to overlap, +1ns not enough
                     point.interval.start_time.nanos = int(
                         self._last_updated[updated_key][1] + 1e6
                     )

--- a/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/src/opentelemetry/exporter/cloud_monitoring/__init__.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-locals
+
 import logging
 import random
 from typing import Optional, Sequence
@@ -67,7 +69,10 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
                 random.randint(0, 16 ** 8)
             )
 
-        self._exporter_start_time_seconds, self._exporter_start_time_nanos = divmod(time_ns(), 1e9)
+        (
+            self._exporter_start_time_seconds,
+            self._exporter_start_time_nanos,
+        ) = divmod(time_ns(), 1e9)
 
     @staticmethod
     def _get_monitored_resource(
@@ -225,15 +230,29 @@ class CloudMonitoringMetricsExporter(MetricsExporter):
             if seconds <= last_updated_time + WRITE_INTERVAL:
                 continue
 
-            if metric_descriptor.metric_kind == MetricDescriptor.MetricKind.CUMULATIVE:
-                if instrument.meter.stateful or updated_key not in self._last_updated:
+            if (
+                metric_descriptor.metric_kind
+                == MetricDescriptor.MetricKind.CUMULATIVE
+            ):
+                if (
+                    instrument.meter.stateful
+                    or updated_key not in self._last_updated
+                ):
                     # The aggregation has not reset since the exporter has started up, so that is the start time
-                    point.interval.start_time.seconds = int(self._exporter_start_time_seconds)
-                    point.interval.start_time.nanos = int(self._exporter_start_time_nanos)
+                    point.interval.start_time.seconds = int(
+                        self._exporter_start_time_seconds
+                    )
+                    point.interval.start_time.nanos = int(
+                        self._exporter_start_time_nanos
+                    )
                 else:
                     # The aggregation reset the last time it was exported
-                    point.interval.start_time.seconds = int(self._last_updated[updated_key][0])
-                    point.interval.start_time.nanos = int(self._last_updated[updated_key][1]+1e6)
+                    point.interval.start_time.seconds = int(
+                        self._last_updated[updated_key][0]
+                    )
+                    point.interval.start_time.nanos = int(
+                        self._last_updated[updated_key][1] + 1e6
+                    )
 
             self._last_updated[updated_key] = (seconds, nanos)
 

--- a/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
@@ -269,6 +269,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         point.interval.end_time.seconds = WRITE_INTERVAL + 1
         point.interval.end_time.nanos = 0
         point.interval.start_time.seconds = 1
+        point.interval.start_time.nanos = 0
 
         series2 = TimeSeries(resource=expected_resource)
         series2.metric.type = "custom.googleapis.com/OpenTelemetry/name"
@@ -279,6 +280,7 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         point.interval.end_time.seconds = WRITE_INTERVAL + 1
         point.interval.end_time.nanos = 0
         point.interval.start_time.seconds = 1
+        point.interval.start_time.nanos = 0
 
         client.create_time_series.assert_has_calls(
             [mock.call(self.project_name, [series1, series2])]
@@ -326,6 +328,8 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         point.interval.end_time.seconds = WRITE_INTERVAL + 2
         point.interval.end_time.nanos = 0
         point.interval.start_time.seconds = 1
+        point.interval.start_time.nanos = 0
+
         client.create_time_series.assert_has_calls(
             [
                 mock.call(self.project_name, [series1, series2]),

--- a/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
+++ b/ext/opentelemetry-exporter-cloud-monitoring/tests/test_cloud_monitoring.py
@@ -48,7 +48,7 @@ class MockMetric:
         description="description",
         value_type=int,
         meter=None,
-        stateful=True
+        stateful=True,
     ):
         self.name = name
         self.description = description
@@ -191,7 +191,9 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
     def test_export(self):
         client = mock.Mock()
 
-        with mock.patch("opentelemetry.exporter.cloud_monitoring.time_ns", lambda: 1e9):
+        with mock.patch(
+            "opentelemetry.exporter.cloud_monitoring.time_ns", lambda: 1e9
+        ):
             exporter = CloudMonitoringMetricsExporter(
                 project_id=self.project_id, client=client
             )
@@ -333,10 +335,11 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
 
     def test_stateless_times(self):
         client = mock.Mock()
-        with mock.patch("opentelemetry.exporter.cloud_monitoring.time_ns", lambda: 1e9):
+        with mock.patch(
+            "opentelemetry.exporter.cloud_monitoring.time_ns", lambda: 1e9
+        ):
             exporter = CloudMonitoringMetricsExporter(
-                project_id=self.project_id,
-                client=client,
+                project_id=self.project_id, client=client,
             )
 
         client.create_metric_descriptor.return_value = MetricDescriptor(
@@ -366,10 +369,17 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         exports_1 = client.create_time_series.call_args_list[0]
 
         # verify the first metric started at exporter start time
-        self.assertEqual(exports_1[0][1][0].points[0].interval.start_time.seconds, 1)
-        self.assertEqual(exports_1[0][1][0].points[0].interval.start_time.nanos, 0)
+        self.assertEqual(
+            exports_1[0][1][0].points[0].interval.start_time.seconds, 1
+        )
+        self.assertEqual(
+            exports_1[0][1][0].points[0].interval.start_time.nanos, 0
+        )
 
-        self.assertEqual(exports_1[0][1][0].points[0].interval.end_time.seconds, WRITE_INTERVAL + 1)
+        self.assertEqual(
+            exports_1[0][1][0].points[0].interval.end_time.seconds,
+            WRITE_INTERVAL + 1,
+        )
 
         agg.last_update_timestamp = (WRITE_INTERVAL * 2 + 2) * 1e9
 
@@ -380,10 +390,18 @@ class TestCloudMonitoringMetricsExporter(unittest.TestCase):
         exports_2 = client.create_time_series.call_args_list[1]
 
         # 1ms ahead of end time of last export
-        self.assertEqual(exports_2[0][1][0].points[0].interval.start_time.seconds, WRITE_INTERVAL + 1)
-        self.assertEqual(exports_2[0][1][0].points[0].interval.start_time.nanos, 1e6)
+        self.assertEqual(
+            exports_2[0][1][0].points[0].interval.start_time.seconds,
+            WRITE_INTERVAL + 1,
+        )
+        self.assertEqual(
+            exports_2[0][1][0].points[0].interval.start_time.nanos, 1e6
+        )
 
-        self.assertEqual(exports_2[0][1][0].points[0].interval.end_time.seconds, WRITE_INTERVAL * 2 + 2)
+        self.assertEqual(
+            exports_2[0][1][0].points[0].interval.end_time.seconds,
+            WRITE_INTERVAL * 2 + 2,
+        )
 
     def test_unique_identifier(self):
         client = mock.Mock()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -366,6 +366,7 @@ class Meter(metrics_api.Meter):
         instrumentation_info: "InstrumentationInfo",
     ):
         self.instrumentation_info = instrumentation_info
+        self.stateful = source.stateful
         self.batcher = UngroupedBatcher(source.stateful)
         self.resource = source.resource
         self.metrics = set()


### PR DESCRIPTION
Uses CUMULATIVE instead of GAUGE for proper representation of Counter, and handles the correct start_time when stateful or stateless.

Open problem: When stateless, if the push interval is too small then data will be lost (blocked by exporter, and aggregator resets). Will need to save records when you can't push and merge into one pushing record once you can.