### PR TITLE
Use is_recording flag in requests instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -56,8 +56,8 @@ _SUPPRESS_REQUESTS_INSTRUMENTATION_KEY = "suppress_requests_instrumentation"
 # pylint: disable=unused-argument
 def _instrument(tracer_provider=None, span_callback=None):
     """Enables tracing of all requests calls that go through
-      :code:`requests.session.Session.request` (this includes
-      :code:`requests.get`, etc.)."""
+    :code:`requests.session.Session.request` (this includes
+    :code:`requests.get`, etc.)."""
 
     # Since
     # https://github.com/psf/requests/commit/d72d1162142d1bf8b1b5711c664fbbd674f349d1

--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -121,39 +121,45 @@ def _instrument(tracer_provider=None, span_callback=None):
         with get_tracer(
             __name__, __version__, tracer_provider
         ).start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
-            span.set_attribute("component", "http")
-            span.set_attribute("http.method", method.upper())
-            span.set_attribute("http.url", url)
+            if span.is_recording():
+                span.set_attribute("component", "http")
+                span.set_attribute("http.method", method.upper())
+                span.set_attribute("http.url", url)
 
-            headers = get_or_create_headers()
-            propagators.inject(type(headers).__setitem__, headers)
+                headers = get_or_create_headers()
+                propagators.inject(type(headers).__setitem__, headers)
 
-            token = context.attach(
-                context.set_value(_SUPPRESS_REQUESTS_INSTRUMENTATION_KEY, True)
-            )
-            try:
-                result = call_wrapped()  # *** PROCEED
-            except Exception as exc:  # pylint: disable=W0703
-                exception = exc
-                result = getattr(exc, "response", None)
-            finally:
-                context.detach(token)
-
-            if exception is not None:
-                span.set_status(
-                    Status(_exception_to_canonical_code(exception))
+                token = context.attach(
+                    context.set_value(_SUPPRESS_REQUESTS_INSTRUMENTATION_KEY, True)
                 )
-                span.record_exception(exception)
+                try:
+                    result = call_wrapped()  # *** PROCEED
+                except Exception as exc:  # pylint: disable=W0703
+                    exception = exc
+                    result = getattr(exc, "response", None)
+                finally:
+                    context.detach(token)
 
-            if result is not None:
-                span.set_attribute("http.status_code", result.status_code)
-                span.set_attribute("http.status_text", result.reason)
-                span.set_status(
-                    Status(http_status_to_canonical_code(result.status_code))
-                )
+                if exception is not None:
+                    span.set_status(
+                        Status(_exception_to_canonical_code(exception))
+                    )
+                    span.record_exception(exception)
 
-            if span_callback is not None:
-                span_callback(span, result)
+                if result is not None:
+                    span.set_attribute("http.status_code", result.status_code)
+                    span.set_attribute("http.status_text", result.reason)
+                    span.set_status(
+                        Status(http_status_to_canonical_code(result.status_code))
+                    )
+
+                if span_callback is not None:
+                    span_callback(span, result)
+            else:
+                try:
+                    result = call_wrapped()  # *** PROCEED
+                except Exception as exc:  # pylint: disable=W0703
+                    exception = exc
 
         if exception is not None:
             raise exception.with_traceback(exception.__traceback__)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -162,8 +162,8 @@ class RequestsIntegrationTestBase(abc.ABC):
             self.assertEqual(result.text, "Hello!")
             self.assert_span(None, 0)
             with self.assertRaises(AttributeError):
-                # pylint: disable=unused-variable
-                attr = mock_span.attributes
+                # pylint: disable=pointless-statement
+                mock_span.attributes
             self.assertFalse(mock_span.is_recording())
             self.assertTrue(mock_span.is_recording.called)
             self.assertFalse(mock_span.set_attribute.called)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -161,9 +161,6 @@ class RequestsIntegrationTestBase(abc.ABC):
             result = self.perform_request(self.URL)
             self.assertEqual(result.text, "Hello!")
             self.assert_span(None, 0)
-            with self.assertRaises(AttributeError):
-                # pylint: disable=pointless-statement
-                mock_span.attributes
             self.assertFalse(mock_span.is_recording())
             self.assertTrue(mock_span.is_recording.called)
             self.assertFalse(mock_span.set_attribute.called)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -147,6 +147,19 @@ class RequestsIntegrationTestBase(abc.ABC):
 
         self.assert_span(num_spans=0)
 
+    def test_not_recording(self):
+        RequestsInstrumentor().uninstrument()
+        RequestsInstrumentor().instrument(
+            tracer_provider=self.original_tracer_provider
+        )
+
+        result = self.perform_request(self.URL)
+        self.assertEqual(result.text, "Hello!")
+
+        span = self.assert_span(None, 0)
+        with self.assertRaises(AttributeError):
+            attr = span.attributes
+
     def test_distributed_context(self):
         previous_propagator = propagators.get_global_httptextformat()
         try:

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -162,7 +162,8 @@ class RequestsIntegrationTestBase(abc.ABC):
             self.assertEqual(result.text, "Hello!")
             self.assert_span(None, 0)
             with self.assertRaises(AttributeError):
-                mock_span.attributes
+                #pylint: disable=unused-variable
+                attr = mock_span.attributes
             self.assertFalse(mock_span.is_recording())
             self.assertTrue(mock_span.is_recording.called)
             self.assertFalse(mock_span.set_attribute.called)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -151,7 +151,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
             RequestsInstrumentor().uninstrument()
             # original_tracer_provider returns a default tracer provider, which
-            # in turn will return an INVALID_SPAN, which is not recording
+            # in turn will return an INVALID_SPAN, which is always not recording
             RequestsInstrumentor().instrument(
                 tracer_provider=self.original_tracer_provider
             )

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -162,7 +162,7 @@ class RequestsIntegrationTestBase(abc.ABC):
             self.assertEqual(result.text, "Hello!")
             self.assert_span(None, 0)
             with self.assertRaises(AttributeError):
-                attr = mock_span.attributes
+                mock_span.attributes
             self.assertFalse(mock_span.is_recording())
             self.assertTrue(mock_span.is_recording.called)
             self.assertFalse(mock_span.set_attribute.called)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -162,7 +162,7 @@ class RequestsIntegrationTestBase(abc.ABC):
             self.assertEqual(result.text, "Hello!")
             self.assert_span(None, 0)
             with self.assertRaises(AttributeError):
-                #pylint: disable=unused-variable
+                # pylint: disable=unused-variable
                 attr = mock_span.attributes
             self.assertFalse(mock_span.is_recording())
             self.assertTrue(mock_span.is_recording.called)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -163,8 +163,9 @@ class RequestsIntegrationTestBase(abc.ABC):
             with self.assertRaises(AttributeError):
                 attr = mock_span.attributes
             self.assertFalse(mock_span.is_recording())
-            mock_span.is_recording.assert_called()
+            self.assertTrue(mock_span.is_recording.called)
             mock_span.set_attribute.assert_not_called()
+            mock_span.set_status.assert_not_called()
 
     def test_distributed_context(self):
         previous_propagator = propagators.get_global_textmap()

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -151,7 +151,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
             RequestsInstrumentor().uninstrument()
             # original_tracer_provider returns a default tracer provider, which
-            # in turn will return an INVALID_SPAN, which is always not recording
+            # in turn will return an INVALID_SPAN, which is not recording
             RequestsInstrumentor().instrument(
                 tracer_provider=self.original_tracer_provider
             )

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -91,7 +91,9 @@ class RequestsIntegrationTestBase(abc.ABC):
     def test_not_foundbasic(self):
         url_404 = "http://httpbin.org/status/404"
         httpretty.register_uri(
-            httpretty.GET, url_404, status=404,
+            httpretty.GET,
+            url_404,
+            status=404,
         )
         result = self.perform_request(url_404)
         self.assertEqual(result.status_code, 404)
@@ -149,7 +151,8 @@ class RequestsIntegrationTestBase(abc.ABC):
 
     def test_not_recording(self):
         with mock.patch(
-            'opentelemetry.trace.INVALID_SPAN', autospec=True) as mock_span:
+            "opentelemetry.trace.INVALID_SPAN", autospec=True
+        ) as mock_span:
             RequestsInstrumentor().uninstrument()
             # original_tracer_provider returns a default tracer provider, which
             # in turn will return an INVALID_SPAN, which is always not recording
@@ -200,7 +203,8 @@ class RequestsIntegrationTestBase(abc.ABC):
             )
 
         RequestsInstrumentor().instrument(
-            tracer_provider=self.tracer_provider, span_callback=span_callback,
+            tracer_provider=self.tracer_provider,
+            span_callback=span_callback,
         )
 
         result = self.perform_request(self.URL)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -149,7 +149,7 @@ class RequestsIntegrationTestBase(abc.ABC):
 
     def test_not_recording(self):
         with mock.patch(
-            "opentelemetry.trace.INVALID_SPAN", autospec=True
+            "opentelemetry.trace.INVALID_SPAN"
         ) as mock_span:
             RequestsInstrumentor().uninstrument()
             # original_tracer_provider returns a default tracer provider, which

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -91,9 +91,7 @@ class RequestsIntegrationTestBase(abc.ABC):
     def test_not_foundbasic(self):
         url_404 = "http://httpbin.org/status/404"
         httpretty.register_uri(
-            httpretty.GET,
-            url_404,
-            status=404,
+            httpretty.GET, url_404, status=404,
         )
         result = self.perform_request(url_404)
         self.assertEqual(result.status_code, 404)
@@ -167,8 +165,8 @@ class RequestsIntegrationTestBase(abc.ABC):
                 attr = mock_span.attributes
             self.assertFalse(mock_span.is_recording())
             self.assertTrue(mock_span.is_recording.called)
-            mock_span.set_attribute.assert_not_called()
-            mock_span.set_status.assert_not_called()
+            self.assertFalse(mock_span.set_attribute.called)
+            self.assertFalse(mock_span.set_status.called)
 
     def test_distributed_context(self):
         previous_propagator = propagators.get_global_textmap()
@@ -203,8 +201,7 @@ class RequestsIntegrationTestBase(abc.ABC):
             )
 
         RequestsInstrumentor().instrument(
-            tracer_provider=self.tracer_provider,
-            span_callback=span_callback,
+            tracer_provider=self.tracer_provider, span_callback=span_callback,
         )
 
         result = self.perform_request(self.URL)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -148,9 +148,7 @@ class RequestsIntegrationTestBase(abc.ABC):
         self.assert_span(num_spans=0)
 
     def test_not_recording(self):
-        with mock.patch(
-            "opentelemetry.trace.INVALID_SPAN"
-        ) as mock_span:
+        with mock.patch("opentelemetry.trace.INVALID_SPAN") as mock_span:
             RequestsInstrumentor().uninstrument()
             # original_tracer_provider returns a default tracer provider, which
             # in turn will return an INVALID_SPAN, which is always not recording

--- a/tests/util/setup.cfg
+++ b/tests/util/setup.cfg
@@ -39,6 +39,7 @@ package_dir=
 packages=find_namespace:
 install_requires =
     opentelemetry-api
+    opentelemetry-sdk
 
 [options.extras_require]
 test = flask~=1.0


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-python/issues/1057

The test util was also missing a dependency to the sdk package, which it [uses](https://github.com/open-telemetry/opentelemetry-python/blob/master/tests/util/src/opentelemetry/test/test_base.py#L21)