### PR TITLE
Fix zipkin exporter translation bug

### DIFF
--- a/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/__init__.py
+++ b/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/__init__.py
@@ -184,9 +184,9 @@ class ZipkinSpanExporter(SpanExporter):
                 ] = span.instrumentation_info.version
 
             if span.status is not None:
-                zipkin_span["tags"][
-                    "otel.status_code"
-                ] = span.status.canonical_code.value
+                zipkin_span["tags"]["otel.status_code"] = str(
+                    span.status.canonical_code.value
+                )
                 if span.status.description is not None:
                     zipkin_span["tags"][
                         "otel.status_description"

--- a/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
+++ b/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
@@ -217,7 +217,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
                     "key_bool": "False",
                     "key_string": "hello_world",
                     "key_float": "111.22",
-                    "otel.status_code": 2,
+                    "otel.status_code": "2",
                     "otel.status_description": "Example description",
                 },
                 "annotations": [
@@ -239,7 +239,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
                 "kind": None,
                 "tags": {
                     "key_resource": "some_resource",
-                    "otel.status_code": 0,
+                    "otel.status_code": "0",
                 },
                 "annotations": None,
             },
@@ -254,7 +254,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
                 "tags": {
                     "key_string": "hello_world",
                     "key_resource": "some_resource",
-                    "otel.status_code": 0,
+                    "otel.status_code": "0",
                 },
                 "annotations": None,
             },
@@ -269,7 +269,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
                 "tags": {
                     "otel.instrumentation_library.name": "name",
                     "otel.instrumentation_library.version": "version",
-                    "otel.status_code": 0,
+                    "otel.status_code": "0",
                 },
                 "annotations": None,
             },
@@ -335,7 +335,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
                 "duration": duration // 10 ** 3,
                 "localEndpoint": local_endpoint,
                 "kind": None,
-                "tags": {"otel.status_code": 0},
+                "tags": {"otel.status_code": "0"},
                 "annotations": None,
                 "debug": True,
                 "parentId": "0aaaaaaaaaaaaaaa",


### PR DESCRIPTION
# Description

Zipkin exporter translation was setting `otel.status_code` attribute as
an integer which resulted in Otel collector rejecting the spans. This
commit casts the value to a string.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually
- [x] Manually

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been updated
- [ ] Documentation has been updated
