### PR TITLE
Renaming SpanContext to SpanReference

### DIFF
--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/exporter.py
@@ -189,13 +189,13 @@ class DatadogSpanExporter(SpanExporter):
 
 def _get_trace_ids(span):
     """Extract tracer ids from span"""
-    ctx = span.get_span_context()
-    trace_id = ctx.trace_id
-    span_id = ctx.span_id
+    ref = span.get_span_reference()
+    trace_id = ref.trace_id
+    span_id = ref.span_id
 
     if isinstance(span.parent, trace_api.Span):
-        parent_id = span.parent.get_span_context().span_id
-    elif isinstance(span.parent, trace_api.SpanContext):
+        parent_id = span.parent.get_span_reference().span_id
+    elif isinstance(span.parent, trace_api.SpanReference):
         parent_id = span.parent.span_id
     else:
         parent_id = 0
@@ -255,16 +255,16 @@ def _get_exc_info(span):
 
 
 def _get_origin(span):
-    ctx = span.get_span_context()
-    origin = ctx.trace_state.get(DD_ORIGIN)
+    ref = span.get_span_reference()
+    origin = ref.trace_state.get(DD_ORIGIN)
     return origin
 
 
 def _get_sampling_rate(span):
-    ctx = span.get_span_context()
+    ref = span.get_span_reference()
     return (
         span.sampler.rate
-        if ctx.trace_flags.sampled
+        if ref.trace_flags.sampled
         and isinstance(span.sampler, sampling.TraceIdRatioBased)
         else None
     )

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/spanprocessor.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/spanprocessor.py
@@ -82,8 +82,8 @@ class DatadogExportSpanProcessor(SpanProcessor):
         self.worker_thread.start()
 
     def on_start(self, span: Span) -> None:
-        ctx = span.get_span_context()
-        trace_id = ctx.trace_id
+        ref = span.get_span_reference()
+        trace_id = ref.trace_id
 
         with self.traces_lock:
             # check upper bound on number of spans for trace before adding new
@@ -102,8 +102,8 @@ class DatadogExportSpanProcessor(SpanProcessor):
             logger.warning("Already shutdown, dropping span.")
             return
 
-        ctx = span.get_span_context()
-        trace_id = ctx.trace_id
+        ref = span.get_span_reference()
+        trace_id = ref.trace_id
 
         with self.traces_lock:
             self.traces_spans_ended_count[trace_id] += 1

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
@@ -175,13 +175,13 @@ class TestDatadogSpanExporter(unittest.TestCase):
             start_times[2] + durations[2],
         )
 
-        span_context = trace_api.SpanContext(
+        span_reference = trace_api.SpanReference(
             trace_id, span_id, is_remote=False
         )
-        parent_span_context = trace_api.SpanContext(
+        parent_span_reference = trace_api.SpanReference(
             trace_id, parent_id, is_remote=False
         )
-        other_context = trace_api.SpanContext(
+        other_reference = trace_api.SpanReference(
             trace_id, other_id, is_remote=False
         )
 
@@ -190,22 +190,22 @@ class TestDatadogSpanExporter(unittest.TestCase):
         otel_spans = [
             trace._Span(
                 name=span_names[0],
-                context=span_context,
-                parent=parent_span_context,
+                reference=span_reference,
+                parent=parent_span_reference,
                 kind=trace_api.SpanKind.CLIENT,
                 instrumentation_info=instrumentation_info,
                 resource=Resource({}),
             ),
             trace._Span(
                 name=span_names[1],
-                context=parent_span_context,
+                reference=parent_span_reference,
                 parent=None,
                 instrumentation_info=instrumentation_info,
                 resource=resource_without_service,
             ),
             trace._Span(
                 name=span_names[2],
-                context=other_context,
+                reference=other_reference,
                 parent=None,
                 resource=resource,
             ),
@@ -283,13 +283,13 @@ class TestDatadogSpanExporter(unittest.TestCase):
     def test_export(self):
         """Test that agent and/or collector are invoked"""
         # create and save span to be used in tests
-        context = trace_api.SpanContext(
+        reference = trace_api.SpanReference(
             trace_id=0x000000000000000000000000DEADBEEF,
             span_id=0x00000000DEADBEF0,
             is_remote=False,
         )
 
-        test_span = trace._Span("test_span", context=context)
+        test_span = trace._Span("test_span", reference=reference)
         test_span.start()
         test_span.end()
 
@@ -483,7 +483,7 @@ class TestDatadogSpanExporter(unittest.TestCase):
         tracer_provider.shutdown()
 
     def test_origin(self):
-        context = trace_api.SpanContext(
+        reference = trace_api.SpanReference(
             trace_id=0x000000000000000000000000DEADBEEF,
             span_id=trace_api.INVALID_SPAN,
             is_remote=True,
@@ -492,9 +492,9 @@ class TestDatadogSpanExporter(unittest.TestCase):
             ),
         )
 
-        root_span = trace._Span(name="root", context=context, parent=None)
+        root_span = trace._Span(name="root", reference=reference, parent=None)
         child_span = trace._Span(
-            name="child", context=context, parent=root_span
+            name="child", reference=reference, parent=root_span
         )
         root_span.start()
         child_span.start()
@@ -520,7 +520,7 @@ class TestDatadogSpanExporter(unittest.TestCase):
         self.assertListEqual(actual, expected)
 
     def test_sampling_rate(self):
-        context = trace_api.SpanContext(
+        reference = trace_api.SpanReference(
             trace_id=0x000000000000000000000000DEADBEEF,
             span_id=0x34BF92DEEFC58C92,
             is_remote=False,
@@ -529,7 +529,7 @@ class TestDatadogSpanExporter(unittest.TestCase):
         sampler = sampling.TraceIdRatioBased(0.5)
 
         span = trace._Span(
-            name="sampled", context=context, parent=None, sampler=sampler
+            name="sampled", reference=reference, parent=None, sampler=sampler
         )
         span.start()
         span.end()

--- a/exporter/opentelemetry-exporter-jaeger/examples/jaeger_exporter_example.py
+++ b/exporter/opentelemetry-exporter-jaeger/examples/jaeger_exporter_example.py
@@ -34,7 +34,7 @@ with tracer.start_as_current_span("foo") as foo:
     foo.set_attribute("my_atribbute", True)
     foo.add_event("event in foo", {"name": "foo1"})
     with tracer.start_as_current_span(
-        "bar", links=[trace.Link(foo.get_span_context())]
+        "bar", links=[trace.Link(foo.get_span_reference())]
     ) as bar:
         time.sleep(0.2)
         bar.set_attribute("speed", 100.0)

--- a/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/__init__.py
+++ b/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/__init__.py
@@ -208,9 +208,9 @@ def _translate_to_jaeger(spans: Span):
     jaeger_spans = []
 
     for span in spans:
-        ctx = span.get_span_context()
-        trace_id = ctx.trace_id
-        span_id = ctx.span_id
+        ref = span.get_span_reference()
+        trace_id = ref.trace_id
+        span_id = ref.span_id
 
         start_time_us = _nsec_to_usec_round(span.start_time)
         duration_us = _nsec_to_usec_round(span.end_time - span.start_time)
@@ -251,7 +251,7 @@ def _translate_to_jaeger(spans: Span):
         refs = _extract_refs_from_span(span)
         logs = _extract_logs_from_span(span)
 
-        flags = int(ctx.trace_flags)
+        flags = int(ref.trace_flags)
 
         jaeger_span = jaeger.Span(
             traceIdHigh=_get_trace_id_high(trace_id),
@@ -279,8 +279,8 @@ def _extract_refs_from_span(span):
 
     refs = []
     for link in span.links:
-        trace_id = link.context.trace_id
-        span_id = link.context.span_id
+        trace_id = link.reference.trace_id
+        span_id = link.reference.span_id
         refs.append(
             jaeger.SpanRef(
                 refType=jaeger.SpanRefType.FOLLOWS_FROM,

--- a/exporter/opentelemetry-exporter-jaeger/tests/test_jaeger_exporter.py
+++ b/exporter/opentelemetry-exporter-jaeger/tests/test_jaeger_exporter.py
@@ -31,13 +31,13 @@ from opentelemetry.trace.status import Status, StatusCanonicalCode
 class TestJaegerSpanExporter(unittest.TestCase):
     def setUp(self):
         # create and save span to be used in tests
-        context = trace_api.SpanContext(
+        reference = trace_api.SpanReference(
             trace_id=0x000000000000000000000000DEADBEEF,
             span_id=0x00000000DEADBEF0,
             is_remote=False,
         )
 
-        self._test_span = trace._Span("test_span", context=context)
+        self._test_span = trace._Span("test_span", reference=reference)
         self._test_span.start()
         self._test_span.end()
 
@@ -177,13 +177,13 @@ class TestJaegerSpanExporter(unittest.TestCase):
             start_times[2] + durations[2],
         )
 
-        span_context = trace_api.SpanContext(
+        span_reference = trace_api.SpanReference(
             trace_id, span_id, is_remote=False
         )
-        parent_span_context = trace_api.SpanContext(
+        parent_span_reference = trace_api.SpanReference(
             trace_id, parent_id, is_remote=False
         )
-        other_context = trace_api.SpanContext(
+        other_reference = trace_api.SpanReference(
             trace_id, other_id, is_remote=False
         )
 
@@ -203,7 +203,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
         link_attributes = {"key_bool": True}
 
         link = trace_api.Link(
-            context=other_context, attributes=link_attributes
+            reference=other_reference, attributes=link_attributes
         )
 
         default_tags = [
@@ -225,17 +225,19 @@ class TestJaegerSpanExporter(unittest.TestCase):
         otel_spans = [
             trace._Span(
                 name=span_names[0],
-                context=span_context,
-                parent=parent_span_context,
+                reference=span_reference,
+                parent=parent_span_reference,
                 events=(event,),
                 links=(link,),
                 kind=trace_api.SpanKind.CLIENT,
             ),
             trace._Span(
-                name=span_names[1], context=parent_span_context, parent=None
+                name=span_names[1],
+                reference=parent_span_reference,
+                parent=None,
             ),
             trace._Span(
-                name=span_names[2], context=other_context, parent=None
+                name=span_names[2], reference=other_reference, parent=None
             ),
         ]
 

--- a/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_trace_exporter.py
@@ -89,17 +89,17 @@ class TestCollectorSpanExporter(unittest.TestCase):
             start_times[1] + durations[1],
             start_times[2] + durations[2],
         )
-        span_context = trace_api.SpanContext(
+        span_reference = trace_api.SpanReference(
             trace_id,
             span_id,
             is_remote=False,
             trace_flags=TraceFlags(TraceFlags.SAMPLED),
             trace_state=trace_api.TraceState({"testKey": "testValue"}),
         )
-        parent_span_context = trace_api.SpanContext(
+        parent_span_reference = trace_api.SpanReference(
             trace_id, parent_id, is_remote=False
         )
-        other_context = trace_api.SpanContext(
+        other_reference = trace_api.SpanReference(
             trace_id, span_id, is_remote=False
         )
         event_attributes = {
@@ -115,30 +115,30 @@ class TestCollectorSpanExporter(unittest.TestCase):
         )
         link_attributes = {"key_bool": True}
         link_1 = trace_api.Link(
-            context=other_context, attributes=link_attributes
+            reference=other_reference, attributes=link_attributes
         )
         link_2 = trace_api.Link(
-            context=parent_span_context, attributes=link_attributes
+            reference=parent_span_reference, attributes=link_attributes
         )
         span_1 = trace._Span(
             name="test1",
-            context=span_context,
-            parent=parent_span_context,
+            reference=span_reference,
+            parent=parent_span_reference,
             events=(event,),
             links=(link_1,),
             kind=trace_api.SpanKind.CLIENT,
         )
         span_2 = trace._Span(
             name="test2",
-            context=parent_span_context,
+            reference=parent_span_reference,
             parent=None,
             kind=trace_api.SpanKind.SERVER,
         )
         span_3 = trace._Span(
             name="test3",
-            context=other_context,
+            reference=other_reference,
             links=(link_2,),
-            parent=span_2.get_span_context(),
+            parent=span_2.get_span_reference(),
         )
         otel_spans = [span_1, span_2, span_3]
         otel_spans[0].start(start_time=start_times[0])
@@ -295,7 +295,7 @@ class TestCollectorSpanExporter(unittest.TestCase):
 
         trace_id = 0x6E0C63257DE34C926F9EFCD03927272E
         span_id = 0x34BF92DEEFC58C92
-        span_context = trace_api.SpanContext(
+        span_reference = trace_api.SpanReference(
             trace_id,
             span_id,
             is_remote=False,
@@ -304,7 +304,7 @@ class TestCollectorSpanExporter(unittest.TestCase):
         otel_spans = [
             trace._Span(
                 name="test1",
-                context=span_context,
+                reference=span_reference,
                 kind=trace_api.SpanKind.CLIENT,
             )
         ]

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/trace_exporter/__init__.py
@@ -71,12 +71,12 @@ class OTLPSpanExporter(
     def _translate_span_id(self, sdk_span: SDKSpan) -> None:
         self._collector_span_kwargs[
             "span_id"
-        ] = sdk_span.context.span_id.to_bytes(8, "big")
+        ] = sdk_span.get_span_reference().span_id.to_bytes(8, "big")
 
     def _translate_trace_id(self, sdk_span: SDKSpan) -> None:
         self._collector_span_kwargs[
             "trace_id"
-        ] = sdk_span.context.trace_id.to_bytes(16, "big")
+        ] = sdk_span.get_span_reference().trace_id.to_bytes(16, "big")
 
     def _translate_parent(self, sdk_span: SDKSpan) -> None:
         if sdk_span.parent is not None:
@@ -85,11 +85,13 @@ class OTLPSpanExporter(
             ] = sdk_span.parent.span_id.to_bytes(8, "big")
 
     def _translate_context_trace_state(self, sdk_span: SDKSpan) -> None:
-        if sdk_span.context.trace_state is not None:
+        if sdk_span.get_span_reference().trace_state is not None:
             self._collector_span_kwargs["trace_state"] = ",".join(
                 [
                     "{}={}".format(key, value)
-                    for key, value in (sdk_span.context.trace_state.items())
+                    for key, value in (
+                        sdk_span.get_span_reference().trace_state.items()
+                    )
                 ]
             )
 
@@ -139,9 +141,11 @@ class OTLPSpanExporter(
 
                 collector_span_link = CollectorSpan.Link(
                     trace_id=(
-                        sdk_span_link.context.trace_id.to_bytes(16, "big")
+                        sdk_span_link.reference.trace_id.to_bytes(16, "big")
                     ),
-                    span_id=(sdk_span_link.context.span_id.to_bytes(8, "big")),
+                    span_id=(
+                        sdk_span_link.reference.span_id.to_bytes(8, "big")
+                    ),
                 )
 
                 for key, value in sdk_span_link.attributes.items():

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
@@ -125,7 +125,7 @@ class TestOTLPSpanExporter(TestCase):
 
         self.span = _Span(
             "a",
-            context=Mock(
+            reference=Mock(
                 **{
                     "trace_state": OrderedDict([("a", "b"), ("c", "d")]),
                     "span_id": 10217189687419569865,
@@ -139,8 +139,8 @@ class TestOTLPSpanExporter(TestCase):
             links=[
                 Mock(
                     **{
-                        "context.trace_id": 1,
-                        "context.span_id": 2,
+                        "reference.trace_id": 1,
+                        "reference.span_id": 2,
                         "attributes": OrderedDict([("a", 1), ("b", False)]),
                         "kind": OTLPSpan.SpanKind.SPAN_KIND_INTERNAL,  # pylint: disable=no-member
                     }

--- a/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/__init__.py
+++ b/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/__init__.py
@@ -70,7 +70,7 @@ from urllib.parse import urlparse
 import requests
 
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
-from opentelemetry.trace import Span, SpanContext, SpanKind
+from opentelemetry.trace import Span, SpanKind, SpanReference
 
 DEFAULT_RETRY = False
 DEFAULT_URL = "http://localhost:9411/api/v2/spans"
@@ -159,7 +159,7 @@ class ZipkinSpanExporter(SpanExporter):
 
         zipkin_spans = []
         for span in spans:
-            context = span.get_span_context()
+            context = span.get_span_reference()
             trace_id = context.trace_id
             span_id = context.span_id
 
@@ -205,9 +205,9 @@ class ZipkinSpanExporter(SpanExporter):
 
             if isinstance(span.parent, Span):
                 zipkin_span["parentId"] = format(
-                    span.parent.get_span_context().span_id, "016x"
+                    span.parent.get_span_reference().span_id, "016x"
                 )
-            elif isinstance(span.parent, SpanContext):
+            elif isinstance(span.parent, SpanReference):
                 zipkin_span["parentId"] = format(span.parent.span_id, "016x")
 
             zipkin_spans.append(zipkin_span)

--- a/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
+++ b/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
@@ -36,13 +36,13 @@ class MockResponse:
 class TestZipkinSpanExporter(unittest.TestCase):
     def setUp(self):
         # create and save span to be used in tests
-        context = trace_api.SpanContext(
+        reference = trace_api.SpanReference(
             trace_id=0x000000000000000000000000DEADBEEF,
             span_id=0x00000000DEADBEF0,
             is_remote=False,
         )
 
-        self._test_span = trace._Span("test_span", context=context)
+        self._test_span = trace._Span("test_span", reference=reference)
         self._test_span.start()
         self._test_span.end()
 
@@ -121,16 +121,16 @@ class TestZipkinSpanExporter(unittest.TestCase):
             start_times[3] + durations[3],
         )
 
-        span_context = trace_api.SpanContext(
+        span_reference = trace_api.SpanReference(
             trace_id,
             span_id,
             is_remote=False,
             trace_flags=TraceFlags(TraceFlags.SAMPLED),
         )
-        parent_span_context = trace_api.SpanContext(
+        parent_span_reference = trace_api.SpanReference(
             trace_id, parent_id, is_remote=False
         )
-        other_context = trace_api.SpanContext(
+        other_reference = trace_api.SpanReference(
             trace_id, other_id, is_remote=False
         )
 
@@ -150,25 +150,27 @@ class TestZipkinSpanExporter(unittest.TestCase):
         link_attributes = {"key_bool": True}
 
         link = trace_api.Link(
-            context=other_context, attributes=link_attributes
+            reference=other_reference, attributes=link_attributes
         )
 
         otel_spans = [
             trace._Span(
                 name=span_names[0],
-                context=span_context,
-                parent=parent_span_context,
+                reference=span_reference,
+                parent=parent_span_reference,
                 events=(event,),
                 links=(link,),
             ),
             trace._Span(
-                name=span_names[1], context=parent_span_context, parent=None
+                name=span_names[1],
+                reference=parent_span_reference,
+                parent=None,
             ),
             trace._Span(
-                name=span_names[2], context=other_context, parent=None
+                name=span_names[2], reference=other_reference, parent=None
             ),
             trace._Span(
-                name=span_names[3], context=other_context, parent=None
+                name=span_names[3], reference=other_reference, parent=None
             ),
         ]
 
@@ -322,20 +324,20 @@ class TestZipkinSpanExporter(unittest.TestCase):
         duration = 50 * 10 ** 6
         end_time = start_time + duration
 
-        span_context = trace_api.SpanContext(
+        span_reference = trace_api.SpanReference(
             trace_id,
             span_id,
             is_remote=False,
             trace_flags=TraceFlags(TraceFlags.SAMPLED),
         )
-        parent_span_context = trace_api.SpanContext(
+        parent_span_reference = trace_api.SpanReference(
             trace_id, parent_id, is_remote=False
         )
 
         otel_span = trace._Span(
             name=span_names[0],
-            context=span_context,
-            parent=parent_span_context,
+            reference=span_reference,
+            parent=parent_span_reference,
         )
 
         otel_span.start(start_time=start_time)
@@ -386,14 +388,14 @@ class TestZipkinSpanExporter(unittest.TestCase):
     def test_max_tag_length(self):
         service_name = "test-service"
 
-        span_context = trace_api.SpanContext(
+        span_reference = trace_api.SpanReference(
             0x0E0C63257DE34C926F9EFCD03927272E,
             0x04BF92DEEFC58C92,
             is_remote=False,
             trace_flags=TraceFlags(TraceFlags.SAMPLED),
         )
 
-        span = trace._Span(name="test-span", context=span_context,)
+        span = trace._Span(name="test-span", reference=span_reference,)
 
         span.start()
         span.resource = Resource({})

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_tasks.py
@@ -73,6 +73,11 @@ class TestCeleryInstrumentation(TestBase):
             },
         )
 
-        self.assertNotEqual(consumer.parent, producer.context)
-        self.assertEqual(consumer.parent.span_id, producer.context.span_id)
-        self.assertEqual(consumer.context.trace_id, producer.context.trace_id)
+        self.assertNotEqual(consumer.parent, producer.get_span_reference())
+        self.assertEqual(
+            consumer.parent.span_id, producer.get_span_reference().span_id
+        )
+        self.assertEqual(
+            consumer.get_span_reference().trace_id,
+            producer.get_span_reference().trace_id,
+        )

--- a/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-celery/tests/test_utils.py
@@ -42,7 +42,7 @@ class TestUtils(unittest.TestCase):
             "routing_key": "celery",
         }
 
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace._Span("name", mock.Mock(spec=trace_api.SpanReference))
         utils.set_attributes_from_context(span, context)
 
         self.assertEqual(
@@ -102,7 +102,7 @@ class TestUtils(unittest.TestCase):
             "retries": 0,
         }
 
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace._Span("name", mock.Mock(spec=trace_api.SpanReference))
         utils.set_attributes_from_context(span, context)
 
         self.assertEqual(len(span.attributes), 0)
@@ -123,7 +123,7 @@ class TestUtils(unittest.TestCase):
 
         # propagate and retrieve a Span
         task_id = "7c6731af-9533-40c3-83a9-25b58f0d837f"
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace._Span("name", mock.Mock(spec=trace_api.SpanReference))
         utils.attach_span(fn_task, task_id, span)
         span_after = utils.retrieve_span(fn_task, task_id)
         self.assertIs(span, span_after)
@@ -136,7 +136,7 @@ class TestUtils(unittest.TestCase):
 
         # propagate a Span
         task_id = "7c6731af-9533-40c3-83a9-25b58f0d837f"
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace._Span("name", mock.Mock(spec=trace_api.SpanReference))
         utils.attach_span(fn_task, task_id, span)
         # delete the Span
         utils.detach_span(fn_task, task_id)

--- a/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
+++ b/instrumentation/opentelemetry-instrumentation-elasticsearch/tests/test_elasticsearch.py
@@ -190,7 +190,9 @@ class TestElasticsearchIntegration(TestBase):
         self.assertEqual(spans[0].name, "parent")
         self.assertEqual(spans[1].name, "Elasticsearch/sw/people/1")
         self.assertIsNotNone(spans[1].parent)
-        self.assertEqual(spans[1].parent.span_id, spans[0].context.span_id)
+        self.assertEqual(
+            spans[1].parent.span_id, spans[0].get_span_reference().span_id
+        )
 
     def test_multithread(self, request_mock):
         request_mock.return_value = (1, {}, {})
@@ -228,7 +230,7 @@ class TestElasticsearchIntegration(TestBase):
 
         self.assertEqual(s2.name, "Elasticsearch/test-index/tweet/1")
         self.assertIsNotNone(s2.parent)
-        self.assertEqual(s2.parent.span_id, s1.context.span_id)
+        self.assertEqual(s2.parent.span_id, s1.get_span_reference().span_id)
         self.assertEqual(s3.name, "Elasticsearch/test-index/tweet/2")
         self.assertIsNone(s3.parent)
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_client.py
@@ -53,7 +53,7 @@ class _GuardedSpan:
         return self.span
 
 
-def _inject_span_context(metadata: MutableMapping[str, str]) -> None:
+def _inject_span_reference(metadata: MutableMapping[str, str]) -> None:
     # pylint:disable=unused-argument
     def append_metadata(
         carrier: MutableMapping[str, str], key: str, value: str
@@ -150,7 +150,7 @@ class OpenTelemetryClientInterceptor(
             with self._metrics_recorder.record_latency(
                 client_info.full_method
             ):
-                _inject_span_context(mutable_metadata)
+                _inject_span_reference(mutable_metadata)
                 metadata = tuple(mutable_metadata.items())
 
                 # If protobuf is used, we can record the bytes in/out. Otherwise, we have no way
@@ -194,7 +194,7 @@ class OpenTelemetryClientInterceptor(
             with self._metrics_recorder.record_latency(
                 client_info.full_method
             ):
-                _inject_span_context(mutable_metadata)
+                _inject_span_reference(mutable_metadata)
                 metadata = tuple(mutable_metadata.items())
                 rpc_info = RpcInfo(
                     full_method=client_info.full_method,
@@ -247,7 +247,7 @@ class OpenTelemetryClientInterceptor(
             with self._metrics_recorder.record_latency(
                 client_info.full_method
             ):
-                _inject_span_context(mutable_metadata)
+                _inject_span_reference(mutable_metadata)
                 metadata = tuple(mutable_metadata.items())
                 rpc_info = RpcInfo(
                     full_method=client_info.full_method,

--- a/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/tests/test_server_interceptor.py
@@ -220,8 +220,14 @@ class TestOpenTelemetryServerInterceptor(TestBase):
         span1, span2 = active_spans_in_handler
         # Spans should belong to separate traces, and each should be a root
         # span
-        self.assertNotEqual(span1.context.span_id, span2.context.span_id)
-        self.assertNotEqual(span1.context.trace_id, span2.context.trace_id)
+        self.assertNotEqual(
+            span1.get_span_reference().span_id,
+            span2.get_span_reference().span_id,
+        )
+        self.assertNotEqual(
+            span1.get_span_reference().trace_id,
+            span2.get_span_reference().trace_id,
+        )
         self.assertIsNone(span1.parent)
         self.assertIsNone(span1.parent)
 
@@ -271,8 +277,14 @@ class TestOpenTelemetryServerInterceptor(TestBase):
         span1, span2 = active_spans_in_handler
         # Spans should belong to separate traces, and each should be a root
         # span
-        self.assertNotEqual(span1.context.span_id, span2.context.span_id)
-        self.assertNotEqual(span1.context.trace_id, span2.context.trace_id)
+        self.assertNotEqual(
+            span1.get_span_reference().span_id,
+            span2.get_span_reference().span_id,
+        )
+        self.assertNotEqual(
+            span1.get_span_reference().trace_id,
+            span2.get_span_reference().trace_id,
+        )
         self.assertIsNone(span1.parent)
         self.assertIsNone(span1.parent)
 

--- a/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
+++ b/instrumentation/opentelemetry-instrumentation-jinja2/tests/test_jinja2.py
@@ -50,8 +50,8 @@ class TestJinja2Instrumentor(TestBase):
         # pylint:disable=unbalanced-tuple-unpacking
         render, template, root = spans[:3]
 
-        self.assertIs(render.parent, root.get_span_context())
-        self.assertIs(template.parent, root.get_span_context())
+        self.assertIs(render.parent, root.get_span_reference())
+        self.assertIs(template.parent, root.get_span_reference())
         self.assertIsNone(root.parent)
 
     def test_render_not_recording(self):
@@ -104,8 +104,8 @@ class TestJinja2Instrumentor(TestBase):
         # pylint:disable=unbalanced-tuple-unpacking
         template, generate, root = spans
 
-        self.assertIs(generate.parent, root.get_span_context())
-        self.assertIs(template.parent, root.get_span_context())
+        self.assertIs(generate.parent, root.get_span_reference())
+        self.assertIs(template.parent, root.get_span_reference())
         self.assertIsNone(root.parent)
 
     def test_generate_inline_template(self):
@@ -147,11 +147,11 @@ class TestJinja2Instrumentor(TestBase):
         # pylint:disable=unbalanced-tuple-unpacking
         compile2, load2, compile1, load1, render, root = spans
 
-        self.assertIs(compile2.parent, load2.get_span_context())
-        self.assertIs(load2.parent, root.get_span_context())
-        self.assertIs(compile1.parent, load1.get_span_context())
-        self.assertIs(load1.parent, render.get_span_context())
-        self.assertIs(render.parent, root.get_span_context())
+        self.assertIs(compile2.parent, load2.get_span_reference())
+        self.assertIs(load2.parent, root.get_span_reference())
+        self.assertIs(compile1.parent, load1.get_span_reference())
+        self.assertIs(load1.parent, render.get_span_reference())
+        self.assertIs(render.parent, root.get_span_reference())
         self.assertIsNone(root.parent)
 
     def test_file_template(self):

--- a/instrumentation/opentelemetry-instrumentation-opentracing-shim/tests/testbed/test_client_server/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-opentracing-shim/tests/testbed/test_client_server/README.rst
@@ -2,9 +2,9 @@
 Client-Server example.
 ======================
 
-This example shows a ``Span`` created by a ``Client``, which will send a ``Message`` / ``SpanContext`` to a ``Server``, which will in turn extract such context and use it as parent of a new (server-side) ``Span``.
+This example shows a ``Span`` created by a ``Client``, which will send a ``Message`` / ``SpanReference`` to a ``Server``, which will in turn extract such context and use it as parent of a new (server-side) ``Span``.
 
-``Client.send()`` is used to send messages and inject the ``SpanContext`` using the ``TEXT_MAP`` format, and ``Server.process()`` will process received messages and will extract the context used as parent.
+``Client.send()`` is used to send messages and inject the ``SpanReference`` using the ``TEXT_MAP`` format, and ``Server.process()`` will process received messages and will extract the context used as parent.
 
 .. code-block:: python
 

--- a/instrumentation/opentelemetry-instrumentation-opentracing-shim/tests/testbed/test_common_request_handler/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-opentracing-shim/tests/testbed/test_common_request_handler/README.rst
@@ -7,7 +7,7 @@ This example shows a ``Span`` used with ``RequestHandler``, which is used as a m
 Implementation details:
 
 
-* For ``threading``, no active ``Span`` is consumed as the tasks may be run concurrently on different threads, and an explicit ``SpanContext`` has to be saved to be used as parent.
+* For ``threading``, no active ``Span`` is consumed as the tasks may be run concurrently on different threads, and an explicit ``SpanReference`` has to be saved to be used as parent.
 
 RequestHandler implementation:
 
@@ -15,7 +15,7 @@ RequestHandler implementation:
 
        def before_request(self, request, request_context):
 
-           # If we should ignore the active Span, use any passed SpanContext
+           # If we should ignore the active Span, use any passed SpanReference
            # as the parent. Else, use the active one.
            span = self.tracer.start_span("send",
                                          child_of=self.context,

--- a/instrumentation/opentelemetry-instrumentation-opentracing-shim/tests/testbed/test_common_request_handler/request_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-opentracing-shim/tests/testbed/test_common_request_handler/request_handler.py
@@ -16,7 +16,7 @@ class RequestHandler:
     def before_request(self, request, request_context):
         logger.info("Before request %s", request)
 
-        # If we should ignore the active Span, use any passed SpanContext
+        # If we should ignore the active Span, use any passed SpanReference
         # as the parent. Else, use the active one.
         if self.ignore_active_span:
             span = self.tracer.start_span(

--- a/instrumentation/opentelemetry-instrumentation-opentracing-shim/tests/testbed/testcase.py
+++ b/instrumentation/opentelemetry-instrumentation-opentracing-shim/tests/testbed/testcase.py
@@ -6,41 +6,45 @@ import opentelemetry.trace as trace_api
 # pylint: disable=C0103
 class OpenTelemetryTestCase(unittest.TestCase):
     def assertSameTrace(self, spanA, spanB):
-        return self.assertEqual(spanA.context.trace_id, spanB.context.trace_id)
+        return self.assertEqual(
+            spanA.get_span_reference().trace_id,
+            spanB.get_span_reference().trace_id,
+        )
 
     def assertNotSameTrace(self, spanA, spanB):
         return self.assertNotEqual(
-            spanA.context.trace_id, spanB.context.trace_id
+            spanA.get_span_reference().trace_id,
+            spanB.get_span_reference().trace_id,
         )
 
     def assertIsChildOf(self, spanA, spanB):
         # spanA is child of spanB
         self.assertIsNotNone(spanA.parent)
 
-        ctxA = spanA.parent
-        if isinstance(spanA.parent, trace_api.Span):
-            ctxA = spanA.parent.context
+        refA = spanA.parent
+        if isinstance(refA, trace_api.Span):
+            refA = spanA.parent.get_span_reference()
 
-        ctxB = spanB
-        if isinstance(ctxB, trace_api.Span):
-            ctxB = spanB.context
+        refB = spanB
+        if isinstance(refB, trace_api.Span):
+            refB = spanB.get_span_reference()
 
-        return self.assertEqual(ctxA.span_id, ctxB.span_id)
+        return self.assertEqual(refA.span_id, refB.span_id)
 
     def assertIsNotChildOf(self, spanA, spanB):
         # spanA is NOT child of spanB
         if spanA.parent is None:
             return
 
-        ctxA = spanA.parent
-        if isinstance(spanA.parent, trace_api.Span):
-            ctxA = spanA.parent.context
+        refA = spanA.parent
+        if isinstance(refA, trace_api.Span):
+            refA = spanA.parent.get_span_reference()
 
-        ctxB = spanB
-        if isinstance(ctxB, trace_api.Span):
-            ctxB = spanB.context
+        refB = spanB
+        if isinstance(refB, trace_api.Span):
+            refB = spanB.get_span_reference()
 
-        self.assertNotEqual(ctxA.span_id, ctxB.span_id)
+        self.assertNotEqual(refA.span_id, refB.span_id)
 
     def assertNamesEqual(self, spans, names):
         self.assertEqual(list(map(lambda x: x.name, spans)), names)

--- a/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-requests/tests/test_requests_integration.py
@@ -198,12 +198,12 @@ class RequestsIntegrationTestBase(abc.ABC):
             headers = dict(httpretty.last_request().headers)
             self.assertIn(MockTextMapPropagator.TRACE_ID_KEY, headers)
             self.assertEqual(
-                str(span.get_span_context().trace_id),
+                str(span.get_span_reference().trace_id),
                 headers[MockTextMapPropagator.TRACE_ID_KEY],
             )
             self.assertIn(MockTextMapPropagator.SPAN_ID_KEY, headers)
             self.assertEqual(
-                str(span.get_span_context().span_id),
+                str(span.get_span_reference().span_id),
                 headers[MockTextMapPropagator.SPAN_ID_KEY],
             )
 

--- a/instrumentation/opentelemetry-instrumentation-sqlite3/tests/test_sqlite3.py
+++ b/instrumentation/opentelemetry-instrumentation-sqlite3/tests/test_sqlite3.py
@@ -52,7 +52,7 @@ class TestSQLite3(TestBase):
         self.assertEqual(root_span.name, "rootSpan")
         self.assertEqual(child_span.name, "sqlite3")
         self.assertIsNotNone(child_span.parent)
-        self.assertIs(child_span.parent, root_span.get_span_context())
+        self.assertIs(child_span.parent, root_span.get_span_reference())
         self.assertIs(child_span.kind, trace_api.SpanKind.CLIENT)
 
     def test_execute(self):

--- a/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-tornado/tests/test_instrumentation.py
@@ -93,14 +93,22 @@ class TestTornadoInstrumentation(TornadoTest):
         manual, server, client = self.sorted_spans(spans)
 
         self.assertEqual(manual.name, "manual")
-        self.assertEqual(manual.parent, server.context)
-        self.assertEqual(manual.context.trace_id, client.context.trace_id)
+        self.assertEqual(manual.parent, server.reference)
+        self.assertEqual(
+            manual.get_span_reference().trace_id,
+            client.get_span_reference().trace_id,
+        )
 
         self.assertEqual(server.name, "MainHandler." + method.lower())
         self.assertTrue(server.parent.is_remote)
-        self.assertNotEqual(server.parent, client.context)
-        self.assertEqual(server.parent.span_id, client.context.span_id)
-        self.assertEqual(server.context.trace_id, client.context.trace_id)
+        self.assertNotEqual(server.parent, client.reference)
+        self.assertEqual(
+            server.parent.span_id, client.get_span_reference().span_id
+        )
+        self.assertEqual(
+            server.get_span_reference().trace_id,
+            client.get_span_reference().trace_id,
+        )
         self.assertEqual(server.kind, SpanKind.SERVER)
         self.assert_span_has_attributes(
             server,
@@ -117,7 +125,7 @@ class TestTornadoInstrumentation(TornadoTest):
         )
 
         self.assertEqual(client.name, method)
-        self.assertFalse(client.context.is_remote)
+        self.assertFalse(client.get_span_reference().is_remote)
         self.assertIsNone(client.parent)
         self.assertEqual(client.kind, SpanKind.CLIENT)
         self.assert_span_has_attributes(
@@ -162,22 +170,36 @@ class TestTornadoInstrumentation(TornadoTest):
         sub2, sub1, sub_wrapper, server, client = self.sorted_spans(spans)
 
         self.assertEqual(sub2.name, "sub-task-2")
-        self.assertEqual(sub2.parent, sub_wrapper.context)
-        self.assertEqual(sub2.context.trace_id, client.context.trace_id)
+        self.assertEqual(sub2.parent, sub_wrapper.get_span_reference())
+        self.assertEqual(
+            sub2.get_span_reference().trace_id,
+            client.get_span_reference().trace_id,
+        )
 
         self.assertEqual(sub1.name, "sub-task-1")
-        self.assertEqual(sub1.parent, sub_wrapper.context)
-        self.assertEqual(sub1.context.trace_id, client.context.trace_id)
+        self.assertEqual(sub1.parent, sub_wrapper.get_span_reference())
+        self.assertEqual(
+            sub1.get_span_reference().trace_id,
+            client.get_span_reference().trace_id,
+        )
 
         self.assertEqual(sub_wrapper.name, "sub-task-wrapper")
-        self.assertEqual(sub_wrapper.parent, server.context)
-        self.assertEqual(sub_wrapper.context.trace_id, client.context.trace_id)
+        self.assertEqual(sub_wrapper.parent, server.get_span_reference())
+        self.assertEqual(
+            sub_wrapper.get_span_reference().trace_id,
+            client.get_span_reference().trace_id,
+        )
 
         self.assertEqual(server.name, handler_name + ".get")
         self.assertTrue(server.parent.is_remote)
-        self.assertNotEqual(server.parent, client.context)
-        self.assertEqual(server.parent.span_id, client.context.span_id)
-        self.assertEqual(server.context.trace_id, client.context.trace_id)
+        self.assertNotEqual(server.parent, client.get_span_reference())
+        self.assertEqual(
+            server.parent.span_id, client.get_span_reference().span_id
+        )
+        self.assertEqual(
+            server.get_span_reference().trace_id,
+            client.get_span_reference().trace_id,
+        )
         self.assertEqual(server.kind, SpanKind.SERVER)
         self.assert_span_has_attributes(
             server,
@@ -194,7 +216,7 @@ class TestTornadoInstrumentation(TornadoTest):
         )
 
         self.assertEqual(client.name, "GET")
-        self.assertFalse(client.context.is_remote)
+        self.assertFalse(client.get_span_reference().is_remote)
         self.assertIsNone(client.parent)
         self.assertEqual(client.kind, SpanKind.CLIENT)
         self.assert_span_has_attributes(
@@ -294,9 +316,14 @@ class TestTornadoInstrumentation(TornadoTest):
 
         self.assertEqual(server.name, "DynamicHandler.get")
         self.assertTrue(server.parent.is_remote)
-        self.assertNotEqual(server.parent, client.context)
-        self.assertEqual(server.parent.span_id, client.context.span_id)
-        self.assertEqual(server.context.trace_id, client.context.trace_id)
+        self.assertNotEqual(server.parent, client.get_span_reference())
+        self.assertEqual(
+            server.parent.span_id, client.get_span_reference().span_id
+        )
+        self.assertEqual(
+            server.get_span_reference().trace_id,
+            client.get_span_reference().trace_id,
+        )
         self.assertEqual(server.kind, SpanKind.SERVER)
         self.assert_span_has_attributes(
             server,
@@ -313,7 +340,7 @@ class TestTornadoInstrumentation(TornadoTest):
         )
 
         self.assertEqual(client.name, "GET")
-        self.assertFalse(client.context.is_remote)
+        self.assertFalse(client.get_span_reference().is_remote)
         self.assertIsNone(client.parent)
         self.assertEqual(client.kind, SpanKind.CLIENT)
         self.assert_span_has_attributes(

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Rename SpanContext to SpanReference
-  ([]())
+  ([#1248](https://github.com/open-telemetry/opentelemetry-python/pull/1248))
 
 ## Version 0.14b0
 

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Rename SpanContext to SpanReference
+  ([]())
+
 ## Version 0.14b0
 
 Released 2020-10-13

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -90,12 +90,12 @@ from opentelemetry.trace.span import (
     DEFAULT_TRACE_OPTIONS,
     DEFAULT_TRACE_STATE,
     INVALID_SPAN,
-    INVALID_SPAN_CONTEXT,
     INVALID_SPAN_ID,
+    INVALID_SPAN_REFERENCE,
     INVALID_TRACE_ID,
     DefaultSpan,
     Span,
-    SpanContext,
+    SpanReference,
     TraceFlags,
     TraceState,
     format_span_id,
@@ -108,12 +108,12 @@ logger = getLogger(__name__)
 
 
 class LinkBase(abc.ABC):
-    def __init__(self, context: "SpanContext") -> None:
-        self._context = context
+    def __init__(self, reference: "SpanReference") -> None:
+        self._reference = reference
 
     @property
-    def context(self) -> "SpanContext":
-        return self._context
+    def reference(self) -> "SpanReference":
+        return self._reference
 
     @property
     @abc.abstractmethod
@@ -125,14 +125,14 @@ class Link(LinkBase):
     """A link to a `Span`.
 
     Args:
-        context: `SpanContext` of the `Span` to link to.
+        reference: `SpanReference` of the `Span` to link to.
         attributes: Link's attributes.
     """
 
     def __init__(
-        self, context: "SpanContext", attributes: types.Attributes = None,
+        self, reference: "SpanReference", attributes: types.Attributes = None,
     ) -> None:
-        super().__init__(context)
+        super().__init__(reference)
         self._attributes = attributes
 
     @property
@@ -223,7 +223,7 @@ class Tracer(abc.ABC):
 
     # Constant used to represent the current span being used as a parent.
     # This is the default behavior when creating spans.
-    CURRENT_SPAN = DefaultSpan(INVALID_SPAN_CONTEXT)
+    CURRENT_SPAN = DefaultSpan(INVALID_SPAN_REFERENCE)
 
     @abc.abstractmethod
     def start_span(
@@ -455,7 +455,7 @@ __all__ = [
     "DEFAULT_TRACE_STATE",
     "IdsGenerator",
     "INVALID_SPAN",
-    "INVALID_SPAN_CONTEXT",
+    "INVALID_SPAN_REFERENCE",
     "INVALID_SPAN_ID",
     "INVALID_TRACE_ID",
     "DefaultSpan",
@@ -465,7 +465,7 @@ __all__ = [
     "LinkBase",
     "RandomIdsGenerator",
     "Span",
-    "SpanContext",
+    "SpanReference",
     "SpanKind",
     "TraceFlags",
     "TraceState",

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py
@@ -64,7 +64,7 @@ class TraceContextTextMapPropagator(textmap.TextMapPropagator):
         carrier: textmap.TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> Context:
-        """Extracts SpanContext from the carrier.
+        """Extracts SpanReference from the carrier.
 
         See `opentelemetry.trace.propagation.textmap.TextMapPropagator.extract`
         """
@@ -96,7 +96,7 @@ class TraceContextTextMapPropagator(textmap.TextMapPropagator):
         )
         tracestate = _parse_tracestate(tracestate_headers)
 
-        span_context = trace.SpanContext(
+        span_reference = trace.SpanReference(
             trace_id=int(trace_id, 16),
             span_id=int(span_id, 16),
             is_remote=True,
@@ -104,7 +104,7 @@ class TraceContextTextMapPropagator(textmap.TextMapPropagator):
             trace_state=tracestate,
         )
         return trace.set_span_in_context(
-            trace.DefaultSpan(span_context), context
+            trace.DefaultSpan(span_reference), context
         )
 
     def inject(
@@ -113,24 +113,24 @@ class TraceContextTextMapPropagator(textmap.TextMapPropagator):
         carrier: textmap.TextMapPropagatorT,
         context: typing.Optional[Context] = None,
     ) -> None:
-        """Injects SpanContext into the carrier.
+        """Injects SpanReference into the carrier.
 
         See `opentelemetry.trace.propagation.textmap.TextMapPropagator.inject`
         """
         span = trace.get_current_span(context)
-        span_context = span.get_span_context()
-        if span_context == trace.INVALID_SPAN_CONTEXT:
+        span_reference = span.get_span_reference()
+        if span_reference == trace.INVALID_SPAN_REFERENCE:
             return
         traceparent_string = "00-{:032x}-{:016x}-{:02x}".format(
-            span_context.trace_id,
-            span_context.span_id,
-            span_context.trace_flags,
+            span_reference.trace_id,
+            span_reference.span_id,
+            span_reference.trace_flags,
         )
         set_in_carrier(
             carrier, self._TRACEPARENT_HEADER_NAME, traceparent_string
         )
-        if span_context.trace_state:
-            tracestate_string = _format_tracestate(span_context.trace_state)
+        if span_reference.trace_state:
+            tracestate_string = _format_tracestate(span_reference.trace_state)
             set_in_carrier(
                 carrier, self._TRACESTATE_HEADER_NAME, tracestate_string
             )

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -23,14 +23,14 @@ class Span(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_span_context(self) -> "SpanContext":
-        """Gets the span's SpanContext.
+    def get_span_reference(self) -> "SpanReference":
+        """Gets the span's SpanReference.
 
         Get an immutable, serializable identifier for this span that can be
         used to create new child spans.
 
         Returns:
-            A :class:`opentelemetry.trace.SpanContext` with a copy of this span's immutable state.
+            A :class:`opentelemetry.trace.SpanReference` with a copy of this span's immutable state.
         """
 
     @abc.abstractmethod
@@ -146,7 +146,7 @@ class TraceState(typing.Dict[str, str]):
 DEFAULT_TRACE_STATE = TraceState.get_default()
 
 
-class SpanContext(
+class SpanReference(
     typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]
 ):
     """The state of a Span to propagate between processes.
@@ -169,7 +169,7 @@ class SpanContext(
         is_remote: bool,
         trace_flags: "TraceFlags" = DEFAULT_TRACE_OPTIONS,
         trace_state: "TraceState" = DEFAULT_TRACE_STATE,
-    ) -> "SpanContext":
+    ) -> "SpanReference":
         if trace_flags is None:
             trace_flags = DEFAULT_TRACE_OPTIONS
         if trace_state is None:
@@ -234,11 +234,11 @@ class DefaultSpan(Span):
     All operations are no-op except context propagation.
     """
 
-    def __init__(self, context: "SpanContext") -> None:
-        self._context = context
+    def __init__(self, reference: "SpanReference") -> None:
+        self._reference = reference
 
-    def get_span_context(self) -> "SpanContext":
-        return self._context
+    def get_span_reference(self) -> "SpanReference":
+        return self._reference
 
     def is_recording(self) -> bool:
         return False
@@ -269,14 +269,14 @@ class DefaultSpan(Span):
 
 INVALID_SPAN_ID = 0x0000000000000000
 INVALID_TRACE_ID = 0x00000000000000000000000000000000
-INVALID_SPAN_CONTEXT = SpanContext(
+INVALID_SPAN_REFERENCE = SpanReference(
     trace_id=INVALID_TRACE_ID,
     span_id=INVALID_SPAN_ID,
     is_remote=False,
     trace_flags=DEFAULT_TRACE_OPTIONS,
     trace_state=DEFAULT_TRACE_STATE,
 )
-INVALID_SPAN = DefaultSpan(INVALID_SPAN_CONTEXT)
+INVALID_SPAN = DefaultSpan(INVALID_SPAN_REFERENCE)
 
 
 def format_trace_id(trace_id: int) -> str:

--- a/opentelemetry-api/tests/propagators/test_global_httptextformat.py
+++ b/opentelemetry-api/tests/propagators/test_global_httptextformat.py
@@ -48,12 +48,12 @@ class TestDefaultGlobalPropagator(unittest.TestCase):
         baggage_entries = baggage.get_all(context=ctx)
         expected = {"key1": "val1", "key2": "val2"}
         self.assertEqual(baggage_entries, expected)
-        span_context = get_current_span(context=ctx).get_span_context()
+        span_reference = get_current_span(context=ctx).get_span_reference()
 
-        self.assertEqual(span_context.trace_id, self.TRACE_ID)
-        self.assertEqual(span_context.span_id, self.SPAN_ID)
+        self.assertEqual(span_reference.trace_id, self.TRACE_ID)
+        self.assertEqual(span_reference.span_id, self.SPAN_ID)
 
-        span = trace.DefaultSpan(span_context)
+        span = trace.DefaultSpan(span_reference)
         ctx = baggage.set_baggage("key3", "val3")
         ctx = baggage.set_baggage("key4", "val4", context=ctx)
         ctx = set_span_in_context(span, context=ctx)

--- a/opentelemetry-api/tests/test_implementation.py
+++ b/opentelemetry-api/tests/test_implementation.py
@@ -38,13 +38,13 @@ class TestAPIOnlyImplementation(unittest.TestCase):
         tracer = tracer_provider.get_tracer(__name__)
         with tracer.start_span("test") as span:
             self.assertEqual(
-                span.get_span_context(), trace.INVALID_SPAN_CONTEXT
+                span.get_span_reference(), trace.INVALID_SPAN_REFERENCE
             )
             self.assertEqual(span, trace.INVALID_SPAN)
             self.assertIs(span.is_recording(), False)
             with tracer.start_span("test2") as span2:
                 self.assertEqual(
-                    span2.get_span_context(), trace.INVALID_SPAN_CONTEXT
+                    span2.get_span_reference(), trace.INVALID_SPAN_REFERENCE
                 )
                 self.assertEqual(span2, trace.INVALID_SPAN)
                 self.assertIs(span2.is_recording(), False)
@@ -55,8 +55,10 @@ class TestAPIOnlyImplementation(unittest.TestCase):
             trace.Span()  # type:ignore
 
     def test_default_span(self):
-        span = trace.DefaultSpan(trace.INVALID_SPAN_CONTEXT)
-        self.assertEqual(span.get_span_context(), trace.INVALID_SPAN_CONTEXT)
+        span = trace.DefaultSpan(trace.INVALID_SPAN_REFERENCE)
+        self.assertEqual(
+            span.get_span_reference(), trace.INVALID_SPAN_REFERENCE
+        )
         self.assertIs(span.is_recording(), False)
 
     # METER

--- a/opentelemetry-api/tests/trace/test_defaultspan.py
+++ b/opentelemetry-api/tests/trace/test_defaultspan.py
@@ -19,7 +19,7 @@ from opentelemetry import trace
 
 class TestDefaultSpan(unittest.TestCase):
     def test_ctor(self):
-        context = trace.SpanContext(
+        context = trace.SpanReference(
             1,
             1,
             is_remote=False,
@@ -27,9 +27,9 @@ class TestDefaultSpan(unittest.TestCase):
             trace_state=trace.DEFAULT_TRACE_STATE,
         )
         span = trace.DefaultSpan(context)
-        self.assertEqual(context, span.get_span_context())
+        self.assertEqual(context, span.get_span_reference())
 
     def test_invalid_span(self):
         self.assertIsNotNone(trace.INVALID_SPAN)
-        self.assertIsNotNone(trace.INVALID_SPAN.get_span_context())
-        self.assertFalse(trace.INVALID_SPAN.get_span_context().is_valid)
+        self.assertIsNotNone(trace.INVALID_SPAN.get_span_reference())
+        self.assertFalse(trace.INVALID_SPAN.get_span_reference().is_valid)

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -30,7 +30,7 @@ class TestTracer(unittest.TestCase):
         be retrievable via get_current_span
         """
         self.assertEqual(trace.get_current_span(), trace.INVALID_SPAN)
-        span = trace.DefaultSpan(trace.INVALID_SPAN_CONTEXT)
+        span = trace.DefaultSpan(trace.INVALID_SPAN_REFERENCE)
         ctx = trace.set_span_in_context(span)
         token = context.attach(ctx)
         try:

--- a/opentelemetry-api/tests/trace/test_immutablespancontext.py
+++ b/opentelemetry-api/tests/trace/test_immutablespancontext.py
@@ -18,9 +18,9 @@ from opentelemetry import trace
 from opentelemetry.trace import TraceFlags, TraceState
 
 
-class TestImmutableSpanContext(unittest.TestCase):
+class TestImmutableSpanReference(unittest.TestCase):
     def test_ctor(self):
-        context = trace.SpanContext(
+        context = trace.SpanReference(
             1,
             1,
             is_remote=False,
@@ -35,7 +35,7 @@ class TestImmutableSpanContext(unittest.TestCase):
         self.assertEqual(context.trace_state, trace.DEFAULT_TRACE_STATE)
 
     def test_attempt_change_attributes(self):
-        context = trace.SpanContext(
+        context = trace.SpanReference(
             1,
             2,
             is_remote=False,

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -30,7 +30,7 @@ class TestTracer(unittest.TestCase):
             self.assertIsInstance(span, trace.Span)
 
     def test_use_span(self):
-        span = trace.DefaultSpan(trace.INVALID_SPAN_CONTEXT)
+        span = trace.DefaultSpan(trace.INVALID_SPAN_REFERENCE)
         with self.tracer.use_span(span):
             pass
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Rename SpanContext to SpanReference
-  ([]())
+  ([#1248](https://github.com/open-telemetry/opentelemetry-python/pull/1248))
 
 ## Version 0.14b0
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Rename SpanContext to SpanReference
+  ([]())
+
 ## Version 0.14b0
 
 Released 2020-10-13

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -75,7 +75,7 @@ class SimpleExportSpanProcessor(SpanProcessor):
         pass
 
     def on_end(self, span: Span) -> None:
-        if not span.context.trace_flags.sampled:
+        if not span.get_span_reference().trace_flags.sampled:
             return
         token = attach(set_value("suppress_instrumentation", True))
         try:
@@ -180,7 +180,7 @@ class BatchExportSpanProcessor(SpanProcessor):
         if self.done:
             logger.warning("Already shutdown, dropping span.")
             return
-        if not span.context.trace_flags.sampled:
+        if not span.get_span_reference().trace_flags.sampled:
             return
         if len(self.queue) == self.max_queue_size:
             if not self._spans_dropped:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -66,7 +66,7 @@ from types import MappingProxyType
 from typing import Optional, Sequence
 
 # pylint: disable=unused-import
-from opentelemetry.trace import Link, SpanContext
+from opentelemetry.trace import Link, SpanReference
 from opentelemetry.util.types import Attributes
 
 
@@ -113,7 +113,7 @@ class Sampler(abc.ABC):
     @abc.abstractmethod
     def should_sample(
         self,
-        parent_span_context: Optional["SpanContext"],
+        parent_span_reference: Optional["SpanReference"],
         trace_id: int,
         name: str,
         attributes: Attributes = None,
@@ -134,7 +134,7 @@ class StaticSampler(Sampler):
 
     def should_sample(
         self,
-        parent_span_context: Optional["SpanContext"],
+        parent_span_reference: Optional["SpanReference"],
         trace_id: int,
         name: str,
         attributes: Attributes = None,
@@ -188,7 +188,7 @@ class TraceIdRatioBased(Sampler):
 
     def should_sample(
         self,
-        parent_span_context: Optional["SpanContext"],
+        parent_span_reference: Optional["SpanReference"],
         trace_id: int,
         name: str,
         attributes: Attributes = None,  # TODO
@@ -220,22 +220,22 @@ class ParentBased(Sampler):
 
     def should_sample(
         self,
-        parent_span_context: Optional["SpanContext"],
+        parent_span_reference: Optional["SpanReference"],
         trace_id: int,
         name: str,
         attributes: Attributes = None,  # TODO
         links: Sequence["Link"] = (),
     ) -> "SamplingResult":
-        if parent_span_context is not None:
+        if parent_span_reference is not None:
             if (
-                not parent_span_context.is_valid
-                or not parent_span_context.trace_flags.sampled
+                not parent_span_reference.is_valid
+                or not parent_span_reference.trace_flags.sampled
             ):
                 return SamplingResult(Decision.DROP)
             return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes)
 
         return self._delegate.should_sample(
-            parent_span_context=parent_span_context,
+            parent_span_reference=parent_span_reference,
             trace_id=trace_id,
             name=name,
             attributes=attributes,

--- a/opentelemetry-sdk/tests/context/test_asyncio.py
+++ b/opentelemetry-sdk/tests/context/test_asyncio.py
@@ -108,4 +108,4 @@ class TestAsyncio(unittest.TestCase):
         for span in span_list:
             if span is expected_parent:
                 continue
-            self.assertEqual(span.parent, expected_parent.get_span_context())
+            self.assertEqual(span.parent, expected_parent.get_span_reference())

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -123,7 +123,7 @@ class TestSimpleExportSpanProcessor(unittest.TestCase):
 def _create_start_and_end_span(name, span_processor):
     span = trace._Span(
         name,
-        trace_api.SpanContext(
+        trace_api.SpanReference(
             0xDEADBEEF,
             0xDEADBEEF,
             is_remote=False,
@@ -403,7 +403,7 @@ class TestConsoleSpanExporter(unittest.TestCase):
 
         # Mocking stdout interferes with debugging and test reporting, mock on
         # the exporter instance instead.
-        span = trace._Span("span name", trace_api.INVALID_SPAN_CONTEXT)
+        span = trace._Span("span name", trace_api.INVALID_SPAN_REFERENCE)
         with mock.patch.object(exporter, "out") as mock_stdout:
             exporter.export([span])
         mock_stdout.write.assert_called_once_with(span.to_json() + os.linesep)

--- a/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
+++ b/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
@@ -61,7 +61,7 @@ class TestInMemorySpanExporter(unittest.TestCase):
         self.assertEqual(len(span_list), 3)
 
     def test_return_code(self):
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = trace._Span("name", mock.Mock(spec=trace_api.SpanReference))
         span_list = (span,)
         memory_exporter = InMemorySpanExporter()
 

--- a/opentelemetry-sdk/tests/trace/test_implementation.py
+++ b/opentelemetry-sdk/tests/trace/test_implementation.py
@@ -15,7 +15,7 @@
 import unittest
 
 from opentelemetry.sdk import trace
-from opentelemetry.trace import INVALID_SPAN, INVALID_SPAN_CONTEXT
+from opentelemetry.trace import INVALID_SPAN, INVALID_SPAN_REFERENCE
 
 
 class TestTracerImplementation(unittest.TestCase):
@@ -29,12 +29,14 @@ class TestTracerImplementation(unittest.TestCase):
     def test_tracer(self):
         tracer = trace.TracerProvider().get_tracer(__name__)
         with tracer.start_span("test") as span:
-            self.assertNotEqual(span.get_span_context(), INVALID_SPAN_CONTEXT)
+            self.assertNotEqual(
+                span.get_span_reference(), INVALID_SPAN_REFERENCE
+            )
             self.assertNotEqual(span, INVALID_SPAN)
             self.assertIs(span.is_recording(), True)
             with tracer.start_span("test2") as span2:
                 self.assertNotEqual(
-                    span2.get_span_context(), INVALID_SPAN_CONTEXT
+                    span2.get_span_reference(), INVALID_SPAN_REFERENCE
                 )
                 self.assertNotEqual(span2, INVALID_SPAN)
                 self.assertIs(span2.is_recording(), True)
@@ -44,6 +46,6 @@ class TestTracerImplementation(unittest.TestCase):
             # pylint: disable=no-value-for-parameter
             span = trace._Span()
 
-        span = trace._Span("name", INVALID_SPAN_CONTEXT)
-        self.assertEqual(span.get_span_context(), INVALID_SPAN_CONTEXT)
+        span = trace._Span("name", INVALID_SPAN_REFERENCE)
+        self.assertEqual(span.get_span_reference(), INVALID_SPAN_REFERENCE)
         self.assertIs(span.is_recording(), True)

--- a/opentelemetry-sdk/tests/trace/test_sampling.py
+++ b/opentelemetry-sdk/tests/trace/test_sampling.py
@@ -60,7 +60,7 @@ class TestSamplingResult(unittest.TestCase):
 class TestSampler(unittest.TestCase):
     def test_always_on(self):
         no_record_always_on = sampling.ALWAYS_ON.should_sample(
-            trace.SpanContext(
+            trace.SpanReference(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_DEFAULT
             ),
             0xDEADBEF1,
@@ -73,7 +73,7 @@ class TestSampler(unittest.TestCase):
         )
 
         sampled_always_on = sampling.ALWAYS_ON.should_sample(
-            trace.SpanContext(
+            trace.SpanReference(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_SAMPLED
             ),
             0xDEADBEF1,
@@ -87,7 +87,7 @@ class TestSampler(unittest.TestCase):
 
     def test_always_off(self):
         no_record_always_off = sampling.ALWAYS_OFF.should_sample(
-            trace.SpanContext(
+            trace.SpanReference(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_DEFAULT
             ),
             0xDEADBEF1,
@@ -98,7 +98,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(no_record_always_off.attributes, {})
 
         sampled_always_on = sampling.ALWAYS_OFF.should_sample(
-            trace.SpanContext(
+            trace.SpanReference(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_SAMPLED
             ),
             0xDEADBEF1,
@@ -110,7 +110,7 @@ class TestSampler(unittest.TestCase):
 
     def test_default_on(self):
         no_record_default_on = sampling.DEFAULT_ON.should_sample(
-            trace.SpanContext(
+            trace.SpanReference(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_DEFAULT
             ),
             0xDEADBEF1,
@@ -121,7 +121,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(no_record_default_on.attributes, {})
 
         sampled_default_on = sampling.DEFAULT_ON.should_sample(
-            trace.SpanContext(
+            trace.SpanReference(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_SAMPLED
             ),
             0xDEADBEF1,
@@ -143,7 +143,7 @@ class TestSampler(unittest.TestCase):
 
     def test_default_off(self):
         no_record_default_off = sampling.DEFAULT_OFF.should_sample(
-            trace.SpanContext(
+            trace.SpanReference(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_DEFAULT
             ),
             0xDEADBEF1,
@@ -154,7 +154,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(no_record_default_off.attributes, {})
 
         sampled_default_off = sampling.DEFAULT_OFF.should_sample(
-            trace.SpanContext(
+            trace.SpanReference(
                 0xDEADBEEF, 0xDEADBEF0, is_remote=False, trace_flags=TO_SAMPLED
             ),
             0xDEADBEF1,
@@ -278,7 +278,7 @@ class TestSampler(unittest.TestCase):
         # Check that the sampling decision matches the parent context if given
         self.assertFalse(
             sampler.should_sample(
-                trace.SpanContext(
+                trace.SpanReference(
                     0xDEADBEF0,
                     0xDEADBEF1,
                     is_remote=False,
@@ -293,7 +293,7 @@ class TestSampler(unittest.TestCase):
         sampler2 = sampling.ParentBased(sampling.ALWAYS_OFF)
         self.assertTrue(
             sampler2.should_sample(
-                trace.SpanContext(
+                trace.SpanReference(
                     0xDEADBEF0,
                     0xDEADBEF1,
                     is_remote=False,

--- a/opentelemetry-sdk/tests/trace/test_span_processor.py
+++ b/opentelemetry-sdk/tests/trace/test_span_processor.py
@@ -149,8 +149,8 @@ class MultiSpanProcessorTestBase(abc.ABC):
 
     @staticmethod
     def create_default_span() -> trace_api.Span:
-        span_context = trace_api.SpanContext(37, 73, is_remote=False)
-        return trace_api.DefaultSpan(span_context)
+        span_reference = trace_api.SpanReference(37, 73, is_remote=False)
+        return trace_api.DefaultSpan(span_reference)
 
     def test_on_start(self):
         multi_processor = self.create_multi_span_processor()

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1048,7 +1048,7 @@ class TestSpanProcessor(unittest.TestCase):
         date_str = ns_to_iso_str(123)
         self.assertEqual(
             span.to_json(indent=None),
-            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "attributes": {"key": "value"}, "events": [{"name": "event", "timestamp": "'
+            '{"name": "span-name", "reference": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "attributes": {"key": "value"}, "events": [{"name": "event", "timestamp": "'
             + date_str
             + '", "attributes": {"key2": "value2"}}], "links": [], "resource": {}}',
         )

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1035,7 +1035,7 @@ class TestSpanProcessor(unittest.TestCase):
         )
 
     def test_attributes_to_json(self):
-        context = trace_api.SpanContext(
+        context = trace_api.SpanReference(
             trace_id=0x000000000000000000000000DEADBEEF,
             span_id=0x00000000DEADBEF0,
             is_remote=False,

--- a/tests/opentelemetry-docker-tests/tests/celery/test_celery_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/celery/test_celery_functional.py
@@ -46,9 +46,12 @@ def test_instrumentation_info(celery_app, memory_exporter):
 
     async_span, run_span = spans
 
-    assert run_span.parent == async_span.context
-    assert run_span.parent.span_id == async_span.context.span_id
-    assert run_span.context.trace_id == async_span.context.trace_id
+    assert run_span.parent == async_span.get_span_reference()
+    assert run_span.parent.span_id == async_span.get_span_reference().span_id
+    assert (
+        run_span.get_span_reference().trace_id
+        == async_span.get_span_reference().trace_id
+    )
 
     assert async_span.instrumentation_info.name == "apply_async/{0}".format(
         opentelemetry.instrumentation.celery.__name__
@@ -154,7 +157,10 @@ def test_fn_task_apply_async(celery_app, memory_exporter):
 
     async_span, run_span = spans
 
-    assert run_span.context.trace_id != async_span.context.trace_id
+    assert (
+        run_span.get_span_reference().trace_id
+        != async_span.get_span_reference().trace_id
+    )
 
     assert async_span.status.is_ok is True
     assert (
@@ -209,7 +215,10 @@ def test_fn_task_delay(celery_app, memory_exporter):
 
     async_span, run_span = spans
 
-    assert run_span.context.trace_id != async_span.context.trace_id
+    assert (
+        run_span.get_span_reference().trace_id
+        != async_span.get_span_reference().trace_id
+    )
 
     assert async_span.status.is_ok is True
     assert (

--- a/tests/opentelemetry-docker-tests/tests/mysql/test_mysql_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/mysql/test_mysql_functional.py
@@ -68,7 +68,7 @@ class TestFunctionalMysql(TestBase):
         self.assertEqual(root_span.name, "rootSpan")
         self.assertEqual(db_span.name, "mysql.opentelemetry-tests")
         self.assertIsNotNone(db_span.parent)
-        self.assertIs(db_span.parent, root_span.get_span_context())
+        self.assertIs(db_span.parent, root_span.get_span_reference())
         self.assertIs(db_span.kind, trace_api.SpanKind.CLIENT)
         self.assertEqual(db_span.attributes["db.instance"], MYSQL_DB_NAME)
         self.assertEqual(db_span.attributes["net.peer.name"], MYSQL_HOST)

--- a/tests/opentelemetry-docker-tests/tests/postgres/test_aiopg_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/postgres/test_aiopg_functional.py
@@ -76,7 +76,7 @@ class TestFunctionalAiopgConnect(TestBase):
         self.assertEqual(root_span.name, "rootSpan")
         self.assertEqual(child_span.name, "postgresql.opentelemetry-tests")
         self.assertIsNotNone(child_span.parent)
-        self.assertIs(child_span.parent, root_span.get_span_context())
+        self.assertIs(child_span.parent, root_span.get_span_reference())
         self.assertIs(child_span.kind, trace_api.SpanKind.CLIENT)
         self.assertEqual(
             child_span.attributes["db.instance"], POSTGRES_DB_NAME
@@ -157,7 +157,7 @@ class TestFunctionalAiopgCreatePool(TestBase):
         self.assertEqual(root_span.name, "rootSpan")
         self.assertEqual(child_span.name, "postgresql.opentelemetry-tests")
         self.assertIsNotNone(child_span.parent)
-        self.assertIs(child_span.parent, root_span.get_span_context())
+        self.assertIs(child_span.parent, root_span.get_span_reference())
         self.assertIs(child_span.kind, trace_api.SpanKind.CLIENT)
         self.assertEqual(
             child_span.attributes["db.instance"], POSTGRES_DB_NAME

--- a/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/postgres/test_psycopg_functional.py
@@ -68,7 +68,7 @@ class TestFunctionalPsycopg(TestBase):
         self.assertEqual(root_span.name, "rootSpan")
         self.assertEqual(child_span.name, "postgresql.opentelemetry-tests")
         self.assertIsNotNone(child_span.parent)
-        self.assertIs(child_span.parent, root_span.get_span_context())
+        self.assertIs(child_span.parent, root_span.get_span_reference())
         self.assertIs(child_span.kind, trace_api.SpanKind.CLIENT)
         self.assertEqual(
             child_span.attributes["db.instance"], POSTGRES_DB_NAME

--- a/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
@@ -51,7 +51,7 @@ class TestFunctionalPymongo(TestBase):
         self.assertIsNot(root_span, None)
         self.assertIsNot(pymongo_span, None)
         self.assertIsNotNone(pymongo_span.parent)
-        self.assertIs(pymongo_span.parent, root_span.get_span_context())
+        self.assertIs(pymongo_span.parent, root_span.get_span_reference())
         self.assertIs(pymongo_span.kind, trace_api.SpanKind.CLIENT)
         self.assertEqual(
             pymongo_span.attributes["db.instance"], MONGODB_DB_NAME

--- a/tests/opentelemetry-docker-tests/tests/pymysql/test_pymysql_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/pymysql/test_pymysql_functional.py
@@ -65,7 +65,7 @@ class TestFunctionalPyMysql(TestBase):
         self.assertEqual(root_span.name, "rootSpan")
         self.assertEqual(db_span.name, "mysql.opentelemetry-tests")
         self.assertIsNotNone(db_span.parent)
-        self.assertIs(db_span.parent, root_span.get_span_context())
+        self.assertIs(db_span.parent, root_span.get_span_reference())
         self.assertIs(db_span.kind, trace_api.SpanKind.CLIENT)
         self.assertEqual(db_span.attributes["db.instance"], MYSQL_DB_NAME)
         self.assertEqual(db_span.attributes["net.peer.name"], MYSQL_HOST)

--- a/tests/opentelemetry-docker-tests/tests/redis/test_redis_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/redis/test_redis_functional.py
@@ -109,7 +109,7 @@ class TestRedisInstrument(TestBase):
 
         # confirm the parenting
         self.assertIsNone(parent_span.parent)
-        self.assertIs(child_span.parent, parent_span.get_span_context())
+        self.assertIs(child_span.parent, parent_span.get_span_reference())
 
         self.assertEqual(parent_span.name, "redis_get")
         self.assertEqual(parent_span.instrumentation_info.name, "redis_svc")

--- a/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/mixins.py
+++ b/tests/opentelemetry-docker-tests/tests/sqlalchemy_tests/mixins.py
@@ -175,7 +175,7 @@ class SQLAlchemyTestMixin(TestBase):
 
         # confirm the parenting
         self.assertIsNone(parent_span.parent)
-        self.assertIs(child_span.parent, parent_span.get_span_context())
+        self.assertIs(child_span.parent, parent_span.get_span_reference())
 
         self.assertEqual(parent_span.name, "sqlalch_op")
         self.assertEqual(parent_span.instrumentation_info.name, "sqlalch_svc")

--- a/tests/util/src/opentelemetry/test/mock_textmap.py
+++ b/tests/util/src/opentelemetry/test/mock_textmap.py
@@ -28,7 +28,7 @@ class NOOPTextMapPropagator(TextMapPropagator):
     """A propagator that does not extract nor inject.
 
     This class is useful for catching edge cases assuming
-    a SpanContext will always be present.
+    a SpanReference will always be present.
     """
 
     def extract(
@@ -68,7 +68,7 @@ class MockTextMapPropagator(TextMapPropagator):
 
         return trace.set_span_in_context(
             trace.DefaultSpan(
-                trace.SpanContext(
+                trace.SpanReference(
                     trace_id=int(trace_id_list[0]),
                     span_id=int(span_id_list[0]),
                     is_remote=True,
@@ -84,8 +84,8 @@ class MockTextMapPropagator(TextMapPropagator):
     ) -> None:
         span = trace.get_current_span(context)
         set_in_carrier(
-            carrier, self.TRACE_ID_KEY, str(span.get_span_context().trace_id)
+            carrier, self.TRACE_ID_KEY, str(span.get_span_reference().trace_id)
         )
         set_in_carrier(
-            carrier, self.SPAN_ID_KEY, str(span.get_span_context().span_id)
+            carrier, self.SPAN_ID_KEY, str(span.get_span_reference().span_id)
         )


### PR DESCRIPTION
# Description

As per the change in the spec, SpanContext is now SpanReference. I took some time in this PR to also rename the context parameter in the Span and Link classes to reference.

Fixes #1245 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit tests

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been updated
- [x] Documentation has been updated
