### PR TITLE
Added ability to extract span attributes from falcon request objects.

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-falcon/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-falcon/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added support for `OTEL_PYTHON_FALCON_TRACED_REQUEST_ATTRS` ([#1158](https://github.com/open-telemetry/opentelemetry-python/pull/1158))
+
 ## Version 0.13b0
 
 Released 2020-09-17

--- a/instrumentation/opentelemetry-instrumentation-falcon/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-falcon/README.rst
@@ -31,6 +31,21 @@ For example,
 
 will exclude requests such as ``https://site/client/123/info`` and ``https://site/xyz/healthcheck``.
 
+Request attributes
+********************
+To extract certain attributes from Falcon's request object and use them as span attributes, set the environment variable ``OTEL_PYTHON_FALCON_TRACED_REQUEST_ATTRS`` to a comma
+delimited list of request attribute names. 
+
+For example,
+
+::
+
+    export OTEL_PYTHON_FALCON_TRACED_REQUEST_ATTRS='query_string,uri_template'
+
+will extract path_info and content_type attributes from every traced request and add them as span attritbues.
+
+Falcon Request object reference: https://falcon.readthedocs.io/en/stable/api/request_and_response.html#id1
+
 References
 ----------
 


### PR DESCRIPTION
# Description

OTEL_PYTHON_FALCON_TRACED_REQUEST_ATTRS env var can be set to a command
separated list of attributes names that will be extracted from Falcon's
request object and set as attributes on spans.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit test

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
