### PR TITLE
Span.is_recording() now based off self._end_time and returns False if…

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -10,6 +10,8 @@
   ([#998](https://github.com/open-telemetry/opentelemetry-python/pull/998))
 - Samplers to accept parent Context
   ([#1267](https://github.com/open-telemetry/opentelemetry-python/pull/1267))
+- Span.is_recording() returns false after span has ended
+  ([#1289](https://github.com/open-telemetry/opentelemetry-python/pull/1289))
 
 ## Version 0.14b0
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -649,7 +649,7 @@ class Span(trace_api.Span):
         self.name = name
 
     def is_recording(self) -> bool:
-        return True
+        return self._end_time is None
 
     @_check_span_ended
     def set_status(self, status: trace_api.Status) -> None:


### PR DESCRIPTION
… span has ended

# Description

`Span.is_recording()` is now based off `self._end_time` and returns `False` if a span has ended.

Fixes (#1243)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

tox full run against pyenvs:

- 3.5.10
- 3.6.12
- 3.7.9
- 3.8.6
- 3.9.0
- pypy3.6-7.3.1

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
