### PR TITLE
Use url.rule instead of request.endpoint for span name flask instrumentation

### DIFF
--- a/docs/getting_started/tests/test_flask.py
+++ b/docs/getting_started/tests/test_flask.py
@@ -45,4 +45,4 @@ class TestFlask(unittest.TestCase):
         output = str(server.stdout.read())
         self.assertIn('"name": "HTTP GET"', output)
         self.assertIn('"name": "example-request"', output)
-        self.assertIn('"name": "hello"', output)
+        self.assertIn('"name": "/"', output)

--- a/instrumentation/opentelemetry-instrumentation-flask/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-flask/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Use `url.rule` instead of `request.endpoint` for span name ([#1260](https://github.com/open-telemetry/opentelemetry-python/pull/1260))
+
 ## Version 0.13b0
 
 Released 2020-09-17

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -110,7 +110,7 @@ def _before_request():
         return
 
     environ = flask.request.environ
-    span_name = flask.request.endpoint or otel_wsgi.get_default_span_name(
+    span_name = flask.request.url_rule.rule or otel_wsgi.get_default_span_name(
         environ
     )
     token = context.attach(

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -110,9 +110,12 @@ def _before_request():
         return
 
     environ = flask.request.environ
-    span_name = flask.request.url_rule.rule or otel_wsgi.get_default_span_name(
-        environ
-    )
+    try:
+        span_name = flask.request.url_rule.rule
+    except AttributeError:
+        pass
+    if span_name is None:
+        span_name = otel_wsgi.get_default_span_name(environ)
     token = context.attach(
         propagators.extract(otel_wsgi.get_header_from_environ, environ)
     )

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -110,6 +110,7 @@ def _before_request():
         return
 
     environ = flask.request.environ
+    span_name = None
     try:
         span_name = flask.request.url_rule.rule
     except AttributeError:

--- a/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/tests/test_programmatic.py
@@ -102,7 +102,7 @@ class TestProgrammatic(InstrumentationTest, TestBase, WsgiTestBase):
 
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
-        self.assertEqual(span_list[0].name, "_hello_endpoint")
+        self.assertEqual(span_list[0].name, "/hello/<int:helloid>")
         self.assertEqual(span_list[0].kind, trace.SpanKind.SERVER)
         self.assertEqual(span_list[0].attributes, expected_attrs)
 
@@ -154,7 +154,7 @@ class TestProgrammatic(InstrumentationTest, TestBase, WsgiTestBase):
         resp.close()
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
-        self.assertEqual(span_list[0].name, "_hello_endpoint")
+        self.assertEqual(span_list[0].name, "/hello/<int:helloid>")
         self.assertEqual(span_list[0].kind, trace.SpanKind.SERVER)
         self.assertEqual(span_list[0].attributes, expected_attrs)
 


### PR DESCRIPTION
From the title, we don't want to be using `endpoint` for the span name. See [specs](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#span) for span name.

Use `url.rule` instead if exists. If not, default to HTTP <method>