### PR TITLE
Adding Resource to MetricRecord

### DIFF
--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/metrics_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/metrics_exporter/__init__.py
@@ -191,7 +191,7 @@ def get_collector_point(metric_record: MetricRecord) -> metrics_pb2.Point:
 
 
 def get_resource(metric_record: MetricRecord) -> resource_pb2.Resource:
-    resource_attributes = metric_record.instrument.meter.resource.attributes
+    resource_attributes = metric_record.resource.attributes
     return resource_pb2.Resource(
         type=infer_oc_resource_type(resource_attributes),
         labels={k: str(v) for k, v in resource_attributes.items()},

--- a/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_metrics_exporter.py
@@ -100,7 +100,12 @@ class TestCollectorMetricsExporter(unittest.TestCase):
             "testName", "testDescription", "unit", float, ValueRecorder
         )
         result = metrics_exporter.get_collector_point(
-            MetricRecord(int_counter, self._key_labels, aggregator)
+            MetricRecord(
+                int_counter,
+                self._key_labels,
+                aggregator,
+                metrics.get_meter_provider().resource,
+            )
         )
         self.assertIsInstance(result, metrics_pb2.Point)
         self.assertIsInstance(result.timestamp, Timestamp)
@@ -108,13 +113,23 @@ class TestCollectorMetricsExporter(unittest.TestCase):
         aggregator.update(123.5)
         aggregator.take_checkpoint()
         result = metrics_exporter.get_collector_point(
-            MetricRecord(float_counter, self._key_labels, aggregator)
+            MetricRecord(
+                float_counter,
+                self._key_labels,
+                aggregator,
+                metrics.get_meter_provider().resource,
+            )
         )
         self.assertEqual(result.double_value, 123.5)
         self.assertRaises(
             TypeError,
             metrics_exporter.get_collector_point(
-                MetricRecord(valuerecorder, self._key_labels, aggregator)
+                MetricRecord(
+                    valuerecorder,
+                    self._key_labels,
+                    aggregator,
+                    metrics.get_meter_provider().resource,
+                )
             ),
         )
 
@@ -130,7 +145,10 @@ class TestCollectorMetricsExporter(unittest.TestCase):
             "testname", "testdesc", "unit", int, Counter, self._labels.keys(),
         )
         record = MetricRecord(
-            test_metric, self._key_labels, aggregate.SumAggregator(),
+            test_metric,
+            self._key_labels,
+            aggregate.SumAggregator(),
+            metrics.get_meter_provider().resource,
         )
 
         result = collector_exporter.export([record])
@@ -155,7 +173,12 @@ class TestCollectorMetricsExporter(unittest.TestCase):
         aggregator = aggregate.SumAggregator()
         aggregator.update(123)
         aggregator.take_checkpoint()
-        record = MetricRecord(test_metric, self._key_labels, aggregator,)
+        record = MetricRecord(
+            test_metric,
+            self._key_labels,
+            aggregator,
+            metrics.get_meter_provider().resource,
+        )
         start_timestamp = Timestamp()
         output_metrics = metrics_exporter.translate_to_collector(
             [record], start_timestamp,

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/metrics_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/metrics_exporter/__init__.py
@@ -137,11 +137,11 @@ class OTLPMetricsExporter(
         #   ValueObserver      Gauge()
         for sdk_metric in data:
 
-            if sdk_metric.instrument.meter.resource not in (
+            if sdk_metric.resource not in (
                 sdk_resource_instrumentation_library_metrics.keys()
             ):
                 sdk_resource_instrumentation_library_metrics[
-                    sdk_metric.instrument.meter.resource
+                    sdk_metric.resource
                 ] = InstrumentationLibraryMetrics()
 
             type_class = {
@@ -217,7 +217,7 @@ class OTLPMetricsExporter(
                 argument = type_class[value_type]["gauge"]["argument"]
 
             sdk_resource_instrumentation_library_metrics[
-                sdk_metric.instrument.meter.resource
+                sdk_metric.resource
             ].metrics.append(
                 OTLPMetric(
                     **{

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
@@ -44,20 +44,19 @@ from opentelemetry.sdk.resources import Resource as SDKResource
 class TestOTLPMetricExporter(TestCase):
     def setUp(self):
         self.exporter = OTLPMetricsExporter()
-
+        resource = SDKResource(OrderedDict([("a", 1), ("b", False)]))
         self.counter_metric_record = MetricRecord(
             Counter(
                 "a",
                 "b",
                 "c",
                 int,
-                MeterProvider(
-                    resource=SDKResource(OrderedDict([("a", 1), ("b", False)]))
-                ).get_meter(__name__),
+                MeterProvider(resource=resource,).get_meter(__name__),
                 ("d",),
             ),
             OrderedDict([("e", "f")]),
             SumAggregator(),
+            resource,
         )
 
     def test_translate_metrics(self):

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -67,7 +67,10 @@ class TestPrometheusMetricExporter(unittest.TestCase):
     def test_export(self):
         with self._registry_register_patch:
             record = MetricRecord(
-                self._test_metric, self._labels_key, SumAggregator(),
+                self._test_metric,
+                self._labels_key,
+                SumAggregator(),
+                get_meter_provider().resource,
             )
             exporter = PrometheusMetricsExporter()
             result = exporter.export([record])
@@ -86,7 +89,9 @@ class TestPrometheusMetricExporter(unittest.TestCase):
         aggregator.update(123)
         aggregator.update(456)
         aggregator.take_checkpoint()
-        record = MetricRecord(metric, key_labels, aggregator)
+        record = MetricRecord(
+            metric, key_labels, aggregator, get_meter_provider().resource
+        )
         collector = CustomCollector("testprefix")
         collector.add_metrics_data([record])
         result_bytes = generate_latest(collector)
@@ -104,7 +109,9 @@ class TestPrometheusMetricExporter(unittest.TestCase):
         aggregator = SumAggregator()
         aggregator.update(123)
         aggregator.take_checkpoint()
-        record = MetricRecord(metric, key_labels, aggregator)
+        record = MetricRecord(
+            metric, key_labels, aggregator, get_meter_provider().resource
+        )
         collector = CustomCollector("testprefix")
         collector.add_metrics_data([record])
 
@@ -132,7 +139,9 @@ class TestPrometheusMetricExporter(unittest.TestCase):
         )
         labels = {"environment": "staging"}
         key_labels = get_dict_as_key(labels)
-        record = MetricRecord(metric, key_labels, None)
+        record = MetricRecord(
+            metric, key_labels, None, get_meter_provider().resource
+        )
         collector = CustomCollector("testprefix")
         collector.add_metrics_data([record])
         collector.collect()

--- a/opentelemetry-api/src/opentelemetry/propagators/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/__init__.py
@@ -65,7 +65,7 @@ Example::
 
 
 .. _Propagation API Specification:
-    https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-propagators.md
+    https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md
 """
 
 import typing

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -12,6 +12,8 @@
   ([#1153](https://github.com/open-telemetry/opentelemetry-python/pull/1153))
 - Renaming metrics Batcher to Processor
   ([#1203](https://github.com/open-telemetry/opentelemetry-python/pull/1203))
+- Adding Resource to MeterRecord
+  ([#1209](https://github.com/open-telemetry/opentelemetry-python/pull/1209))
 
 ## Version 0.13b0
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -352,7 +352,7 @@ class Meter(metrics_api.Meter):
         instrumentation_info: "InstrumentationInfo",
     ):
         self.instrumentation_info = instrumentation_info
-        self.batcher = Batcher(source.stateful)
+        self.batcher = Batcher(source.stateful, source.resource)
         self.resource = source.resource
         self.metrics = set()
         self.observers = set()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
@@ -80,11 +80,12 @@ class ConsoleMetricsExporter(MetricsExporter):
     ) -> "MetricsExportResult":
         for record in metric_records:
             print(
-                '{}(data="{}", labels="{}", value={})'.format(
+                '{}(data="{}", labels="{}", value={}, resource={})'.format(
                     type(self).__name__,
                     record.instrument,
                     record.labels,
                     record.aggregator.checkpoint,
+                    record.resource.attributes,
                 )
             )
         return MetricsExportResult.SUCCESS

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
@@ -17,6 +17,7 @@ from typing import Sequence, Tuple
 
 from opentelemetry import metrics as metrics_api
 from opentelemetry.sdk.metrics.export.aggregate import Aggregator
+from opentelemetry.sdk.resources import Resource
 
 
 class MetricsExportResult(Enum):
@@ -30,10 +31,12 @@ class MetricRecord:
         instrument: metrics_api.InstrumentT,
         labels: Tuple[Tuple[str, str]],
         aggregator: Aggregator,
+        resource: Resource,
     ):
         self.instrument = instrument
         self.labels = labels
         self.aggregator = aggregator
+        self.resource = resource
 
 
 class MetricsExporter:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/batcher.py
@@ -15,6 +15,7 @@
 from typing import Sequence
 
 from opentelemetry.sdk.metrics.export import MetricRecord
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.util import get_dict_as_key
 
 
@@ -26,13 +27,14 @@ class Batcher:
     will be sent to an exporter for exporting.
     """
 
-    def __init__(self, stateful: bool):
+    def __init__(self, stateful: bool, resource: Resource):
         self._batch_map = {}
         # stateful=True indicates the batcher computes checkpoints from over
         # the process lifetime. False indicates the batcher computes
         # checkpoints which describe the updates of a single collection period
         # (deltas)
         self.stateful = stateful
+        self._resource = resource
 
     def checkpoint_set(self) -> Sequence[MetricRecord]:
         """Returns a list of MetricRecords used for exporting.
@@ -46,7 +48,9 @@ class Batcher:
             (instrument, aggregator_type, _, labels),
             aggregator,
         ) in self._batch_map.items():
-            metric_records.append(MetricRecord(instrument, labels, aggregator))
+            metric_records.append(
+                MetricRecord(instrument, labels, aggregator, self._resource)
+            )
         return metric_records
 
     def finished_collection(self):

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -88,7 +88,7 @@ class TestBatcher(unittest.TestCase):
 
     def test_finished_collection_stateless(self):
         meter = metrics.MeterProvider().get_meter(__name__)
-        batcher = Batcher(True, meter.resource)
+        batcher = Batcher(False, meter.resource)
         aggregator = SumAggregator()
         metric = metrics.Counter(
             "available memory", "available memory", "bytes", int, meter

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -51,11 +51,12 @@ class TestConsoleMetricsExporter(unittest.TestCase):
         labels = {"environment": "staging"}
         aggregator = SumAggregator()
         record = MetricRecord(metric, labels, aggregator, meter.resource)
-        result = '{}(data="{}", labels="{}", value={})'.format(
+        result = '{}(data="{}", labels="{}", value={}, resource={})'.format(
             ConsoleMetricsExporter.__name__,
             metric,
             labels,
             aggregator.checkpoint,
+            meter.resource.attributes,
         )
         with mock.patch("sys.stdout") as mock_stdout:
             exporter.export([record])


### PR DESCRIPTION
# Description

Adding the Resource as a parameter to the Batcher (aka Processor see #1203). Not having the resource in the MetricRecord currently causes an issue retrieving resource information in the OTLP exporter.

Fixes #1208

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been update
- [ ] Documentation has been updated
