### PR TITLE
Span.is_recording() returns false after end() has been called (#1243)

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([#1251](https://github.com/open-telemetry/opentelemetry-python/pull/1251))
 - Fix b3 propagator entrypoint
   ([#1265](https://github.com/open-telemetry/opentelemetry-python/pull/1265))
+- Span.is_recording() returns false after span has ended
+  ([#1243](https://github.com/open-telemetry/opentelemetry-python/pull/1243))
 
 ## Version 0.14b0
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -581,15 +581,9 @@ class Span(trace_api.Span):
             return
 
         with self._lock:
-            is_recording = self._is_recording
-            has_ended = self.end_time is not None
-
-        if has_ended:
-            logger.warning("Setting attribute on ended span.")
-            return
-
-        if not is_recording:
-            return
+            if self.end_time is not None:
+                logger.warning("Setting attribute on ended span.")
+                return
 
         # Freeze mutable sequences defensively
         if isinstance(value, MutableSequence):
@@ -604,10 +598,6 @@ class Span(trace_api.Span):
 
     @_check_span_ended
     def _add_event(self, event: EventBase) -> None:
-        with self._lock:
-            if not self._is_recording:
-                return
-
         self.events.append(event)
 
     def add_event(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -637,7 +637,9 @@ class Span(trace_api.Span):
                     raise RuntimeError("Calling end() on a not started span.")
                 if not has_ended:
                     if self.status is None:
-                        self.status = Status(canonical_code=StatusCanonicalCode.OK)
+                        self.status = Status(
+                            canonical_code=StatusCanonicalCode.OK
+                        )
 
                     self._end_time = (
                         end_time if end_time is not None else time_ns()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -585,16 +585,16 @@ class Span(trace_api.Span):
                 logger.warning("Setting attribute on ended span.")
                 return
 
-        # Freeze mutable sequences defensively
-        if isinstance(value, MutableSequence):
-            value = tuple(value)
-        if isinstance(value, bytes):
-            try:
-                value = value.decode()
-            except ValueError:
-                logger.warning("Byte attribute could not be decoded.")
-                return
-        self.attributes[key] = value
+            # Freeze mutable sequences defensively
+            if isinstance(value, MutableSequence):
+                value = tuple(value)
+            if isinstance(value, bytes):
+                try:
+                    value = value.decode()
+                except ValueError:
+                    logger.warning("Byte attribute could not be decoded.")
+                    return
+            self.attributes[key] = value
 
     @_check_span_ended
     def _add_event(self, event: EventBase) -> None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -536,7 +536,7 @@ class Span(trace_api.Span):
         f_span["context"] = self._format_context(self.context)
         f_span["kind"] = str(self.kind)
         f_span["parent_id"] = parent_id
-        f_span["is_recording"] = self.is_recording()
+        f_span["is_recording"] = self._is_recording
         f_span["start_time"] = start_time
         f_span["end_time"] = end_time
         if self.status is not None:
@@ -553,7 +553,7 @@ class Span(trace_api.Span):
 
     def set_attribute(self, key: str, value: types.AttributeValue) -> None:
         with self._lock:
-            is_recording = self.is_recording()
+            is_recording = self._is_recording
             has_ended = self.end_time is not None
 
         if has_ended:
@@ -582,7 +582,7 @@ class Span(trace_api.Span):
 
     def _add_event(self, event: EventBase) -> None:
         with self._lock:
-            is_recording = self.is_recording()
+            is_recording = self._is_recording
             has_ended = self.end_time is not None
 
         if has_ended:
@@ -616,7 +616,7 @@ class Span(trace_api.Span):
         parent_context: Optional[context_api.Context] = None,
     ) -> None:
         with self._lock:
-            if not self.is_recording():
+            if not self._is_recording:
                 return
             has_started = self.start_time is not None
             if not has_started:
@@ -630,7 +630,7 @@ class Span(trace_api.Span):
 
     def end(self, end_time: Optional[int] = None) -> None:
         with self._lock:
-            is_recording = self.is_recording()
+            is_recording = self._is_recording
             has_ended = self.end_time is not None
             if is_recording:
                 if self.start_time is None:

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1041,6 +1041,7 @@ class TestSpanProcessor(unittest.TestCase):
     },
     "kind": "SpanKind.INTERNAL",
     "parent_id": null,
+    "is_recording": true,
     "start_time": null,
     "end_time": null,
     "attributes": {},
@@ -1051,7 +1052,7 @@ class TestSpanProcessor(unittest.TestCase):
         )
         self.assertEqual(
             span.to_json(indent=None),
-            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "attributes": {}, "events": [], "links": [], "resource": {}}',
+            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "is_recording": true, "start_time": null, "end_time": null, "attributes": {}, "events": [], "links": [], "resource": {}}',
         )
 
     def test_attributes_to_json(self):
@@ -1068,7 +1069,7 @@ class TestSpanProcessor(unittest.TestCase):
         date_str = ns_to_iso_str(123)
         self.assertEqual(
             span.to_json(indent=None),
-            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "attributes": {"key": "value"}, "events": [{"name": "event", "timestamp": "'
+            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "{}"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "is_recording": true, "start_time": null, "end_time": null, "attributes": {"key": "value"}, "events": [{"name": "event", "timestamp": "'
             + date_str
             + '", "attributes": {"key2": "value2"}}], "links": [], "resource": {}}',
         )


### PR DESCRIPTION
# Description

Span.is_recording() returns false after end() has been called. Also added an 'is_recording' attr to Span.to_json() output for more transparency.

Fixes (#1243)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

`tox` with installed pyenvs:
* 3.5.10
* 3.6.12
* 3.7.9
* 3.8.6
* 3.9.0
* pypy3.6-7.3.1

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
