### PR TITLE
chore: fix intermittent build failures

### DIFF
--- a/docs/getting_started/tests/test_flask.py
+++ b/docs/getting_started/tests/test_flask.py
@@ -29,10 +29,7 @@ class TestFlask(unittest.TestCase):
         server = subprocess.Popen(
             [sys.executable, server_script], stdout=subprocess.PIPE,
         )
-        retry_strategy = Retry(
-            total=10,
-            backoff_factor=1,
-        )
+        retry_strategy = Retry(total=10, backoff_factor=1)
         adapter = HTTPAdapter(max_retries=retry_strategy)
         http = requests.Session()
         http.mount("http://", adapter)

--- a/docs/getting_started/tests/test_flask.py
+++ b/docs/getting_started/tests/test_flask.py
@@ -18,6 +18,8 @@ import unittest
 from time import sleep
 
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 
 class TestFlask(unittest.TestCase):
@@ -27,10 +29,16 @@ class TestFlask(unittest.TestCase):
         server = subprocess.Popen(
             [sys.executable, server_script], stdout=subprocess.PIPE,
         )
-        sleep(1)
+        retry_strategy = Retry(
+            total=10,
+            backoff_factor=1,
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        http = requests.Session()
+        http.mount("http://", adapter)
 
         try:
-            result = requests.get("http://localhost:5000")
+            result = http.get("http://localhost:5000")
             self.assertEqual(result.status_code, 200)
 
             sleep(0.1)


### PR DESCRIPTION
# Description

This test was causing pypy3-core-getting-started jobs to fail intermittently. Removing the arbitrary sleep and replacing it with a retry strategy.

Fixes #1044

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been updated
