### PR TITLE
docs: using correct python specifier for docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
     - 'instrumentation/**'
     - 'opentelemetry-python/opentelemetry-api/src/opentelemetry/**'
     - 'opentelemetry-python/opentelemetry-sdk/src/opentelemetry/sdk/**'
-    
+
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python py38
       uses: actions/setup-python@v2
       with:
-        python-version: py38
+        python-version: '3.8'
     - name: Build docs
       run: |
         pip install --upgrade tox


### PR DESCRIPTION
There is a build error with the docs Github action currently,
that is due to incorrect Python specifier syntax.

	Run actions/setup-python@v2
	Version py38 was not found in the local cache
	Error: Version py38 with arch x64 not found
	The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

## Type of change

- [x] build issue

# How Has This Been Tested?

I don't have the ability to test this on my side, but I can attest that this syntax is correct.