### PR TITLE
Make SpanProcessor.on_start accept parent Context

### DIFF
--- a/exporter/opentelemetry-exporter-datadog/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-datadog/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+ - Make `SpanProcessor.on_start` accept parent Context
+  ([#1251](https://github.com/open-telemetry/opentelemetry-python/pull/1251))
+
 ## Version 0.14b0
 
 Released 2020-10-13

--- a/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/spanprocessor.py
+++ b/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/spanprocessor.py
@@ -17,7 +17,7 @@ import logging
 import threading
 import typing
 
-from opentelemetry.context import attach, detach, set_value
+from opentelemetry.context import Context, attach, detach, set_value
 from opentelemetry.sdk.trace import Span, SpanProcessor
 from opentelemetry.sdk.trace.export import SpanExporter
 from opentelemetry.trace import INVALID_TRACE_ID
@@ -81,7 +81,9 @@ class DatadogExportSpanProcessor(SpanProcessor):
         self.done = False
         self.worker_thread.start()
 
-    def on_start(self, span: Span) -> None:
+    def on_start(
+        self, span: Span, parent_context: typing.Optional[Context] = None
+    ) -> None:
         ctx = span.get_span_context()
         trace_id = ctx.trace_id
 

--- a/instrumentation/opentelemetry-instrumentation-falcon/tests/app.py
+++ b/instrumentation/opentelemetry-instrumentation-falcon/tests/app.py
@@ -5,6 +5,7 @@ import falcon
 
 class HelloWorldResource:
     def _handle_request(self, _, resp):
+        # pylint: disable=no-member
         resp.status = falcon.HTTP_201
         resp.body = "Hello World"
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Make `SpanProcessor.on_start` accept parent Context
+  ([#1251](https://github.com/open-telemetry/opentelemetry-python/pull/1251))
+
 ## Version 0.14b0
 
 Released 2020-10-13

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -80,8 +80,7 @@ class SpanProcessor:
 
         Args:
             span: The :class:`opentelemetry.trace.Span` that just started.
-            parent_context: The parent :class:`opentelemetry.context.Context`
-                of the span that just started
+            parent_context: The parent context of the span that just started.
         """
 
     def on_end(self, span: "Span") -> None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -205,7 +205,7 @@ class ConcurrentMultiSpanProcessor(SpanProcessor):
         self,
         func: Callable[[SpanProcessor], Callable[..., None]],
         *args: Any,
-        **kwargs: Any,
+        **kwargs: Any
     ):
         futures = []
         for sp in self._span_processors:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -68,7 +68,11 @@ class SpanProcessor:
     in the same order as they were registered.
     """
 
-    def on_start(self, span: "Span") -> None:
+    def on_start(
+        self,
+        span: "Span",
+        parent_context: Optional[context_api.Context] = None,
+    ) -> None:
         """Called when a :class:`opentelemetry.trace.Span` is started.
 
         This method is called synchronously on the thread that starts the
@@ -76,6 +80,8 @@ class SpanProcessor:
 
         Args:
             span: The :class:`opentelemetry.trace.Span` that just started.
+            parent_context: The parent :class:`opentelemetry.context.Context`
+                of the span that just started
         """
 
     def on_end(self, span: "Span") -> None:
@@ -124,9 +130,13 @@ class SynchronousMultiSpanProcessor(SpanProcessor):
         with self._lock:
             self._span_processors = self._span_processors + (span_processor,)
 
-    def on_start(self, span: "Span") -> None:
+    def on_start(
+        self,
+        span: "Span",
+        parent_context: Optional[context_api.Context] = None,
+    ) -> None:
         for sp in self._span_processors:
-            sp.on_start(span)
+            sp.on_start(span, parent_context=parent_context)
 
     def on_end(self, span: "Span") -> None:
         for sp in self._span_processors:
@@ -192,17 +202,26 @@ class ConcurrentMultiSpanProcessor(SpanProcessor):
             self._span_processors = self._span_processors + (span_processor,)
 
     def _submit_and_await(
-        self, func: Callable[[SpanProcessor], Callable[..., None]], *args: Any
+        self,
+        func: Callable[[SpanProcessor], Callable[..., None]],
+        *args: Any,
+        **kwargs: Any,
     ):
         futures = []
         for sp in self._span_processors:
-            future = self._executor.submit(func(sp), *args)
+            future = self._executor.submit(func(sp), *args, **kwargs)
             futures.append(future)
         for future in futures:
             future.result()
 
-    def on_start(self, span: "Span") -> None:
-        self._submit_and_await(lambda sp: sp.on_start, span)
+    def on_start(
+        self,
+        span: "Span",
+        parent_context: Optional[context_api.Context] = None,
+    ) -> None:
+        self._submit_and_await(
+            lambda sp: sp.on_start, span, parent_context=parent_context
+        )
 
     def on_end(self, span: "Span") -> None:
         self._submit_and_await(lambda sp: sp.on_end, span)
@@ -582,7 +601,11 @@ class Span(trace_api.Span):
             )
         )
 
-    def start(self, start_time: Optional[int] = None) -> None:
+    def start(
+        self,
+        start_time: Optional[int] = None,
+        parent_context: Optional[context_api.Context] = None,
+    ) -> None:
         with self._lock:
             if not self.is_recording():
                 return
@@ -594,7 +617,7 @@ class Span(trace_api.Span):
         if has_started:
             logger.warning("Calling start() on a started span.")
             return
-        self.span_processor.on_start(self)
+        self.span_processor.on_start(self, parent_context=parent_context)
 
     def end(self, end_time: Optional[int] = None) -> None:
         with self._lock:
@@ -762,7 +785,7 @@ class Tracer(trace_api.Tracer):
             if sampling_result.decision.is_sampled()
             else trace_api.TraceFlags(trace_api.TraceFlags.DEFAULT)
         )
-        context = trace_api.SpanContext(
+        span_context = trace_api.SpanContext(
             trace_id,
             self.source.ids_generator.generate_span_id(),
             is_remote=False,
@@ -775,7 +798,7 @@ class Tracer(trace_api.Tracer):
             # pylint:disable=protected-access
             span = _Span(
                 name=name,
-                context=context,
+                context=span_context,
                 parent=parent_span_context,
                 sampler=self.source.sampler,
                 resource=self.source.resource,
@@ -786,9 +809,9 @@ class Tracer(trace_api.Tracer):
                 instrumentation_info=self.instrumentation_info,
                 set_status_on_exception=set_status_on_exception,
             )
-            span.start(start_time=start_time)
+            span.start(start_time=start_time, parent_context=context)
         else:
-            span = trace_api.DefaultSpan(context=context)
+            span = trace_api.DefaultSpan(context=span_context)
         return span
 
     @contextmanager

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -21,7 +21,7 @@ import typing
 from enum import Enum
 
 from opentelemetry.configuration import Configuration
-from opentelemetry.context import attach, detach, set_value
+from opentelemetry.context import Context, attach, detach, set_value
 from opentelemetry.sdk.trace import Span, SpanProcessor
 from opentelemetry.util import time_ns
 
@@ -70,7 +70,9 @@ class SimpleExportSpanProcessor(SpanProcessor):
     def __init__(self, span_exporter: SpanExporter):
         self.span_exporter = span_exporter
 
-    def on_start(self, span: Span) -> None:
+    def on_start(
+        self, span: Span, parent_context: typing.Optional[Context] = None
+    ) -> None:
         pass
 
     def on_end(self, span: Span) -> None:
@@ -172,7 +174,9 @@ class BatchExportSpanProcessor(SpanProcessor):
         ] * self.max_export_batch_size  # type: typing.List[typing.Optional[Span]]
         self.worker_thread.start()
 
-    def on_start(self, span: Span) -> None:
+    def on_start(
+        self, span: Span, parent_context: typing.Optional[Context] = None
+    ) -> None:
         pass
 
     def on_end(self, span: Span) -> None:

--- a/opentelemetry-sdk/tests/error_handler/test_error_handler.py
+++ b/opentelemetry-sdk/tests/error_handler/test_error_handler.py
@@ -25,7 +25,8 @@ from opentelemetry.sdk.error_handler import (
 
 
 class TestErrorHandler(TestCase):
-    def test_default_error_handler(self):
+    @patch("opentelemetry.sdk.error_handler.iter_entry_points")
+    def test_default_error_handler(self, mock_iter_entry_points):
 
         with self.assertLogs(logger, ERROR):
             with GlobalErrorHandler():

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -17,9 +17,11 @@ import shutil
 import subprocess
 import unittest
 from logging import ERROR, WARNING
+from typing import Optional
 from unittest import mock
 
 from opentelemetry import trace as trace_api
+from opentelemetry.context import Context
 from opentelemetry.sdk import resources, trace
 from opentelemetry.sdk.trace import Resource, sampling
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
@@ -434,6 +436,8 @@ class TestSpanCreation(unittest.TestCase):
 
 
 class TestSpan(unittest.TestCase):
+    # pylint: disable=too-many-public-methods
+
     def setUp(self):
         self.tracer = new_tracer()
 
@@ -733,6 +737,20 @@ class TestSpan(unittest.TestCase):
         )
         self.assertIs(span.status.description, "Test description")
 
+    def test_start_accepts_context(self):
+        # pylint: disable=no-self-use
+        span_processor = mock.Mock(spec=trace.SpanProcessor)
+        span = trace._Span(
+            "name",
+            mock.Mock(spec=trace_api.SpanContext),
+            span_processor=span_processor,
+        )
+        context = Context()
+        span.start(parent_context=context)
+        span_processor.on_start.assert_called_once_with(
+            span, parent_context=context
+        )
+
     def test_span_override_start_and_end_time(self):
         """Span sending custom start_time and end_time values"""
         span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
@@ -898,7 +916,9 @@ class MySpanProcessor(trace.SpanProcessor):
         self.name = name
         self.span_list = span_list
 
-    def on_start(self, span: "trace.Span") -> None:
+    def on_start(
+        self, span: "trace.Span", parent_context: Optional[Context] = None
+    ) -> None:
         self.span_list.append(span_event_start_fmt(self.name, span.name))
 
     def on_end(self, span: "trace.Span") -> None:


### PR DESCRIPTION
# Description
Adds optional parent `Context` parameter to `SpanProcessor.on_start` as per spec.

Fixes #1250 

## Type of change

- [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
Additional unit tests checking that the parent Context is passed through from tracer.start_span to SpanProcessor.on_start

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
