### PR TITLE
Add env variable for turning off collection of db.statement.parameters

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- DBAPI instrumentation collection of db.statement.parameters can now be turned off by setting `OTEL_PYTHON_DBAPI_CAPTURE_STATEMENT_PARAMS` to `False` ([#1306](https://github.com/open-telemetry/opentelemetry-python/pull/1306))
+
 ## Version 0.13b0
 
 Released 2020-09-17

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -20,7 +20,7 @@ Python Database API Specification v2.0.
 .. envvar:: OTEL_PYTHON_DBAPI_CAPTURE_STATEMENT_PARAMS
 
 The :envvar:`OTEL_PYTHON_DBAPI_CAPTURE_STATEMENT_PARAMS` environment variable allows the user
-to turn off the collection of `db.statement.parameters` by setting the value to "False"
+to turn off the collection of db.statement.parameters by setting the value to "False"
 
 Usage
 -----

--- a/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/src/opentelemetry/instrumentation/dbapi/__init__.py
@@ -48,11 +48,11 @@ API
 import functools
 import logging
 import typing
-from opentelemetry.configuration import Configuration
 
 import wrapt
 
 from opentelemetry import trace as trace_api
+from opentelemetry.configuration import Configuration
 from opentelemetry.instrumentation.dbapi.version import __version__
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.trace import SpanKind, TracerProvider, get_tracer
@@ -321,7 +321,9 @@ class TracedCursor:
             # Capture of statement parameters is enabled by default
             # Setting OTEL_PYTHON_DBAPI_CAPTURE_STATEMENT_PARAMS to False will
             # disable this feature
-            TracedCursor._capture_statement_params = Configuration().DBAPI_CAPTURE_STATEMENT_PARAMS
+            TracedCursor._capture_statement_params = (
+                Configuration().DBAPI_CAPTURE_STATEMENT_PARAMS
+            )
             if TracedCursor._capture_statement_params is None:
                 # Configuration was not set.  We will default to True.
                 TracedCursor._capture_statement_params = True

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 from opentelemetry import trace as trace_api
 from opentelemetry.configuration import Configuration
 from opentelemetry.instrumentation import dbapi
+from opentelemetry.instrumentation.dbapi import TracedCursor
 from opentelemetry.test.test_base import TestBase
 
 
@@ -27,6 +28,10 @@ class TestDBApiIntegration(TestBase):
     def setUp(self):
         super().setUp()
         self.tracer = self.tracer_provider.get_tracer(__name__)
+        # Reset _capture_statement_params so it is recalculated for each test
+        TracedCursor._capture_statement_params = (  # pylint: disable=protected-access
+            None
+        )
 
     def test_span_succeeded(self):
         connection_props = {

--- a/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-dbapi/tests/test_dbapi_integration.py
@@ -71,10 +71,7 @@ class TestDBApiIntegration(TestBase):
         )
 
     @patch.dict(
-        "os.environ",
-        {
-            "OTEL_PYTHON_DBAPI_CAPTURE_STATEMENT_PARAMS": "False",
-        },
+        "os.environ", {"OTEL_PYTHON_DBAPI_CAPTURE_STATEMENT_PARAMS": "False"}
     )
     def test_span_succeeded_with_capturing_statement_params_disabled(self):
         Configuration._reset()  # pylint: disable=protected-access


### PR DESCRIPTION
# Description

Add env variable to enable the user to run off the collection of db.statement.parameters

Fixes # (issue)
https://github.com/open-telemetry/opentelemetry-python/issues/1215

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit Tests
