### PR TITLE
Rename HTTPTextFormat to TextMapPropagator

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,17 +103,14 @@ nitpick_ignore = [
     # with "class reference target not found: ObjectProxy".
     ("py:class", "ObjectProxy"),
     # TODO: Understand why sphinx is not able to find this local class
+    ("py:class", "opentelemetry.trace.propagation.textmap.TextMapPropagator",),
     (
-        "py:class",
-        "opentelemetry.trace.propagation.httptextformat.HTTPTextFormat",
+        "any",
+        "opentelemetry.trace.propagation.textmap.TextMapPropagator.extract",
     ),
     (
         "any",
-        "opentelemetry.trace.propagation.httptextformat.HTTPTextFormat.extract",
-    ),
-    (
-        "any",
-        "opentelemetry.trace.propagation.httptextformat.HTTPTextFormat.inject",
+        "opentelemetry.trace.propagation.textmap.TextMapPropagator.inject",
     ),
 ]
 

--- a/docs/examples/datadog_exporter/server.py
+++ b/docs/examples/datadog_exporter/server.py
@@ -35,19 +35,19 @@ trace.get_tracer_provider().add_span_processor(
 )
 
 # append Datadog format for propagation to and from Datadog instrumented services
-global_httptextformat = propagators.get_global_httptextformat()
+global_textmap = propagators.get_global_textmap()
 if isinstance(
-    global_httptextformat, propagators.composite.CompositeHTTPPropagator
+    global_textmap, propagators.composite.CompositeHTTPPropagator
 ) and not any(
-    isinstance(p, DatadogFormat) for p in global_httptextformat._propagators
+    isinstance(p, DatadogFormat) for p in global_textmap._propagators
 ):
-    propagators.set_global_httptextformat(
+    propagators.set_global_textmap(
         propagators.composite.CompositeHTTPPropagator(
-            global_httptextformat._propagators + [DatadogFormat()]
+            global_textmap._propagators + [DatadogFormat()]
         )
     )
 else:
-    propagators.set_global_httptextformat(DatadogFormat())
+    propagators.set_global_textmap(DatadogFormat())
 
 tracer = trace.get_tracer(__name__)
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -194,7 +194,7 @@ an example using Zipkin's `b3 propagation <https://github.com/openzipkin/b3-prop
     from opentelemetry import propagators
     from opentelemetry.sdk.trace.propagation.b3_format import B3Format
 
-    propagators.set_global_httptextformat(B3Format())
+    propagators.set_global_textmap(B3Format())
 
 
 Adding Metrics

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/__init__.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/__init__.py
@@ -50,7 +50,7 @@ a distributed trace.
     trace.get_tracer_provider().add_span_processor(span_processor)
 
     # Optional: use Datadog format for propagation in distributed traces
-    propagators.set_global_httptextformat(DatadogFormat())
+    propagators.set_global_textmap(DatadogFormat())
 
     with tracer.start_as_current_span("foo"):
         print("Hello world!")

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
@@ -17,10 +17,10 @@ import typing
 from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.trace import get_current_span, set_span_in_context
-from opentelemetry.trace.propagation.httptextformat import (
+from opentelemetry.trace.propagation.textmap import (
     Getter,
-    HTTPTextFormat,
-    HTTPTextFormatT,
+    TextMapPropagator,
+    TextMapPropagatorT,
     Setter,
 )
 
@@ -28,7 +28,7 @@ from opentelemetry.trace.propagation.httptextformat import (
 from . import constants
 
 
-class DatadogFormat(HTTPTextFormat):
+class DatadogFormat(TextMapPropagator):
     """Propagator for the Datadog HTTP header format.
     """
 
@@ -39,8 +39,8 @@ class DatadogFormat(HTTPTextFormat):
 
     def extract(
         self,
-        get_from_carrier: Getter[HTTPTextFormatT],
-        carrier: HTTPTextFormatT,
+        get_from_carrier: Getter[TextMapPropagatorT],
+        carrier: TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> Context:
         trace_id = extract_first_element(
@@ -81,8 +81,8 @@ class DatadogFormat(HTTPTextFormat):
 
     def inject(
         self,
-        set_in_carrier: Setter[HTTPTextFormatT],
-        carrier: HTTPTextFormatT,
+        set_in_carrier: Setter[TextMapPropagatorT],
+        carrier: TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> None:
         span = get_current_span(context)
@@ -120,8 +120,8 @@ def format_span_id(span_id: int) -> str:
 
 
 def extract_first_element(
-    items: typing.Iterable[HTTPTextFormatT],
-) -> typing.Optional[HTTPTextFormatT]:
+    items: typing.Iterable[TextMapPropagatorT],
+) -> typing.Optional[TextMapPropagatorT]:
     if items is None:
         return None
     return next(iter(items), None)

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py
@@ -19,9 +19,9 @@ from opentelemetry.context import Context
 from opentelemetry.trace import get_current_span, set_span_in_context
 from opentelemetry.trace.propagation.textmap import (
     Getter,
+    Setter,
     TextMapPropagator,
     TextMapPropagatorT,
-    Setter,
 )
 
 # pylint:disable=relative-beyond-top-level

--- a/instrumentation/opentelemetry-instrumentation-opentracing-shim/src/opentelemetry/instrumentation/opentracing_shim/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-opentracing-shim/src/opentelemetry/instrumentation/opentracing_shim/__init__.py
@@ -676,7 +676,7 @@ class TracerShim(Tracer):
         if format not in self._supported_formats:
             raise UnsupportedFormatException
 
-        propagator = propagators.get_global_httptextformat()
+        propagator = propagators.get_global_textmap()
 
         ctx = set_span_in_context(DefaultSpan(span_context.unwrap()))
         propagator.inject(type(carrier).__setitem__, carrier, context=ctx)
@@ -710,7 +710,7 @@ class TracerShim(Tracer):
             value = dict_object.get(key)
             return [value] if value is not None else []
 
-        propagator = propagators.get_global_httptextformat()
+        propagator = propagators.get_global_textmap()
         ctx = propagator.extract(get_as_list, carrier)
         span = get_current_span(ctx)
         if span is not None:

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -22,7 +22,7 @@ import opentelemetry.instrumentation.requests
 from opentelemetry import context, propagators, trace
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.sdk import resources
-from opentelemetry.test.mock_httptextformat import MockHTTPTextFormat
+from opentelemetry.test.mock_textmap import MockTextMapPropagator
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace.status import StatusCanonicalCode
 
@@ -148,28 +148,28 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assert_span(num_spans=0)
 
     def test_distributed_context(self):
-        previous_propagator = propagators.get_global_httptextformat()
+        previous_propagator = propagators.get_global_textmap()
         try:
-            propagators.set_global_httptextformat(MockHTTPTextFormat())
+            propagators.set_global_textmap(MockTextMapPropagator())
             result = self.perform_request(self.URL)
             self.assertEqual(result.text, "Hello!")
 
             span = self.assert_span()
 
             headers = dict(httpretty.last_request().headers)
-            self.assertIn(MockHTTPTextFormat.TRACE_ID_KEY, headers)
+            self.assertIn(MockTextMapPropagator.TRACE_ID_KEY, headers)
             self.assertEqual(
                 str(span.get_context().trace_id),
-                headers[MockHTTPTextFormat.TRACE_ID_KEY],
+                headers[MockTextMapPropagator.TRACE_ID_KEY],
             )
-            self.assertIn(MockHTTPTextFormat.SPAN_ID_KEY, headers)
+            self.assertIn(MockTextMapPropagator.SPAN_ID_KEY, headers)
             self.assertEqual(
                 str(span.get_context().span_id),
-                headers[MockHTTPTextFormat.SPAN_ID_KEY],
+                headers[MockTextMapPropagator.SPAN_ID_KEY],
             )
 
         finally:
-            propagators.set_global_httptextformat(previous_propagator)
+            propagators.set_global_textmap(previous_propagator)
 
     def test_span_callback(self):
         RequestsInstrumentor().uninstrument()

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -14,6 +14,9 @@
   ([#1045](https://github.com/open-telemetry/opentelemetry-python/pull/1045))
 - Rename CorrelationContext to Baggage
   ([#1060](https://github.com/open-telemetry/opentelemetry-python/pull/1060))
+- Rename HTTPTextFormat to TextMapPropagator. This change also updates `get_global_httptextformat` and
+  `set_global_httptextformat` to `get_global_textmap` and `set_global_textmap`
+  ([#1085](https://github.com/open-telemetry/opentelemetry-python/pull/1085))
 
 ## Version 0.12b0
 

--- a/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
@@ -18,10 +18,10 @@ import urllib.parse
 from opentelemetry import baggage
 from opentelemetry.context import get_current
 from opentelemetry.context.context import Context
-from opentelemetry.trace.propagation import httptextformat
+from opentelemetry.trace.propagation import textmap
 
 
-class BaggagePropagator(httptextformat.HTTPTextFormat):
+class BaggagePropagator(textmap.TextMapPropagator):
     MAX_HEADER_LENGTH = 8192
     MAX_PAIR_LENGTH = 4096
     MAX_PAIRS = 180
@@ -29,16 +29,14 @@ class BaggagePropagator(httptextformat.HTTPTextFormat):
 
     def extract(
         self,
-        get_from_carrier: httptextformat.Getter[
-            httptextformat.HTTPTextFormatT
-        ],
-        carrier: httptextformat.HTTPTextFormatT,
+        get_from_carrier: textmap.Getter[textmap.TextMapPropagatorT],
+        carrier: textmap.TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> Context:
         """Extract Baggage from the carrier.
 
         See
-        `opentelemetry.trace.propagation.httptextformat.HTTPTextFormat.extract`
+        `opentelemetry.trace.propagation.textmap.TextMapPropagator.extract`
         """
 
         if context is None:
@@ -73,14 +71,14 @@ class BaggagePropagator(httptextformat.HTTPTextFormat):
 
     def inject(
         self,
-        set_in_carrier: httptextformat.Setter[httptextformat.HTTPTextFormatT],
-        carrier: httptextformat.HTTPTextFormatT,
+        set_in_carrier: textmap.Setter[textmap.TextMapPropagatorT],
+        carrier: textmap.TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> None:
         """Injects Baggage into the carrier.
 
         See
-        `opentelemetry.trace.propagation.httptextformat.HTTPTextFormat.inject`
+        `opentelemetry.trace.propagation.textmap.TextMapPropagator.inject`
         """
         baggage_entries = baggage.get_all(context=context)
         if not baggage_entries:
@@ -100,8 +98,8 @@ def _format_baggage(baggage_entries: typing.Mapping[str, object]) -> str:
 
 
 def _extract_first_element(
-    items: typing.Iterable[httptextformat.HTTPTextFormatT],
-) -> typing.Optional[httptextformat.HTTPTextFormatT]:
+    items: typing.Iterable[textmap.TextMapPropagatorT],
+) -> typing.Optional[textmap.TextMapPropagatorT]:
     if items is None:
         return None
     return next(iter(items), None)

--- a/opentelemetry-api/src/opentelemetry/propagators/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/__init__.py
@@ -22,7 +22,7 @@ Example::
     from opentelemetry import propagators
 
 
-    PROPAGATOR = propagators.get_global_httptextformat()
+    PROPAGATOR = propagators.get_global_textmap()
 
 
     def get_header_from_flask_request(request, key):
@@ -58,15 +58,15 @@ import typing
 from opentelemetry.baggage.propagation import BaggagePropagator
 from opentelemetry.context.context import Context
 from opentelemetry.propagators import composite
-from opentelemetry.trace.propagation import httptextformat
-from opentelemetry.trace.propagation.tracecontexthttptextformat import (
-    TraceContextHTTPTextFormat,
+from opentelemetry.trace.propagation import textmap
+from opentelemetry.trace.propagation.tracecontext import (
+    TraceContextTextMapPropagator,
 )
 
 
 def extract(
-    get_from_carrier: httptextformat.Getter[httptextformat.HTTPTextFormatT],
-    carrier: httptextformat.HTTPTextFormatT,
+    get_from_carrier: textmap.Getter[textmap.TextMapPropagatorT],
+    carrier: textmap.TextMapPropagatorT,
     context: typing.Optional[Context] = None,
 ) -> Context:
     """ Uses the configured propagator to extract a Context from the carrier.
@@ -82,14 +82,12 @@ def extract(
         context: an optional Context to use. Defaults to current
             context if not set.
     """
-    return get_global_httptextformat().extract(
-        get_from_carrier, carrier, context
-    )
+    return get_global_textmap().extract(get_from_carrier, carrier, context)
 
 
 def inject(
-    set_in_carrier: httptextformat.Setter[httptextformat.HTTPTextFormatT],
-    carrier: httptextformat.HTTPTextFormatT,
+    set_in_carrier: textmap.Setter[textmap.TextMapPropagatorT],
+    carrier: textmap.TextMapPropagatorT,
     context: typing.Optional[Context] = None,
 ) -> None:
     """ Uses the configured propagator to inject a Context into the carrier.
@@ -103,20 +101,18 @@ def inject(
         context: an optional Context to use. Defaults to current
             context if not set.
     """
-    get_global_httptextformat().inject(set_in_carrier, carrier, context)
+    get_global_textmap().inject(set_in_carrier, carrier, context)
 
 
 _HTTP_TEXT_FORMAT = composite.CompositeHTTPPropagator(
-    [TraceContextHTTPTextFormat(), BaggagePropagator()],
-)  # type: httptextformat.HTTPTextFormat
+    [TraceContextTextMapPropagator(), BaggagePropagator()],
+)  # type: textmap.TextMapPropagator
 
 
-def get_global_httptextformat() -> httptextformat.HTTPTextFormat:
+def get_global_textmap() -> textmap.TextMapPropagator:
     return _HTTP_TEXT_FORMAT
 
 
-def set_global_httptextformat(
-    http_text_format: httptextformat.HTTPTextFormat,
-) -> None:
+def set_global_textmap(http_text_format: textmap.TextMapPropagator,) -> None:
     global _HTTP_TEXT_FORMAT  # pylint:disable=global-statement
     _HTTP_TEXT_FORMAT = http_text_format

--- a/opentelemetry-api/src/opentelemetry/propagators/composite.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/composite.py
@@ -15,12 +15,12 @@ import logging
 import typing
 
 from opentelemetry.context.context import Context
-from opentelemetry.trace.propagation import httptextformat
+from opentelemetry.trace.propagation import textmap
 
 logger = logging.getLogger(__name__)
 
 
-class CompositeHTTPPropagator(httptextformat.HTTPTextFormat):
+class CompositeHTTPPropagator(textmap.TextMapPropagator):
     """ CompositeHTTPPropagator provides a mechanism for combining multiple
     propagators into a single one.
 
@@ -29,16 +29,14 @@ class CompositeHTTPPropagator(httptextformat.HTTPTextFormat):
     """
 
     def __init__(
-        self, propagators: typing.Sequence[httptextformat.HTTPTextFormat]
+        self, propagators: typing.Sequence[textmap.TextMapPropagator]
     ) -> None:
         self._propagators = propagators
 
     def extract(
         self,
-        get_from_carrier: httptextformat.Getter[
-            httptextformat.HTTPTextFormatT
-        ],
-        carrier: httptextformat.HTTPTextFormatT,
+        get_from_carrier: textmap.Getter[textmap.TextMapPropagatorT],
+        carrier: textmap.TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> Context:
         """ Run each of the configured propagators with the given context and carrier.
@@ -46,7 +44,7 @@ class CompositeHTTPPropagator(httptextformat.HTTPTextFormat):
         propagators write the same context key, the propagator later in the list
         will override previous propagators.
 
-        See `opentelemetry.trace.propagation.httptextformat.HTTPTextFormat.extract`
+        See `opentelemetry.trace.propagation.textmap.TextMapPropagator.extract`
         """
         for propagator in self._propagators:
             context = propagator.extract(get_from_carrier, carrier, context)
@@ -54,8 +52,8 @@ class CompositeHTTPPropagator(httptextformat.HTTPTextFormat):
 
     def inject(
         self,
-        set_in_carrier: httptextformat.Setter[httptextformat.HTTPTextFormatT],
-        carrier: httptextformat.HTTPTextFormatT,
+        set_in_carrier: textmap.Setter[textmap.TextMapPropagatorT],
+        carrier: textmap.TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> None:
         """ Run each of the configured propagators with the given context and carrier.
@@ -63,7 +61,7 @@ class CompositeHTTPPropagator(httptextformat.HTTPTextFormat):
         propagators write the same carrier key, the propagator later in the list
         will override previous propagators.
 
-        See `opentelemetry.trace.propagation.httptextformat.HTTPTextFormat.inject`
+        See `opentelemetry.trace.propagation.textmap.TextMapPropagator.inject`
         """
         for propagator in self._propagators:
             propagator.inject(set_in_carrier, carrier, context)

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/textmap.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/textmap.py
@@ -17,16 +17,16 @@ import typing
 
 from opentelemetry.context.context import Context
 
-HTTPTextFormatT = typing.TypeVar("HTTPTextFormatT")
+TextMapPropagatorT = typing.TypeVar("TextMapPropagatorT")
 
-Setter = typing.Callable[[HTTPTextFormatT, str, str], None]
-Getter = typing.Callable[[HTTPTextFormatT, str], typing.List[str]]
+Setter = typing.Callable[[TextMapPropagatorT, str, str], None]
+Getter = typing.Callable[[TextMapPropagatorT, str], typing.List[str]]
 
 
-class HTTPTextFormat(abc.ABC):
+class TextMapPropagator(abc.ABC):
     """This class provides an interface that enables extracting and injecting
     context into headers of HTTP requests. HTTP frameworks and clients
-    can integrate with HTTPTextFormat by providing the object containing the
+    can integrate with TextMapPropagator by providing the object containing the
     headers, and a getter and setter function for the extraction and
     injection of values, respectively.
 
@@ -35,8 +35,8 @@ class HTTPTextFormat(abc.ABC):
     @abc.abstractmethod
     def extract(
         self,
-        get_from_carrier: Getter[HTTPTextFormatT],
-        carrier: HTTPTextFormatT,
+        get_from_carrier: Getter[TextMapPropagatorT],
+        carrier: TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> Context:
         """Create a Context from values in the carrier.
@@ -63,8 +63,8 @@ class HTTPTextFormat(abc.ABC):
     @abc.abstractmethod
     def inject(
         self,
-        set_in_carrier: Setter[HTTPTextFormatT],
-        carrier: HTTPTextFormatT,
+        set_in_carrier: Setter[TextMapPropagatorT],
+        carrier: TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> None:
         """Inject values from a Context into a carrier.

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py
@@ -17,7 +17,7 @@ import typing
 
 import opentelemetry.trace as trace
 from opentelemetry.context.context import Context
-from opentelemetry.trace.propagation import httptextformat
+from opentelemetry.trace.propagation import textmap
 
 #    Keys and values are strings of up to 256 printable US-ASCII characters.
 #    Implementations should conform to the `W3C Trace Context - Tracestate`_
@@ -46,7 +46,7 @@ _MEMBER_FORMAT_RE = re.compile(_MEMBER_FORMAT)
 _TRACECONTEXT_MAXIMUM_TRACESTATE_KEYS = 32
 
 
-class TraceContextHTTPTextFormat(httptextformat.HTTPTextFormat):
+class TraceContextTextMapPropagator(textmap.TextMapPropagator):
     """Extracts and injects using w3c TraceContext's headers.
     """
 
@@ -60,15 +60,13 @@ class TraceContextHTTPTextFormat(httptextformat.HTTPTextFormat):
 
     def extract(
         self,
-        get_from_carrier: httptextformat.Getter[
-            httptextformat.HTTPTextFormatT
-        ],
-        carrier: httptextformat.HTTPTextFormatT,
+        get_from_carrier: textmap.Getter[textmap.TextMapPropagatorT],
+        carrier: textmap.TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> Context:
         """Extracts SpanContext from the carrier.
 
-        See `opentelemetry.trace.propagation.httptextformat.HTTPTextFormat.extract`
+        See `opentelemetry.trace.propagation.textmap.TextMapPropagator.extract`
         """
         header = get_from_carrier(carrier, self._TRACEPARENT_HEADER_NAME)
 
@@ -111,13 +109,13 @@ class TraceContextHTTPTextFormat(httptextformat.HTTPTextFormat):
 
     def inject(
         self,
-        set_in_carrier: httptextformat.Setter[httptextformat.HTTPTextFormatT],
-        carrier: httptextformat.HTTPTextFormatT,
+        set_in_carrier: textmap.Setter[textmap.TextMapPropagatorT],
+        carrier: textmap.TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> None:
         """Injects SpanContext into the carrier.
 
-        See `opentelemetry.trace.propagation.httptextformat.HTTPTextFormat.inject`
+        See `opentelemetry.trace.propagation.textmap.TextMapPropagator.inject`
         """
         span = trace.get_current_span(context)
         span_context = span.get_context()

--- a/opentelemetry-api/tests/trace/propagation/test_tracecontexthttptextformat.py
+++ b/opentelemetry-api/tests/trace/propagation/test_tracecontexthttptextformat.py
@@ -16,9 +16,9 @@ import typing
 import unittest
 
 from opentelemetry import trace
-from opentelemetry.trace.propagation import tracecontexthttptextformat
+from opentelemetry.trace.propagation import tracecontext
 
-FORMAT = tracecontexthttptextformat.TraceContextHTTPTextFormat()
+FORMAT = tracecontext.TraceContextTextMapPropagator()
 
 
 def get_as_list(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
@@ -18,15 +18,15 @@ from re import compile as re_compile
 import opentelemetry.trace as trace
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import generate_span_id, generate_trace_id
-from opentelemetry.trace.propagation.httptextformat import (
+from opentelemetry.trace.propagation.textmap import (
     Getter,
-    HTTPTextFormat,
-    HTTPTextFormatT,
+    TextMapPropagator,
+    TextMapPropagatorT,
     Setter,
 )
 
 
-class B3Format(HTTPTextFormat):
+class B3Format(TextMapPropagator):
     """Propagator for the B3 HTTP header format.
 
     See: https://github.com/openzipkin/b3-propagation
@@ -44,8 +44,8 @@ class B3Format(HTTPTextFormat):
 
     def extract(
         self,
-        get_from_carrier: Getter[HTTPTextFormatT],
-        carrier: HTTPTextFormatT,
+        get_from_carrier: Getter[TextMapPropagatorT],
+        carrier: TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> Context:
         trace_id = format_trace_id(trace.INVALID_TRACE_ID)
@@ -134,8 +134,8 @@ class B3Format(HTTPTextFormat):
 
     def inject(
         self,
-        set_in_carrier: Setter[HTTPTextFormatT],
-        carrier: HTTPTextFormatT,
+        set_in_carrier: Setter[TextMapPropagatorT],
+        carrier: TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> None:
         span = trace.get_current_span(context=context)
@@ -170,8 +170,8 @@ def format_span_id(span_id: int) -> str:
 
 
 def _extract_first_element(
-    items: typing.Iterable[HTTPTextFormatT],
-) -> typing.Optional[HTTPTextFormatT]:
+    items: typing.Iterable[TextMapPropagatorT],
+) -> typing.Optional[TextMapPropagatorT]:
     if items is None:
         return None
     return next(iter(items), None)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
@@ -20,9 +20,9 @@ from opentelemetry.context import Context
 from opentelemetry.sdk.trace import generate_span_id, generate_trace_id
 from opentelemetry.trace.propagation.textmap import (
     Getter,
+    Setter,
     TextMapPropagator,
     TextMapPropagatorT,
-    Setter,
 )
 
 

--- a/tests/util/src/opentelemetry/test/mock_textmap.py
+++ b/tests/util/src/opentelemetry/test/mock_textmap.py
@@ -18,9 +18,9 @@ from opentelemetry import trace
 from opentelemetry.context import Context, get_current
 from opentelemetry.trace.propagation.textmap import (
     Getter,
+    Setter,
     TextMapPropagator,
     TextMapPropagatorT,
-    Setter,
 )
 
 

--- a/tests/util/src/opentelemetry/test/mock_textmap.py
+++ b/tests/util/src/opentelemetry/test/mock_textmap.py
@@ -16,15 +16,15 @@ import typing
 
 from opentelemetry import trace
 from opentelemetry.context import Context, get_current
-from opentelemetry.trace.propagation.httptextformat import (
+from opentelemetry.trace.propagation.textmap import (
     Getter,
-    HTTPTextFormat,
-    HTTPTextFormatT,
+    TextMapPropagator,
+    TextMapPropagatorT,
     Setter,
 )
 
 
-class NOOPHTTPTextFormat(HTTPTextFormat):
+class NOOPTextMapPropagator(TextMapPropagator):
     """A propagator that does not extract nor inject.
 
     This class is useful for catching edge cases assuming
@@ -33,22 +33,22 @@ class NOOPHTTPTextFormat(HTTPTextFormat):
 
     def extract(
         self,
-        get_from_carrier: Getter[HTTPTextFormatT],
-        carrier: HTTPTextFormatT,
+        get_from_carrier: Getter[TextMapPropagatorT],
+        carrier: TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> Context:
         return get_current()
 
     def inject(
         self,
-        set_in_carrier: Setter[HTTPTextFormatT],
-        carrier: HTTPTextFormatT,
+        set_in_carrier: Setter[TextMapPropagatorT],
+        carrier: TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> None:
         return None
 
 
-class MockHTTPTextFormat(HTTPTextFormat):
+class MockTextMapPropagator(TextMapPropagator):
     """Mock propagator for testing purposes."""
 
     TRACE_ID_KEY = "mock-traceid"
@@ -56,8 +56,8 @@ class MockHTTPTextFormat(HTTPTextFormat):
 
     def extract(
         self,
-        get_from_carrier: Getter[HTTPTextFormatT],
-        carrier: HTTPTextFormatT,
+        get_from_carrier: Getter[TextMapPropagatorT],
+        carrier: TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> Context:
         trace_id_list = get_from_carrier(carrier, self.TRACE_ID_KEY)
@@ -78,8 +78,8 @@ class MockHTTPTextFormat(HTTPTextFormat):
 
     def inject(
         self,
-        set_in_carrier: Setter[HTTPTextFormatT],
-        carrier: HTTPTextFormatT,
+        set_in_carrier: Setter[TextMapPropagatorT],
+        carrier: TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> None:
         span = trace.get_current_span(context)


### PR DESCRIPTION
# Description

As per spec, this change renames the HTTPTextFormat to TextFormatPropagator. Updated the file names accordingly.

Fixes #1083 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Unit tests

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been updated
- [x] Documentation has been updated
