### PR TITLE
Renaming OTEL_RESOURCE env var

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -7,6 +7,8 @@
   ([#904](https://github.com/open-telemetry/opentelemetry-python/pull/904))
 - Implement Views in metrics SDK
   ([#596](https://github.com/open-telemetry/opentelemetry-python/pull/596))
+- Update environment variable OTEL_RESOURCE to OTEL_RESOURCE_ATTRIBUTES as per
+  the specification
 
 ## Version 0.11b0
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -74,7 +74,7 @@ class ResourceDetector(abc.ABC):
 class OTELResourceDetector(ResourceDetector):
     # pylint: disable=no-self-use
     def detect(self) -> "Resource":
-        env_resources_items = os.environ.get("OTEL_RESOURCE")
+        env_resources_items = os.environ.get("OTEL_RESOURCE_ATTRIBUTES")
         env_resource_map = {}
         if env_resources_items:
             env_resource_map = {

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -167,36 +167,36 @@ class TestResources(unittest.TestCase):
 
 class TestOTELResourceDetector(unittest.TestCase):
     def setUp(self) -> None:
-        os.environ["OTEL_RESOURCE"] = ""
+        os.environ["OTEL_RESOURCE_ATTRIBUTES"] = ""
 
     def tearDown(self) -> None:
-        os.environ.pop("OTEL_RESOURCE")
+        os.environ.pop("OTEL_RESOURCE_ATTRIBUTES")
 
     def test_empty(self):
         detector = resources.OTELResourceDetector()
-        os.environ["OTEL_RESOURCE"] = ""
+        os.environ["OTEL_RESOURCE_ATTRIBUTES"] = ""
         self.assertEqual(detector.detect(), resources.Resource.create_empty())
 
     def test_one(self):
         detector = resources.OTELResourceDetector()
-        os.environ["OTEL_RESOURCE"] = "k=v"
+        os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "k=v"
         self.assertEqual(detector.detect(), resources.Resource({"k": "v"}))
 
     def test_one_with_whitespace(self):
         detector = resources.OTELResourceDetector()
-        os.environ["OTEL_RESOURCE"] = "    k  = v   "
+        os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "    k  = v   "
         self.assertEqual(detector.detect(), resources.Resource({"k": "v"}))
 
     def test_multiple(self):
         detector = resources.OTELResourceDetector()
-        os.environ["OTEL_RESOURCE"] = "k=v,k2=v2"
+        os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "k=v,k2=v2"
         self.assertEqual(
             detector.detect(), resources.Resource({"k": "v", "k2": "v2"})
         )
 
     def test_multiple_with_whitespace(self):
         detector = resources.OTELResourceDetector()
-        os.environ["OTEL_RESOURCE"] = "    k  = v  , k2   = v2 "
+        os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "    k  = v  , k2   = v2 "
         self.assertEqual(
             detector.detect(), resources.Resource({"k": "v", "k2": "v2"})
         )


### PR DESCRIPTION
# Description

The environment variable OTEL_RESOURCE has been renamed to OTEL_RESOURCE_ATTRIBUTES as per the specification open-telemetry/opentelemetry-specification#758

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Unit tests have been run

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been updated
