### PR TITLE
Refactor is_valid to be an instance attribute

### DIFF
--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Refactor `SpanContext.is_valid` from a method to a data attribute
+  ([#1005](https://github.com/open-telemetry/opentelemetry-python/pull/1005))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -187,6 +187,10 @@ class SpanContext:
         self.trace_flags = trace_flags
         self.trace_state = trace_state
         self.is_remote = is_remote
+        self.is_valid = (
+            self.trace_id != INVALID_TRACE_ID
+            and self.span_id != INVALID_SPAN_ID
+        )
 
     def __repr__(self) -> str:
         return (
@@ -197,20 +201,6 @@ class SpanContext:
             format_span_id(self.span_id),
             self.trace_state,
             self.is_remote,
-        )
-
-    def is_valid(self) -> bool:
-        """Get whether this `SpanContext` is valid.
-
-        A `SpanContext` is said to be invalid if its trace ID or span ID is
-        invalid (i.e. ``0``).
-
-        Returns:
-            True if the `SpanContext` is valid, false otherwise.
-        """
-        return (
-            self.trace_id != INVALID_TRACE_ID
-            and self.span_id != INVALID_SPAN_ID
         )
 
 

--- a/opentelemetry-api/tests/trace/test_defaultspan.py
+++ b/opentelemetry-api/tests/trace/test_defaultspan.py
@@ -32,4 +32,4 @@ class TestDefaultSpan(unittest.TestCase):
     def test_invalid_span(self):
         self.assertIsNotNone(trace.INVALID_SPAN)
         self.assertIsNotNone(trace.INVALID_SPAN.get_context())
-        self.assertFalse(trace.INVALID_SPAN.get_context().is_valid())
+        self.assertFalse(trace.INVALID_SPAN.get_context().is_valid)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -763,7 +763,7 @@ class Tracer(trace_api.Tracer):
         ):
             raise TypeError("parent must be a Span, SpanContext or None.")
 
-        if parent_context is None or not parent_context.is_valid():
+        if parent_context is None or not parent_context.is_valid:
             parent = parent_context = None
             trace_id = generate_trace_id()
             trace_flags = None

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -165,7 +165,7 @@ class TestSpanCreation(unittest.TestCase):
         new_span = tracer.start_span(
             "root", parent=trace_api.INVALID_SPAN_CONTEXT
         )
-        self.assertTrue(new_span.context.is_valid())
+        self.assertTrue(new_span.context.is_valid)
         self.assertIsNone(new_span.parent)
 
     def test_instrumentation_info(self):


### PR DESCRIPTION
# Description

Refactoring of `SpanContext.is_valid()` to be a variable, rather than a method. This makes the API consistent with `is_remote`, which is defined similarly in the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spancontext).

Since I am new to this project, I am not sure whether the removal of the method might break something downstream, but adding a deprecation warning would require also choosing a different name for the attribute.

Fixes #996

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated **(where?)**
- [x] Unit tests have been **updated**
- [x] Documentation has been **removed (by removing the method)**
