### PR TITLE
Span name updated to follow semantic conventions to reduce cardinality

### DIFF
--- a/docs/getting_started/tests/test_flask.py
+++ b/docs/getting_started/tests/test_flask.py
@@ -38,6 +38,6 @@ class TestFlask(unittest.TestCase):
             server.terminate()
 
         output = str(server.stdout.read())
-        self.assertIn('"name": ""', output)
+        self.assertIn('"name": "HTTP get"', output)
         self.assertIn('"name": "example-request"', output)
         self.assertIn('"name": "hello"', output)

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Updating span name to match semantic conventions
+  ([#972](https://github.com/open-telemetry/opentelemetry-python/pull/972))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/src/opentelemetry/instrumentation/aiohttp_client/__init__.py
@@ -126,7 +126,7 @@ def create_trace_config(
     ):
         http_method = params.method.upper()
         if trace_config_ctx.span_name is None:
-            request_span_name = http_method
+            request_span_name = "HTTP {}".format(http_method)
         elif callable(trace_config_ctx.span_name):
             request_span_name = str(trace_config_ctx.span_name(params))
         else:

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/tests/test_aiohttp_client_integration.py
@@ -118,7 +118,7 @@ class TestAioHttpIntegration(TestBase):
                 self.assert_spans(
                     [
                         (
-                            "GET",
+                            "HTTP GET",
                             (span_status, None),
                             {
                                 "component": "http",
@@ -192,7 +192,7 @@ class TestAioHttpIntegration(TestBase):
         self.assert_spans(
             [
                 (
-                    "GET",
+                    "HTTP GET",
                     (StatusCanonicalCode.OK, None),
                     {
                         "component": "http",
@@ -232,7 +232,7 @@ class TestAioHttpIntegration(TestBase):
             self.assert_spans(
                 [
                     (
-                        "GET",
+                        "HTTP GET",
                         (expected_status, None),
                         {
                             "component": "http",
@@ -260,7 +260,7 @@ class TestAioHttpIntegration(TestBase):
         self.assert_spans(
             [
                 (
-                    "GET",
+                    "HTTP GET",
                     (StatusCanonicalCode.DEADLINE_EXCEEDED, None),
                     {
                         "component": "http",
@@ -290,7 +290,7 @@ class TestAioHttpIntegration(TestBase):
         self.assert_spans(
             [
                 (
-                    "GET",
+                    "HTTP GET",
                     (StatusCanonicalCode.DEADLINE_EXCEEDED, None),
                     {
                         "component": "http",

--- a/instrumentation/opentelemetry-instrumentation-requests/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-requests/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Change package name to opentelemetry-instrumentation-requests
   ([#961](https://github.com/open-telemetry/opentelemetry-python/pull/961))
+- Span name reported updated to follow semantic conventions to reduce
+  cardinality ([#972](https://github.com/open-telemetry/opentelemetry-python/pull/972))
 
 ## 0.7b1
 

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -80,11 +80,7 @@ def _instrument(tracer_provider=None, span_callback=None):
 
         # See
         # https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#http-client
-        try:
-            parsed_url = urlparse(url)
-            span_name = parsed_url.path
-        except ValueError as exc:  # Invalid URL
-            span_name = "<Unparsable URL: {}>".format(exc)
+        span_name = "HTTP {}".format(method)
 
         exception = None
 
@@ -111,6 +107,7 @@ def _instrument(tracer_provider=None, span_callback=None):
                 span.set_status(
                     Status(_exception_to_canonical_code(exception))
                 )
+                span.record_exception(exception)
 
             if result is not None:
                 span.set_attribute("http.status_code", result.status_code)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -51,7 +51,7 @@ class TestRequestsIntegration(TestBase):
         span = span_list[0]
 
         self.assertIs(span.kind, trace.SpanKind.CLIENT)
-        self.assertEqual(span.name, "/status/200")
+        self.assertEqual(span.name, "HTTP get")
 
         self.assertEqual(
             span.attributes,
@@ -102,7 +102,7 @@ class TestRequestsIntegration(TestBase):
         self.assertEqual(len(span_list), 1)
         span = span_list[0]
 
-        self.assertTrue(span.name.startswith("<Unparsable URL"))
+        self.assertEqual(span.name, "HTTP post")
         self.assertEqual(
             span.attributes,
             {"component": "http", "http.method": "POST", "http.url": url},

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -685,12 +685,20 @@ class Span(trace_api.Span):
 
     def record_exception(self, exception: Exception) -> None:
         """Records an exception as a span event."""
+        try:
+            stacktrace = traceback.format_exc()
+        except Exception:  # pylint: disable=broad-except
+            # workaround for python 3.4, format_exc can raise
+            # an AttributeError if the __context__ on
+            # an exception is None
+            stacktrace = "Exception occurred on stacktrace formatting"
+
         self.add_event(
             name="exception",
             attributes={
                 "exception.type": exception.__class__.__name__,
                 "exception.message": str(exception),
-                "exception.stacktrace": traceback.format_exc(),
+                "exception.stacktrace": stacktrace,
             },
         )
 


### PR DESCRIPTION
# Description

Using the path for span names in the requests instrumentation led to high cardinality in the reported data. This changes updates the name to use the method instead as defined in the [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#name)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested locally
- [x] Ran unit tests

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been updated
