### PR TITLE
Fix zipkin event translation

### DIFF
--- a/exporter/opentelemetry-exporter-zipkin/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-zipkin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Zipkin exporter now accepts a ``max_tag_value_length`` attribute to customize the
   maximum allowed size a tag value can have. ([#1151](https://github.com/open-telemetry/opentelemetry-python/pull/1151)) 
+- Fixed OTLP events to Zipkin annotations translation. ([#1161](https://github.com/open-telemetry/opentelemetry-python/pull/1161))
 
 ## Version 0.13b0
 

--- a/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
+++ b/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
@@ -223,7 +223,15 @@ class TestZipkinSpanExporter(unittest.TestCase):
                 "annotations": [
                     {
                         "timestamp": event_timestamp // 10 ** 3,
-                        "value": "event0",
+                        "value": json.dumps(
+                            {
+                                "event0": {
+                                    "annotation_bool": True,
+                                    "annotation_string": "annotation_test",
+                                    "key_float": 0.3,
+                                }
+                            }
+                        ),
                     }
                 ],
                 "debug": True,


### PR DESCRIPTION
# Description

Updated zipkin exporter to correctly translate OTLP events as specified by the OpenTelemetry specification: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk_exporters/zipkin.md#events


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
