### PR TITLE
Added ability to extract span attributes from django request objects.

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-django/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Changed span name extraction from request to comply semantic convention ([#992](https://github.com/open-telemetry/opentelemetry-python/pull/992)) 
+- Added support for `OTEL_PYTHON_DJANGO_TRACED_REQUEST_ATTRS` ([#1154](https://github.com/open-telemetry/opentelemetry-python/pull/1154))
 
 ## Version 0.13b0
 

--- a/instrumentation/opentelemetry-instrumentation-django/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-django/README.rst
@@ -30,6 +30,21 @@ For example,
 
 will exclude requests such as ``https://site/client/123/info`` and ``https://site/xyz/healthcheck``.
 
+Request attributes
+********************
+To extract certain attributes from Django's request object and use them as span attributes, set the environment variable ``OTEL_PYTHON_DJANGO_TRACED_REQUEST_ATTRS`` to a comma
+delimited list of request attribute names. 
+
+For example,
+
+::
+
+    export OTEL_PYTHON_DJANGO_TRACED_REQUEST_ATTRS='path_info,content_type'
+
+will extract path_info and content_type attributes from every traced request and add them as span attritbues.
+
+Django Request object reference: https://docs.djangoproject.com/en/3.1/ref/request-response/#attributes
+
 References
 ----------
 


### PR DESCRIPTION

# Description

OTEL_PYTHON_DJANGO_TRACED_REQUEST_ATTRS env var can be set to a command
separated list of attributes names that will be extracted from Django's
request object and set as attributes on spans. 

This is ported from OpenTracing Django instrumentation to make the upgrade path smoother for OpenTracing users. (github.com/opentracing-contrib/python-django)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
