### PR TITLE
Migrate pytest config to pyproject.toml

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ mypy==0.770
 sphinx~=2.1
 sphinx-rtd-theme~=0.4
 sphinx-autodoc-typehints~=1.10.2
-pytest!=5.2.3
+pytest>=6.0
 pytest-cov>=2.8
 readme-renderer~=24.0
 grpcio-tools==1.29.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,7 @@ exclude = '''
   )/
 )
 '''
+[tool.pytest.ini_options]
+addopts = "-rs -v"
+log_cli = true
+log_cli_level = "warning"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-addopts = -rs -v
-log_cli = true
-log_cli_level = warning


### PR DESCRIPTION
# Description

Moves pytest configuration from `pytest.ini` to `pyproject.toml`

Since version 6.0, pytest supports configuration via the `pyproject.toml` file. I think it would be nice to get rid of some files in the repo's root directory, so I can also look into moving other configuration if this is something we want. Pretty much every tool has at least an open ticket for `pyproject.toml` support by now.

# How Has This Been Tested?

I ran `tox -f py38-api` to make sure the output looks the same.