### PR TITLE
Make Instances of SpanContext Immutable

### DIFF
--- a/mypy-relaxed.ini
+++ b/mypy-relaxed.ini
@@ -10,7 +10,7 @@
   disallow_untyped_calls = True
 ; disallow_untyped_defs = True
   disallow_incomplete_defs = True
-;  check_untyped_defs = True
+  check_untyped_defs = True
   disallow_untyped_decorators = True
   allow_untyped_globals = True
 ; Due to disabling some other warnings, unused ignores may occur.

--- a/mypy-relaxed.ini
+++ b/mypy-relaxed.ini
@@ -10,7 +10,7 @@
   disallow_untyped_calls = True
 ; disallow_untyped_defs = True
   disallow_incomplete_defs = True
-  check_untyped_defs = True
+;  check_untyped_defs = True
   disallow_untyped_decorators = True
   allow_untyped_globals = True
 ; Due to disabling some other warnings, unused ignores may occur.

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -10,6 +10,8 @@
   ([#1153](https://github.com/open-telemetry/opentelemetry-python/pull/1153))
 - Update baggage propagation header
   ([#1194](https://github.com/open-telemetry/opentelemetry-python/pull/1194))
+- Make instances of SpanContext immutable
+  ([#1134](https://github.com/open-telemetry/opentelemetry-python/pull/1134))
 
 ## Version 0.13b0
 

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -143,7 +143,9 @@ class TraceState(typing.Dict[str, str]):
 DEFAULT_TRACE_STATE = TraceState.get_default()
 
 
-class SpanContext(typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]):
+class SpanContext(
+    typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]
+):
     """The state of a Span to propagate between processes.
 
     This class includes the immutable attributes of a :class:`.Span` that must
@@ -179,27 +181,27 @@ class SpanContext(typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]
 
     @property
     def trace_id(self) -> int:
-        return int(self[0])
+        return self[0]
 
     @property
     def span_id(self) -> int:
-        return int(self[1])
+        return self[1]
 
     @property
     def is_remote(self) -> bool:
-        return bool(self[2])
+        return self[2]
 
     @property
     def trace_flags(self) -> "TraceFlags":
-        return TraceFlags(self[3])
+        return self[3]
 
     @property
     def trace_state(self) -> "TraceState":
-        return TraceState(self[4])
+        return self[4]
 
     @property
     def is_valid(self) -> bool:
-        return bool(self[5])
+        return self[5]
 
     def __getattr__(self, *args: str) -> None:
         raise TypeError

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -1,9 +1,12 @@
 import abc
+import logging
 import types as python_types
 import typing
 
 from opentelemetry.trace.status import Status
 from opentelemetry.util import types
+
+_logger = logging.getLogger(__name__)
 
 
 class Span(abc.ABC):
@@ -203,14 +206,11 @@ class SpanContext(
     def is_valid(self) -> bool:
         return self[5]
 
-    def __getattr__(self, *args: str) -> None:
-        raise TypeError
-
     def __setattr__(self, *args: str) -> None:
-        raise TypeError
+        _logger.warning("This method has been deprecated: SpanContext is immutable.")
 
     def __delattr__(self, *args: str) -> None:
-        raise TypeError
+        _logger.warning("This method has been deprecated: SpanContext is immutable.")
 
     def __repr__(self) -> str:
         return (

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -169,13 +169,13 @@ class SpanContext(typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]
             trace_flags = DEFAULT_TRACE_OPTIONS
         if trace_state is None:
             trace_state = DEFAULT_TRACE_STATE
-            
+
         is_valid = trace_id != INVALID_TRACE_ID and span_id != INVALID_SPAN_ID
 
         return tuple.__new__(
             cls,
-            (trace_id, span_id, trace_flags, trace_state, is_remote, is_valid),
-         )
+            (trace_id, span_id, is_remote, trace_flags, trace_state, is_valid),
+        )
 
     @property
     def trace_id(self) -> int:

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -143,7 +143,7 @@ class TraceState(typing.Dict[str, str]):
 DEFAULT_TRACE_STATE = TraceState.get_default()
 
 
-class SpanContext:
+class SpanContext(tuple):
     """The state of a Span to propagate between processes.
 
     This class includes the immutable attributes of a :class:`.Span` that must
@@ -157,8 +157,8 @@ class SpanContext:
         is_remote: True if propagated from a remote parent.
     """
 
-    def __init__(
-        self,
+    def __new__(
+        cls,
         trace_id: int,
         span_id: int,
         is_remote: bool,
@@ -169,15 +169,46 @@ class SpanContext:
             trace_flags = DEFAULT_TRACE_OPTIONS
         if trace_state is None:
             trace_state = DEFAULT_TRACE_STATE
-        self.trace_id = trace_id
-        self.span_id = span_id
-        self.trace_flags = trace_flags
-        self.trace_state = trace_state
-        self.is_remote = is_remote
-        self.is_valid = (
-            self.trace_id != INVALID_TRACE_ID
-            and self.span_id != INVALID_SPAN_ID
+            
+        is_valid = (
+            trace_id != INVALID_TRACE_ID
+            and span_id != INVALID_SPAN_ID
         )
+
+        return tuple.__new__(cls, (trace_id, span_id, trace_flags, trace_state, is_remote, is_valid))
+
+    @property
+    def trace_id(self):
+        return tuple.__getitem__(self, 0)
+
+    @property
+    def span_id(self):
+        return tuple.__getitem__(self, 1)
+
+    @property
+    def trace_flags(self):
+        return tuple.__getitem__(self, 2)
+
+    @property
+    def trace_state(self):
+        return tuple.__getitem__(self, 3)
+
+    @property
+    def is_remote(self):
+        return tuple.__getitem__(self, 4)
+
+    @property
+    def is_valid(self):
+        return tuple.__getitem__(self, 5)
+
+    def __getattr__(self, *args):
+        raise TypeError
+
+    def __setattr__(self, *args):
+        raise TypeError
+
+    def __delattr__(self, *args):
+        raise TypeError
 
     def __repr__(self) -> str:
         return (

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -143,7 +143,7 @@ class TraceState(typing.Dict[str, str]):
 DEFAULT_TRACE_STATE = TraceState.get_default()
 
 
-class SpanContext(tuple):
+class SpanContext(typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]):
     """The state of a Span to propagate between processes.
 
     This class includes the immutable attributes of a :class:`.Span` that must
@@ -164,7 +164,7 @@ class SpanContext(tuple):
         is_remote: bool,
         trace_flags: "TraceFlags" = DEFAULT_TRACE_OPTIONS,
         trace_state: "TraceState" = DEFAULT_TRACE_STATE,
-    ) -> None:
+    ) -> "SpanContext":
         if trace_flags is None:
             trace_flags = DEFAULT_TRACE_OPTIONS
         if trace_state is None:
@@ -175,39 +175,39 @@ class SpanContext(tuple):
             and span_id != INVALID_SPAN_ID
         )
 
-        return tuple.__new__(cls, (trace_id, span_id, trace_flags, trace_state, is_remote, is_valid))
+        return tuple.__new__(cls, (trace_id, span_id, is_remote, trace_flags, trace_state, is_valid))
 
     @property
-    def trace_id(self):
-        return tuple.__getitem__(self, 0)
+    def trace_id(self) -> int:
+        return int(self[0])
 
     @property
-    def span_id(self):
-        return tuple.__getitem__(self, 1)
+    def span_id(self) -> int:
+        return int(self[1])
 
     @property
-    def trace_flags(self):
-        return tuple.__getitem__(self, 2)
+    def is_remote(self) -> bool:
+        return bool(self[2])
 
     @property
-    def trace_state(self):
-        return tuple.__getitem__(self, 3)
+    def trace_flags(self) -> "TraceFlags":
+        return TraceFlags(self[3])
 
     @property
-    def is_remote(self):
-        return tuple.__getitem__(self, 4)
+    def trace_state(self) -> "TraceState":
+        return TraceState(self[4])
 
     @property
-    def is_valid(self):
-        return tuple.__getitem__(self, 5)
+    def is_valid(self) -> bool:
+        return bool(self[5])
 
-    def __getattr__(self, *args):
+    def __getattr__(self, *args: str) -> None:
         raise TypeError
 
-    def __setattr__(self, *args):
+    def __setattr__(self, *args: str) -> None:
         raise TypeError
 
-    def __delattr__(self, *args):
+    def __delattr__(self, *args: str) -> None:
         raise TypeError
 
     def __repr__(self) -> str:

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -170,12 +170,12 @@ class SpanContext(typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]
         if trace_state is None:
             trace_state = DEFAULT_TRACE_STATE
             
-        is_valid = (
-            trace_id != INVALID_TRACE_ID
-            and span_id != INVALID_SPAN_ID
-        )
+        is_valid = trace_id != INVALID_TRACE_ID and span_id != INVALID_SPAN_ID
 
-        return tuple.__new__(cls, (trace_id, span_id, is_remote, trace_flags, trace_state, is_valid))
+        return tuple.__new__(
+            cls,
+            (trace_id, span_id, trace_flags, trace_state, is_remote, is_valid),
+         )
 
     @property
     def trace_id(self) -> int:

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -184,33 +184,37 @@ class SpanContext(
 
     @property
     def trace_id(self) -> int:
-        return self[0]
+        return self[0]  # pylint: disable=unsubscriptable-object
 
     @property
     def span_id(self) -> int:
-        return self[1]
+        return self[1]  # pylint: disable=unsubscriptable-object
 
     @property
     def is_remote(self) -> bool:
-        return self[2]
+        return self[2]  # pylint: disable=unsubscriptable-object
 
     @property
     def trace_flags(self) -> "TraceFlags":
-        return self[3]
+        return self[3]  # pylint: disable=unsubscriptable-object
 
     @property
     def trace_state(self) -> "TraceState":
-        return self[4]
+        return self[4]  # pylint: disable=unsubscriptable-object
 
     @property
     def is_valid(self) -> bool:
-        return self[5]
+        return self[5]  # pylint: disable=unsubscriptable-object
 
     def __setattr__(self, *args: str) -> None:
-        _logger.warning("This method has been deprecated: SpanContext is immutable.")
+        _logger.debug(
+            "Immutable type, ignoring call to set attribute", stack_info=True
+        )
 
     def __delattr__(self, *args: str) -> None:
-        _logger.warning("This method has been deprecated: SpanContext is immutable.")
+        _logger.debug(
+            "Immutable type, ignoring call to set attribute", stack_info=True
+        )
 
     def __repr__(self) -> str:
         return (

--- a/opentelemetry-api/tests/trace/test_immutablespancontext.py
+++ b/opentelemetry-api/tests/trace/test_immutablespancontext.py
@@ -15,6 +15,7 @@
 import unittest
 
 from opentelemetry import trace
+from opentelemetry.trace import TraceFlags, TraceState 
 
 
 class TestImmutableSpanContext(unittest.TestCase):
@@ -36,7 +37,7 @@ class TestImmutableSpanContext(unittest.TestCase):
     def test_attempt_change_attributes(self):
         context = trace.SpanContext(
             1,
-            1,
+            2,
             is_remote=False,
             trace_flags=trace.DEFAULT_TRACE_OPTIONS,
             trace_state=trace.DEFAULT_TRACE_STATE,
@@ -45,18 +46,16 @@ class TestImmutableSpanContext(unittest.TestCase):
         with self.assertRaises(TypeError):
             context.trace_id = 2
         with self.assertRaises(TypeError):
-            context.span_id = 2
+            context.span_id = 3
         with self.assertRaises(TypeError):
             context.is_remote = True
         with self.assertRaises(TypeError):
-            context.trace_flags = 2
+            context.trace_flags = TraceFlags(3)
         with self.assertRaises(TypeError):
-            context.trace_state = 2
+            context.trace_state = TraceState([("test", "test")])
 
         self.assertEqual(context.trace_id, 1)
-        self.assertEqual(context.span_id, 1)
+        self.assertEqual(context.span_id, 2)
         self.assertEqual(context.is_remote, False)
         self.assertEqual(context.trace_flags, trace.DEFAULT_TRACE_OPTIONS)
         self.assertEqual(context.trace_state, trace.DEFAULT_TRACE_STATE)
-
-        self.assertEqual(context.trace_id, 1)

--- a/opentelemetry-api/tests/trace/test_immutablespancontext.py
+++ b/opentelemetry-api/tests/trace/test_immutablespancontext.py
@@ -1,0 +1,62 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from opentelemetry import trace
+
+
+class TestImmutableSpanContext(unittest.TestCase):
+    def test_ctor(self):
+        context = trace.SpanContext(
+            1,
+            1,
+            is_remote=False,
+            trace_flags=trace.DEFAULT_TRACE_OPTIONS,
+            trace_state=trace.DEFAULT_TRACE_STATE,
+        )
+
+        self.assertEqual(context.trace_id, 1)
+        self.assertEqual(context.span_id, 1)
+        self.assertEqual(context.is_remote, False)
+        self.assertEqual(context.trace_flags, trace.DEFAULT_TRACE_OPTIONS)
+        self.assertEqual(context.trace_state, trace.DEFAULT_TRACE_STATE)
+
+    def test_attempt_change_attributes(self):
+        context = trace.SpanContext(
+            1,
+            1,
+            is_remote=False,
+            trace_flags=trace.DEFAULT_TRACE_OPTIONS,
+            trace_state=trace.DEFAULT_TRACE_STATE,
+        )
+
+        with self.assertRaises(TypeError):
+            context.trace_id = 2
+        with self.assertRaises(TypeError):
+            context.span_id = 2
+        with self.assertRaises(TypeError):
+            context.is_remote = True
+        with self.assertRaises(TypeError):
+            context.trace_flags = 2
+        with self.assertRaises(TypeError):
+            context.trace_state = 2
+
+        self.assertEqual(context.trace_id, 1)
+        self.assertEqual(context.span_id, 1)
+        self.assertEqual(context.is_remote, False)
+        self.assertEqual(context.trace_flags, trace.DEFAULT_TRACE_OPTIONS)
+        self.assertEqual(context.trace_state, trace.DEFAULT_TRACE_STATE)
+
+        self.assertEqual(context.trace_id, 1)

--- a/opentelemetry-api/tests/trace/test_immutablespancontext.py
+++ b/opentelemetry-api/tests/trace/test_immutablespancontext.py
@@ -44,11 +44,11 @@ class TestImmutableSpanContext(unittest.TestCase):
         )
 
         # attempt to change the attribute values
-        context.trace_id = 2
-        context.span_id = 3
-        context.is_remote = True
-        context.trace_flags = TraceFlags(3)
-        context.trace_state = TraceState([("test", "test")])
+        context.trace_id = 2  # type: ignore
+        context.span_id = 3  # type: ignore
+        context.is_remote = True  # type: ignore
+        context.trace_flags = TraceFlags(3)  # type: ignore
+        context.trace_state = TraceState([("test", "test")])  # type: ignore
 
         # check if attributes changed
         self.assertEqual(context.trace_id, 1)

--- a/opentelemetry-api/tests/trace/test_immutablespancontext.py
+++ b/opentelemetry-api/tests/trace/test_immutablespancontext.py
@@ -43,17 +43,14 @@ class TestImmutableSpanContext(unittest.TestCase):
             trace_state=trace.DEFAULT_TRACE_STATE,
         )
 
-        with self.assertRaises(TypeError):
-            context.trace_id = 2
-        with self.assertRaises(TypeError):
-            context.span_id = 3
-        with self.assertRaises(TypeError):
-            context.is_remote = True
-        with self.assertRaises(TypeError):
-            context.trace_flags = TraceFlags(3)
-        with self.assertRaises(TypeError):
-            context.trace_state = TraceState([("test", "test")])
+        # attempt to change the attribute values
+        context.trace_id = 2
+        context.span_id = 3
+        context.is_remote = True
+        context.trace_flags = TraceFlags(3)
+        context.trace_state = TraceState([("test", "test")])
 
+        # check if attributes changed
         self.assertEqual(context.trace_id, 1)
         self.assertEqual(context.span_id, 2)
         self.assertEqual(context.is_remote, False)

--- a/opentelemetry-api/tests/trace/test_immutablespancontext.py
+++ b/opentelemetry-api/tests/trace/test_immutablespancontext.py
@@ -15,7 +15,7 @@
 import unittest
 
 from opentelemetry import trace
-from opentelemetry.trace import TraceFlags, TraceState 
+from opentelemetry.trace import TraceFlags, TraceState
 
 
 class TestImmutableSpanContext(unittest.TestCase):


### PR DESCRIPTION
# Description

This PR makes instances of SpanContext Immutable to match the OpenTelemetry specifications. 

Fixes #: https://github.com/open-telemetry/opentelemetry-python/issues/1002

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

[Unit tests](https://github.com/open-o11y/opentelemetry-python/compare/master...open-o11y:1002-make-spancontext-immutable?expand=1#diff-0924a59286313e337f50e00112a27df8) have been added to test the following behavior:

* instantiating a SpanContext returns an object with the correct values set
* trying to change an attribute throws TypeError
* after trying to change an attribute, the object maintains its original values

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated 
- [x] Unit tests have been added
- [x] Documentation has been updated

_Note: documentation did not need updating as SpanContext is already assumed to be Immutable (from the specifications)._
