### PR TITLE
Record exception on context manager exit

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py
@@ -50,7 +50,11 @@ from opentelemetry.instrumentation.metric import (
 from opentelemetry.instrumentation.requests.version import __version__
 from opentelemetry.instrumentation.utils import http_status_to_canonical_code
 from opentelemetry.trace import SpanKind, get_tracer
-from opentelemetry.trace.status import Status, StatusCanonicalCode
+from opentelemetry.trace.status import (
+    EXCEPTION_STATUS_FIELD,
+    Status,
+    StatusCanonicalCode,
+)
 
 # A key to a context variable to avoid creating duplicate spans when instrumenting
 # both, Session.request and Session.send, since Session.request calls into Session.send
@@ -121,8 +125,6 @@ def _instrument(tracer_provider=None, span_callback=None):
         method = method.upper()
         span_name = "HTTP {}".format(method)
 
-        exception = None
-
         recorder = RequestsInstrumentor().metric_recorder
 
         labels = {}
@@ -132,6 +134,7 @@ def _instrument(tracer_provider=None, span_callback=None):
         with get_tracer(
             __name__, __version__, tracer_provider
         ).start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            exception = None
             with recorder.record_duration(labels):
                 if span.is_recording():
                     span.set_attribute("component", "http")
@@ -150,15 +153,14 @@ def _instrument(tracer_provider=None, span_callback=None):
                     result = call_wrapped()  # *** PROCEED
                 except Exception as exc:  # pylint: disable=W0703
                     exception = exc
+                    setattr(
+                        exception,
+                        EXCEPTION_STATUS_FIELD,
+                        _exception_to_canonical_code(exception),
+                    )
                     result = getattr(exc, "response", None)
                 finally:
                     context.detach(token)
-
-                if exception is not None and span.is_recording():
-                    span.set_status(
-                        Status(_exception_to_canonical_code(exception))
-                    )
-                    span.record_exception(exception)
 
                 if result is not None:
                     if span.is_recording():
@@ -184,8 +186,8 @@ def _instrument(tracer_provider=None, span_callback=None):
                 if span_callback is not None:
                     span_callback(span, result)
 
-        if exception is not None:
-            raise exception.with_traceback(exception.__traceback__)
+            if exception is not None:
+                raise exception.with_traceback(exception.__traceback__)
 
         return result
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -282,6 +282,7 @@ class Tracer(abc.ABC):
         kind: SpanKind = SpanKind.INTERNAL,
         attributes: types.Attributes = None,
         links: typing.Sequence[Link] = (),
+        record_exception: bool = True,
     ) -> typing.Iterator["Span"]:
         """Context manager for creating a new span and set it
         as the current span in this tracer's context.
@@ -320,6 +321,8 @@ class Tracer(abc.ABC):
                 meaningful even if there is no parent.
             attributes: The span's attributes.
             links: Links span to other spans
+            record_exception: Whether to record any exceptions raised within the
+                context as error event on the span.
 
         Yields:
             The newly-created span.
@@ -328,7 +331,10 @@ class Tracer(abc.ABC):
     @contextmanager  # type: ignore
     @abc.abstractmethod
     def use_span(
-        self, span: "Span", end_on_exit: bool = False
+        self,
+        span: "Span",
+        end_on_exit: bool = False,
+        record_exception: bool = True,
     ) -> typing.Iterator[None]:
         """Context manager for setting the passed span as the
         current span in the context, as well as resetting the
@@ -345,6 +351,8 @@ class Tracer(abc.ABC):
             span: The span to start and make current.
             end_on_exit: Whether to end the span automatically when leaving the
                 context manager.
+            record_exception: Whether to record any exceptions raised within the
+                context as error event on the span.
         """
 
 
@@ -375,13 +383,17 @@ class DefaultTracer(Tracer):
         kind: SpanKind = SpanKind.INTERNAL,
         attributes: types.Attributes = None,
         links: typing.Sequence[Link] = (),
+        record_exception: bool = True,
     ) -> typing.Iterator["Span"]:
         # pylint: disable=unused-argument,no-self-use
         yield INVALID_SPAN
 
     @contextmanager  # type: ignore
     def use_span(
-        self, span: "Span", end_on_exit: bool = False
+        self,
+        span: "Span",
+        end_on_exit: bool = False,
+        record_exception: bool = True,
     ) -> typing.Iterator[None]:
         # pylint: disable=unused-argument,no-self-use
         yield

--- a/opentelemetry-api/src/opentelemetry/trace/status.py
+++ b/opentelemetry-api/src/opentelemetry/trace/status.py
@@ -19,6 +19,9 @@ import typing
 logger = logging.getLogger(__name__)
 
 
+EXCEPTION_STATUS_FIELD = "_otel_status_code"
+
+
 class StatusCanonicalCode(enum.Enum):
     """Represents the canonical set of status codes of a finished Span."""
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -14,6 +14,7 @@
   ([#1203](https://github.com/open-telemetry/opentelemetry-python/pull/1203))
 - Protect access to Span implementation
   ([#1188](https://github.com/open-telemetry/opentelemetry-python/pull/1188))
+- `start_as_current_span` and `use_span` can now optionally auto-record any exceptions raised inside the context manager. ([#1162](https://github.com/open-telemetry/opentelemetry-python/pull/1162))
 
 ## Version 0.13b0
 


### PR DESCRIPTION
# Description

This updates the tracer context manager to record exceptions automatically on 
exit if an exception was raised within the context manager's context.

This should be helpful in some situations when manually instrumenting apps. For example, 
it can help record any uncaught/unexpected exceptions which one would expect from a tracing
system. This can also be helpful in simplifying auto-instrumentations. I think this should be the
default behavior but happy to hear other thoughts. Otel spec does not say anything about this and leaves span creation/activation to each language implementation. Both OpenTracing and OpenCensus did it AFAICT:

- https://github.com/census-instrumentation/opencensus-python/blob/master/opencensus/trace/span.py#L382-L391
- https://github.com/opentracing/opentracing-python/blob/master/opentracing/scope.py#L79-L83

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit Test

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
