### PR TITLE
Docs workflow not triggered on push to instrumentation directory

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
     paths:
     - 'docs/**'
     - 'exporter/**'
-    - 'ext/**'
+    - 'instrumentation/**'
     - 'opentelemetry-python/opentelemetry-api/src/opentelemetry/**'
     - 'opentelemetry-python/opentelemetry-sdk/src/opentelemetry/sdk/**'
     


### PR DESCRIPTION
While investigating docs failures #1280, found some config leftover from the move to `instrumentation` from `ext`.