### PR TITLE
Remove redundant circleci matrix parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ workflows:
       - build:
           matrix:
             parameters:
-              version: ["py38", "py37", "py36", "py35", "pypy3"]
+              version: ["py37", "py36", "py35", "pypy3"]
               package: ["core", "exporter", "instrumentation"]
       - build-py34:
           matrix:


### PR DESCRIPTION
# Description

Removes py38 from the matrix of the primary build job. Since python 3.8 has a separate build job, it does not need to be in the main matrix. Its inclusion results in the same tests being run twice.

# Checklist:

- [ ] Changelogs have been updated
- [ ] Documentation has been updated
