### PR TITLE
Add Contrib Repo Tests workflow on Core PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Core Repo Tests
 
 on:
   push:
@@ -6,7 +6,11 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CONTRIB_REPO_SHA: 5c9e043d6921550d82668788e3758a733fb11cb8
+  # Set variable to 'master' if your change will not affect Contrib.
+  # Otherwise, set variable to the commit of your branch on
+  # opentelemetry-python-contrib which is compatible with these Core repo
+  # changes.
+  CONTRIB_REPO_SHA: 9398616add7071085a9a8448899a7de178b84bbf
 
 jobs:
   build:
@@ -62,7 +66,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .tox
-          key: tox-cache-${{ matrix.python-version }}-${{ matrix.package }}-${{ matrix.os }}-${{ hashFiles('tox.ini', 'dev-requirements.txt') }}
+          key: tox-cache-${{ matrix.python-version }}-${{ matrix.package }}-${{ matrix.os }}-${{ hashFiles('tox.ini', 'dev-requirements.txt') }}-core
       - name: run tox
         run: tox -f ${{ matrix.python-version }}-${{ matrix.package }}
   misc:
@@ -92,6 +96,87 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .tox
-          key: tox-cache-${{ matrix.tox-environment }}-${{ hashFiles('tox.ini', 'dev-requirements.txt') }}
+          key: tox-cache-${{ matrix.tox-environment }}-${{ hashFiles('tox.ini', 'dev-requirements.txt') }}-core
+      - name: run tox
+        run: tox -e ${{ matrix.tox-environment }}
+  contrib-build:
+    env:
+      # We use these variables to convert between tox and GHA version literals
+      py35: 3.5
+      py36: 3.6
+      py37: 3.7
+      py38: 3.8
+      pypy3: pypy3
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
+      matrix:
+        python-version: [ py35, py36, py37, py38, pypy3 ]
+        package: ["instrumentation", "exporter"]
+        os: [ ubuntu-latest ]
+        include:
+          # py35-instrumentation segfaults on 18.04 so we instead run on 20.04
+          - python-version: py35
+            package: instrumentation
+            os: ubuntu-20.04
+        exclude:
+          - os: ubuntu-latest
+            python-version: py35
+            package: instrumentation
+    steps:
+      - name: Checkout Contrib Repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
+        uses: actions/checkout@v2
+        with:
+          repository: open-telemetry/opentelemetry-python-contrib
+          ref: ${{ env.CONTRIB_REPO_SHA }}
+      - name: Checkout Core Repo @ SHA ${{ github.sha }}
+        uses: actions/checkout@v2
+        with:
+          repository: open-telemetry/opentelemetry-python
+          path: opentelemetry-python-core
+      - name: Set up Python ${{ env[matrix.python-version] }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env[matrix.python-version] }}
+      - name: Install tox
+        run: pip install -U tox-factor
+      - name: Cache tox environment
+        # Preserves .tox directory between runs for faster installs
+        uses: actions/cache@v2
+        with:
+          path: .tox
+          key: tox-cache-${{ matrix.python-version }}-${{ matrix.package }}-${{ matrix.os }}-${{ hashFiles('tox.ini', 'dev-requirements.txt') }}-contrib
+      - name: run tox
+        run: tox -f ${{ matrix.python-version }}-${{ matrix.package }}
+  contrib-misc:
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-environment: [ "docker-tests", "lint" ]
+    name: ${{ matrix.tox-environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Contrib Repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
+        uses: actions/checkout@v2
+        with:
+          repository: open-telemetry/opentelemetry-python-contrib
+          ref: ${{ env.CONTRIB_REPO_SHA }}
+      - name: Checkout Core Repo @ SHA ${{ github.sha }}
+        uses: actions/checkout@v2
+        with:
+          repository: open-telemetry/opentelemetry-python
+          path: opentelemetry-python-core
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install tox
+        run: pip install -U tox
+      - name: Cache tox environment
+        # Preserves .tox directory between runs for faster installs
+        uses: actions/cache@v2
+        with:
+          path: .tox
+          key: tox-cache-${{ matrix.tox-environment }}-${{ hashFiles('tox.ini', 'dev-requirements.txt') }}-contrib
       - name: run tox
         run: tox -e ${{ matrix.tox-environment }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tox-environment: [ "docker-tests", "lint" ]
+        tox-environment: [ "docker-tests"]
     name: ${{ matrix.tox-environment }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: 9398616add7071085a9a8448899a7de178b84bbf
+  CONTRIB_REPO_SHA: master
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,10 @@ To quickly get up and running, you can use the `scripts/eachdist.py` tool that
 ships with this project. First create a virtualenv and activate it.
 Then run `python scripts/eachdist.py develop` to install all required packages
 as well as the project's packages themselves (in `--editable` mode).
+
+Further, you'll want to clone the Contrib repo locally to resolve paths needed
+to run tests. `git clone git@github.com:open-telemetry/opentelemetry-python-contrib.git opentelemetry-python-contrib`.
+
 You can then run `scripts/eachdist.py test` to test everything or
 `scripts/eachdist.py lint` to lint everything (fixing anything that is auto-fixable).
 

--- a/docs/examples/opentelemetry-example-app/setup.cfg
+++ b/docs/examples/opentelemetry-example-app/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     opentelemetry-sdk == 0.16.dev0
     opentelemetry-instrumentation-requests == 0.15.b0
     opentelemetry-instrumentation-flask == 0.15.b0
+    opentelemetry-instrumentation-grpc == 0.15.b0
     flask
     requests
     protobuf>=3.13.0

--- a/eachdist.ini
+++ b/eachdist.ini
@@ -10,10 +10,6 @@ sortfirst=
     opentelemetry-instrumentation
     opentelemetry-proto
     tests/util
-    instrumentation/opentelemetry-instrumentation-wsgi
-    instrumentation/opentelemetry-instrumentation-dbapi
-    instrumentation/opentelemetry-instrumentation-asgi
-    instrumentation/opentelemetry-instrumentation-botocore
     instrumentation/*
     exporter/*
     ext/*

--- a/tox.ini
+++ b/tox.ini
@@ -135,10 +135,7 @@ commands =
 basepython: python3.8
 recreate = True
 deps =
-  -e {toxinidir}/opentelemetry-api
-  -e {toxinidir}/opentelemetry-sdk
   -c dev-requirements.txt
-  -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc
   asgiref
   pylint
   flake8

--- a/tox.ini
+++ b/tox.ini
@@ -160,8 +160,12 @@ deps =
   -r {toxinidir}/docs-requirements.txt
 
 commands_pre =
-  pip install -e {toxinidir}/opentelemetry-api \ 
-              -e {toxinidir}/opentelemetry-sdk
+  pip install -e {toxinidir}/opentelemetry-api \
+              -e {toxinidir}/opentelemetry-sdk \
+              -e {toxinidir}/opentelemetry-instrumentation \
+              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests \
+              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi \
+              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask
 
 changedir = docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -160,8 +160,7 @@ deps =
   -r {toxinidir}/docs-requirements.txt
 
 commands_pre =
-  pip install -e {toxinidir}/tests/util \
-              -e {toxinidir}/opentelemetry-python-contrib/exporter/opentelemetry-exporter-datadog \
+  pip install -e {toxinidir}/opentelemetry-python-contrib/exporter/opentelemetry-exporter-datadog \
               -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc \
               -e {toxinidir}/opentelemetry-instrumentation \
               -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests \

--- a/tox.ini
+++ b/tox.ini
@@ -159,6 +159,10 @@ deps =
   -c {toxinidir}/dev-requirements.txt
   -r {toxinidir}/docs-requirements.txt
 
+commands_pre =
+  pip install -e {toxinidir}/opentelemetry-api \ 
+              -e {toxinidir}/opentelemetry-sdk
+
 changedir = docs
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ envlist =
 
     ; opentelemetry-example-app
     py3{5,6,7,8}-test-core-example-app
-    pypy3-test-core-example-app
 
     ; opentelemetry-exporter-jaeger
     py3{5,6,7,8}-test-exporter-jaeger

--- a/tox.ini
+++ b/tox.ini
@@ -160,11 +160,13 @@ deps =
   -r {toxinidir}/docs-requirements.txt
 
 commands_pre =
-  pip install -e {toxinidir}/opentelemetry-api \
-              -e {toxinidir}/opentelemetry-sdk \
+  pip install -e {toxinidir}/tests/util \
+              -e {toxinidir}/opentelemetry-python-contrib/exporter/opentelemetry-exporter-datadog \
+              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc \
               -e {toxinidir}/opentelemetry-instrumentation \
               -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests \
               -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi \
+              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-django \
               -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask
 
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -156,15 +156,6 @@ deps =
   -c {toxinidir}/dev-requirements.txt
   -r {toxinidir}/docs-requirements.txt
 
-commands_pre =
-  pip install -e {toxinidir}/opentelemetry-python-contrib/exporter/opentelemetry-exporter-datadog \
-              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc \
-              -e {toxinidir}/opentelemetry-instrumentation \
-              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests \
-              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi \
-              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-django \
-              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask
-
 changedir = docs
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -135,8 +135,10 @@ commands =
 basepython: python3.8
 recreate = True
 deps =
-  -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc
+  -e {toxinidir}/opentelemetry-api
+  -e {toxinidir}/opentelemetry-sdk
   -c dev-requirements.txt
+  -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc
   asgiref
   pylint
   flake8


### PR DESCRIPTION
# Description

Add tests to check if PRs on the Core repo will break tests from the Contrib Repo.

To test against a particular Contrib Repo PR, change the env variable `CONTRIB_REPO_SHA` to prove tests pass. Once they pass, PRs in Core and Contrib can be merged at the same time.

This fixes:
- `tox -e lint`
- `tox -e docs`

Related to #1233

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

New tests added to make sure Core changes don't affect Contrib.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
- [x] Unit tests have been added
~- [ ] Documentation has been updated~
