### PR TITLE
dropping support for python 3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,6 @@ executors:
   py35:
     docker:
       - image: circleci/python:3.5
-  py34:
-    docker:
-      - image: circleci/python:3.4
   pypy3:
     docker:
       - image: pypy:3
@@ -101,23 +98,6 @@ jobs:
       - run_tox_scenario:
           pattern: py38-<< parameters.package >>
 
-  build-py34:
-    parameters:
-      package:
-        type: string
-        default: "core"
-    executor: py34
-    steps:
-      - checkout
-      - run:
-          name: "Install tox"
-          command: sudo pip install -U tox virtualenv tox-factor
-      - restore_tox_cache
-      - run:
-          name: "Run scripts/run-tox-scenario"
-          command: tox -f py34-<< parameters.package >>
-      - save_tox_cache
-
   build:
     parameters:
       version:
@@ -142,10 +122,6 @@ workflows:
           matrix:
             parameters:
               version: ["py37", "py36", "py35", "pypy3"]
-              package: ["core", "exporter", "instrumentation"]
-      - build-py34:
-          matrix:
-            parameters:
               package: ["core", "exporter", "instrumentation"]
       - docs
       - lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ jobs:
   build:
     env:
       # We use these variables to convert between tox and GHA version literals
-      py34: 3.4
       py35: 3.5
       py36: 3.6
       py37: 3.7
@@ -16,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
       matrix:
-        python-version: [ py34, py35, py36, py37, py38, pypy3 ]
+        python-version: [ py35, py36, py37, py38, pypy3 ]
         package: ["instrumentation", "core", "exporter"]
         os: [ ubuntu-latest ]
         include:

--- a/docs/examples/opentelemetry-example-app/setup.cfg
+++ b/docs/examples/opentelemetry-example-app/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages = find_namespace:

--- a/exporter/opentelemetry-exporter-jaeger/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-jaeger/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/exporter/opentelemetry-exporter-jaeger/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/exporter/opentelemetry-exporter-opencensus/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-opencensus/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4'
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/exporter/opentelemetry-exporter-opencensus/setup.cfg
+++ b/exporter/opentelemetry-exporter-opencensus/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/exporter/opentelemetry-exporter-prometheus/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-prometheus/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/exporter/opentelemetry-exporter-prometheus/setup.cfg
+++ b/exporter/opentelemetry-exporter-prometheus/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/exporter/opentelemetry-exporter-zipkin/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-zipkin/CHANGELOG.md
@@ -9,6 +9,8 @@
   ([#1064](https://github.com/open-telemetry/opentelemetry-python/pull/1064))
 - Zipkin exporter report instrumentation info. 
   ([#1097](https://github.com/open-telemetry/opentelemetry-python/pull/1097))  
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
 
 ## Version 0.12b0
 

--- a/exporter/opentelemetry-exporter-zipkin/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-boto/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-boto/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## Unreleased  
+
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
 
 ## Version 0.12b0
 

--- a/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-boto/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-botocore/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-botocore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-botocore/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - bugfix: cursors and connections now produce spans when used with context managers
   ([#1028](https://github.com/open-telemetry/opentelemetry-python/pull/1028))
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
 
 ## Version 0.12b0
 

--- a/instrumentation/opentelemetry-instrumentation-dbapi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-django/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-django/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-django/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-django/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-flask/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-flask/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-flask/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-grpc/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-grpc/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-grpc/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-jinja2/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/setup.cfg
@@ -28,7 +28,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7

--- a/instrumentation/opentelemetry-instrumentation-mysql/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-mysql/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-mysql/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-mysql/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-opentracing-shim/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-opentracing-shim/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-opentracing-shim/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-opentracing-shim/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-psycopg2/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-psycopg2/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymemcache/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-pymongo/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-pymysql/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-pymysql/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-pyramid/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-redis/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-redis/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-redis/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-requests/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-requests/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add support for instrumenting prepared requests
   ([#1040](https://github.com/open-telemetry/opentelemetry-python/pull/1040))
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
 
 ## Version 0.12b0
 

--- a/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-requests/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sqlalchemy/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-system-metrics/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-system-metrics/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/instrumentation/opentelemetry-instrumentation-wsgi/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-wsgi/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -19,6 +19,8 @@
   ([#1085](https://github.com/open-telemetry/opentelemetry-python/pull/1085))
 - Fix api/sdk setup.cfg to include missing python files
   ([#1091](https://github.com/open-telemetry/opentelemetry-python/pull/1091))
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
 
 ## Version 0.12b0
 

--- a/opentelemetry-api/setup.cfg
+++ b/opentelemetry-api/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -17,7 +17,6 @@ import threading
 import typing
 from functools import wraps
 from os import environ
-from sys import version_info
 
 from pkg_resources import iter_entry_points
 
@@ -48,11 +47,7 @@ def _load_runtime_context(func: _F) -> _F:
             if _RUNTIME_CONTEXT is None:
                 # FIXME use a better implementation of a configuration manager to avoid having
                 # to get configuration values straight from environment variables
-                if version_info < (3, 5):
-                    # contextvars are not supported in 3.4, use thread-local storage
-                    default_context = "threadlocal_context"
-                else:
-                    default_context = "contextvars_context"
+                default_context = "contextvars_context"
 
                 configured_context = environ.get(
                     "OTEL_CONTEXT", default_context

--- a/opentelemetry-instrumentation/CHANGELOG.md
+++ b/opentelemetry-instrumentation/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## 0.9b0
 
 Released 2020-06-10

--- a/opentelemetry-instrumentation/setup.cfg
+++ b/opentelemetry-instrumentation/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
+
 ## Version 0.10b0
 
 Released 2020-06-23

--- a/opentelemetry-proto/setup.cfg
+++ b/opentelemetry-proto/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -16,6 +16,8 @@
   ([#1082](https://github.com/open-telemetry/opentelemetry-python/pull/1082))
 - Fix api/sdk setup.cfg to include missing python files
   ([#1091](https://github.com/open-telemetry/opentelemetry-python/pull/1091))
+- Drop support for Python 3.4
+  ([#1099](https://github.com/open-telemetry/opentelemetry-python/pull/1099))
 
 ## Version 0.12b0
 

--- a/opentelemetry-sdk/setup.cfg
+++ b/opentelemetry-sdk/setup.cfg
@@ -28,14 +28,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/opentelemetry-sdk/tests/conftest.py
+++ b/opentelemetry-sdk/tests/conftest.py
@@ -13,16 +13,11 @@
 # limitations under the License.
 
 from os import environ
-from sys import version_info
 
 
 def pytest_sessionstart(session):
     # pylint: disable=unused-argument
-    if version_info < (3, 5):
-        # contextvars are not supported in 3.4, use thread-local storage
-        environ["OTEL_CONTEXT"] = "threadlocal_context"
-    else:
-        environ["OTEL_CONTEXT"] = "contextvars_context"
+    environ["OTEL_CONTEXT"] = "contextvars_context"
 
 
 def pytest_sessionfinish(session):

--- a/tests/util/setup.cfg
+++ b/tests/util/setup.cfg
@@ -26,14 +26,13 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.4
+python_requires = >=3.5
 package_dir=
     =src
 packages=find_namespace:

--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,15 @@ envlist =
     ; Environments are organized by individual package, allowing
     ; for specifying supported Python versions per package.
     ; opentelemetry-api
-    py3{4,5,6,7,8}-test-core-api
+    py3{5,6,7,8}-test-core-api
     pypy3-test-core-api
 
     ; opentelemetry-proto
-    py3{4,5,6,7,8}-test-core-proto
+    py3{5,6,7,8}-test-core-proto
     pypy3-test-core-proto
 
     ; opentelemetry-sdk
-    py3{4,5,6,7,8}-test-core-sdk
+    py3{5,6,7,8}-test-core-sdk
     pypy3-test-core-sdk
 
     ; opentelemetry-instrumentation
@@ -21,11 +21,11 @@ envlist =
     pypy3-test-core-instrumentation
 
     ; docs/getting-started
-    py3{4,5,6,7,8}-test-core-getting-started
+    py3{5,6,7,8}-test-core-getting-started
     pypy3-test-core-getting-started
 
     ; opentelemetry-example-app
-    py3{4,5,6,7,8}-test-instrumentation-example-app
+    py3{5,6,7,8}-test-instrumentation-example-app
     pypy3-test-instrumentation-example-app
 
     ; opentelemetry-instrumentation-aiohttp-client
@@ -41,11 +41,11 @@ envlist =
     pypy3-test-instrumentation-botocore
 
     ; opentelemetry-instrumentation-django
-    py3{4,5,6,7,8}-test-instrumentation-django
+    py3{5,6,7,8}-test-instrumentation-django
     pypy3-test-instrumentation-django
 
     ; opentelemetry-instrumentation-dbapi
-    py3{4,5,6,7,8}-test-instrumentation-dbapi
+    py3{5,6,7,8}-test-instrumentation-dbapi
     pypy3-test-instrumentation-dbapi
 
     ; opentelemetry-instrumentation-boto
@@ -53,7 +53,7 @@ envlist =
     pypy3-test-instrumentation-boto
 
     ; opentelemetry-instrumentation-elasticsearch
-    py3{4,5,6,7,8}-test-instrumentation-elasticsearch{2,5,6,7}
+    py3{5,6,7,8}-test-instrumentation-elasticsearch{2,5,6,7}
     pypy3-test-instrumentation-elasticsearch{2,5,6,7}
 
     ; opentelemetry-instrumentation-fastapi
@@ -62,11 +62,11 @@ envlist =
     pypy3-test-instrumentation-fastapi
 
     ; opentelemetry-instrumentation-flask
-    py3{4,5,6,7,8}-test-instrumentation-flask
+    py3{5,6,7,8}-test-instrumentation-flask
     pypy3-test-instrumentation-flask
 
     ; opentelemetry-instrumentation-requests
-    py3{4,5,6,7,8}-test-instrumentation-requests
+    py3{5,6,7,8}-test-instrumentation-requests
     pypy3-test-instrumentation-requests
 
     ; opentelemetry-instrumentation-starlette.
@@ -75,22 +75,22 @@ envlist =
     pypy3-test-instrumentation-starlette
 
     ; opentelemetry-instrumentation-jinja2
-    py3{4,5,6,7,8}-test-instrumentation-jinja2
+    py3{5,6,7,8}-test-instrumentation-jinja2
     pypy3-test-instrumentation-jinja2
 
     ; opentelemetry-exporter-jaeger
-    py3{4,5,6,7,8}-test-exporter-jaeger
+    py3{5,6,7,8}-test-exporter-jaeger
     pypy3-test-exporter-jaeger
 
     ; opentelemetry-exporter-datadog
     py3{5,6,7,8}-test-exporter-datadog
 
     ; opentelemetry-instrumentation-mysql
-    py3{4,5,6,7,8}-test-instrumentation-mysql
+    py3{5,6,7,8}-test-instrumentation-mysql
     pypy3-test-instrumentation-mysql
 
     ; opentelemetry-exporter-opencensus
-    py3{4,5,6,7,8}-test-exporter-opencensus
+    py3{5,6,7,8}-test-exporter-opencensus
     ; exporter-opencensus intentionally excluded from pypy3
 
     ; opentelemetry-exporter-otlp
@@ -98,27 +98,27 @@ envlist =
     ; exporter-otlp intentionally excluded from pypy3
 
     ; opentelemetry-exporter-prometheus
-    py3{4,5,6,7,8}-test-exporter-prometheus
+    py3{5,6,7,8}-test-exporter-prometheus
     pypy3-test-exporter-prometheus
 
     ; opentelemetry-instrumentation-psycopg2
-    py3{4,5,6,7,8}-test-instrumentation-psycopg2
+    py3{5,6,7,8}-test-instrumentation-psycopg2
     ; ext-psycopg2 intentionally excluded from pypy3
 
     ; opentelemetry-instrumentation-pymemcache
-    py3{4,5,6,7,8}-test-instrumentation-pymemcache
+    py3{5,6,7,8}-test-instrumentation-pymemcache
     pypy3-test-instrumentation-pymemcache
 
     ; opentelemetry-instrumentation-pymongo
-    py3{4,5,6,7,8}-test-instrumentation-pymongo
+    py3{5,6,7,8}-test-instrumentation-pymongo
     pypy3-test-instrumentation-pymongo
 
     ; opentelemetry-instrumentation-pymysql
-    py3{4,5,6,7,8}-test-instrumentation-pymysql
+    py3{5,6,7,8}-test-instrumentation-pymysql
     pypy3-test-instrumentation-pymysql
 
     ; opentelemetry-instrumentation-pyramid
-    py3{4,5,6,7,8}-test-instrumentation-pyramid
+    py3{5,6,7,8}-test-instrumentation-pyramid
     pypy3-test-instrumentation-pyramid
 
     ; opentelemetry-instrumentation-asgi
@@ -130,30 +130,30 @@ envlist =
     ; ext-asyncpg intentionally excluded from pypy3
 
     ; opentelemetry-instrumentation-sqlite3
-    py3{4,5,6,7,8}-test-instrumentation-sqlite3
+    py3{5,6,7,8}-test-instrumentation-sqlite3
     pypy3-test-instrumentation-sqlite3
 
     ; opentelemetry-instrumentation-wsgi
-    py3{4,5,6,7,8}-test-instrumentation-wsgi
+    py3{5,6,7,8}-test-instrumentation-wsgi
     pypy3-test-instrumentation-wsgi
 
     ; opentelemetry-exporter-zipkin
-    py3{4,5,6,7,8}-test-exporter-zipkin
+    py3{5,6,7,8}-test-exporter-zipkin
     pypy3-test-exporter-zipkin
 
     ; opentelemetry-opentracing-shim
-    py3{4,5,6,7,8}-test-core-opentracing-shim
+    py3{5,6,7,8}-test-core-opentracing-shim
     pypy3-test-core-opentracing-shim
 
     ; opentelemetry-instrumentation-grpc
     py3{5,6,7,8}-test-instrumentation-grpc
 
     ; opentelemetry-instrumentation-sqlalchemy
-    py3{4,5,6,7,8}-test-instrumentation-sqlalchemy
+    py3{5,6,7,8}-test-instrumentation-sqlalchemy
     pypy3-test-instrumentation-sqlalchemy
 
     ; opentelemetry-instrumentation-redis
-    py3{4,5,6,7,8}-test-instrumentation-redis
+    py3{5,6,7,8}-test-instrumentation-redis
     pypy3-test-instrumentation-redis
 
     ; opentelemetry-instrumentation-celery
@@ -161,7 +161,7 @@ envlist =
     pypy3-test-instrumentation-celery
 
     ; opentelemetry-instrumentation-system-metrics
-    py3{4,5,6,7,8}-test-instrumentation-system-metrics
+    py3{5,6,7,8}-test-instrumentation-system-metrics
     ; instrumentation-system-metrics intentionally excluded from pypy3
     ; known limitation: gc.get_count won't work under pypy
 
@@ -235,7 +235,7 @@ changedir =
 
 commands_pre =
 ; Install without -e to test the actual installation
-  py3{4,5,6,7,8}: python -m pip install -U pip setuptools wheel
+  py3{5,6,7,8}: python -m pip install -U pip setuptools wheel
 ; Install common packages for all the tests. These are not needed in all the
 ; cases but it saves a lot of boilerplate in this file.
   test: pip install {toxinidir}/opentelemetry-api {toxinidir}/opentelemetry-sdk {toxinidir}/tests/util
@@ -336,10 +336,6 @@ commands =
 ; Test that mypy can pick up typeinfo from an installed package (otherwise,
 ; implicit Any due to unfollowed import would result).
   mypyinstalled: mypy --namespace-packages opentelemetry-api/tests/mypysmoke.py --strict
-
-[testenv:py34-test-core-opentracing-shim]
-commands =
-  pytest --ignore-glob='*[asyncio].py'
 
 [testenv:lint]
 basepython: python3.8


### PR DESCRIPTION
# Description

As discussed at the SIG meeting on Sep 10, it was agreed that dropping support for 3.4 would be better done before we reach GA. This has been previously discussed in this issue here: https://github.com/open-telemetry/opentelemetry-python/issues/25. Many instrumentations that we provide support for only support Python 3.5+ already. Python 3.4 was end of lifed over a year ago (Mar 2019)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
