### PR TITLE
docs: updating tox target in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,8 @@ You can run:
 - `tox` to run all existing tox commands, including unit tests for all packages
   under multiple Python versions
 - `tox -e docs` to regenerate the API docs
-- `tox -e test-api` and `tox -e test-sdk` to run the API and SDK unit tests
-- `tox -e py37-test-api` to e.g. run the API unit tests under a specific
+- `tox -e test-core-api` and `tox -e test-core-sdk` to run the API and SDK unit tests
+- `tox -e py37-test-core-api` to e.g. run the API unit tests under a specific
   Python version
 - `tox -e lint` to run lint checks on all code
 


### PR DESCRIPTION
The tox targets were updated a while ago, but the contributing doc was not.