### PR TITLE
Stop TracerProvider from being overridden

### DIFF
--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Update environment variable names, prefix changed from `OPENTELEMETRY` to `OTEL`
   ([#904](https://github.com/open-telemetry/opentelemetry-python/pull/904))
-- Stop TracerProvider from being overridden
+- Stop TracerProvider and MeterProvider from being overridden
   ([#959](https://github.com/open-telemetry/opentelemetry-python/pull/959))
 
 ## Version 0.11b0

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Update environment variable names, prefix changed from `OPENTELEMETRY` to `OTEL`
   ([#904](https://github.com/open-telemetry/opentelemetry-python/pull/904))
+- Stop TracerProvider from being overridden
+  ([#959](https://github.com/open-telemetry/opentelemetry-python/pull/959))
 
 ## Version 0.11b0
 

--- a/opentelemetry-api/src/opentelemetry/metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/__init__.py
@@ -459,7 +459,8 @@ def set_meter_provider(meter_provider: MeterProvider) -> None:
     global _METER_PROVIDER  # pylint: disable=global-statement
 
     if _METER_PROVIDER is not None:
-        logger.warning("Overriding current MeterProvider")
+        logger.warning("Overriding of current MeterProvider is not allowed")
+        return
 
     _METER_PROVIDER = meter_provider
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -77,7 +77,6 @@ import typing
 from contextlib import contextmanager
 from logging import getLogger
 
-from opentelemetry.configuration import Configuration
 from opentelemetry.trace.propagation import (
     get_current_span,
     set_span_in_context,
@@ -483,4 +482,5 @@ __all__ = [
     "get_tracer_provider",
     "set_tracer_provider",
     "set_span_in_context",
+    "Status",
 ]

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -70,39 +70,9 @@ either implicit or explicit context propagation consistently throughout.
     `set_tracer_provider`.
 """
 
-__all__ = [
-    "DEFAULT_TRACE_OPTIONS",
-    "DEFAULT_TRACE_STATE",
-    "INVALID_SPAN",
-    "INVALID_SPAN_CONTEXT",
-    "INVALID_SPAN_ID",
-    "INVALID_TRACE_ID",
-    "DefaultSpan",
-    "DefaultTracer",
-    "DefaultTracerProvider",
-    "LazyLink",
-    "Link",
-    "LinkBase",
-    "ParentSpan",
-    "Span",
-    "SpanContext",
-    "SpanKind",
-    "TraceFlags",
-    "TraceState",
-    "TracerProvider",
-    "Tracer",
-    "format_span_id",
-    "format_trace_id",
-    "get_current_span",
-    "get_tracer",
-    "get_tracer_provider",
-    "set_tracer_provider",
-    "set_span_in_context",
-]
 
 import abc
 import enum
-import types as python_types
 import typing
 from contextlib import contextmanager
 from logging import getLogger
@@ -465,7 +435,8 @@ def set_tracer_provider(tracer_provider: TracerProvider) -> None:
     global _TRACER_PROVIDER  # pylint: disable=global-statement
 
     if _TRACER_PROVIDER is not None:
-        logger.warning("Overriding current TracerProvider")
+        logger.warning("Overriding of current TracerProvider is not allowed")
+        return
 
     _TRACER_PROVIDER = tracer_provider
 
@@ -478,3 +449,34 @@ def get_tracer_provider() -> TracerProvider:
         _TRACER_PROVIDER = _load_trace_provider("tracer_provider")
 
     return _TRACER_PROVIDER
+
+
+__all__ = [
+    "DEFAULT_TRACE_OPTIONS",
+    "DEFAULT_TRACE_STATE",
+    "INVALID_SPAN",
+    "INVALID_SPAN_CONTEXT",
+    "INVALID_SPAN_ID",
+    "INVALID_TRACE_ID",
+    "DefaultSpan",
+    "DefaultTracer",
+    "DefaultTracerProvider",
+    "LazyLink",
+    "Link",
+    "LinkBase",
+    "ParentSpan",
+    "Span",
+    "SpanContext",
+    "SpanKind",
+    "TraceFlags",
+    "TraceState",
+    "TracerProvider",
+    "Tracer",
+    "format_span_id",
+    "format_trace_id",
+    "get_current_span",
+    "get_tracer",
+    "get_tracer_provider",
+    "set_tracer_provider",
+    "set_span_in_context",
+]

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -431,7 +431,11 @@ def get_tracer(
 
 
 def set_tracer_provider(tracer_provider: TracerProvider) -> None:
-    """Sets the current global :class:`~.TracerProvider` object."""
+    """Sets the current global :class:`~.TracerProvider` object.
+
+    This can only be done once, a warning will be logged if any furter attempt
+    is made.
+    """
     global _TRACER_PROVIDER  # pylint: disable=global-statement
 
     if _TRACER_PROVIDER is not None:

--- a/opentelemetry-api/tests/metrics/test_globals.py
+++ b/opentelemetry-api/tests/metrics/test_globals.py
@@ -16,8 +16,8 @@ class TestGlobals(unittest.TestCase):
                 test.output,
                 [
                     (
-                        "WARNING:opentelemetry.metrics:Overriding current "
-                        "MeterProvider"
+                        "WARNING:opentelemetry.metrics:Overriding of current "
+                        "MeterProvider is not allowed"
                     )
                 ],
             )

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -31,8 +31,8 @@ class TestGlobals(unittest.TestCase):
                 test.output,
                 [
                     (
-                        "WARNING:opentelemetry.trace:Overriding current "
-                        "TracerProvider"
+                        "WARNING:opentelemetry.trace:Overriding of current "
+                        "TracerProvider is not allowed"
                     )
                 ],
             )

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -25,6 +25,7 @@ class TestGlobals(unittest.TestCase):
     def test_tracer_provider_override_warning(self):
         """trace.set_tracer_provider should throw a warning when overridden"""
         trace.set_tracer_provider(TracerProvider())
+        tracer_provider = trace.get_tracer_provider()
         with self.assertLogs(level=WARNING) as test:
             trace.set_tracer_provider(TracerProvider())
             self.assertEqual(
@@ -36,6 +37,7 @@ class TestGlobals(unittest.TestCase):
                     )
                 ],
             )
+        self.assertIs(tracer_provider, trace.get_tracer_provider())
 
 
 class TestTracer(unittest.TestCase):

--- a/tests/util/src/opentelemetry/test/test_base.py
+++ b/tests/util/src/opentelemetry/test/test_base.py
@@ -36,7 +36,7 @@ class TestBase(unittest.TestCase):
         cls.tracer_provider, cls.memory_exporter = result
         # This is done because set_tracer_provider cannot override the
         # current tracer provider.
-        trace_api._TRACER_PROVIDER = None
+        trace_api._TRACER_PROVIDER = None  # pylint: disable=protected-access
         trace_api.set_tracer_provider(cls.tracer_provider)
         cls.original_meter_provider = metrics_api.get_meter_provider()
         result = cls.create_meter_provider()
@@ -47,7 +47,7 @@ class TestBase(unittest.TestCase):
     def tearDownClass(cls):
         # This is done because set_tracer_provider cannot override the
         # current tracer provider.
-        trace_api._TRACER_PROVIDER = None
+        trace_api._TRACER_PROVIDER = None  # pylint: disable=protected-access
         trace_api.set_tracer_provider(cls.original_tracer_provider)
         metrics_api.set_meter_provider(cls.original_meter_provider)
 

--- a/tests/util/src/opentelemetry/test/test_base.py
+++ b/tests/util/src/opentelemetry/test/test_base.py
@@ -34,6 +34,9 @@ class TestBase(unittest.TestCase):
         cls.original_tracer_provider = trace_api.get_tracer_provider()
         result = cls.create_tracer_provider()
         cls.tracer_provider, cls.memory_exporter = result
+        # This is done because set_tracer_provider cannot override the
+        # current tracer provider.
+        trace_api._TRACER_PROVIDER = None
         trace_api.set_tracer_provider(cls.tracer_provider)
         cls.original_meter_provider = metrics_api.get_meter_provider()
         result = cls.create_meter_provider()
@@ -42,6 +45,9 @@ class TestBase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        # This is done because set_tracer_provider cannot override the
+        # current tracer provider.
+        trace_api._TRACER_PROVIDER = None
         trace_api.set_tracer_provider(cls.original_tracer_provider)
         metrics_api.set_meter_provider(cls.original_meter_provider)
 

--- a/tests/util/src/opentelemetry/test/test_base.py
+++ b/tests/util/src/opentelemetry/test/test_base.py
@@ -41,6 +41,9 @@ class TestBase(unittest.TestCase):
         cls.original_meter_provider = metrics_api.get_meter_provider()
         result = cls.create_meter_provider()
         cls.meter_provider, cls.memory_metrics_exporter = result
+        # This is done because set_meter_provider cannot override the
+        # current meter provider.
+        metrics_api._METER_PROVIDER = None  # pylint: disable=protected-access
         metrics_api.set_meter_provider(cls.meter_provider)
 
     @classmethod
@@ -49,6 +52,9 @@ class TestBase(unittest.TestCase):
         # current tracer provider.
         trace_api._TRACER_PROVIDER = None  # pylint: disable=protected-access
         trace_api.set_tracer_provider(cls.original_tracer_provider)
+        # This is done because set_meter_provider cannot override the
+        # current meter provider.
+        metrics_api._METER_PROVIDER = None  # pylint: disable=protected-access
         metrics_api.set_meter_provider(cls.original_meter_provider)
 
     def setUp(self):


### PR DESCRIPTION
# Description

The actual behavior allows overriding of the current `TracerProvider`. Setting of `TracerProvider` can happen in the auto instrumentation steps and later it can be overridden in application code, causing span processors to be lost.

Fixes #958

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This PR introduces a change in the following test that asserts that the appropriate warning is raised and that the tracer provider is not overridden even after calling `set_tracer_provider` twice.


- [x] `opentelemetry-api/tests/trace/test_globals.py:test_tracer_provider_override_warning`


# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
