### PR TITLE
ReadTheDocs and pkg_resources fix

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,6 +2,11 @@ sphinx~=2.4
 sphinx-rtd-theme~=0.4
 sphinx-autodoc-typehints~=1.10.2
 
+# Need to install the api/sdk in the venv for autodoc. Modifying sys.path
+# doesn't work for pkg_resources.
+./opentelemetry-api
+./opentelemetry-sdk
+
 # Required by ext packages
 asgiref~=3.0
 asyncpg>=0.12.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,8 +25,6 @@ settings.configure()
 
 
 source_dirs = [
-    os.path.abspath("../opentelemetry-api/src/"),
-    os.path.abspath("../opentelemetry-sdk/src/"),
     os.path.abspath("../opentelemetry-instrumentation/src/"),
 ]
 


### PR DESCRIPTION
# Description

ReadTheDocs builds do not currently install the OTel packages in a virtualenv, but just update `sys.path` to include the modules. Autodoc imports the modules, which runs this code, but since the package isn't installed, `pkg_resources.get_distribution()` fails.

This change has `opentelemetry-api` and `opentelemetry-sdk` installed in the virtualenv to fix this.

Fixes #1144

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran the commands from https://readthedocs.org/projects/opentelemetry-python/builds/11937984/ and the issue is resolved.
```console
$ python3 -m venv venv-docs && source venv-docs/bin/activate
$ python -m pip install --upgrade --no-cache-dir pip
$ python -m pip install --upgrade --no-cache-dir Pygments==2.3.1 setuptools==41.0.1 docutils==0.14 mock==1.0.1 pillow==5
.4.1 'alabaster>=0.7,<0.8,!=0.7.5' commonmark==0.8.1 recommonmark==0.5.0 'sphinx<2' 'sphinx-rtd-theme<0.5' 'readthedocs-sphinx-ext<1.1'
$ python -m pip install --exists-action=w --no-cache-dir -r docs-requirements.txt
$ sphinx-build -T -E -b html -d _build/doctrees-readthedocs -D language=en . _build/html
```

# Checklist:

- [x] Followed the style guidelines of this project