### PR TITLE
Drop mauriciovasquezbernal from approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ Approvers ([@open-telemetry/python-approvers](https://github.com/orgs/open-telem
 - [Chris Kleinknecht](https://github.com/c24t), Google
 - [Diego Hurtado](https://github.com/ocelotl)
 - [Hector Hernandez](https://github.com/hectorhdzg), Microsoft
-- [Mauricio Vásquez](https://github.com/mauriciovasquezbernal), Kinvolk
 - [Reiley Yang](https://github.com/reyang), Microsoft
 - [Yusuke Tsutsumi](https://github.com/toumorokoshi), Google
 


### PR DESCRIPTION
I haven't contributed to the project in a while and I don't expect to start
contributing again. This commit removes myself as an approver of the project.