### PR TITLE
Make event attributes immutable

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -10,6 +10,8 @@
   ([#1105](https://github.com/open-telemetry/opentelemetry-python/pull/1120))
 - Allow for Custom Trace and Span IDs Generation - `IdsGenerator` for TracerProvider
   ([#1153](https://github.com/open-telemetry/opentelemetry-python/pull/1153))
+- Event attributes are now immutable
+  ([#1195](https://github.com/open-telemetry/opentelemetry-python/pull/1195))
 
 ## Version 0.13b0
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -41,7 +41,11 @@ from opentelemetry import trace as trace_api
 from opentelemetry.sdk import util
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import sampling
-from opentelemetry.sdk.util import BoundedDict, BoundedList, make_immutable_dict
+from opentelemetry.sdk.util import (
+    BoundedDict,
+    BoundedList,
+    make_immutable_dict
+)
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
 from opentelemetry.trace import SpanContext
 from opentelemetry.trace.propagation import SPAN_KEY

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -335,7 +335,7 @@ def _filter_attribute_values(attributes: types.Attributes):
                 attributes.pop(attr_key)
 
 
-def make_immutable_dict(attributes):
+def _create_immutable_attributes(attributes):
     return MappingProxyType(attributes.copy() if attributes else {})
 
 
@@ -403,7 +403,9 @@ class Span(trace_api.Span):
             for event in events:
                 _filter_attribute_values(event.attributes)
                 # pylint: disable=protected-access
-                event._attributes = make_immutable_dict(event.attributes)
+                event._attributes = _create_immutable_attributes(
+                    event.attributes
+                )
                 self.events.append(event)
 
         if links is None:
@@ -562,7 +564,7 @@ class Span(trace_api.Span):
         timestamp: Optional[int] = None,
     ) -> None:
         _filter_attribute_values(attributes)
-        attributes = make_immutable_dict(attributes)
+        attributes = _create_immutable_attributes(attributes)
         self._add_event(
             Event(
                 name=name,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -340,6 +340,7 @@ def _filter_attribute_values(attributes: types.Attributes):
                 attributes.pop(attr_key)
 
 
+# pylint: disable=protected-access
 def _make_event_attributes_immutable(event: EventBase) -> None:
     event._attributes = make_immutable_dict(event.attributes)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -44,7 +44,7 @@ from opentelemetry.sdk.trace import sampling
 from opentelemetry.sdk.util import (
     BoundedDict,
     BoundedList,
-    make_immutable_dict
+    make_immutable_dict,
 )
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
 from opentelemetry.trace import SpanContext

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -14,6 +14,7 @@
 import datetime
 import threading
 from collections import OrderedDict, deque
+from types import MappingProxyType
 
 try:
     # pylint: disable=ungrouped-imports
@@ -42,6 +43,12 @@ def get_dict_as_key(labels):
                 labels.items(),
             )
         )
+    )
+
+
+def make_immutable_dict(attributes):
+    return MappingProxyType(
+        attributes.copy() if attributes else {}
     )
 
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -14,7 +14,6 @@
 import datetime
 import threading
 from collections import OrderedDict, deque
-from types import MappingProxyType
 
 try:
     # pylint: disable=ungrouped-imports
@@ -44,10 +43,6 @@ def get_dict_as_key(labels):
             )
         )
     )
-
-
-def make_immutable_dict(attributes):
-    return MappingProxyType(attributes.copy() if attributes else {})
 
 
 class BoundedList(Sequence):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -47,9 +47,7 @@ def get_dict_as_key(labels):
 
 
 def make_immutable_dict(attributes):
-    return MappingProxyType(
-        attributes.copy() if attributes else {}
-    )
+    return MappingProxyType(attributes.copy() if attributes else {})
 
 
 class BoundedList(Sequence):

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -598,11 +598,9 @@ class TestSpan(unittest.TestCase):
                 root.events[3].attributes, {"name": ("original_contents",)}
             )
 
-
     def test_events_are_immutable(self):
         event_properties = [
-            prop for prop in dir(trace.EventBase)
-            if not prop.startswith("_")
+            prop for prop in dir(trace.EventBase) if not prop.startswith("_")
         ]
 
         with self.tracer.start_as_current_span("root") as root:


### PR DESCRIPTION
# Description

This PR makes it more difficult for someone to edit the attributes of an `Event` once it has been added to a `Span`, as well as adding some regression tests around the other properties of an `Event` to ensure they have similar protections.

It isn't particularly straightforward or idiomatic to make objects truly immutable in Python, but if these steps don't go far enough let me know!

I don't believe a documentation change is necessary because events are meant to be immutable[ according to the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-events), but this should probably be considered a breaking change in case people were relying on the event attributes being mutable up until now.

Fixes #1038

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've added regression tests to:
- make sure that the properties of an `Event` raise an error when someone directly tries to change them; and
- make sure that an error is raised if someone tries to directly edit any of the `attributes` dictionary tuples.

I've also added a new test for my change to make sure that an error is raised if someone tryies to directly edit the `attributes` dictionary itself.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
