### PR TITLE
Allow None in sequence attributes values (#998)

### DIFF
--- a/opentelemetry-api/src/opentelemetry/util/types.py
+++ b/opentelemetry-api/src/opentelemetry/util/types.py
@@ -20,10 +20,10 @@ AttributeValue = Union[
     bool,
     int,
     float,
-    Sequence[str],
-    Sequence[bool],
-    Sequence[int],
-    Sequence[float],
+    Sequence[Union[None, str]],
+    Sequence[Union[None, bool]],
+    Sequence[Union[None, int]],
+    Sequence[Union[None, float]],
 ]
 Attributes = Optional[Mapping[str, AttributeValue]]
 AttributesFormatter = Callable[[], Attributes]

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([#1251](https://github.com/open-telemetry/opentelemetry-python/pull/1251))
 - Fix b3 propagator entrypoint
   ([#1265](https://github.com/open-telemetry/opentelemetry-python/pull/1265))
+- Allow None in sequence attributes values
+  ([#998](https://github.com/open-telemetry/opentelemetry-python/pull/998))
 
 ## Version 0.14b0
 

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -564,6 +564,14 @@ class TestSpan(unittest.TestCase):
         self.assertTrue(trace._is_valid_attribute_value("hi"))
         self.assertTrue(trace._is_valid_attribute_value(3.4))
         self.assertTrue(trace._is_valid_attribute_value(15))
+        # None in sequences are valid
+        self.assertTrue(trace._is_valid_attribute_value(["A", None, None]))
+        self.assertTrue(
+            trace._is_valid_attribute_value(["A", None, None, "B"])
+        )
+        self.assertTrue(trace._is_valid_attribute_value([None, None]))
+        self.assertFalse(trace._is_valid_attribute_value(["A", None, 1]))
+        self.assertFalse(trace._is_valid_attribute_value([None, "A", None, 1]))
 
     def test_sampling_attributes(self):
         sampling_attributes = {


### PR DESCRIPTION
# Description

[As per the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/common/common.md#attributes), None values in attribute sequences are valid

> `null` values within arrays MUST be preserved as-is (i.e., passed on to spanprocessors / exporters as `null`). If exporters do not support exporting `null` values, they MAY replace those values by 0, `false`, or empty strings.
This is required for map/dictionary structures represented as two arrays with indices that are kept in sync (e.g., two attributes `header_keys` and `header_values`, both containing an array of strings to represent a mapping `header_keys[i] -> header_values[i]`).

Fixes #998

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests have been added

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added