### PR TITLE
In types.Attributes, change Dict -> Mapping

### DIFF
--- a/opentelemetry-api/src/opentelemetry/util/types.py
+++ b/opentelemetry-api/src/opentelemetry/util/types.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Callable, Dict, Optional, Sequence, Union
+from typing import Callable, Mapping, Optional, Sequence, Union
 
 AttributeValue = Union[
     str,
@@ -25,5 +25,5 @@ AttributeValue = Union[
     Sequence[int],
     Sequence[float],
 ]
-Attributes = Optional[Dict[str, AttributeValue]]
-AttributesFormatter = Callable[[], Optional[Dict[str, AttributeValue]]]
+Attributes = Optional[Mapping[str, AttributeValue]]
+AttributesFormatter = Callable[[], Attributes]


### PR DESCRIPTION
# Description

Fixes these kinds of type errors which I'm seeing in the Google cloud exporter:

```py
def usesAttributes(a: types.Attributes) -> None:
    pass

foo: Dict[str, str] = {"key": "value"}

# Causes type error:
# has incompatible type "Dict[str, str]"; expected
# "Optional[Dict[str, Union[str, bool, int, float, Sequence[str], Sequence[bool], Sequence[int], Sequence[float]]]]
usesAttributes(foo)
```

- This happens because `Dict` is invariant ([see this mypy FAQ](https://mypy.readthedocs.io/en/latest/common_issues.html#variance)). Using `Mapping` solves this because it is covariant.
- This also has the benefit that `Mapping` is immutable so MyPy will complain if you try and set a value on it.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

For GoogleCloudPlatform/opentelemetry-operations-python#64

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This is just a type annotation change. All mypy assertions are passing

- [x] MyPy tox env

# Checklist:
(rest are N/A)
- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated