### PR TITLE
chore: one more inconsistent test to skip

### DIFF
--- a/ext/opentelemetry-ext-docker-tests/tests/celery/test_celery_functional.py
+++ b/ext/opentelemetry-ext-docker-tests/tests/celery/test_celery_functional.py
@@ -178,6 +178,7 @@ def test_fn_task_apply_async(celery_app, memory_exporter):
     )
 
 
+@pytest.mark.skip(reason="inconsistent test results")
 def test_concurrent_delays(celery_app, memory_exporter):
     @celery_app.task
     def fn_task():


### PR DESCRIPTION
This test fails inconsistently, skipping it for now.