### PR TITLE
use python 3.8 to build docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,8 +15,11 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - name: Set up Python py38
+      uses: actions/setup-python@v2
+      with:
+        python-version: py38
     - name: Build docs
       run: |
         pip install --upgrade tox


### PR DESCRIPTION
# Description

The current docs github action uses python latest, which has switched to python 3.9. Tracking the issue to support python 3.9 in #1283, but for addressing the docs build failure, switching the environment to build using python 3.8

Fixes #1280 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested building docs with python 3.8

# Checklist:

- [x] Followed the style guidelines of this project
