### PR TITLE
added gunicorn production server documentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -50,6 +50,17 @@ Modify the application's ``wsgi.py`` file as shown below.
     application = get_wsgi_application()
     application = OpenTelemetryMiddleware(application)
 
+
+Usage in Production Server (gunicorn)
+------------------------------------
+
+Modify the ``gunicorn.config.py`` file as shown below.
+
+.. code-block:: python
+
+    def post_fork(server, worker):
+        worker(DjangoInstrumentor().instrument())
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-wsgi/src/opentelemetry/instrumentation/wsgi/__init__.py
@@ -54,12 +54,43 @@ Modify the application's ``wsgi.py`` file as shown below.
 Usage in Production Server (gunicorn)
 ------------------------------------
 
+Installation
+------------
+
+.. code-block:: python
+
+    $ pip install opentelemetry-instrumentation-otcollector
+    $ pip install opentelemetry-api
+    $ pip install opentelemetry-sdk
+
+Execution
+---------
+
 Modify the ``gunicorn.config.py`` file as shown below.
 
 .. code-block:: python
 
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+    from opentelemetry.ext.otcollector.trace_exporter import CollectorSpanExporter
+
+    span_exporter = CollectorSpanExporter(
+    # optional:
+    # endpoint="myCollectorUrl:55678",
+    # service_name="test_service",
+    # host_name="machine/container name",
+    )
+
+    tracer_provider = TracerProvider()
+    trace.set_tracer_provider(tracer_provider)
+    span_processor = BatchExportSpanProcessor(span_exporter)
+    tracer_provider.add_span_processor(span_processor)
+
     def post_fork(server, worker):
-        worker(DjangoInstrumentor().instrument())
+        "pipeline" : [
+            tracer_provider,
+            span_processor,
+            span_exporter ]
 
 API
 ---


### PR DESCRIPTION
# Description

Achieving OpenTelemetry instrumentation in a Django production servers like gunicorn, since instrumentation of the application on works on a development server. You have to install gunicorn in your application to effect this change.

Fixes # (1197)

## Documentation

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

I have applied tox lint checks
