### PR TITLE
docs: fix outdated alpha statement

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,8 +11,8 @@ The Python `OpenTelemetry <https://opentelemetry.io/>`_ client.
 This documentation describes the :doc:`opentelemetry-api <api/api>`,
 :doc:`opentelemetry-sdk <sdk/sdk>`, and several `integration packages <#integrations>`_.
 
-**Please note** that this library is currently in alpha, and shouldn't be
-used in production environments.
+**Please note** that this library is currently in _beta_, and shouldn't
+generally be used in production environments.
 
 Installation
 ------------

--- a/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-aiohttp-client/setup.cfg
@@ -23,7 +23,7 @@ url = https://github.com/open-telemetry/opentelemetry-python/instrumentation/ope
 platforms = any
 license = Apache-2.0
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 4 - Beta
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python


### PR DESCRIPTION
# Description

`README.md` and the opentelemetry website say this library is in beta, and releases have been called betas since March, so update `docs/index.rst` to be consistent with that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Checked that the markdown preview in Github looks right.

# Checklist:

- [x] Documentation has been updated
