### PR TITLE
Rework gRPC status based on new rules

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -113,8 +113,9 @@ class _OpenTelemetryServicerContext(grpc.ServicerContext):
     def abort(self, code, details):
         self.code = code
         self.details = details
+        self._active_span.set_attribute("rpc.status_code", code.name)
         self._active_span.set_status(
-            Status(status_code=StatusCode(code.value[0]), description=details)
+            Status(status_code=StatusCode.ERROR, description=details)
         )
         return self._servicer_context.abort(code, details)
 
@@ -125,18 +126,16 @@ class _OpenTelemetryServicerContext(grpc.ServicerContext):
         self.code = code
         # use details if we already have it, otherwise the status description
         details = self.details or code.value[1]
+        self._active_span.set_attribute("rpc.status_code", code.name)
         self._active_span.set_status(
-            Status(status_code=StatusCode(code.value[0]), description=details)
+            Status(status_code=StatusCode.ERROR, description=details)
         )
         return self._servicer_context.set_code(code)
 
     def set_details(self, details):
         self.details = details
         self._active_span.set_status(
-            Status(
-                status_code=StatusCode(self.code.value[0]),
-                description=details,
-            )
+            Status(status_code=StatusCode.ERROR, description=details)
         )
         return self._servicer_context.set_details(details)
 

--- a/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
+++ b/instrumentation/opentelemetry-instrumentation-grpc/src/opentelemetry/instrumentation/grpc/_server.py
@@ -113,7 +113,7 @@ class _OpenTelemetryServicerContext(grpc.ServicerContext):
     def abort(self, code, details):
         self.code = code
         self.details = details
-        self._active_span.set_attribute("rpc.status_code", code.name)
+        self._active_span.set_attribute("rpc.grpc.status_code", code.name)
         self._active_span.set_status(
             Status(status_code=StatusCode.ERROR, description=details)
         )
@@ -126,7 +126,7 @@ class _OpenTelemetryServicerContext(grpc.ServicerContext):
         self.code = code
         # use details if we already have it, otherwise the status description
         details = self.details or code.value[1]
-        self._active_span.set_attribute("rpc.status_code", code.name)
+        self._active_span.set_attribute("rpc.grpc.status_code", code.name)
         self._active_span.set_status(
             Status(status_code=StatusCode.ERROR, description=details)
         )
@@ -188,6 +188,7 @@ class OpenTelemetryServerInterceptor(grpc.ServerInterceptor):
         attributes = {
             "rpc.method": handler_call_details.method,
             "rpc.system": "grpc",
+            "rpc.grpc.status_code": grpc.StatusCode.OK,
         }
 
         metadata = dict(context.invocation_metadata())


### PR DESCRIPTION
# Description

As of #1214, the status codes changed and no longer line up with gRPC status codes, so now we'll just set `StatusCode.ERROR` and store the actual gRPC status code in the trace as `grpc.status_code`.

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Mostly observation in Jaeger.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
