### PR TITLE
Rename record_error to record_exception per spec

### DIFF
--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Return INVALID_SPAN if no TracerProvider set for get_current_span
   ([#751](https://github.com/open-telemetry/opentelemetry-python/pull/751))
 - Rename record_error to record_exception
+  ([#927](https://github.com/open-telemetry/opentelemetry-python/pull/927))
 
 ## 0.9b0
 

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Return INVALID_SPAN if no TracerProvider set for get_current_span
   ([#751](https://github.com/open-telemetry/opentelemetry-python/pull/751))
+- Rename record_error to record_exception
 
 ## 0.9b0
 

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -89,8 +89,8 @@ class Span(abc.ABC):
         """
 
     @abc.abstractmethod
-    def record_error(self, err: Exception) -> None:
-        """Records an error as a span event."""
+    def record_exception(self, exception: Exception) -> None:
+        """Records an exception as a span event."""
 
     def __enter__(self) -> "Span":
         """Invoked when `Span` is used as a context manager.
@@ -257,7 +257,7 @@ class DefaultSpan(Span):
     def set_status(self, status: Status) -> None:
         pass
 
-    def record_error(self, err: Exception) -> None:
+    def record_exception(self, exception: Exception) -> None:
         pass
 
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for resources and resource detector
   ([#853](https://github.com/open-telemetry/opentelemetry-python/pull/853))
 - Rename record_error to record_exception
+  ([#927](https://github.com/open-telemetry/opentelemetry-python/pull/927))
 
 ## Version 0.10b0
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for resources and resource detector
   ([#853](https://github.com/open-telemetry/opentelemetry-python/pull/853))
+- Rename record_error to record_exception
 
 ## Version 0.10b0
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -683,14 +683,14 @@ class Span(trace_api.Span):
 
         super().__exit__(exc_type, exc_val, exc_tb)
 
-    def record_error(self, err: Exception) -> None:
-        """Records an error as a span event."""
+    def record_exception(self, exception: Exception) -> None:
+        """Records an exception as a span event."""
         self.add_event(
-            name="error",
+            name="exception",
             attributes={
-                "error.type": err.__class__.__name__,
-                "error.message": str(err),
-                "error.stack": traceback.format_exc(),
+                "exception.type": exception.__class__.__name__,
+                "exception.message": str(exception),
+                "exception.stacktrace": traceback.format_exc(),
             },
         )
 

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -801,18 +801,23 @@ class TestSpan(unittest.TestCase):
             .start_as_current_span("root")
         )
 
-    def test_record_error(self):
+    def test_record_exception(self):
         span = trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
         try:
             raise ValueError("invalid")
         except ValueError as err:
-            span.record_error(err)
-        error_event = span.events[0]
-        self.assertEqual("error", error_event.name)
-        self.assertEqual("invalid", error_event.attributes["error.message"])
-        self.assertEqual("ValueError", error_event.attributes["error.type"])
+            span.record_exception(err)
+        exception_event = span.events[0]
+        self.assertEqual("exception", exception_event.name)
+        self.assertEqual(
+            "invalid", exception_event.attributes["exception.message"]
+        )
+        self.assertEqual(
+            "ValueError", exception_event.attributes["exception.type"]
+        )
         self.assertIn(
-            "ValueError: invalid", error_event.attributes["error.stack"]
+            "ValueError: invalid",
+            exception_event.attributes["exception.stacktrace"],
         )
 
 


### PR DESCRIPTION
The spec renamed record_error to record_exception. This change follows that change. See https://github.com/open-telemetry/opentelemetry-specification/blob/b8948d9cec3994e396898feca7a10025d08370db/specification/trace/api.md#record-exception