### PR TITLE
suppress instrument boto3 XRay.put_trace_segments()

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -90,12 +90,10 @@ class BotocoreInstrumentor(BaseInstrumentor):
         unwrap(BaseClient, "_make_api_call")
 
     def _patched_api_call(self, original_func, instance, args, kwargs):
+        if context_api.get_value("suppress_instrumentation"):
+            return original_func(*args, **kwargs)
 
         endpoint_name = deep_getattr(instance, "_endpoint._endpoint_prefix")
-
-        if context_api.get_value("suppress_instrumentation"):
-            result = original_func(*args, **kwargs)
-            return result
 
         with self._tracer.start_as_current_span(
             "{}.command".format(endpoint_name), kind=SpanKind.CONSUMER,

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -56,6 +56,7 @@ import logging
 from botocore.client import BaseClient
 from wrapt import ObjectProxy, wrap_function_wrapper
 
+from opentelemetry import context as context_api
 from opentelemetry.instrumentation.botocore.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.sdk.trace import Resource
@@ -91,7 +92,8 @@ class BotocoreInstrumentor(BaseInstrumentor):
     def _patched_api_call(self, original_func, instance, args, kwargs):
 
         endpoint_name = deep_getattr(instance, "_endpoint._endpoint_prefix")
-        if endpoint_name == "xray" and "PutTraceSegments" in args:
+
+        if context_api.get_value("suppress_instrumentation"):
             result = original_func(*args, **kwargs)
             return
 

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -95,7 +95,7 @@ class BotocoreInstrumentor(BaseInstrumentor):
 
         if context_api.get_value("suppress_instrumentation"):
             result = original_func(*args, **kwargs)
-            return
+            return result
 
         with self._tracer.start_as_current_span(
             "{}.command".format(endpoint_name), kind=SpanKind.CONSUMER,

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -91,6 +91,9 @@ class BotocoreInstrumentor(BaseInstrumentor):
     def _patched_api_call(self, original_func, instance, args, kwargs):
 
         endpoint_name = deep_getattr(instance, "_endpoint._endpoint_prefix")
+        if endpoint_name == "xray" and "PutTraceSegments" in args:
+            result = original_func(*args, **kwargs)
+            return
 
         with self._tracer.start_as_current_span(
             "{}.command".format(endpoint_name), kind=SpanKind.CONSUMER,

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -26,6 +26,7 @@ from moto import (  # pylint: disable=import-error
     mock_xray,
 )
 
+from opentelemetry.context import attach, detach, set_value
 from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.test.test_base import TestBase
@@ -282,8 +283,10 @@ class TestBotocoreInstrumentor(TestBase):
         xray_client = self.session.create_client(
             "xray", region_name="us-east-1"
         )
+        token = attach(set_value("suppress_instrumentation", True))
         xray_client.put_trace_segments(TraceSegmentDocuments=["str1"])
         xray_client.put_trace_segments(TraceSegmentDocuments=["str2"])
+        detach(token)
 
         spans = self.memory_exporter.get_finished_spans()
         assert not spans, spans

--- a/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/tests/test_botocore_instrumentation.py
@@ -279,7 +279,7 @@ class TestBotocoreInstrumentor(TestBase):
         self.assertTrue("params" not in span.attributes.keys())
 
     @mock_xray
-    def test_xray_client(self):
+    def test_suppress_instrumentation_xray_client(self):
         xray_client = self.session.create_client(
             "xray", region_name="us-east-1"
         )
@@ -289,4 +289,4 @@ class TestBotocoreInstrumentor(TestBase):
         detach(token)
 
         spans = self.memory_exporter.get_finished_spans()
-        assert not spans, spans
+        self.assertEqual(0, len(spans))


### PR DESCRIPTION
# Description

I am going to create an AWS XRay exporter in OpenTelemetry-Python, to emit telemetry data to AWS XRay service via boto3 API [XRay.put_trace_segments()](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/xray.html?highlight=xray#XRay.Client.put_trace_segments). This PR is the prerequisite for this in-process exporter. 
When I was working on the AWSXrayExporter, the botocore instrumentor would instrument function `XRay.put_trace_segments()` inside of AWSXrayExporter, causes infinite recursive loop. This PR is inspired from AWS XRay SDK, skip instrument this specific function to avoid infinite recursion.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] End to end test
Have created the AWSXrayExporter in local and enable botocore instrumentor in my test App to instrument a boto3 S3.list_buckets function. No infinite recursion problem happen.

- [ ] Covered by unit test

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
