### PR TITLE
Fix Jaeger exporter to correctly translate span.kind attribute

### DIFF
--- a/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/__init__.py
+++ b/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/__init__.py
@@ -70,12 +70,21 @@ from opentelemetry.configuration import Configuration
 from opentelemetry.exporter.jaeger.gen.agent import Agent as agent
 from opentelemetry.exporter.jaeger.gen.jaeger import Collector as jaeger
 from opentelemetry.sdk.trace.export import Span, SpanExporter, SpanExportResult
+from opentelemetry.trace import SpanKind
 from opentelemetry.trace.status import StatusCode
 
 DEFAULT_AGENT_HOST_NAME = "localhost"
 DEFAULT_AGENT_PORT = 6831
 
 UDP_PACKET_MAX_LENGTH = 65000
+
+OTLP_JAEGER_SPAN_KIND = {
+    SpanKind.CLIENT: "client",
+    SpanKind.SERVER: "server",
+    SpanKind.CONSUMER: "consumer",
+    SpanKind.PRODUCER: "producer",
+    SpanKind.INTERNAL: "internal",
+}
 
 logger = logging.getLogger(__name__)
 
@@ -226,7 +235,7 @@ def _translate_to_jaeger(spans: Span):
             [
                 _get_long_tag("status.code", status.status_code.value),
                 _get_string_tag("status.message", status.description),
-                _get_string_tag("span.kind", span.kind.name),
+                _get_string_tag("span.kind", OTLP_JAEGER_SPAN_KIND[span.kind]),
             ]
         )
 

--- a/exporter/opentelemetry-exporter-jaeger/tests/test_jaeger_exporter.py
+++ b/exporter/opentelemetry-exporter-jaeger/tests/test_jaeger_exporter.py
@@ -25,6 +25,7 @@ from opentelemetry.exporter.jaeger.gen.jaeger import ttypes as jaeger
 from opentelemetry.sdk import trace
 from opentelemetry.sdk.trace import Resource
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
+from opentelemetry.trace import SpanKind
 from opentelemetry.trace.status import Status, StatusCode
 
 
@@ -151,6 +152,10 @@ class TestJaegerSpanExporter(unittest.TestCase):
         self.assertEqual(nsec_to_usec_round(5499), 5)
         self.assertEqual(nsec_to_usec_round(5500), 6)
 
+    def test_all_otlp_span_kinds_are_mapped(self):
+        for kind in SpanKind:
+            self.assertIn(kind, jaeger_exporter.OTLP_JAEGER_SPAN_KIND)
+
     # pylint: disable=too-many-locals
     def test_translate_to_jaeger(self):
         # pylint: disable=invalid-name
@@ -216,9 +221,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
                 key="status.message", vType=jaeger.TagType.STRING, vStr=None
             ),
             jaeger.Tag(
-                key="span.kind",
-                vType=jaeger.TagType.STRING,
-                vStr=trace_api.SpanKind.INTERNAL.name,
+                key="span.kind", vType=jaeger.TagType.STRING, vStr="internal",
             ),
         ]
 
@@ -315,7 +318,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
                     jaeger.Tag(
                         key="span.kind",
                         vType=jaeger.TagType.STRING,
-                        vStr=trace_api.SpanKind.CLIENT.name,
+                        vStr="client",
                     ),
                     jaeger.Tag(
                         key="error", vType=jaeger.TagType.BOOL, vBool=True
@@ -391,7 +394,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
                     jaeger.Tag(
                         key="span.kind",
                         vType=jaeger.TagType.STRING,
-                        vStr=trace_api.SpanKind.INTERNAL.name,
+                        vStr="internal",
                     ),
                     jaeger.Tag(
                         key="otel.instrumentation_library.name",


### PR DESCRIPTION
According to opentracing semantic conventions, span.kind attribute
should be one of the following four values: "server", "client",
"producer", "consumer". The spec does not mention the casing of the
strings but all examples show them in lower case. Moreoever, the
OpenTelemetry collector recognizes these values only when they are
lower case. Today if opentelemetry-python exports a span using the
jaeger exporter to the OpenTelemetry collector, it loses the span.kind
information. Using the debug logger exporter in the collector prints the
following to the screen:

    Span #0
        Trace ID       : 31789e02d79452eaedb72769bed5fac7
        Parent ID      : a6398bc507d8a982
        ID             : 4a00eaa815e69785
        Name           : custom
        Kind           : SPAN_KIND_UNSPECIFIED

    Span #1
        Trace ID       : 31789e02d79452eaedb72769bed5fac7
        Parent ID      :
        ID             : a6398bc507d8a982
        Name           : HelloWorldResource.on_get
        Kind           : SPAN_KIND_UNSPECIFIED

After the patch, span kind is correctly understood and represented by
the collector:

    Span #0
        Trace ID       : 8e4aeaa621f7e67c813a9cf26c56a202
        Parent ID      : 13f4cc8db8dfe5b3
        ID             : e8032193bb9dca98
        Name           : custom
        Kind           : SPAN_KIND_INTERNAL

    Span #1
        Trace ID       : 8e4aeaa621f7e67c813a9cf26c56a202
        Parent ID      :
        ID             : 13f4cc8db8dfe5b3
        Name           : HelloWorldResource.on_get
        Kind           : SPAN_KIND_SERVER

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated existing tests
- [x] Manually tested by exporting to Jaeger collector and OpenTelemetry collector

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added

