### PR TITLE
Make return value of `get_correlations` immutable

### DIFF
--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Change return value type of `correlationcontext.get_correlations` to immutable `MappingProxyType`
+  ([#1024](https://github.com/open-telemetry/opentelemetry-python/pull/1024))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/opentelemetry-api/src/opentelemetry/correlationcontext/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/correlationcontext/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import typing
+from types import MappingProxyType
 
 from opentelemetry.context import get_value, set_value
 from opentelemetry.context.context import Context
@@ -22,7 +23,7 @@ _CORRELATION_CONTEXT_KEY = "correlation-context"
 
 def get_correlations(
     context: typing.Optional[Context] = None,
-) -> typing.Dict[str, object]:
+) -> typing.Mapping[str, object]:
     """Returns the name/value pairs in the CorrelationContext
 
     Args:
@@ -33,8 +34,8 @@ def get_correlations(
     """
     correlations = get_value(_CORRELATION_CONTEXT_KEY, context=context)
     if isinstance(correlations, dict):
-        return correlations.copy()
-    return {}
+        return MappingProxyType(correlations.copy())
+    return MappingProxyType({})
 
 
 def get_correlation(
@@ -67,7 +68,7 @@ def set_correlation(
     Returns:
         A Context with the value updated
     """
-    correlations = get_correlations(context=context)
+    correlations = dict(get_correlations(context=context))
     correlations[name] = value
     return set_value(_CORRELATION_CONTEXT_KEY, correlations, context=context)
 
@@ -84,7 +85,7 @@ def remove_correlation(
     Returns:
         A Context with the name/value removed
     """
-    correlations = get_correlations(context=context)
+    correlations = dict(get_correlations(context=context))
     correlations.pop(name, None)
 
     return set_value(_CORRELATION_CONTEXT_KEY, correlations, context=context)

--- a/opentelemetry-api/src/opentelemetry/correlationcontext/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/correlationcontext/propagation/__init__.py
@@ -94,7 +94,7 @@ class CorrelationContextPropagator(httptextformat.HTTPTextFormat):
         )
 
 
-def _format_correlations(correlations: typing.Dict[str, object]) -> str:
+def _format_correlations(correlations: typing.Mapping[str, object]) -> str:
     return ",".join(
         key + "=" + urllib.parse.quote_plus(str(value))
         for key, value in correlations.items()

--- a/opentelemetry-api/tests/correlationcontext/test_correlation_context.py
+++ b/opentelemetry-api/tests/correlationcontext/test_correlation_context.py
@@ -48,7 +48,8 @@ class TestCorrelationContextManager(unittest.TestCase):
         ctx = cctx.set_correlation("test", "value")
         self.assertEqual(cctx.get_correlation("test", context=ctx), "value")
         correlations = cctx.get_correlations(context=ctx)
-        correlations["test"] = "mess-this-up"
+        with self.assertRaises(TypeError):
+            correlations["test"] = "mess-this-up"
         self.assertEqual(cctx.get_correlation("test", context=ctx), "value")
 
     def test_remove_correlations(self):


### PR DESCRIPTION
# Description

Makes return value of `get_correlations` immutable via a proxy view of a copy of the original dict.

According to the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/correlationcontext/api.md#get-correlations):

> the returned value can be either an immutable collection or an immutable iterator

Fixes #1020 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
