### PR TITLE
OTLP exporter: Handle error case when no credentials supplied

### DIFF
--- a/docs/examples/django/pages/views.py
+++ b/docs/examples/django/pages/views.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from django.http import HttpResponse
+
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (

--- a/docs/examples/django/pages/views.py
+++ b/docs/examples/django/pages/views.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from django.http import HttpResponse
-
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (

--- a/exporter/opentelemetry-exporter-otlp/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-otlp/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add Gzip compression for exporter
   ([#1141](https://github.com/open-telemetry/opentelemetry-python/pull/1141))
+- OTLP exporter: Handle error case when no credentials supplied
+  ([#1366](https://github.com/open-telemetry/opentelemetry-python/pull/1366))
 ## Version 0.15b0
 
 Released 2020-11-02

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/__init__.py
@@ -53,7 +53,7 @@ Additional details are available `in the specification
     trace.set_tracer_provider(TracerProvider(resource=resource)))
     tracer = trace.get_tracer(__name__)
 
-    otlp_exporter = OTLPSpanExporter(endpoint="localhost:55680")
+    otlp_exporter = OTLPSpanExporter(endpoint="localhost:55680", insecure=True)
 
     span_processor = BatchExportSpanProcessor(otlp_exporter)
 

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/exporter.py
@@ -201,15 +201,23 @@ class OTLPExporterMixin(
             self._client = self._stub(
                 insecure_channel(endpoint, compression=compression_algorithm)
             )
-        else:
-            credentials = credentials or _load_credential_from_file(
-                Configuration().EXPORTER_OTLP_CERTIFICATE
+            return
+
+        # secure mode
+        if (
+            credentials is None
+            and Configuration().EXPORTER_OTLP_CERTIFICATE is None
+        ):
+            raise ValueError("No credentials set in secure mode.")
+
+        credentials = credentials or _load_credential_from_file(
+            Configuration().EXPORTER_OTLP_CERTIFICATE
+        )
+        self._client = self._stub(
+            secure_channel(
+                endpoint, credentials, compression=compression_algorithm
             )
-            self._client = self._stub(
-                secure_channel(
-                    endpoint, credentials, compression=compression_algorithm
-                )
-            )
+        )
 
     @abstractmethod
     def _translate_data(

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
@@ -91,6 +91,10 @@ class TestOTLPMetricExporter(TestCase):
         self.assertIsNotNone(kwargs["credentials"])
         self.assertIsInstance(kwargs["credentials"], ChannelCredentials)
 
+    def test_no_credentials_error(self):
+        with self.assertRaises(ValueError):
+            OTLPMetricsExporter()
+
     @patch("opentelemetry.sdk.metrics.export.aggregate.time_ns")
     def test_translate_metrics(self, mock_time_ns):
         # pylint: disable=no-member

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
@@ -183,6 +183,10 @@ class TestOTLPSpanExporter(TestCase):
         self.assertIsNotNone(kwargs["credentials"])
         self.assertIsInstance(kwargs["credentials"], ChannelCredentials)
 
+    def test_no_credentials_error(self):
+        with self.assertRaises(ValueError):
+            OTLPSpanExporter()
+
     @patch("opentelemetry.exporter.otlp.exporter.expo")
     @patch("opentelemetry.exporter.otlp.exporter.sleep")
     def test_unavailable(self, mock_sleep, mock_expo):


### PR DESCRIPTION
Signed-off-by: Abhilash Gnan <abhilashgnan@gmail.com>

# Description

Env var support for OTLP exporter was added in https://github.com/open-telemetry/opentelemetry-python/pull/1101. There is a error case(https://github.com/open-telemetry/opentelemetry-python/pull/1101#discussion_r515398394) which needs to be handled when `credentials` is not available in case of `insecure=False`(default).

This PR adds a `ValueError` for such case. Also, modified sample code to have `insecure=True`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
