### PR TITLE
Make zipkin tag value length configurable

### DIFF
--- a/exporter/opentelemetry-exporter-zipkin/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-zipkin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Zipkin exporter now accepts a ``max_tag_value_length`` attribute to customize the
+  maximum allowed size a tag value can have. ([#1151](https://github.com/open-telemetry/opentelemetry-python/pull/1151)) 
+
 ## Version 0.13b0
 
 Released 2020-09-17


### PR DESCRIPTION
# Description

Zipkin exporter truncates tag values to a maximum length of 128
characters. This commit makes this value configurable while keeping
128 as the default value.

The change required to move some functions to the zipkin exporter class. This has a nice side-effect of the zipkin exporter becoming a bit more customizable by sub-classing it. It can especially be very useful for vendor distributions.  


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added unit test

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
