### PR TITLE
[Prototype] Move SpanContext into Span

### DIFF
--- a/exporter/opentelemetry-exporter-jaeger/examples/jaeger_exporter_example.py
+++ b/exporter/opentelemetry-exporter-jaeger/examples/jaeger_exporter_example.py
@@ -34,7 +34,7 @@ with tracer.start_as_current_span("foo") as foo:
     foo.set_attribute("my_atribbute", True)
     foo.add_event("event in foo", {"name": "foo1"})
     with tracer.start_as_current_span(
-        "bar", links=[trace.Link(foo.get_context())]
+        "bar", links=[trace.Link(foo)]
     ) as bar:
         time.sleep(0.2)
         bar.set_attribute("speed", 100.0)

--- a/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/__init__.py
+++ b/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/__init__.py
@@ -192,9 +192,8 @@ def _translate_to_jaeger(spans: Span):
     jaeger_spans = []
 
     for span in spans:
-        ctx = span.get_context()
-        trace_id = ctx.trace_id
-        span_id = ctx.span_id
+        trace_id = span.trace_id
+        span_id = span.span_id
 
         start_time_us = _nsec_to_usec_round(span.start_time)
         duration_us = _nsec_to_usec_round(span.end_time - span.start_time)
@@ -235,7 +234,7 @@ def _translate_to_jaeger(spans: Span):
         refs = _extract_refs_from_span(span)
         logs = _extract_logs_from_span(span)
 
-        flags = int(ctx.trace_flags)
+        flags = int(span.trace_flags)
 
         jaeger_span = jaeger.Span(
             traceIdHigh=_get_trace_id_high(trace_id),
@@ -263,8 +262,8 @@ def _extract_refs_from_span(span):
 
     refs = []
     for link in span.links:
-        trace_id = link.context.trace_id
-        span_id = link.context.span_id
+        trace_id = link.span.trace_id
+        span_id = link.span.span_id
         refs.append(
             jaeger.SpanRef(
                 refType=jaeger.SpanRefType.FOLLOWS_FROM,

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -85,12 +85,10 @@ from opentelemetry.trace.span import (
     DEFAULT_TRACE_OPTIONS,
     DEFAULT_TRACE_STATE,
     INVALID_SPAN,
-    INVALID_SPAN_CONTEXT,
     INVALID_SPAN_ID,
     INVALID_TRACE_ID,
     DefaultSpan,
     Span,
-    SpanContext,
     TraceFlags,
     TraceState,
     format_span_id,
@@ -102,16 +100,16 @@ from opentelemetry.util import _load_trace_provider, types
 logger = getLogger(__name__)
 
 # TODO: quarantine
-ParentSpan = typing.Optional[typing.Union["Span", "SpanContext"]]
+ParentSpan = typing.Optional["Span"]
 
 
 class LinkBase(abc.ABC):
-    def __init__(self, context: "SpanContext") -> None:
-        self._context = context
+    def __init__(self, span: "Span") -> None:
+        self._span = span
 
     @property
-    def context(self) -> "SpanContext":
-        return self._context
+    def span(self) -> "Span":
+        return self._span
 
     @property
     @abc.abstractmethod
@@ -128,9 +126,9 @@ class Link(LinkBase):
     """
 
     def __init__(
-        self, context: "SpanContext", attributes: types.Attributes = None,
+        self, span: "Span", attributes: types.Attributes = None,
     ) -> None:
-        super().__init__(context)
+        super().__init__(span)
         self._attributes = attributes
 
     @property
@@ -221,7 +219,7 @@ class Tracer(abc.ABC):
 
     # Constant used to represent the current span being used as a parent.
     # This is the default behavior when creating spans.
-    CURRENT_SPAN = DefaultSpan(INVALID_SPAN_CONTEXT)
+    CURRENT_SPAN = INVALID_SPAN
 
     @abc.abstractmethod
     def start_span(

--- a/opentelemetry-api/tests/propagators/test_global_httptextformat.py
+++ b/opentelemetry-api/tests/propagators/test_global_httptextformat.py
@@ -49,12 +49,11 @@ class TestDefaultGlobalPropagator(unittest.TestCase):
         baggage_entries = baggage.get_all(context=ctx)
         expected = {"key1": "val1", "key2": "val2"}
         self.assertEqual(baggage_entries, expected)
-        span_context = get_current_span(context=ctx).get_context()
+        span = get_current_span(context=ctx)
 
-        self.assertEqual(span_context.trace_id, self.TRACE_ID)
-        self.assertEqual(span_context.span_id, self.SPAN_ID)
+        self.assertEqual(span.trace_id, self.TRACE_ID)
+        self.assertEqual(span.span_id, self.SPAN_ID)
 
-        span = trace.DefaultSpan(span_context)
         ctx = baggage.set_baggage("key3", "val3")
         ctx = baggage.set_baggage("key4", "val4", context=ctx)
         ctx = set_span_in_context(span, context=ctx)

--- a/opentelemetry-api/tests/test_implementation.py
+++ b/opentelemetry-api/tests/test_implementation.py
@@ -37,13 +37,9 @@ class TestAPIOnlyImplementation(unittest.TestCase):
         tracer_provider = trace.DefaultTracerProvider()
         tracer = tracer_provider.get_tracer(__name__)
         with tracer.start_span("test") as span:
-            self.assertEqual(span.get_context(), trace.INVALID_SPAN_CONTEXT)
             self.assertEqual(span, trace.INVALID_SPAN)
             self.assertIs(span.is_recording(), False)
             with tracer.start_span("test2") as span2:
-                self.assertEqual(
-                    span2.get_context(), trace.INVALID_SPAN_CONTEXT
-                )
                 self.assertEqual(span2, trace.INVALID_SPAN)
                 self.assertIs(span2.is_recording(), False)
 
@@ -53,8 +49,8 @@ class TestAPIOnlyImplementation(unittest.TestCase):
             trace.Span()  # type:ignore
 
     def test_default_span(self):
-        span = trace.DefaultSpan(trace.INVALID_SPAN_CONTEXT)
-        self.assertEqual(span.get_context(), trace.INVALID_SPAN_CONTEXT)
+        span = trace.INVALID_SPAN
+        self.assertEqual(False, span.is_valid)
         self.assertIs(span.is_recording(), False)
 
     # METER

--- a/opentelemetry-api/tests/trace/test_defaultspan.py
+++ b/opentelemetry-api/tests/trace/test_defaultspan.py
@@ -19,17 +19,25 @@ from opentelemetry import trace
 
 class TestDefaultSpan(unittest.TestCase):
     def test_ctor(self):
-        context = trace.SpanContext(
+        span = trace.DefaultSpan(
             1,
             1,
             is_remote=False,
             trace_flags=trace.DEFAULT_TRACE_OPTIONS,
             trace_state=trace.DEFAULT_TRACE_STATE,
         )
-        span = trace.DefaultSpan(context)
-        self.assertEqual(context, span.get_context())
+        self.assertEqual(1, span.trace_id)
+        self.assertEqual(1, span.trace_id)
+        self.assertEqual(False, span.is_remote)
+        self.assertEqual(trace.DEFAULT_TRACE_OPTIONS, span.trace_flags)
+        self.assertEqual(trace.DEFAULT_TRACE_STATE, span.trace_state)
 
     def test_invalid_span(self):
+        # TODO: Test the actual expected values of an invalid Span.
         self.assertIsNotNone(trace.INVALID_SPAN)
-        self.assertIsNotNone(trace.INVALID_SPAN.get_context())
-        self.assertFalse(trace.INVALID_SPAN.get_context().is_valid)
+        self.assertIsNotNone(trace.INVALID_SPAN.trace_id)
+        self.assertIsNotNone(trace.INVALID_SPAN.span_id)
+        self.assertIsNotNone(trace.INVALID_SPAN.is_remote)
+        self.assertIsNotNone(trace.INVALID_SPAN.trace_flags)
+        self.assertIsNotNone(trace.INVALID_SPAN.trace_state)
+        self.assertFalse(trace.INVALID_SPAN.is_valid)

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -49,7 +49,7 @@ class TestTracer(unittest.TestCase):
         be retrievable via get_current_span
         """
         self.assertEqual(trace.get_current_span(), trace.INVALID_SPAN)
-        span = trace.DefaultSpan(trace.INVALID_SPAN_CONTEXT)
+        span = trace.INVALID_SPAN
         ctx = trace.set_span_in_context(span)
         token = context.attach(ctx)
         try:

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -30,7 +30,7 @@ class TestTracer(unittest.TestCase):
             self.assertIsInstance(span, trace.Span)
 
     def test_use_span(self):
-        span = trace.DefaultSpan(trace.INVALID_SPAN_CONTEXT)
+        span = trace.INVALID_SPAN
         with self.tracer.use_span(span):
             pass
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -75,7 +75,7 @@ class SimpleExportSpanProcessor(SpanProcessor):
         pass
 
     def on_end(self, span: Span) -> None:
-        if not span.context.trace_flags.sampled:
+        if not span.trace_flags.sampled:
             return
         token = attach(set_value("suppress_instrumentation", True))
         try:
@@ -180,7 +180,7 @@ class BatchExportSpanProcessor(SpanProcessor):
         if self.done:
             logger.warning("Already shutdown, dropping span.")
             return
-        if not span.context.trace_flags.sampled:
+        if not span.trace_flags.sampled:
             return
         if len(self.queue) == self.max_queue_size:
             if not self._spans_dropped:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/propagation/b3_format.py
@@ -121,14 +121,12 @@ class B3Format(TextMapPropagator):
 
         return trace.set_span_in_context(
             trace.DefaultSpan(
-                trace.SpanContext(
-                    # trace an span ids are encoded in hex, so must be converted
-                    trace_id=trace_id,
-                    span_id=span_id,
-                    is_remote=True,
-                    trace_flags=trace.TraceFlags(options),
-                    trace_state=trace.TraceState(),
-                )
+                # trace an span ids are encoded in hex, so must be converted
+                trace_id=trace_id,
+                span_id=span_id,
+                is_remote=True,
+                trace_flags=trace.TraceFlags(options),
+                trace_state=trace.TraceState(),
             )
         )
 
@@ -140,16 +138,15 @@ class B3Format(TextMapPropagator):
     ) -> None:
         span = trace.get_current_span(context=context)
 
-        span_context = span.get_context()
-        if span_context == trace.INVALID_SPAN_CONTEXT:
+        if span == trace.INVALID_SPAN:
             return
 
-        sampled = (trace.TraceFlags.SAMPLED & span_context.trace_flags) != 0
+        sampled = (trace.TraceFlags.SAMPLED & span.trace_flags) != 0
         set_in_carrier(
-            carrier, self.TRACE_ID_KEY, format_trace_id(span_context.trace_id),
+            carrier, self.TRACE_ID_KEY, format_trace_id(span.trace_id),
         )
         set_in_carrier(
-            carrier, self.SPAN_ID_KEY, format_span_id(span_context.span_id)
+            carrier, self.SPAN_ID_KEY, format_span_id(span.span_id)
         )
         span_parent = getattr(span, "parent", None)
         if span_parent is not None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -66,7 +66,7 @@ from types import MappingProxyType
 from typing import Optional, Sequence
 
 # pylint: disable=unused-import
-from opentelemetry.trace import Link, SpanContext
+from opentelemetry.trace import Link, Span
 from opentelemetry.util.types import Attributes
 
 
@@ -113,7 +113,7 @@ class Sampler(abc.ABC):
     @abc.abstractmethod
     def should_sample(
         self,
-        parent_context: Optional["SpanContext"],
+        parent: Optional["Span"],
         trace_id: int,
         name: str,
         attributes: Attributes = None,
@@ -134,7 +134,7 @@ class StaticSampler(Sampler):
 
     def should_sample(
         self,
-        parent_context: Optional["SpanContext"],
+        parent: Optional["Span"],
         trace_id: int,
         name: str,
         attributes: Attributes = None,
@@ -188,7 +188,7 @@ class TraceIdRatioBased(Sampler):
 
     def should_sample(
         self,
-        parent_context: Optional["SpanContext"],
+        parent: Optional["Span"],
         trace_id: int,
         name: str,
         attributes: Attributes = None,  # TODO
@@ -220,22 +220,22 @@ class ParentBased(Sampler):
 
     def should_sample(
         self,
-        parent_context: Optional["SpanContext"],
+        parent: Optional["Span"],
         trace_id: int,
         name: str,
         attributes: Attributes = None,  # TODO
         links: Sequence["Link"] = (),
     ) -> "SamplingResult":
-        if parent_context is not None:
+        if parent is not None:
             if (
-                not parent_context.is_valid
-                or not parent_context.trace_flags.sampled
+                not parent.is_valid
+                or not parent.trace_flags.sampled
             ):
                 return SamplingResult(Decision.DROP)
             return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes)
 
         return self._delegate.should_sample(
-            parent_context=parent_context,
+            parent=parent,
             trace_id=trace_id,
             name=name,
             attributes=attributes,

--- a/opentelemetry-sdk/tests/context/test_asyncio.py
+++ b/opentelemetry-sdk/tests/context/test_asyncio.py
@@ -108,4 +108,4 @@ class TestAsyncio(unittest.TestCase):
         for span in span_list:
             if span is expected_parent:
                 continue
-            self.assertEqual(span.parent, expected_parent.get_context())
+            self.assertEqual(span.parent, expected_parent)

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -123,12 +123,10 @@ class TestSimpleExportSpanProcessor(unittest.TestCase):
 def _create_start_and_end_span(name, span_processor):
     span = trace.Span(
         name,
-        trace_api.SpanContext(
-            0xDEADBEEF,
-            0xDEADBEEF,
-            is_remote=False,
-            trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
-        ),
+        0xDEADBEEF,
+        0xDEADBEEF,
+        is_remote=False,
+        trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         span_processor=span_processor,
     )
     span.start()
@@ -403,7 +401,7 @@ class TestConsoleSpanExporter(unittest.TestCase):
 
         # Mocking stdout interferes with debugging and test reporting, mock on
         # the exporter instance instead.
-        span = trace.Span("span name", trace_api.INVALID_SPAN_CONTEXT)
+        span = trace.Span("span name", 0, 0, False)
         with mock.patch.object(exporter, "out") as mock_stdout:
             exporter.export([span])
         mock_stdout.write.assert_called_once_with(span.to_json() + os.linesep)
@@ -421,5 +419,5 @@ class TestConsoleSpanExporter(unittest.TestCase):
         exporter = export.ConsoleSpanExporter(
             out=mock_stdout, formatter=formatter
         )
-        exporter.export([trace.Span("span name", mock.Mock())])
+        exporter.export([trace.Span("span name", 1, 2, False)])
         mock_stdout.write.assert_called_once_with(mock_span_str)

--- a/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
+++ b/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
@@ -61,7 +61,7 @@ class TestInMemorySpanExporter(unittest.TestCase):
         self.assertEqual(len(span_list), 3)
 
     def test_return_code(self):
-        span = trace.Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace.Span("name", 1, 2, False)
         span_list = (span,)
         memory_exporter = InMemorySpanExporter()
 

--- a/opentelemetry-sdk/tests/trace/test_implementation.py
+++ b/opentelemetry-sdk/tests/trace/test_implementation.py
@@ -15,7 +15,7 @@
 import unittest
 
 from opentelemetry.sdk import trace
-from opentelemetry.trace import INVALID_SPAN, INVALID_SPAN_CONTEXT
+from opentelemetry.trace import INVALID_SPAN, INVALID_TRACE_ID, INVALID_SPAN_ID
 
 
 class TestTracerImplementation(unittest.TestCase):
@@ -29,11 +29,10 @@ class TestTracerImplementation(unittest.TestCase):
     def test_tracer(self):
         tracer = trace.TracerProvider().get_tracer(__name__)
         with tracer.start_span("test") as span:
-            self.assertNotEqual(span.get_context(), INVALID_SPAN_CONTEXT)
+            self.assertNotEqual(span, INVALID_SPAN)
             self.assertNotEqual(span, INVALID_SPAN)
             self.assertIs(span.is_recording(), True)
             with tracer.start_span("test2") as span2:
-                self.assertNotEqual(span2.get_context(), INVALID_SPAN_CONTEXT)
                 self.assertNotEqual(span2, INVALID_SPAN)
                 self.assertIs(span2.is_recording(), True)
 
@@ -42,6 +41,12 @@ class TestTracerImplementation(unittest.TestCase):
             # pylint: disable=no-value-for-parameter
             span = trace.Span()
 
-        span = trace.Span("name", INVALID_SPAN_CONTEXT)
-        self.assertEqual(span.get_context(), INVALID_SPAN_CONTEXT)
+        span = trace.Span(
+            "name",
+            INVALID_TRACE_ID,
+            INVALID_SPAN_ID,
+            is_remote=False,
+        )
+        self.assertEqual(span.trace_id, INVALID_TRACE_ID)
+        self.assertEqual(span.span_id, INVALID_SPAN_ID)
         self.assertIs(span.is_recording(), True)

--- a/opentelemetry-sdk/tests/trace/test_sampling.py
+++ b/opentelemetry-sdk/tests/trace/test_sampling.py
@@ -60,7 +60,7 @@ class TestSamplingResult(unittest.TestCase):
 class TestSampler(unittest.TestCase):
     def test_always_on(self):
         no_record_always_on = sampling.ALWAYS_ON.should_sample(
-            trace.SpanContext(
+            trace.DefaultSpan(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_DEFAULT
             ),
             0xDEADBEF1,
@@ -73,7 +73,7 @@ class TestSampler(unittest.TestCase):
         )
 
         sampled_always_on = sampling.ALWAYS_ON.should_sample(
-            trace.SpanContext(
+            trace.DefaultSpan(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_SAMPLED
             ),
             0xDEADBEF1,
@@ -87,7 +87,7 @@ class TestSampler(unittest.TestCase):
 
     def test_always_off(self):
         no_record_always_off = sampling.ALWAYS_OFF.should_sample(
-            trace.SpanContext(
+            trace.DefaultSpan(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_DEFAULT
             ),
             0xDEADBEF1,
@@ -98,7 +98,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(no_record_always_off.attributes, {})
 
         sampled_always_on = sampling.ALWAYS_OFF.should_sample(
-            trace.SpanContext(
+            trace.DefaultSpan(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_SAMPLED
             ),
             0xDEADBEF1,
@@ -110,7 +110,7 @@ class TestSampler(unittest.TestCase):
 
     def test_default_on(self):
         no_record_default_on = sampling.DEFAULT_ON.should_sample(
-            trace.SpanContext(
+            trace.DefaultSpan(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_DEFAULT
             ),
             0xDEADBEF1,
@@ -121,7 +121,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(no_record_default_on.attributes, {})
 
         sampled_default_on = sampling.DEFAULT_ON.should_sample(
-            trace.SpanContext(
+            trace.DefaultSpan(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_SAMPLED
             ),
             0xDEADBEF1,
@@ -143,7 +143,7 @@ class TestSampler(unittest.TestCase):
 
     def test_default_off(self):
         no_record_default_off = sampling.DEFAULT_OFF.should_sample(
-            trace.SpanContext(
+            trace.DefaultSpan(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_DEFAULT
             ),
             0xDEADBEF1,
@@ -154,7 +154,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(no_record_default_off.attributes, {})
 
         sampled_default_off = sampling.DEFAULT_OFF.should_sample(
-            trace.SpanContext(
+            trace.DefaultSpan(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_SAMPLED
             ),
             0xDEADBEF1,
@@ -278,7 +278,7 @@ class TestSampler(unittest.TestCase):
         # Check that the sampling decision matches the parent context if given
         self.assertFalse(
             sampler.should_sample(
-                trace.SpanContext(
+                trace.DefaultSpan(
                     0xDEADBEF0,
                     0xDEADBEF1,
                     is_remote=False,
@@ -293,7 +293,7 @@ class TestSampler(unittest.TestCase):
         sampler2 = sampling.ParentBased(sampling.ALWAYS_OFF)
         self.assertTrue(
             sampler2.should_sample(
-                trace.SpanContext(
+                trace.DefaultSpan(
                     0xDEADBEF0,
                     0xDEADBEF1,
                     is_remote=False,

--- a/opentelemetry-sdk/tests/trace/test_span_processor.py
+++ b/opentelemetry-sdk/tests/trace/test_span_processor.py
@@ -149,8 +149,7 @@ class MultiSpanProcessorTestBase(abc.ABC):
 
     @staticmethod
     def create_default_span() -> trace_api.Span:
-        span_context = trace_api.SpanContext(37, 73, is_remote=False)
-        return trace_api.DefaultSpan(span_context)
+        return trace_api.DefaultSpan(37, 73, is_remote=False)
 
     def test_on_start(self):
         multi_processor = self.create_multi_span_processor()


### PR DESCRIPTION
# Description

Prototype for moving `SpanContext` into `Span` (https://github.com/open-telemetry/opentelemetry-specification/pull/1022) 

For simplicity purposes, only updated:
* API
* SDK
* The Jaeger exporter

I'd like to get the Maintainers feedback - from my side here are my points:

* This prototype required changes that have been only **very recently** merged to the Specification (such as https://github.com/open-telemetry/opentelemetry-specification/pull/994). Although we have prototypes for the aforementioned changes, we actually won't know how *good* it all these recent changes will play along with **this specific** change, and there's the general possibility that this *may* become a can of warms.
* The changes, from instrumentation code perspective, do not really represent a change, as mostly this has to be updated in the API/SDK/`Propagator`s (no instrumentation, based on my digging, would need to be greatly updated).
* Now `Link` will either reference `Span` (as shown in the prototype) or replicate the Trace/Span/ ids and flag/state. Not a pretty change, but it will work.
* The change itself is neither a *big issue* nor a *big improvement* for Python overall. It won't break much existing user's code, but it doesn't bring anything useful to the table IMHO.

cc @lzchen @codeboten in case I may have overseen either *good* or *bad* impacts of this change ;)
