### PR TITLE
Implement IdsGenerator interface for TracerProvider and include default RandomIdsGenerator

### DIFF
--- a/docs/api/trace.ids_generator.rst
+++ b/docs/api/trace.ids_generator.rst
@@ -1,0 +1,7 @@
+opentelemetry.trace.ids_generator
+=================================
+
+.. automodule:: opentelemetry.trace.ids_generator
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/trace.rst
+++ b/docs/api/trace.rst
@@ -8,6 +8,7 @@ Submodules
 
    trace.status
    trace.span
+   trace.ids_generator
 
 Module contents
 ---------------

--- a/docs/examples/opentelemetry-example-app/tests/test_flask_example.py
+++ b/docs/examples/opentelemetry-example-app/tests/test_flask_example.py
@@ -21,7 +21,6 @@ from werkzeug.wrappers import BaseResponse
 
 import opentelemetry_example_app.flask_example as flask_example
 from opentelemetry import trace
-from opentelemetry.sdk import trace as trace_sdk
 
 
 class TestFlaskExample(unittest.TestCase):
@@ -46,7 +45,8 @@ class TestFlaskExample(unittest.TestCase):
         self.send_patcher.stop()
 
     def test_full_path(self):
-        trace_id = trace_sdk.generate_trace_id()
+        ids_generator = trace.RandomIdsGenerator()
+        trace_id = ids_generator.generate_trace_id()
         # We need to use the Werkzeug test app because
         # The headers are injected at the wsgi layer.
         # The flask test app will not include these, and
@@ -58,7 +58,7 @@ class TestFlaskExample(unittest.TestCase):
             headers={
                 "traceparent": "00-{:032x}-{:016x}-{:02x}".format(
                     trace_id,
-                    trace_sdk.generate_span_id(),
+                    ids_generator.generate_span_id(),
                     trace.TraceFlags.SAMPLED,
                 )
             },

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_format.py
@@ -30,11 +30,12 @@ def get_as_list(dict_object, key):
 class TestDatadogFormat(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        ids_generator = trace_api.RandomIdsGenerator()
         cls.serialized_trace_id = propagator.format_trace_id(
-            trace.generate_trace_id()
+            ids_generator.generate_trace_id()
         )
         cls.serialized_parent_id = propagator.format_span_id(
-            trace.generate_span_id()
+            ids_generator.generate_span_id()
         )
         cls.serialized_origin = "origin-service"
 
@@ -107,7 +108,7 @@ class TestDatadogFormat(unittest.TestCase):
             "child",
             trace_api.SpanContext(
                 parent_context.trace_id,
-                trace.generate_span_id(),
+                trace_api.RandomIdsGenerator().generate_span_id(),
                 is_remote=False,
                 trace_flags=parent_context.trace_flags,
                 trace_state=parent_context.trace_state,
@@ -152,7 +153,7 @@ class TestDatadogFormat(unittest.TestCase):
             "child",
             trace_api.SpanContext(
                 parent_context.trace_id,
-                trace.generate_span_id(),
+                trace_api.RandomIdsGenerator().generate_span_id(),
                 is_remote=False,
                 trace_flags=parent_context.trace_flags,
                 trace_state=parent_context.trace_state,

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([#1123](https://github.com/open-telemetry/opentelemetry-python/pull/1123))
 - Store `int`s as `int`s in the global Configuration object
   ([#1118](https://github.com/open-telemetry/opentelemetry-python/pull/1118))
+- Allow for Custom Trace and Span IDs Generation - `IdsGenerator` for TracerProvider
+  ([#1153](https://github.com/open-telemetry/opentelemetry-python/pull/1153))
 
 ## Version 0.13b0
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -77,6 +77,7 @@ import typing
 from contextlib import contextmanager
 from logging import getLogger
 
+from opentelemetry.trace.ids_generator import IdsGenerator, RandomIdsGenerator
 from opentelemetry.trace.propagation import (
     get_current_span,
     set_span_in_context,
@@ -436,6 +437,7 @@ def get_tracer_provider() -> TracerProvider:
 __all__ = [
     "DEFAULT_TRACE_OPTIONS",
     "DEFAULT_TRACE_STATE",
+    "IdsGenerator",
     "INVALID_SPAN",
     "INVALID_SPAN_CONTEXT",
     "INVALID_SPAN_ID",
@@ -446,6 +448,7 @@ __all__ = [
     "Link",
     "LinkBase",
     "ParentSpan",
+    "RandomIdsGenerator",
     "Span",
     "SpanContext",
     "SpanKind",

--- a/opentelemetry-api/src/opentelemetry/trace/ids_generator.py
+++ b/opentelemetry-api/src/opentelemetry/trace/ids_generator.py
@@ -1,0 +1,52 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import random
+
+
+class IdsGenerator(abc.ABC):
+    @abc.abstractmethod
+    def generate_span_id(self) -> int:
+        """Get a new span ID.
+
+        Returns:
+            A 64-bit int for use as a span ID
+        """
+
+    @abc.abstractmethod
+    def generate_trace_id(self) -> int:
+        """Get a new trace ID.
+
+        Implementations should at least make the 64 least significant bits
+        uniformly random. Samplers like the `TraceIdRatioBased` sampler rely on
+        this randomness to make sampling decisions.
+
+        See `the specification on TraceIdRatioBased <https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#traceidratiobased>`_.
+
+        Returns:
+            A 128-bit int for use as a trace ID
+        """
+
+
+class RandomIdsGenerator(IdsGenerator):
+    """The default IDs generator for TracerProvider which randomly generates all
+    bits when generating IDs.
+    """
+
+    def generate_span_id(self) -> int:
+        return random.getrandbits(64)
+
+    def generate_trace_id(self) -> int:
+        return random.getrandbits(128)

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -8,6 +8,8 @@
   ([#1128](https://github.com/open-telemetry/opentelemetry-python/pull/1128))
 - Add support for `OTEL_BSP_MAX_QUEUE_SIZE`, `OTEL_BSP_SCHEDULE_DELAY_MILLIS`, `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` and `OTEL_BSP_EXPORT_TIMEOUT_MILLIS` environment variables
   ([#1105](https://github.com/open-telemetry/opentelemetry-python/pull/1120))
+- Allow for Custom Trace and Span IDs Generation - `IdsGenerator` for TracerProvider
+  ([#1153](https://github.com/open-telemetry/opentelemetry-python/pull/1153))
 
 ## Version 0.13b0
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
@@ -17,7 +17,6 @@ from re import compile as re_compile
 
 import opentelemetry.trace as trace
 from opentelemetry.context import Context
-from opentelemetry.sdk.trace import generate_span_id, generate_trace_id
 from opentelemetry.trace.propagation.textmap import (
     Getter,
     Setter,
@@ -103,8 +102,9 @@ class B3Format(TextMapPropagator):
             self._trace_id_regex.fullmatch(trace_id) is None
             or self._span_id_regex.fullmatch(span_id) is None
         ):
-            trace_id = generate_trace_id()
-            span_id = generate_span_id()
+            ids_generator = trace.get_tracer_provider().ids_generator
+            trace_id = ids_generator.generate_trace_id()
+            span_id = ids_generator.generate_span_id()
             sampled = "0"
 
         else:

--- a/opentelemetry-sdk/tests/trace/propagation/test_b3_format.py
+++ b/opentelemetry-sdk/tests/trace/propagation/test_b3_format.py
@@ -38,7 +38,7 @@ def get_child_parent_new_carrier(old_carrier):
         "child",
         trace_api.SpanContext(
             parent_context.trace_id,
-            trace.generate_span_id(),
+            trace_api.RandomIdsGenerator().generate_span_id(),
             is_remote=False,
             trace_flags=parent_context.trace_flags,
             trace_state=parent_context.trace_state,
@@ -56,14 +56,15 @@ def get_child_parent_new_carrier(old_carrier):
 class TestB3Format(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        ids_generator = trace_api.RandomIdsGenerator()
         cls.serialized_trace_id = b3_format.format_trace_id(
-            trace.generate_trace_id()
+            ids_generator.generate_trace_id()
         )
         cls.serialized_span_id = b3_format.format_span_id(
-            trace.generate_span_id()
+            ids_generator.generate_span_id()
         )
         cls.serialized_parent_id = b3_format.format_span_id(
-            trace.generate_span_id()
+            ids_generator.generate_span_id()
         )
 
     def test_extract_multi_header(self):
@@ -246,8 +247,12 @@ class TestB3Format(unittest.TestCase):
         span_context = trace_api.get_current_span(ctx).get_context()
         self.assertEqual(span_context.trace_id, trace_api.INVALID_TRACE_ID)
 
-    @patch("opentelemetry.sdk.trace.propagation.b3_format.generate_trace_id")
-    @patch("opentelemetry.sdk.trace.propagation.b3_format.generate_span_id")
+    @patch(
+        "opentelemetry.sdk.trace.propagation.b3_format.trace.RandomIdsGenerator.generate_trace_id"
+    )
+    @patch(
+        "opentelemetry.sdk.trace.propagation.b3_format.trace.RandomIdsGenerator.generate_span_id"
+    )
     def test_invalid_trace_id(
         self, mock_generate_span_id, mock_generate_trace_id
     ):
@@ -268,8 +273,12 @@ class TestB3Format(unittest.TestCase):
         self.assertEqual(span_context.trace_id, 1)
         self.assertEqual(span_context.span_id, 2)
 
-    @patch("opentelemetry.sdk.trace.propagation.b3_format.generate_trace_id")
-    @patch("opentelemetry.sdk.trace.propagation.b3_format.generate_span_id")
+    @patch(
+        "opentelemetry.sdk.trace.propagation.b3_format.trace.RandomIdsGenerator.generate_trace_id"
+    )
+    @patch(
+        "opentelemetry.sdk.trace.propagation.b3_format.trace.RandomIdsGenerator.generate_span_id"
+    )
     def test_invalid_span_id(
         self, mock_generate_span_id, mock_generate_trace_id
     ):

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -615,14 +615,15 @@ class TestSpan(unittest.TestCase):
             self.assertEqual(root.events[3].attributes, {"attr2": (1, 2)})
 
     def test_links(self):
+        ids_generator = trace_api.RandomIdsGenerator()
         other_context1 = trace_api.SpanContext(
-            trace_id=trace.generate_trace_id(),
-            span_id=trace.generate_span_id(),
+            trace_id=ids_generator.generate_trace_id(),
+            span_id=ids_generator.generate_span_id(),
             is_remote=False,
         )
         other_context2 = trace_api.SpanContext(
-            trace_id=trace.generate_trace_id(),
-            span_id=trace.generate_span_id(),
+            trace_id=ids_generator.generate_trace_id(),
+            span_id=ids_generator.generate_span_id(),
             is_remote=False,
         )
 


### PR DESCRIPTION
# Description

This PR moves in the direction of supporting custom forms of trace & span ID generation. The [opentelemtry-java SDK](https://github.com/open-telemetry/opentelemetry-java/blob/485cc52c6ff1bb3fa12cd950d6eb97d3ceae6e41/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/IdsGenerator.java) and [opentelemetry-js SDK](https://github.com/open-telemetry/opentelemetry-js/blob/b7d6e74c5bec6a24f5d617d31402ea95c54f126f/packages/opentelemetry-core/src/trace/IdGenerator.ts) do this as well.

Fixes #1152 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I was able to setup a simple small script that output the traces to the console as expected:

```
#!/usr/bin/env python3

# OTel Tracing
from opentelemetry import trace
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.trace import SpanKind
from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleExportSpanProcessor


if __name__ == '__main__':
    # Console Exporter Setup
    trace.set_tracer_provider(TracerProvider())

    trace.get_tracer_provider().add_span_processor(
        SimpleExportSpanProcessor(ConsoleSpanExporter())
    )

    # Final Tracer Setup
    tracer = trace.get_tracer(__name__)

    with tracer.start_span('my_first_span', kind= SpanKind.SERVER):
        with tracer.start_span('my_second_span', parent=trace.get_current_span(), kind= SpanKind.SERVER):
            print('Hello, world!')
```

to get output:

```
Hello, world!
{
    "name": "my_second_span",
    "context": {
        "trace_id": "0xdb6a810342a9a20651eb96829f0fa3f4",
        "span_id": "0xa986b94247d4bc48",
        "trace_state": "{}"
    },
    "kind": "SpanKind.SERVER",
    "parent_id": null,
    "start_time": "2020-09-24T04:05:04.528721Z",
    "end_time": "2020-09-24T04:05:04.528738Z",
    "status": {
        "canonical_code": "OK"
    },
    "attributes": {},
    "events": [],
    "links": [],
    "resource": {
        "telemetry.sdk.language": "python",
        "telemetry.sdk.name": "opentelemetry",
        "telemetry.sdk.version": "0.14.dev0"
    }
}
{
    "name": "my_first_span",
    "context": {
        "trace_id": "0x85354f7a3a0f9e091d54b8d1560d32c0",
        "span_id": "0x1a39976cb621bcbb",
        "trace_state": "{}"
    },
    "kind": "SpanKind.SERVER",
    "parent_id": null,
    "start_time": "2020-09-24T04:05:04.528678Z",
    "end_time": "2020-09-24T04:05:04.529366Z",
    "status": {
        "canonical_code": "OK"
    },
    "attributes": {},
    "events": [],
    "links": [],
    "resource": {
        "telemetry.sdk.language": "python",
        "telemetry.sdk.name": "opentelemetry",
        "telemetry.sdk.version": "0.14.dev0"
    }
}
```

However, I did not think it was necessary to include tests for the `RandomIdsGenerator.py` file since it is just doing the same thing the SDK was always doing before and the method implementations are just 2 lines overall.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
~- [ ] Unit tests have been added~ No unit tests included for this change
- [x] Documentation has been updated
