### PR TITLE
Increase docker-tests retry count

### DIFF
--- a/tests/opentelemetry-docker-tests/tests/check_availability.py
+++ b/tests/opentelemetry-docker-tests/tests/check_availability.py
@@ -36,7 +36,7 @@ POSTGRES_PORT = int(os.getenv("POSTGRESQL_PORT", "5432"))
 POSTGRES_USER = os.getenv("POSTGRESQL_HOST", "testuser")
 REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
 REDIS_PORT = int(os.getenv("REDIS_PORT ", "6379"))
-RETRY_COUNT = 5
+RETRY_COUNT = 8
 RETRY_INTERVAL = 5  # Seconds
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Increases the retry count for the pre-test availability checks in the docker-tests from 5 to 8.

MySQL was not always ready in time on my laptop. Bumping retries up to 6 was enough for me, but as this stage normally shouldn't fail, I thought giving it another 10 extra seconds would not hurt.