### PR TITLE
Added context propagation support to celery instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-celery/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-celery/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Span operation names now include the task type. ([#1135](https://github.com/open-telemetry/opentelemetry-python/pull/1135))
+- Added automatic context propagation. ([#1135](https://github.com/open-telemetry/opentelemetry-python/pull/1135))
+
 ## Version 0.12b0
 
 Released 2020-08-14

--- a/instrumentation/opentelemetry-instrumentation-celery/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-celery/README.rst
@@ -29,11 +29,20 @@ Usage
 
 .. code-block:: python
 
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
     from opentelemetry.instrumentation.celery import CeleryInstrumentor
 
-    CeleryInstrumentor().instrument()
-
     from celery import Celery
+    from celery.signals import worker_process_init
+
+    @worker_process_init.connect(weak=False)
+    def init_celery_tracing(*args, **kwargs):
+        trace.set_tracer_provider(TracerProvider())
+        span_processor = BatchExportSpanProcessor(ConsoleSpanExporter())
+        trace.get_tracer_provider().add_span_processor(span_processor)
+        CeleryInstrumentor().instrument()
 
     app = Celery("tasks", broker="amqp://localhost")
 
@@ -42,6 +51,15 @@ Usage
         return x + y
 
     add.delay(42, 50)
+
+
+Setting up tracing 
+--------------------
+
+When tracing a celery worker process, tracing and instrumention both must be initialized after the celery worker
+process is initialized. This is required for any tracing components that might use threading to work correctly
+such as the BatchExportSpanProcessor. Celery provides a signal called ``worker_process_init`` that can be used to
+accomplish this as shown in the example above.
 
 References
 ----------

--- a/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
+++ b/instrumentation/opentelemetry-instrumentation-celery/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
 [options.extras_require]
 test =
     pytest
+    celery ~= 4.0
     opentelemetry-test == 0.14.dev0
 
 [options.packages.find]

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/celery_test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/celery_test_tasks.py
@@ -1,0 +1,29 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from celery import Celery
+
+
+class Config:
+    result_backend = "rpc"
+    broker_backend = "memory"
+
+
+app = Celery(broker="memory:///")
+app.config_from_object(Config)
+
+
+@app.task
+def task_add(num_a, num_b):
+    return num_a + num_b

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -1,0 +1,78 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import time
+
+from opentelemetry.instrumentation.celery import CeleryInstrumentor
+from opentelemetry.test.test_base import TestBase
+from opentelemetry.trace import SpanKind
+
+from .celery_test_tasks import app, task_add
+
+
+class TestCeleryInstrumentation(TestBase):
+    def setUp(self):
+        super().setUp()
+        self._worker = app.Worker(app=app, pool="solo", concurrency=1)
+        self._thread = threading.Thread(target=self._worker.start)
+        self._thread.daemon = True
+        self._thread.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self._worker.stop()
+        self._thread.join()
+
+    def test_task(self):
+        CeleryInstrumentor().instrument()
+
+        result = task_add.delay(1, 2)
+        while not result.ready():
+            time.sleep(0.05)
+
+        spans = self.sorted_spans(self.memory_exporter.get_finished_spans())
+        self.assertEqual(len(spans), 2)
+
+        consumer, producer = spans
+
+        self.assertEqual(consumer.name, "run/tests.celery_test_tasks.task_add")
+        self.assertEqual(consumer.kind, SpanKind.CONSUMER)
+        self.assert_span_has_attributes(
+            consumer,
+            {
+                "celery.action": "run",
+                "celery.state": "SUCCESS",
+                "messaging.destination": "celery",
+                "celery.task_name": "tests.celery_test_tasks.task_add",
+            },
+        )
+
+        self.assertEqual(
+            producer.name, "apply_async/tests.celery_test_tasks.task_add"
+        )
+        self.assertEqual(producer.kind, SpanKind.PRODUCER)
+        self.assert_span_has_attributes(
+            producer,
+            {
+                "celery.action": "apply_async",
+                "celery.task_name": "tests.celery_test_tasks.task_add",
+                "messaging.destination_kind": "queue",
+                "messaging.destination": "celery",
+            },
+        )
+
+        self.assertNotEqual(consumer.parent, producer.context)
+        self.assertEqual(consumer.parent.span_id, producer.context.span_id)
+        self.assertEqual(consumer.context.trace_id, producer.context.trace_id)

--- a/tests/opentelemetry-docker-tests/tests/mysql/test_mysql_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/mysql/test_mysql_functional.py
@@ -75,15 +75,13 @@ class TestFunctionalMysql(TestBase):
         self.assertEqual(db_span.attributes["net.peer.port"], MYSQL_PORT)
 
     def test_execute(self):
-        """Should create a child span for execute
-        """
+        """Should create a child span for execute"""
         with self._tracer.start_as_current_span("rootSpan"):
             self._cursor.execute("CREATE TABLE IF NOT EXISTS test (id INT)")
         self.validate_spans()
 
     def test_execute_with_connection_context_manager(self):
-        """Should create a child span for execute with connection context
-        """
+        """Should create a child span for execute with connection context"""
         with self._tracer.start_as_current_span("rootSpan"):
             with self._connection as conn:
                 cursor = conn.cursor()
@@ -91,16 +89,14 @@ class TestFunctionalMysql(TestBase):
         self.validate_spans()
 
     def test_execute_with_cursor_context_manager(self):
-        """Should create a child span for execute with cursor context
-        """
+        """Should create a child span for execute with cursor context"""
         with self._tracer.start_as_current_span("rootSpan"):
             with self._connection.cursor() as cursor:
                 cursor.execute("CREATE TABLE IF NOT EXISTS test (id INT)")
         self.validate_spans()
 
     def test_executemany(self):
-        """Should create a child span for executemany
-        """
+        """Should create a child span for executemany"""
         with self._tracer.start_as_current_span("rootSpan"):
             data = (("1",), ("2",), ("3",))
             stmt = "INSERT INTO test (id) VALUES (%s)"
@@ -108,8 +104,7 @@ class TestFunctionalMysql(TestBase):
         self.validate_spans()
 
     def test_callproc(self):
-        """Should create a child span for callproc
-        """
+        """Should create a child span for callproc"""
         with self._tracer.start_as_current_span("rootSpan"), self.assertRaises(
             Exception
         ):

--- a/tests/opentelemetry-docker-tests/tests/postgres/test_aiopg_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/postgres/test_aiopg_functional.py
@@ -85,8 +85,7 @@ class TestFunctionalAiopgConnect(TestBase):
         self.assertEqual(child_span.attributes["net.peer.port"], POSTGRES_PORT)
 
     def test_execute(self):
-        """Should create a child span for execute method
-        """
+        """Should create a child span for execute method"""
         with self._tracer.start_as_current_span("rootSpan"):
             async_call(
                 self._cursor.execute(
@@ -96,8 +95,7 @@ class TestFunctionalAiopgConnect(TestBase):
         self.validate_spans()
 
     def test_executemany(self):
-        """Should create a child span for executemany
-        """
+        """Should create a child span for executemany"""
         with pytest.raises(psycopg2.ProgrammingError):
             with self._tracer.start_as_current_span("rootSpan"):
                 data = (("1",), ("2",), ("3",))
@@ -106,8 +104,7 @@ class TestFunctionalAiopgConnect(TestBase):
             self.validate_spans()
 
     def test_callproc(self):
-        """Should create a child span for callproc
-        """
+        """Should create a child span for callproc"""
         with self._tracer.start_as_current_span("rootSpan"), self.assertRaises(
             Exception
         ):
@@ -169,8 +166,7 @@ class TestFunctionalAiopgCreatePool(TestBase):
         self.assertEqual(child_span.attributes["net.peer.port"], POSTGRES_PORT)
 
     def test_execute(self):
-        """Should create a child span for execute method
-        """
+        """Should create a child span for execute method"""
         with self._tracer.start_as_current_span("rootSpan"):
             async_call(
                 self._cursor.execute(
@@ -180,8 +176,7 @@ class TestFunctionalAiopgCreatePool(TestBase):
         self.validate_spans()
 
     def test_executemany(self):
-        """Should create a child span for executemany
-        """
+        """Should create a child span for executemany"""
         with pytest.raises(psycopg2.ProgrammingError):
             with self._tracer.start_as_current_span("rootSpan"):
                 data = (("1",), ("2",), ("3",))
@@ -190,8 +185,7 @@ class TestFunctionalAiopgCreatePool(TestBase):
             self.validate_spans()
 
     def test_callproc(self):
-        """Should create a child span for callproc
-        """
+        """Should create a child span for callproc"""
         with self._tracer.start_as_current_span("rootSpan"), self.assertRaises(
             Exception
         ):

--- a/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_functional.py
@@ -77,8 +77,7 @@ class TestFunctionalPsycopg(TestBase):
         self.assertEqual(child_span.attributes["net.peer.port"], POSTGRES_PORT)
 
     def test_execute(self):
-        """Should create a child span for execute method
-        """
+        """Should create a child span for execute method"""
         with self._tracer.start_as_current_span("rootSpan"):
             self._cursor.execute(
                 "CREATE TABLE IF NOT EXISTS test (id integer)"
@@ -86,8 +85,7 @@ class TestFunctionalPsycopg(TestBase):
         self.validate_spans()
 
     def test_execute_with_connection_context_manager(self):
-        """Should create a child span for execute with connection context
-        """
+        """Should create a child span for execute with connection context"""
         with self._tracer.start_as_current_span("rootSpan"):
             with self._connection as conn:
                 cursor = conn.cursor()
@@ -95,8 +93,7 @@ class TestFunctionalPsycopg(TestBase):
         self.validate_spans()
 
     def test_execute_with_cursor_context_manager(self):
-        """Should create a child span for execute with cursor context
-        """
+        """Should create a child span for execute with cursor context"""
         with self._tracer.start_as_current_span("rootSpan"):
             with self._connection.cursor() as cursor:
                 cursor.execute("CREATE TABLE IF NOT EXISTS test (id INT)")
@@ -104,8 +101,7 @@ class TestFunctionalPsycopg(TestBase):
         self.assertTrue(cursor.closed)
 
     def test_executemany(self):
-        """Should create a child span for executemany
-        """
+        """Should create a child span for executemany"""
         with self._tracer.start_as_current_span("rootSpan"):
             data = (("1",), ("2",), ("3",))
             stmt = "INSERT INTO test (id) VALUES (%s)"
@@ -113,8 +109,7 @@ class TestFunctionalPsycopg(TestBase):
         self.validate_spans()
 
     def test_callproc(self):
-        """Should create a child span for callproc
-        """
+        """Should create a child span for callproc"""
         with self._tracer.start_as_current_span("rootSpan"), self.assertRaises(
             Exception
         ):

--- a/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
@@ -64,8 +64,7 @@ class TestFunctionalPymongo(TestBase):
         )
 
     def test_insert(self):
-        """Should create a child span for insert
-        """
+        """Should create a child span for insert"""
         with self._tracer.start_as_current_span("rootSpan"):
             self._collection.insert_one(
                 {"name": "testName", "value": "testValue"}
@@ -73,8 +72,7 @@ class TestFunctionalPymongo(TestBase):
         self.validate_spans()
 
     def test_update(self):
-        """Should create a child span for update
-        """
+        """Should create a child span for update"""
         with self._tracer.start_as_current_span("rootSpan"):
             self._collection.update_one(
                 {"name": "testName"}, {"$set": {"value": "someOtherValue"}}
@@ -82,15 +80,13 @@ class TestFunctionalPymongo(TestBase):
         self.validate_spans()
 
     def test_find(self):
-        """Should create a child span for find
-        """
+        """Should create a child span for find"""
         with self._tracer.start_as_current_span("rootSpan"):
             self._collection.find_one()
         self.validate_spans()
 
     def test_delete(self):
-        """Should create a child span for delete
-        """
+        """Should create a child span for delete"""
         with self._tracer.start_as_current_span("rootSpan"):
             self._collection.delete_one({"name": "testName"})
         self.validate_spans()

--- a/tests/opentelemetry-docker-tests/tests/pymysql/test_pymysql_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/pymysql/test_pymysql_functional.py
@@ -72,23 +72,20 @@ class TestFunctionalPyMysql(TestBase):
         self.assertEqual(db_span.attributes["net.peer.port"], MYSQL_PORT)
 
     def test_execute(self):
-        """Should create a child span for execute
-        """
+        """Should create a child span for execute"""
         with self._tracer.start_as_current_span("rootSpan"):
             self._cursor.execute("CREATE TABLE IF NOT EXISTS test (id INT)")
         self.validate_spans()
 
     def test_execute_with_cursor_context_manager(self):
-        """Should create a child span for execute with cursor context
-        """
+        """Should create a child span for execute with cursor context"""
         with self._tracer.start_as_current_span("rootSpan"):
             with self._connection.cursor() as cursor:
                 cursor.execute("CREATE TABLE IF NOT EXISTS test (id INT)")
         self.validate_spans()
 
     def test_executemany(self):
-        """Should create a child span for executemany
-        """
+        """Should create a child span for executemany"""
         with self._tracer.start_as_current_span("rootSpan"):
             data = (("1",), ("2",), ("3",))
             stmt = "INSERT INTO test (id) VALUES (%s)"
@@ -96,8 +93,7 @@ class TestFunctionalPyMysql(TestBase):
         self.validate_spans()
 
     def test_callproc(self):
-        """Should create a child span for callproc
-        """
+        """Should create a child span for callproc"""
         with self._tracer.start_as_current_span("rootSpan"), self.assertRaises(
             Exception
         ):


### PR DESCRIPTION
# Description

- Adds context propagation to celery instrumentation. 
- Updated celery span operation names to include task type and task name.

fixes #862 
fixes #876

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual tests
- [x] Added unit test
- [x] Updated docker tests

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
