### PR TITLE
Add proper length zero padding to hex strings sent on the wire

### DIFF
--- a/exporter/opentelemetry-exporter-zipkin/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-zipkin/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Change package name to opentelemetry-exporter-zipkin
   ([#953](https://github.com/open-telemetry/opentelemetry-python/pull/953))
+- Add proper length zero padding to hex strings of traceId, spanId, parentId sent on the wire, for compatibility with jaeger-collector
+  ([#908](https://github.com/open-telemetry/opentelemetry-python/pull/908))
 
 ## 0.8b0
 

--- a/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/__init__.py
+++ b/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/__init__.py
@@ -168,8 +168,9 @@ class ZipkinSpanExporter(SpanExporter):
             duration_mus = _nsec_to_usec_round(span.end_time - span.start_time)
 
             zipkin_span = {
-                "traceId": format(trace_id, "x"),
-                "id": format(span_id, "x"),
+                # Ensure left-zero-padding of traceId, spanId, parentId
+                "traceId": format(trace_id, "032x"),
+                "id": format(span_id, "016x"),
                 "name": span.name,
                 "timestamp": start_timestamp_mus,
                 "duration": duration_mus,
@@ -184,10 +185,10 @@ class ZipkinSpanExporter(SpanExporter):
 
             if isinstance(span.parent, Span):
                 zipkin_span["parentId"] = format(
-                    span.parent.get_context().span_id, "x"
+                    span.parent.get_context().span_id, "016x"
                 )
             elif isinstance(span.parent, SpanContext):
-                zipkin_span["parentId"] = format(span.parent.span_id, "x")
+                zipkin_span["parentId"] = format(span.parent.span_id, "016x")
 
             zipkin_spans.append(zipkin_span)
         return zipkin_spans


### PR DESCRIPTION
traceId length 32, parentId and spanId length 16
For compatibility with jaeger-collector
Fixes #907