### PR TITLE
ext/django: accept middlewares declared as tuples

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
@@ -51,8 +51,12 @@ class DjangoInstrumentor(BaseInstrumentor):
         # https://docs.djangoproject.com/en/3.0/ref/middleware/#middleware-ordering
 
         settings_middleware = getattr(settings, "MIDDLEWARE", [])
-        settings_middleware.append(self._opentelemetry_middleware)
+        # Django allows to specify middlewares as a tuple, so we convert this tuple to a
+        # list, otherwise we wouldn't be able to call append/remove
+        if isinstance(settings_middleware, tuple):
+            settings_middleware = list(settings_middleware)
 
+        settings_middleware.append(self._opentelemetry_middleware)
         setattr(settings, "MIDDLEWARE", settings_middleware)
 
     def _uninstrument(self, **kwargs):


### PR DESCRIPTION
Hello there.

This tiny change add support for django configurations where the middlewares are listed as a tuple (I am under the impression this is fairly common in "old" projects).

Have a nice day !

