### PR TITLE
Set dependencies version for tests util pkg

### DIFF
--- a/tests/util/setup.cfg
+++ b/tests/util/setup.cfg
@@ -37,8 +37,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api
-    opentelemetry-sdk
+    opentelemetry-api == 0.16.dev0
+    opentelemetry-sdk == 0.16.dev0
 
 [options.extras_require]
 test = flask~=1.0


### PR DESCRIPTION
# Description

The `test/util` package was not downloading the `opentelemetry-api` and `opentelemetry-sdk` package at the matching version.

Normally this wasn't a problem because they get installed first, but if `tests/util` were to be installed first, then it would install from Pypi (which would be an older version).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

All CI test still pass as they normally would.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
