### PR TITLE
Fix B3 propagator to not crash work with DefaultSpan

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
@@ -140,21 +140,23 @@ class B3Format(TextMapPropagator):
     ) -> None:
         span = trace.get_current_span(context=context)
 
-        if span.get_context() == trace.INVALID_SPAN_CONTEXT:
+        span_context = span.get_context()
+        if span_context == trace.INVALID_SPAN_CONTEXT:
             return
 
-        sampled = (trace.TraceFlags.SAMPLED & span.context.trace_flags) != 0
+        sampled = (trace.TraceFlags.SAMPLED & span_context.trace_flags) != 0
         set_in_carrier(
-            carrier, self.TRACE_ID_KEY, format_trace_id(span.context.trace_id),
+            carrier, self.TRACE_ID_KEY, format_trace_id(span_context.trace_id),
         )
         set_in_carrier(
-            carrier, self.SPAN_ID_KEY, format_span_id(span.context.span_id)
+            carrier, self.SPAN_ID_KEY, format_span_id(span_context.span_id)
         )
-        if span.parent is not None:
+        span_parent = getattr(span, "parent", None)
+        if span_parent is not None:
             set_in_carrier(
                 carrier,
                 self.PARENT_SPAN_ID_KEY,
-                format_span_id(span.parent.span_id),
+                format_span_id(span_parent.span_id),
             )
         set_in_carrier(carrier, self.SAMPLED_KEY, "1" if sampled else "0")
 

--- a/opentelemetry-sdk/tests/trace/propagation/test_b3_format.py
+++ b/opentelemetry-sdk/tests/trace/propagation/test_b3_format.py
@@ -307,3 +307,16 @@ class TestB3Format(unittest.TestCase):
         new_carrier = {}
         FORMAT.inject(dict.__setitem__, new_carrier, get_current())
         assert len(new_carrier) == 0
+
+    @staticmethod
+    def test_default_span():
+        """Make sure propagator does not crash when working with DefaultSpan"""
+
+        def getter(carrier, key):
+            return carrier.get(key, None)
+
+        def setter(carrier, key, value):
+            carrier[key] = value
+
+        ctx = FORMAT.extract(getter, {})
+        FORMAT.inject(setter, {}, ctx)


### PR DESCRIPTION
# Description

B3 propagator was crashing as it could not find `.context` and `.parent` attributes when passed a context with a DefaultSpan instance. I ran into it while trying to instrument a demo grpc service with opentelemetry. I think grpc instrumentation might probably have another issue where it extracts context from incoming request and uses that as the parent for an outgoing request missing the spans in between. I plan to look into that as well later.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual test
- [x] Added unit test

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
