### PR TITLE
Revert "pin flake8 at 3.7.9 (#679)"

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 pylint==2.4.4
-flake8==3.7.9
+flake8~=3.7
 isort~=4.3
 black>=19.3b0,==19.*
 mypy==0.770


### PR DESCRIPTION
# Description

This reverts commit 021723a5c1cdde8cd15b542179e1fd83bd32819b.

Underlying issue was fixed by commit 20cf4cb087371


Fixes #680 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```console
$ flake8 --version
3.8.0 (mccabe: 0.6.1, pycodestyle: 2.6.0, pyflakes: 2.2.0) CPython 3.8.2 on Darwin
$ git checkout 20cf4cb087371
Note: switching to '20cf4cb087371'.
…
HEAD is now at 20cf4cb refactor: Typing fixes #768, upgrade mypy to 0.770 (#769)
$ flake8 ./opentelemetry-api/src/opentelemetry/util/__init__.py
$ git checkout HEAD~1
Previous HEAD position was 20cf4cb refactor: Typing fixes #768, upgrade mypy to 0.770 (#769)
HEAD is now at b108596 bugfix: Fix for byte type attributes crashing spans       (#775)
$ flake8 ./opentelemetry-api/src/opentelemetry/util/__init__.py
./opentelemetry-api/src/opentelemetry/util/__init__.py:39:12: F821 undefined name 'TracerProvider'
./opentelemetry-api/src/opentelemetry/util/__init__.py:39:30: F821 undefined name 'MeterProvider'

```