### PR TITLE
Pass meter to observers

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -240,6 +240,7 @@ class Observer(metrics_api.Observer):
         description: str,
         unit: str,
         value_type: Type[metrics_api.ValueT],
+        meter: "Meter",
         label_keys: Sequence[str] = (),
         enabled: bool = True,
     ):
@@ -248,6 +249,7 @@ class Observer(metrics_api.Observer):
         self.description = description
         self.unit = unit
         self.value_type = value_type
+        self.meter = meter
         self.label_keys = label_keys
         self.enabled = enabled
 
@@ -448,7 +450,14 @@ class Meter(metrics_api.Meter):
         enabled: bool = True,
     ) -> metrics_api.Observer:
         ob = observer_type(
-            callback, name, description, unit, value_type, label_keys, enabled
+            callback,
+            name,
+            description,
+            unit,
+            value_type,
+            self,
+            label_keys,
+            enabled,
         )
         with self.observers_lock:
             self.observers.add(ob)

--- a/opentelemetry-sdk/tests/metrics/test_view.py
+++ b/opentelemetry-sdk/tests/metrics/test_view.py
@@ -42,12 +42,14 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(
             view.get_default_aggregator(ud_counter), aggregate.SumAggregator
         )
-        observer = metrics.SumObserver(lambda: None, "", "", "1", int)
+        observer = metrics.SumObserver(lambda: None, "", "", "1", int, meter)
         self.assertEqual(
             view.get_default_aggregator(observer),
             aggregate.LastValueAggregator,
         )
-        ud_observer = metrics.SumObserver(lambda: None, "", "", "1", int)
+        ud_observer = metrics.SumObserver(
+            lambda: None, "", "", "1", int, meter
+        )
         self.assertEqual(
             view.get_default_aggregator(ud_observer),
             aggregate.LastValueAggregator,
@@ -57,7 +59,9 @@ class TestUtil(unittest.TestCase):
             view.get_default_aggregator(recorder),
             aggregate.MinMaxSumCountAggregator,
         )
-        v_observer = metrics.ValueObserver(lambda: None, "", "", "1", int)
+        v_observer = metrics.ValueObserver(
+            lambda: None, "", "", "1", int, meter
+        )
         self.assertEqual(
             view.get_default_aggregator(v_observer),
             aggregate.ValueObserverAggregator,


### PR DESCRIPTION
Fixes #1050.

- Pass meter into Observer constructors, like we already do for synchronous instruments
- Updated tests
