### PR TITLE
Add missing "is" in OT shim docs

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-opentracing-shim/src/opentelemetry/instrumentation/opentracing_shim/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-opentracing-shim/src/opentelemetry/instrumentation/opentracing_shim/__init__.py
@@ -496,7 +496,7 @@ class ScopeManagerShim(ScopeManager):
             span.
 
         Warning:
-            This property is *not* a part of the OpenTracing API. It used
+            This property is *not* a part of the OpenTracing API. It is used
             internally by the current implementation of the OpenTracing shim
             and will likely be removed in future versions.
         """


### PR DESCRIPTION
# Description

This PR adds a missing word in the OT shim documentation.

## Type of change

Please delete options that are not relevant.

- [ ] This change requires a documentation update

# How Has This Been Tested?

This PR doesn't contain code changes.
