### PR TITLE
Bugfix django instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-django/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Django instrumentation is now enabled by default but can be disabled by setting `OTEL_PYTHON_DJANGO_INSTRUMENT` to `False` ([#1239](https://github.com/open-telemetry/opentelemetry-python/pull/1239))
+- Bugfix use request.path replace request.get_full_path(). It will get correct span name ([#1309](https://github.com/open-telemetry/opentelemetry-python/pull/1309#))
 
 ## Version 0.14b0
 

--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware.py
@@ -81,7 +81,7 @@ class _DjangoMiddleware(MiddlewareMixin):
             if getattr(request, "resolver_match"):
                 match = request.resolver_match
             else:
-                match = resolve(request.get_full_path())
+                match = resolve(request.path)
 
             if hasattr(match, "route"):
                 return match.route

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -263,7 +263,10 @@ class TestMiddleware(TestBase, WsgiTestBase):
             else "tests.views.route_span_name",
         )
 
-        # test have query_string
+    def test_span_name_for_query_string(self):
+        """
+        request not have query string
+        """
         Client().get("/span_name/1234/?query=test")
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)

--- a/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
+++ b/instrumentation/opentelemetry-instrumentation-django/tests/test_middleware.py
@@ -250,7 +250,21 @@ class TestMiddleware(TestBase, WsgiTestBase):
         self.assertEqual(len(span_list), 1)
 
     def test_span_name(self):
+        # test no query_string
         Client().get("/span_name/1234/")
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+
+        span = span_list[0]
+        self.assertEqual(
+            span.name,
+            "^span_name/([0-9]{4})/$"
+            if DJANGO_2_2
+            else "tests.views.route_span_name",
+        )
+
+        # test have query_string
+        Client().get("/span_name/1234/?query=test")
         span_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(span_list), 1)
 


### PR DESCRIPTION
# Description

Fix: Django instrumentation if request have query_string will not correct resolver we need use request.path to replace request.get_full_path()

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test have query string and not have query string to get correct span name

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
