### PR TITLE
Add required argument to initialize Span

### DIFF
--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
@@ -195,6 +195,7 @@ class TestDatadogSpanExporter(unittest.TestCase):
                 kind=trace_api.SpanKind.CLIENT,
                 instrumentation_info=instrumentation_info,
                 resource=Resource({}),
+                force_direct_creation=True,
             ),
             trace.Span(
                 name=span_names[1],
@@ -202,12 +203,14 @@ class TestDatadogSpanExporter(unittest.TestCase):
                 parent=None,
                 instrumentation_info=instrumentation_info,
                 resource=resource_without_service,
+                force_direct_creation=True,
             ),
             trace.Span(
                 name=span_names[2],
                 context=other_context,
                 parent=None,
                 resource=resource,
+                force_direct_creation=True,
             ),
         ]
 
@@ -289,7 +292,9 @@ class TestDatadogSpanExporter(unittest.TestCase):
             is_remote=False,
         )
 
-        test_span = trace.Span("test_span", context=context)
+        test_span = trace.Span(
+            "test_span", context=context, force_direct_creation=True
+        )
         test_span.start()
         test_span.end()
 
@@ -492,9 +497,17 @@ class TestDatadogSpanExporter(unittest.TestCase):
             ),
         )
 
-        root_span = trace.Span(name="root", context=context, parent=None)
+        root_span = trace.Span(
+            name="root",
+            context=context,
+            parent=None,
+            force_direct_creation=True,
+        )
         child_span = trace.Span(
-            name="child", context=context, parent=root_span
+            name="child",
+            context=context,
+            parent=root_span,
+            force_direct_creation=True,
         )
         root_span.start()
         child_span.start()
@@ -529,7 +542,11 @@ class TestDatadogSpanExporter(unittest.TestCase):
         sampler = sampling.TraceIdRatioBased(0.5)
 
         span = trace.Span(
-            name="sampled", context=context, parent=None, sampler=sampler
+            name="sampled",
+            context=context,
+            parent=None,
+            sampler=sampler,
+            force_direct_creation=True,
         )
         span.start()
         span.end()

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
@@ -113,6 +113,7 @@ class TestDatadogFormat(unittest.TestCase):
                 trace_state=parent_context.trace_state,
             ),
             parent=parent_context,
+            force_direct_creation=True,
         )
 
         child_carrier = {}
@@ -158,6 +159,7 @@ class TestDatadogFormat(unittest.TestCase):
                 trace_state=parent_context.trace_state,
             ),
             parent=parent_context,
+            force_direct_creation=True,
         )
 
         child_carrier = {}

--- a/exporter/opentelemetry-exporter-jaeger/tests/test_jaeger_exporter.py
+++ b/exporter/opentelemetry-exporter-jaeger/tests/test_jaeger_exporter.py
@@ -36,7 +36,9 @@ class TestJaegerSpanExporter(unittest.TestCase):
             is_remote=False,
         )
 
-        self._test_span = trace.Span("test_span", context=context)
+        self._test_span = trace.Span(
+            "test_span", context=context, force_direct_creation=True
+        )
         self._test_span.start()
         self._test_span.end()
 
@@ -194,11 +196,20 @@ class TestJaegerSpanExporter(unittest.TestCase):
                 events=(event,),
                 links=(link,),
                 kind=trace_api.SpanKind.CLIENT,
+                force_direct_creation=True,
             ),
             trace.Span(
-                name=span_names[1], context=parent_context, parent=None
+                name=span_names[1],
+                context=parent_context,
+                parent=None,
+                force_direct_creation=True,
             ),
-            trace.Span(name=span_names[2], context=other_context, parent=None),
+            trace.Span(
+                name=span_names[2],
+                context=other_context,
+                parent=None,
+                force_direct_creation=True,
+            ),
         ]
 
         otel_spans[0].start(start_time=start_times[0])

--- a/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_trace_exporter.py
@@ -127,18 +127,21 @@ class TestCollectorSpanExporter(unittest.TestCase):
             events=(event,),
             links=(link_1,),
             kind=trace_api.SpanKind.CLIENT,
+            force_direct_creation=True,
         )
         span_2 = trace.Span(
             name="test2",
             context=parent_context,
             parent=None,
             kind=trace_api.SpanKind.SERVER,
+            force_direct_creation=True,
         )
         span_3 = trace.Span(
             name="test3",
             context=other_context,
             links=(link_2,),
             parent=span_2.get_context(),
+            force_direct_creation=True,
         )
         otel_spans = [span_1, span_2, span_3]
         otel_spans[0].start(start_time=start_times[0])
@@ -306,6 +309,7 @@ class TestCollectorSpanExporter(unittest.TestCase):
                 name="test1",
                 context=span_context,
                 kind=trace_api.SpanKind.CLIENT,
+                force_direct_creation=True,
             )
         ]
         result_status = collector_exporter.export(otel_spans)

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
@@ -150,6 +150,7 @@ class TestOTLPSpanExporter(TestCase):
             instrumentation_info=InstrumentationInfo(
                 name="name", version="version"
             ),
+            force_direct_creation=True,
         )
 
         self.span.start()

--- a/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
+++ b/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
@@ -41,7 +41,9 @@ class TestZipkinSpanExporter(unittest.TestCase):
             is_remote=False,
         )
 
-        self._test_span = trace.Span("test_span", context=context)
+        self._test_span = trace.Span(
+            "test_span", context=context, force_direct_creation=True
+        )
         self._test_span.start()
         self._test_span.end()
 
@@ -160,12 +162,26 @@ class TestZipkinSpanExporter(unittest.TestCase):
                 parent=parent_context,
                 events=(event,),
                 links=(link,),
+                force_direct_creation=True,
             ),
             trace.Span(
-                name=span_names[1], context=parent_context, parent=None
+                name=span_names[1],
+                context=parent_context,
+                parent=None,
+                force_direct_creation=True,
             ),
-            trace.Span(name=span_names[2], context=other_context, parent=None),
-            trace.Span(name=span_names[3], context=other_context, parent=None),
+            trace.Span(
+                name=span_names[2],
+                context=other_context,
+                parent=None,
+                force_direct_creation=True,
+            ),
+            trace.Span(
+                name=span_names[3],
+                context=other_context,
+                parent=None,
+                force_direct_creation=True,
+            ),
         ]
 
         otel_spans[0].start(start_time=start_times[0])
@@ -303,7 +319,10 @@ class TestZipkinSpanExporter(unittest.TestCase):
         )
 
         otel_span = trace.Span(
-            name=span_names[0], context=span_context, parent=parent_context,
+            name=span_names[0],
+            context=span_context,
+            parent=parent_context,
+            force_direct_creation=True,
         )
 
         otel_span.start(start_time=start_time)

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
@@ -42,7 +42,11 @@ class TestUtils(unittest.TestCase):
             "routing_key": "celery",
         }
 
-        span = trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace.Span(
+            "name",
+            mock.Mock(spec=trace_api.SpanContext),
+            force_direct_creation=True,
+        )
         utils.set_attributes_from_context(span, context)
 
         self.assertEqual(
@@ -78,7 +82,11 @@ class TestUtils(unittest.TestCase):
             "retries": 0,
         }
 
-        span = trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace.Span(
+            "name",
+            mock.Mock(spec=trace_api.SpanContext),
+            force_direct_creation=True,
+        )
         utils.set_attributes_from_context(span, context)
 
         self.assertEqual(len(span.attributes), 0)
@@ -99,7 +107,11 @@ class TestUtils(unittest.TestCase):
 
         # propagate and retrieve a Span
         task_id = "7c6731af-9533-40c3-83a9-25b58f0d837f"
-        span = trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace.Span(
+            "name",
+            mock.Mock(spec=trace_api.SpanContext),
+            force_direct_creation=True,
+        )
         utils.attach_span(fn_task, task_id, span)
         span_after = utils.retrieve_span(fn_task, task_id)
         self.assertIs(span, span_after)
@@ -112,7 +124,11 @@ class TestUtils(unittest.TestCase):
 
         # propagate a Span
         task_id = "7c6731af-9533-40c3-83a9-25b58f0d837f"
-        span = trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace.Span(
+            "name",
+            mock.Mock(spec=trace_api.SpanContext),
+            force_direct_creation=True,
+        )
         utils.attach_span(fn_task, task_id, span)
         # delete the Span
         utils.detach_span(fn_task, task_id)

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Update sampling result names
   ([#1128](https://github.com/open-telemetry/opentelemetry-python/pull/1128))
+- Add required argument to initialize Span
+  ([#1136](https://github.com/open-telemetry/opentelemetry-python/pull/1136))
 
 ## Version 0.13b0
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -357,6 +357,7 @@ class Span(trace_api.Span):
             this `Span`.
     """
 
+    # pylint: disable=too-many-locals
     def __init__(
         self,
         name: str,
@@ -372,7 +373,13 @@ class Span(trace_api.Span):
         span_processor: SpanProcessor = SpanProcessor(),
         instrumentation_info: InstrumentationInfo = None,
         set_status_on_exception: bool = True,
+        force_direct_creation: bool = False,
     ) -> None:
+
+        if not force_direct_creation:
+            raise ValueError(
+                "Span objects via Tracer instead of this constructor."
+            )
 
         self.name = name
         self.context = context
@@ -778,6 +785,7 @@ class Tracer(trace_api.Tracer):
                 links=links,
                 instrumentation_info=self.instrumentation_info,
                 set_status_on_exception=set_status_on_exception,
+                force_direct_creation=True,
             )
             span.start(start_time=start_time)
         else:

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -130,6 +130,7 @@ def _create_start_and_end_span(name, span_processor):
             trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         ),
         span_processor=span_processor,
+        force_direct_creation=True,
     )
     span.start()
     span.end()
@@ -383,7 +384,11 @@ class TestConsoleSpanExporter(unittest.TestCase):
 
         # Mocking stdout interferes with debugging and test reporting, mock on
         # the exporter instance instead.
-        span = trace.Span("span name", trace_api.INVALID_SPAN_CONTEXT)
+        span = trace.Span(
+            "span name",
+            trace_api.INVALID_SPAN_CONTEXT,
+            force_direct_creation=True,
+        )
         with mock.patch.object(exporter, "out") as mock_stdout:
             exporter.export([span])
         mock_stdout.write.assert_called_once_with(span.to_json() + os.linesep)
@@ -401,5 +406,7 @@ class TestConsoleSpanExporter(unittest.TestCase):
         exporter = export.ConsoleSpanExporter(
             out=mock_stdout, formatter=formatter
         )
-        exporter.export([trace.Span("span name", mock.Mock())])
+        exporter.export(
+            [trace.Span("span name", mock.Mock(), force_direct_creation=True)]
+        )
         mock_stdout.write.assert_called_once_with(mock_span_str)

--- a/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
+++ b/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
@@ -61,7 +61,11 @@ class TestInMemorySpanExporter(unittest.TestCase):
         self.assertEqual(len(span_list), 3)
 
     def test_return_code(self):
-        span = trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace.Span(
+            "name",
+            mock.Mock(spec=trace_api.SpanContext),
+            force_direct_creation=True,
+        )
         span_list = (span,)
         memory_exporter = InMemorySpanExporter()
 

--- a/opentelemetry-sdk/tests/trace/propagation/test_b3_format.py
+++ b/opentelemetry-sdk/tests/trace/propagation/test_b3_format.py
@@ -33,7 +33,7 @@ def get_child_parent_new_carrier(old_carrier):
     ctx = FORMAT.extract(get_as_list, old_carrier)
     parent_context = trace_api.get_current_span(ctx).get_context()
 
-    parent = trace.Span("parent", parent_context)
+    parent = trace.Span("parent", parent_context, force_direct_creation=True)
     child = trace.Span(
         "child",
         trace_api.SpanContext(
@@ -44,6 +44,7 @@ def get_child_parent_new_carrier(old_carrier):
             trace_state=parent_context.trace_state,
         ),
         parent=parent.get_context(),
+        force_direct_creation=True,
     )
 
     new_carrier = {}

--- a/opentelemetry-sdk/tests/trace/test_implementation.py
+++ b/opentelemetry-sdk/tests/trace/test_implementation.py
@@ -40,8 +40,10 @@ class TestTracerImplementation(unittest.TestCase):
     def test_span(self):
         with self.assertRaises(Exception):
             # pylint: disable=no-value-for-parameter
-            span = trace.Span()
+            span = trace.Span(force_direct_creation=True)
 
-        span = trace.Span("name", INVALID_SPAN_CONTEXT)
+        span = trace.Span(
+            "name", INVALID_SPAN_CONTEXT, force_direct_creation=True
+        )
         self.assertEqual(span.get_context(), INVALID_SPAN_CONTEXT)
         self.assertIs(span.is_recording(), True)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -404,13 +404,21 @@ class TestSpanCreation(unittest.TestCase):
         span = tracer.start_span("foo")
         self.assertFalse(span.context.is_remote)
 
+    def test_disallow_direct_span_creation(self):
+        with self.assertRaises(ValueError):
+            trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
+
 
 class TestSpan(unittest.TestCase):
     def setUp(self):
         self.tracer = new_tracer()
 
     def test_basic_span(self):
-        span = trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace.Span(
+            "name",
+            mock.Mock(spec=trace_api.SpanContext),
+            force_direct_creation=True,
+        )
         self.assertEqual(span.name, "name")
 
     def test_attributes(self):
@@ -656,7 +664,11 @@ class TestSpan(unittest.TestCase):
 
     def test_start_span(self):
         """Start twice, end a not started"""
-        span = trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace.Span(
+            "name",
+            mock.Mock(spec=trace_api.SpanContext),
+            force_direct_creation=True,
+        )
 
         # end not started span
         self.assertRaises(RuntimeError, span.end)
@@ -682,7 +694,11 @@ class TestSpan(unittest.TestCase):
 
     def test_span_override_start_and_end_time(self):
         """Span sending custom start_time and end_time values"""
-        span = trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace.Span(
+            "name",
+            mock.Mock(spec=trace_api.SpanContext),
+            force_direct_creation=True,
+        )
         start_time = 123
         span.start(start_time)
         self.assertEqual(start_time, span.start_time)
@@ -781,7 +797,11 @@ class TestSpan(unittest.TestCase):
         )
 
     def test_record_exception(self):
-        span = trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace.Span(
+            "name",
+            mock.Mock(spec=trace_api.SpanContext),
+            force_direct_creation=True,
+        )
         try:
             raise ValueError("invalid")
         except ValueError as err:
@@ -921,7 +941,7 @@ class TestSpanProcessor(unittest.TestCase):
             is_remote=False,
             trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         )
-        span = trace.Span("span-name", context)
+        span = trace.Span("span-name", context, force_direct_creation=True)
         span.resource = Resource({})
 
         self.assertEqual(


### PR DESCRIPTION
# Description

Adding a parameter to SDK Span constructor. An additional argument is now required to call the Span constructor, else an Exception is raised. This is to discourage callers from creating Spans directly.

Fixes [#1000](https://github.com/open-telemetry/opentelemetry-python/issues/1000)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Unit test to verify an exception will be thrown when the constructor is called without the additional argument
- [X] Tox suite to check no existing functionality has been broken

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
