### PR TITLE
Remove non-inclusive language from comments in pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,7 @@
 # run arbitrary code.
 extension-pkg-whitelist=
 
-# Add files or directories to the denylist. They should be base names, not
+# Add list of files or directories to be excluded. They should be base names, not
 # paths.
 ignore=CVS,gen,proto
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@ extension-pkg-whitelist=
 # paths.
 ignore=CVS,gen,proto
 
-# Add files or directories matching the regex patterns to the denylist. The
+# Add files or directories matching the regex patterns to be excluded. The
 # regex matches against base names, not paths.
 ignore-patterns=
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -5,11 +5,11 @@
 # run arbitrary code.
 extension-pkg-whitelist=
 
-# Add files or directories to the blacklist. They should be base names, not
+# Add files or directories to the denylist. They should be base names, not
 # paths.
 ignore=CVS,gen,proto
 
-# Add files or directories matching the regex patterns to the blacklist. The
+# Add files or directories matching the regex patterns to the denylist. The
 # regex matches against base names, not paths.
 ignore-patterns=
 


### PR DESCRIPTION
# Description

Remove non-inclusive language from comments in pylint

Addresses #1076 the actionable part

## Type of change

Comment change in code

# How Has This Been Tested?

Locally

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
