### PR TITLE
Fix api/sdk setup.cfg to include missing python files

### DIFF
--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Rename HTTPTextFormat to TextMapPropagator. This change also updates `get_global_httptextformat` and
   `set_global_httptextformat` to `get_global_textmap` and `set_global_textmap`
   ([#1085](https://github.com/open-telemetry/opentelemetry-python/pull/1085))
+- Fix api/sdk setup.cfg to include missing python files
+  ([#1091](https://github.com/open-telemetry/opentelemetry-python/pull/1091))
 
 ## Version 0.12b0
 

--- a/opentelemetry-api/setup.cfg
+++ b/opentelemetry-api/setup.cfg
@@ -47,7 +47,6 @@ install_requires =
 
 [options.packages.find]
 where = src
-include = opentelemetry.*
 
 [options.entry_points]
 opentelemetry_context =

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -14,6 +14,8 @@
   ([#1053](https://github.com/open-telemetry/opentelemetry-python/pull/1053))
 - Rename Resource labels to attributes
   ([#1082](https://github.com/open-telemetry/opentelemetry-python/pull/1082))
+- Fix api/sdk setup.cfg to include missing python files
+  ([#1091](https://github.com/open-telemetry/opentelemetry-python/pull/1091))
 
 ## Version 0.12b0
 

--- a/opentelemetry-sdk/setup.cfg
+++ b/opentelemetry-sdk/setup.cfg
@@ -46,7 +46,6 @@ install_requires =
 
 [options.packages.find]
 where = src
-include = opentelemetry.sdk.*
 
 [options.entry_points]
 opentelemetry_meter_provider =


### PR DESCRIPTION
# Description

The `include` line in `setup.cfg` was causing only packages *under* `opentelemetry.sdk` and `opentelemetry` to be included, missing the `opentelemetry.sdk` package itself (with `version.py` and `__init__.py` files). I don't think we need the `include` at all, so removed. It is not in any of the other packages' setup files.

Fixes #1078

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Installing the packages (regular install, not editable) before and after into separate venvs and comparing the site-packages
```bash
rm -rf venv-before
python3 -m venv venv-before
source venv-before/bin/activate
pip install file:./opentelemetry-api file:./opentelemetry-sdk
tree -I *.pyc -I __pycache__ venv-before/lib/python3.8/site-packages/opentelemetry
```

Before:
```bash
Processing ./opentelemetry-api
Processing ./opentelemetry-sdk
Using legacy setup.py install for opentelemetry-api, since package 'wheel' is not installed.
Using legacy setup.py install for opentelemetry-sdk, since package 'wheel' is not installed.
Installing collected packages: opentelemetry-api, opentelemetry-sdk
    Running setup.py install for opentelemetry-api ... done
    Running setup.py install for opentelemetry-sdk ... done
Successfully installed opentelemetry-api-0.13.dev0 opentelemetry-sdk-0.13.dev0
venv-before/lib/python3.8/site-packages/opentelemetry
├── baggage
│   ├── __init__.py
│   └── propagation
│       └── __init__.py
├── configuration
│   ├── __init__.py
│   └── py.typed
├── context
│   ├── aiocontextvarsfix.py
│   ├── context.py
│   ├── contextvars_context.py
│   ├── __init__.py
│   ├── py.typed
│   └── threadlocal_context.py
├── distributedcontext
│   └── py.typed
├── metrics
│   ├── __init__.py
│   └── py.typed
├── propagators
│   ├── composite.py
│   └── __init__.py
├── sdk
│   ├── metrics
│   │   ├── export
│   │   │   ├── aggregate.py
│   │   │   ├── batcher.py
│   │   │   ├── controller.py
│   │   │   ├── __init__.py
│   │   │   └── in_memory_metrics_exporter.py
│   │   ├── __init__.py
│   │   └── view.py
│   ├── resources
│   │   └── __init__.py
│   ├── trace
│   │   ├── export
│   │   │   ├── __init__.py
│   │   │   └── in_memory_span_exporter.py
│   │   ├── __init__.py
│   │   ├── propagation
│   │   │   ├── b3_format.py
│   │   │   └── __init__.py
│   │   └── sampling.py
│   └── util
│       ├── __init__.py
│       └── instrumentation.py
├── trace
│   ├── __init__.py
│   ├── propagation
│   │   ├── __init__.py
│   │   ├── textmap.py
│   │   └── tracecontext.py
│   ├── py.typed
│   ├── span.py
│   └── status.py
└── util
    ├── __init__.py
    ├── py.typed
    └── types.py

18 directories, 41 files
```

After:
```bash
Processing ./opentelemetry-api
Processing ./opentelemetry-sdk
Using legacy setup.py install for opentelemetry-api, since package 'wheel' is not installed.
Using legacy setup.py install for opentelemetry-sdk, since package 'wheel' is not installed.
Installing collected packages: opentelemetry-api, opentelemetry-sdk
    Running setup.py install for opentelemetry-api ... done
    Running setup.py install for opentelemetry-sdk ... done
Successfully installed opentelemetry-api-0.13.dev0 opentelemetry-sdk-0.13.dev0
venv-after/lib/python3.8/site-packages/opentelemetry
├── baggage
│   ├── __init__.py
│   └── propagation
│       └── __init__.py
├── configuration
│   ├── __init__.py
│   └── py.typed
├── context
│   ├── aiocontextvarsfix.py
│   ├── context.py
│   ├── contextvars_context.py
│   ├── __init__.py
│   ├── py.typed
│   └── threadlocal_context.py
├── distributedcontext
│   └── py.typed
├── __init__.pyi
├── metrics
│   ├── __init__.py
│   └── py.typed
├── propagators
│   ├── composite.py
│   └── __init__.py
├── sdk
│   ├── __init__.py
│   ├── metrics
│   │   ├── export
│   │   │   ├── aggregate.py
│   │   │   ├── batcher.py
│   │   │   ├── controller.py
│   │   │   ├── __init__.py
│   │   │   └── in_memory_metrics_exporter.py
│   │   ├── __init__.py
│   │   └── view.py
│   ├── resources
│   │   └── __init__.py
│   ├── trace
│   │   ├── export
│   │   │   ├── __init__.py
│   │   │   └── in_memory_span_exporter.py
│   │   ├── __init__.py
│   │   ├── propagation
│   │   │   ├── b3_format.py
│   │   │   └── __init__.py
│   │   └── sampling.py
│   ├── util
│   │   ├── __init__.py
│   │   └── instrumentation.py
│   └── version.py
├── trace
│   ├── __init__.py
│   ├── propagation
│   │   ├── __init__.py
│   │   ├── textmap.py
│   │   └── tracecontext.py
│   ├── py.typed
│   ├── span.py
│   └── status.py
├── util
│   ├── __init__.py
│   ├── py.typed
│   └── types.py
└── version.py

18 directories, 45 files
```

Diff of two venvs with `diff --color <(find venv-before/lib/python3.8/site-packages/ -type f -not -name "*.pyc" -printf "%P\n" | sort) <(find venv-after/lib/python3.8/site-packages/ -type f -not -name "*.pyc" -printf "%P\n" | sort)`
```diff
20a21
> opentelemetry/__init__.pyi
32a34
> opentelemetry/sdk/__init__.py
48a51
> opentelemetry/sdk/version.py
58a62
> opentelemetry/version.py
```

So those 4 extra files were included after this change.


# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
