### PR TITLE
Add timestamps to aggregators and OTLP metrics exporter

### DIFF
--- a/exporter/opentelemetry-exporter-otlp/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-otlp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add timestamps to OTLP exporter
+  ([#1199](https://github.com/open-telemetry/opentelemetry-python/pull/1199))
 - Update OpenTelemetry protos to v0.5.0
   ([#1143](https://github.com/open-telemetry/opentelemetry-python/pull/1143))
 

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/metrics_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/metrics_exporter/__init__.py
@@ -85,6 +85,12 @@ def _get_data_points(
                     data_point_class(
                         labels=string_key_values,
                         value=view_data.aggregator.current,
+                        start_time_unix_nano=(
+                            view_data.aggregator.last_checkpoint_timestamp
+                        ),
+                        time_unix_nano=(
+                            view_data.aggregator.last_update_timestamp
+                        ),
                     )
                 )
                 break

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
@@ -14,6 +14,7 @@
 
 from collections import OrderedDict
 from unittest import TestCase
+from unittest.mock import patch
 
 from opentelemetry.exporter.otlp.metrics_exporter import OTLPMetricsExporter
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
@@ -59,8 +60,11 @@ class TestOTLPMetricExporter(TestCase):
             resource,
         )
 
-    def test_translate_metrics(self):
+    @patch("opentelemetry.sdk.metrics.export.aggregate.time_ns")
+    def test_translate_metrics(self, mock_time_ns):
         # pylint: disable=no-member
+
+        mock_time_ns.configure_mock(**{"return_value": 1})
 
         self.counter_metric_record.instrument.add(1, OrderedDict([("a", "b")]))
 
@@ -91,6 +95,7 @@ class TestOTLPMetricExporter(TestCase):
                                                     )
                                                 ],
                                                 value=1,
+                                                time_unix_nano=1,
                                             )
                                         ],
                                         aggregation_temporality=(

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add timestamps to aggregators
+  ([#1199](https://github.com/open-telemetry/opentelemetry-python/pull/1199))
 - Add Global Error Handler
   ([#1080](https://github.com/open-telemetry/opentelemetry-python/pull/1080))
 - Update sampling result names

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
@@ -16,6 +16,7 @@ import abc
 import logging
 import threading
 from collections import OrderedDict, namedtuple
+from math import inf
 
 from opentelemetry.util import time_ns
 
@@ -30,9 +31,10 @@ class Aggregator(abc.ABC):
     """
 
     def __init__(self, config=None):
-        self.current = None
-        self.checkpoint = None
-        if config:
+        self._lock = threading.Lock()
+        self.last_update_timestamp = 0
+        self.last_checkpoint_timestamp = 0
+        if config is not None:
             self.config = config
         else:
             self.config = {}
@@ -40,14 +42,32 @@ class Aggregator(abc.ABC):
     @abc.abstractmethod
     def update(self, value):
         """Updates the current with the new value."""
+        self.last_update_timestamp = time_ns()
 
     @abc.abstractmethod
     def take_checkpoint(self):
         """Stores a snapshot of the current value."""
+        self.last_checkpoint_timestamp = time_ns()
 
     @abc.abstractmethod
     def merge(self, other):
         """Combines two aggregator values."""
+        self.last_update_timestamp = max(
+            self.last_update_timestamp, other.last_update_timestamp
+        )
+        self.last_checkpoint_timestamp = min(
+            self.last_checkpoint_timestamp, other.last_checkpoint_timestamp
+        )
+
+    def _verify_type(self, other):
+        if isinstance(other, self.__class__):
+            return True
+        logger.warning(
+            "Error in merging %s with %s.",
+            self.__class__.__name__,
+            other.__class__.__name__,
+        )
+        return False
 
 
 class SumAggregator(Aggregator):
@@ -57,81 +77,62 @@ class SumAggregator(Aggregator):
         super().__init__(config=config)
         self.current = 0
         self.checkpoint = 0
-        self._lock = threading.Lock()
-        self.last_update_timestamp = None
 
     def update(self, value):
         with self._lock:
             self.current += value
-            self.last_update_timestamp = time_ns()
+            super().update(value)
 
     def take_checkpoint(self):
         with self._lock:
             self.checkpoint = self.current
             self.current = 0
+            super().take_checkpoint()
 
     def merge(self, other):
-        if verify_type(self, other):
+        if self._verify_type(other):
             with self._lock:
                 self.checkpoint += other.checkpoint
-                self.last_update_timestamp = get_latest_timestamp(
-                    self.last_update_timestamp, other.last_update_timestamp
-                )
+                super().merge(other)
 
 
 class MinMaxSumCountAggregator(Aggregator):
     """Aggregator for ValueRecorder metrics that keeps min, max, sum, count."""
 
     _TYPE = namedtuple("minmaxsumcount", "min max sum count")
-    _EMPTY = _TYPE(None, None, None, 0)
-
-    @classmethod
-    def _merge_checkpoint(cls, val1, val2):
-        if val1 is cls._EMPTY:
-            return val2
-        if val2 is cls._EMPTY:
-            return val1
-        return cls._TYPE(
-            min(val1.min, val2.min),
-            max(val1.max, val2.max),
-            val1.sum + val2.sum,
-            val1.count + val2.count,
-        )
+    _EMPTY = _TYPE(inf, -inf, 0, 0)
 
     def __init__(self, config=None):
         super().__init__(config=config)
         self.current = self._EMPTY
         self.checkpoint = self._EMPTY
-        self._lock = threading.Lock()
-        self.last_update_timestamp = None
 
     def update(self, value):
         with self._lock:
-            if self.current is self._EMPTY:
-                self.current = self._TYPE(value, value, value, 1)
-            else:
-                self.current = self._TYPE(
-                    min(self.current.min, value),
-                    max(self.current.max, value),
-                    self.current.sum + value,
-                    self.current.count + 1,
-                )
-            self.last_update_timestamp = time_ns()
+            self.current = self._TYPE(
+                min(self.current.min, value),
+                max(self.current.max, value),
+                self.current.sum + value,
+                self.current.count + 1,
+            )
+            super().update(value)
 
     def take_checkpoint(self):
         with self._lock:
             self.checkpoint = self.current
             self.current = self._EMPTY
+            super().take_checkpoint()
 
     def merge(self, other):
-        if verify_type(self, other):
+        if self._verify_type(other):
             with self._lock:
-                self.checkpoint = self._merge_checkpoint(
-                    self.checkpoint, other.checkpoint
+                self.checkpoint = self._TYPE(
+                    min(self.checkpoint.min, other.checkpoint.min),
+                    max(self.checkpoint.max, other.checkpoint.max),
+                    self.checkpoint.sum + other.checkpoint.sum,
+                    self.checkpoint.count + other.checkpoint.count,
                 )
-                self.last_update_timestamp = get_latest_timestamp(
-                    self.last_update_timestamp, other.last_update_timestamp
-                )
+                super().merge(other)
 
 
 class HistogramAggregator(Aggregator):
@@ -139,75 +140,53 @@ class HistogramAggregator(Aggregator):
 
     def __init__(self, config=None):
         super().__init__(config=config)
-        self._lock = threading.Lock()
-        self.last_update_timestamp = None
-        boundaries = self.config.get("bounds")
-        if boundaries and self._validate_boundaries(boundaries):
-            self._boundaries = boundaries
-        else:
-            # no buckets except < 0 and >
-            self._boundaries = (0,)
+        # no buckets except < 0 and >
+        bounds = (0,)
+        config_bounds = self.config.get("bounds")
+        if config_bounds is not None:
+            if all(
+                config_bounds[i] < config_bounds[i + 1]
+                for i in range(len(config_bounds) - 1)
+            ):
+                bounds = config_bounds
+            else:
+                logger.warning(
+                    "Bounds must be all different and sorted in increasing"
+                    " order. Using default."
+                )
 
-        self.current = OrderedDict([(bb, 0) for bb in self._boundaries])
-        self.checkpoint = OrderedDict([(bb, 0) for bb in self._boundaries])
-
-        self.current[">"] = 0
-        self.checkpoint[">"] = 0
-
-    # pylint: disable=R0201
-    def _validate_boundaries(self, boundaries):
-        if not boundaries:
-            logger.warning("Bounds is empty. Using default.")
-            return False
-        if not all(
-            boundaries[ii] < boundaries[ii + 1]
-            for ii in range(len(boundaries) - 1)
-        ):
-            logger.warning(
-                "Bounds must be sorted in increasing order. Using default."
-            )
-            return False
-        return True
-
-    @classmethod
-    def _merge_checkpoint(cls, val1, val2):
-        if val1.keys() == val2.keys():
-            for ii, bb in val2.items():
-                val1[ii] += bb
-        else:
-            logger.warning("Cannot merge histograms with different buckets.")
-        return val1
+        self.current = OrderedDict([(bb, 0) for bb in bounds])
+        self.current[inf] = 0
+        self.checkpoint = OrderedDict([(bb, 0) for bb in bounds])
+        self.checkpoint[inf] = 0
 
     def update(self, value):
         with self._lock:
-            if self.current is None:
-                self.current = [0 for ii in range(len(self._boundaries) + 1)]
-            # greater than max value
-            if value >= self._boundaries[len(self._boundaries) - 1]:
-                self.current[">"] += 1
-            else:
-                for bb in self._boundaries:
-                    # find first bucket that value is less than
-                    if value < bb:
-                        self.current[bb] += 1
-                        break
-            self.last_update_timestamp = time_ns()
+            for bb in self.current.keys():
+                # find first bucket that value is less than
+                if value < bb:
+                    self.current[bb] += 1
+                    break
+            super().update(value)
 
     def take_checkpoint(self):
         with self._lock:
-            self.checkpoint = self.current
-            self.current = OrderedDict([(bb, 0) for bb in self._boundaries])
-            self.current[">"] = 0
+            self.checkpoint = self.current.copy()
+            for bb in self.current.keys():
+                self.current[bb] = 0
+            super().take_checkpoint()
 
     def merge(self, other):
-        if verify_type(self, other):
+        if self._verify_type(other):
             with self._lock:
-                self.checkpoint = self._merge_checkpoint(
-                    self.checkpoint, other.checkpoint
-                )
-                self.last_update_timestamp = get_latest_timestamp(
-                    self.last_update_timestamp, other.last_update_timestamp
-                )
+                if self.checkpoint.keys() == other.checkpoint.keys():
+                    for ii, bb in other.checkpoint.items():
+                        self.checkpoint[ii] += bb
+                    super().merge(other)
+                else:
+                    logger.warning(
+                        "Cannot merge histograms with different buckets."
+                    )
 
 
 class LastValueAggregator(Aggregator):
@@ -215,27 +194,29 @@ class LastValueAggregator(Aggregator):
 
     def __init__(self, config=None):
         super().__init__(config=config)
-        self._lock = threading.Lock()
-        self.last_update_timestamp = None
+        self.current = None
+        self.checkpoint = None
 
     def update(self, value):
         with self._lock:
             self.current = value
-            self.last_update_timestamp = time_ns()
+            super().update(value)
 
     def take_checkpoint(self):
         with self._lock:
             self.checkpoint = self.current
             self.current = None
+            super().take_checkpoint()
 
     def merge(self, other):
         last = self.checkpoint
-        self.last_update_timestamp = get_latest_timestamp(
+        self.last_update_timestamp = max(
             self.last_update_timestamp, other.last_update_timestamp
         )
         if self.last_update_timestamp == other.last_update_timestamp:
             last = other.checkpoint
         self.checkpoint = last
+        super().merge(other)
 
 
 class ValueObserverAggregator(Aggregator):
@@ -248,46 +229,27 @@ class ValueObserverAggregator(Aggregator):
         self.mmsc = MinMaxSumCountAggregator()
         self.current = None
         self.checkpoint = self._TYPE(None, None, None, 0, None)
-        self.last_update_timestamp = None
 
     def update(self, value):
         self.mmsc.update(value)
         self.current = value
-        self.last_update_timestamp = time_ns()
+        super().update(value)
 
     def take_checkpoint(self):
         self.mmsc.take_checkpoint()
         self.checkpoint = self._TYPE(*(self.mmsc.checkpoint + (self.current,)))
+        super().take_checkpoint()
 
     def merge(self, other):
-        if verify_type(self, other):
+        if self._verify_type(other):
             self.mmsc.merge(other.mmsc)
             last = self.checkpoint.last
-            self.last_update_timestamp = get_latest_timestamp(
+
+            self.last_update_timestamp = max(
                 self.last_update_timestamp, other.last_update_timestamp
             )
+
             if self.last_update_timestamp == other.last_update_timestamp:
                 last = other.checkpoint.last
             self.checkpoint = self._TYPE(*(self.mmsc.checkpoint + (last,)))
-
-
-def get_latest_timestamp(time_stamp, other_timestamp):
-    if time_stamp is None:
-        return other_timestamp
-    if other_timestamp is not None:
-        if time_stamp < other_timestamp:
-            return other_timestamp
-    return time_stamp
-
-
-# pylint: disable=R1705
-def verify_type(this, other):
-    if isinstance(other, this.__class__):
-        return True
-    else:
-        logger.warning(
-            "Error in merging %s with %s.",
-            this.__class__.__name__,
-            other.__class__.__name__,
-        )
-        return False
+            super().merge(other)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
@@ -55,7 +55,7 @@ class Aggregator(abc.ABC):
         self.last_update_timestamp = max(
             self.last_update_timestamp, other.last_update_timestamp
         )
-        self.last_checkpoint_timestamp = min(
+        self.last_checkpoint_timestamp = max(
             self.last_checkpoint_timestamp, other.last_checkpoint_timestamp
         )
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
@@ -210,13 +210,10 @@ class LastValueAggregator(Aggregator):
 
     def merge(self, other):
         last = self.checkpoint
-        self.last_update_timestamp = max(
-            self.last_update_timestamp, other.last_update_timestamp
-        )
+        super().merge(other)
         if self.last_update_timestamp == other.last_update_timestamp:
             last = other.checkpoint
         self.checkpoint = last
-        super().merge(other)
 
 
 class ValueObserverAggregator(Aggregator):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/aggregate.py
@@ -136,7 +136,7 @@ class MinMaxSumCountAggregator(Aggregator):
 
 
 class HistogramAggregator(Aggregator):
-    """Agregator for ValueRecorder metrics that keeps a histogram of values."""
+    """Aggregator for ValueRecorder metrics that keeps a histogram of values."""
 
     def __init__(self, config=None):
         super().__init__(config=config)

--- a/opentelemetry-sdk/tests/metrics/test_view.py
+++ b/opentelemetry-sdk/tests/metrics/test_view.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from math import inf
 from unittest import mock
 
 from opentelemetry.sdk import metrics
@@ -223,7 +224,7 @@ class TestHistogramView(unittest.TestCase):
         checkpoint = metrics_list[0].aggregator.checkpoint
         self.assertEqual(
             tuple(checkpoint.items()),
-            ((20, 1), (40, 1), (60, 0), (80, 0), (100, 0), (">", 1)),
+            ((20, 1), (40, 1), (60, 0), (80, 0), (100, 0), (inf, 1)),
         )
         exporter.clear()
 
@@ -238,7 +239,7 @@ class TestHistogramView(unittest.TestCase):
         checkpoint = metrics_list[0].aggregator.checkpoint
         self.assertEqual(
             tuple(checkpoint.items()),
-            ((20, 2), (40, 2), (60, 0), (80, 0), (100, 0), (">", 2)),
+            ((20, 2), (40, 2), (60, 0), (80, 0), (100, 0), (inf, 2)),
         )
 
     def test_histogram_stateless(self):
@@ -278,7 +279,7 @@ class TestHistogramView(unittest.TestCase):
         checkpoint = metrics_list[0].aggregator.checkpoint
         self.assertEqual(
             tuple(checkpoint.items()),
-            ((20, 1), (40, 1), (60, 0), (80, 0), (100, 0), (">", 1)),
+            ((20, 1), (40, 1), (60, 0), (80, 0), (100, 0), (inf, 1)),
         )
         exporter.clear()
 
@@ -293,7 +294,7 @@ class TestHistogramView(unittest.TestCase):
         checkpoint = metrics_list[0].aggregator.checkpoint
         self.assertEqual(
             tuple(checkpoint.items()),
-            ((20, 1), (40, 1), (60, 0), (80, 0), (100, 0), (">", 1)),
+            ((20, 1), (40, 1), (60, 0), (80, 0), (100, 0), (inf, 1)),
         )
 
 


### PR DESCRIPTION
# Description

Add timestamps to aggregators and OTLP metrics exporter.

Fixes #1008

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Refactored aggregator and OTLP metric exporter tests.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
