### PR TITLE
Bug fix: Serialize event attributes properly

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -463,7 +463,7 @@ class Span(trace_api.Span):
     def _format_attributes(attributes):
         if isinstance(attributes, BoundedDict):
             return attributes._dict  # pylint: disable=protected-access
-        elif isinstance(attributes, MappingProxyType):
+        if isinstance(attributes, MappingProxyType):
             return attributes.copy()
         return attributes
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -463,6 +463,8 @@ class Span(trace_api.Span):
     def _format_attributes(attributes):
         if isinstance(attributes, BoundedDict):
             return attributes._dict  # pylint: disable=protected-access
+        elif isinstance(attributes, MappingProxyType):
+            return attributes.copy()
         return attributes
 
     @staticmethod

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1048,5 +1048,7 @@ class TestSpanProcessor(unittest.TestCase):
         date_str = ns_to_iso_str(123)
         self.assertEqual(
             span.to_json(indent=None),
-            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "attributes": {"key": "value"}, "events": [{"name": "event", "timestamp": "' + date_str + '", "attributes": {"key2": "value2"}}], "links": [], "resource": {}}',
+            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "attributes": {"key": "value"}, "events": [{"name": "event", "timestamp": "'
+            + date_str
+            + '", "attributes": {"key2": "value2"}}], "links": [], "resource": {}}',
         )

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -22,6 +22,7 @@ from unittest import mock
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk import resources, trace
 from opentelemetry.sdk.trace import Resource, sampling
+from opentelemetry.sdk.util import ns_to_iso_str
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
 from opentelemetry.trace.status import StatusCanonicalCode
 from opentelemetry.util import time_ns
@@ -1031,4 +1032,21 @@ class TestSpanProcessor(unittest.TestCase):
         self.assertEqual(
             span.to_json(indent=None),
             '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "attributes": {}, "events": [], "links": [], "resource": {}}',
+        )
+
+    def test_attributes_to_json(self):
+        context = trace_api.SpanContext(
+            trace_id=0x000000000000000000000000DEADBEEF,
+            span_id=0x00000000DEADBEF0,
+            is_remote=False,
+            trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
+        )
+        span = trace._Span("span-name", context)
+        span.resource = Resource({})
+        span.set_attribute("key", "value")
+        span.add_event("event", {"key2": "value2"}, 123)
+        date_str = ns_to_iso_str(123)
+        self.assertEqual(
+            span.to_json(indent=None),
+            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "attributes": {"key": "value"}, "events": [{"name": "event", "timestamp": "' + date_str + '", "attributes": {"key2": "value2"}}], "links": [], "resource": {}}',
         )


### PR DESCRIPTION
Since `Event` s as part of a `Span` are immutable, the attributes associated with them were created to be immutable as well (`MappingProxyType`) [here](https://github.com/open-telemetry/opentelemetry-python/blob/master/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L343). These did not serialize properly since we missed the [type check](https://github.com/open-telemetry/opentelemetry-python/blob/master/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L464) here. Simply adding the type check and returning the underlying dictionary if attempting to format the immutable attributes is the solution.