### PR TITLE
Fix grpc tests when running from cmd-line/eachdist script

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
@@ -42,7 +42,7 @@ packages=find_namespace:
 install_requires =
     opentelemetry-api == 0.13dev0
     opentelemetry-sdk == 0.13dev0
-    grpcio == 1.30
+    grpcio ~= 1.27
 
 [options.extras_require]
 test =

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py
@@ -49,6 +49,7 @@ class TestClientProto(TestBase):
         GrpcInstrumentorClient().uninstrument()
         self.memory_metrics_exporter.clear()
         self.server.stop(None)
+        self.channel.close()
 
     def _verify_success_records(self, num_bytes_out, num_bytes_in, method):
         # pylint: disable=protected-access,no-member


### PR DESCRIPTION
# Description

When running the grpc tests from the command line with `pytest instrumentation/opentelemetry-instrumentation-grpc/tests` or `python scripts/eachdist.py test` the 2nd test in the `TestClientProto` test case was failing with:
```
instrumentation/opentelemetry-instrumentation-grpc/tests/test_client_interceptor.py:200: in _verify_error_records
    ("status_code", grpc.StatusCode.INVALID_ARGUMENT),
E   AssertionError: Tuples differ: (('me[65 chars]code', <StatusCode.UNAVAILABLE: (14, 'unavailable')>)) != (('me[65 chars]code', <StatusCode.INVALID_ARGUMENT: (3, 'invalid argument')>))
E   
E   First differing element 1:
E   ('status_code', <StatusCode.UNAVAILABLE: (14, 'unavailable')>)
E   ('status_code', <StatusCode.INVALID_ARGUMENT: (3, 'invalid argument')>)
E   
E     (('method', '/GRPCTestServer/BidirectionalStreamingMethod'),
E   -  ('status_code', <StatusCode.UNAVAILABLE: (14, 'unavailable')>))
E   ?                              ^ -   ^ ^^    ^^   ^ -   ^ ^^
E   
E   +  ('status_code', <StatusCode.INVALID_ARGUMENT: (3, 'invalid argument')>))
E   ?                              ^   + ^^ ^^^^ ++ 
```
Looks like the problem is a leftover connection from the previous test due to the `channel` not being properly closed on test teardown. The current test then fails to connect to the test server which results in `StatusCode.UNAVAILABLE`.

For tox tests this was already addressed in #974 by pinning the gprc version to 1.30

## Type of change

- [x] ~~Bug~~ fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Run `pytest instrumentation/opentelemetry-instrumentation-grpc/tests` without and with closing the `channel`.

