### PR TITLE
Rename MetricRecord to ExportRecord to comply with Metrics Spec

### DIFF
--- a/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_metrics_exporter.py
@@ -28,7 +28,7 @@ from opentelemetry.sdk.metrics import (
     get_dict_as_key,
 )
 from opentelemetry.sdk.metrics.export import (
-    MetricRecord,
+    ExportRecord,
     MetricsExportResult,
     aggregate,
 )
@@ -100,7 +100,7 @@ class TestCollectorMetricsExporter(unittest.TestCase):
             "testName", "testDescription", "unit", float,
         )
         result = metrics_exporter.get_collector_point(
-            MetricRecord(
+            ExportRecord(
                 int_counter,
                 self._key_labels,
                 aggregator,
@@ -113,7 +113,7 @@ class TestCollectorMetricsExporter(unittest.TestCase):
         aggregator.update(123.5)
         aggregator.take_checkpoint()
         result = metrics_exporter.get_collector_point(
-            MetricRecord(
+            ExportRecord(
                 float_counter,
                 self._key_labels,
                 aggregator,
@@ -124,7 +124,7 @@ class TestCollectorMetricsExporter(unittest.TestCase):
         self.assertRaises(
             TypeError,
             metrics_exporter.get_collector_point(
-                MetricRecord(
+                ExportRecord(
                     valuerecorder,
                     self._key_labels,
                     aggregator,
@@ -144,7 +144,7 @@ class TestCollectorMetricsExporter(unittest.TestCase):
         test_metric = self._meter.create_counter(
             "testname", "testdesc", "unit", int, self._labels.keys(),
         )
-        record = MetricRecord(
+        record = ExportRecord(
             test_metric,
             self._key_labels,
             aggregate.SumAggregator(),
@@ -173,7 +173,7 @@ class TestCollectorMetricsExporter(unittest.TestCase):
         aggregator = aggregate.SumAggregator()
         aggregator.update(123)
         aggregator.take_checkpoint()
-        record = MetricRecord(
+        record = ExportRecord(
             test_metric,
             self._key_labels,
             aggregator,

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
@@ -40,7 +40,7 @@ from opentelemetry.proto.resource.v1.resource_pb2 import (
     Resource as OTLPResource,
 )
 from opentelemetry.sdk.metrics import Counter, MeterProvider
-from opentelemetry.sdk.metrics.export import MetricRecord
+from opentelemetry.sdk.metrics.export import ExportRecord
 from opentelemetry.sdk.metrics.export.aggregate import SumAggregator
 from opentelemetry.sdk.resources import Resource as SDKResource
 
@@ -50,7 +50,7 @@ class TestOTLPMetricExporter(TestCase):
         self.exporter = OTLPMetricsExporter(insecure=True)
         resource = SDKResource(OrderedDict([("a", 1), ("b", False)]))
 
-        self.counter_metric_record = MetricRecord(
+        self.counter_export_record = ExportRecord(
             Counter(
                 "c",
                 "d",
@@ -97,9 +97,9 @@ class TestOTLPMetricExporter(TestCase):
 
         mock_time_ns.configure_mock(**{"return_value": 1})
 
-        self.counter_metric_record.aggregator.checkpoint = 1
-        self.counter_metric_record.aggregator.initial_checkpoint_timestamp = 1
-        self.counter_metric_record.aggregator.last_update_timestamp = 1
+        self.counter_export_record.aggregator.checkpoint = 1
+        self.counter_export_record.aggregator.initial_checkpoint_timestamp = 1
+        self.counter_export_record.aggregator.last_update_timestamp = 1
 
         expected = ExportMetricsServiceRequest(
             resource_metrics=[
@@ -146,6 +146,6 @@ class TestOTLPMetricExporter(TestCase):
         )
 
         # pylint: disable=protected-access
-        actual = self.exporter._translate_data([self.counter_metric_record])
+        actual = self.exporter._translate_data([self.counter_export_record])
 
         self.assertEqual(expected, actual)

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -24,7 +24,7 @@ from opentelemetry.exporter.prometheus import (
 )
 from opentelemetry.metrics import get_meter_provider, set_meter_provider
 from opentelemetry.sdk import metrics
-from opentelemetry.sdk.metrics.export import MetricRecord, MetricsExportResult
+from opentelemetry.sdk.metrics.export import ExportRecord, MetricsExportResult
 from opentelemetry.sdk.metrics.export.aggregate import (
     MinMaxSumCountAggregator,
     SumAggregator,
@@ -66,7 +66,7 @@ class TestPrometheusMetricExporter(unittest.TestCase):
 
     def test_export(self):
         with self._registry_register_patch:
-            record = MetricRecord(
+            record = ExportRecord(
                 self._test_metric,
                 self._labels_key,
                 SumAggregator(),
@@ -89,7 +89,7 @@ class TestPrometheusMetricExporter(unittest.TestCase):
         aggregator.update(123)
         aggregator.update(456)
         aggregator.take_checkpoint()
-        record = MetricRecord(
+        record = ExportRecord(
             metric, key_labels, aggregator, get_meter_provider().resource
         )
         collector = CustomCollector("testprefix")
@@ -107,7 +107,7 @@ class TestPrometheusMetricExporter(unittest.TestCase):
         aggregator = SumAggregator()
         aggregator.update(123)
         aggregator.take_checkpoint()
-        record = MetricRecord(
+        record = ExportRecord(
             metric, key_labels, aggregator, get_meter_provider().resource
         )
         collector = CustomCollector("testprefix")
@@ -135,7 +135,7 @@ class TestPrometheusMetricExporter(unittest.TestCase):
         metric = StubMetric("tesname", "testdesc", "unit", int, meter)
         labels = {"environment": "staging"}
         key_labels = get_dict_as_key(labels)
-        record = MetricRecord(
+        record = ExportRecord(
             metric, key_labels, None, get_meter_provider().resource
         )
         collector = CustomCollector("testprefix")

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-- Add optional parameter to `record_exception` method ([#1314](https://github.com/open-telemetry/opentelemetry-python/pull/1314))
+- Rename `MetricRecord` class to `ExportRecord`
+  ([#1367](https://github.com/open-telemetry/opentelemetry-python/pull/1367))
+- Add optional parameter to `record_exception` method
+  ([#1314](https://github.com/open-telemetry/opentelemetry-python/pull/1314))
 - Update exception handling optional parameters, add escaped attribute to record_exception
   ([#1365](https://github.com/open-telemetry/opentelemetry-python/pull/1365))
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
@@ -25,7 +25,7 @@ class MetricsExportResult(Enum):
     FAILURE = 1
 
 
-class MetricRecord:
+class ExportRecord:
     def __init__(
         self,
         instrument: metrics_api.InstrumentT,
@@ -47,12 +47,12 @@ class MetricsExporter:
     """
 
     def export(
-        self, metric_records: Sequence[MetricRecord]
+        self, export_records: Sequence[ExportRecord]
     ) -> "MetricsExportResult":
         """Exports a batch of telemetry data.
 
         Args:
-            metric_records: A sequence of `MetricRecord` s. A `MetricRecord`
+            export_records: A sequence of `ExportRecord` s. A `ExportRecord`
                 contains the metric to be exported, the labels associated
                 with that metric, as well as the aggregator used to export the
                 current checkpointed value.
@@ -76,16 +76,16 @@ class ConsoleMetricsExporter(MetricsExporter):
     """
 
     def export(
-        self, metric_records: Sequence[MetricRecord]
+        self, export_records: Sequence[ExportRecord]
     ) -> "MetricsExportResult":
-        for record in metric_records:
+        for export_record in export_records:
             print(
                 '{}(data="{}", labels="{}", value={}, resource={})'.format(
                     type(self).__name__,
-                    record.instrument,
-                    record.labels,
-                    record.aggregator.checkpoint,
-                    record.resource.attributes,
+                    export_record.instrument,
+                    export_record.labels,
+                    export_record.aggregator.checkpoint,
+                    export_record.resource.attributes,
                 )
             )
         return MetricsExportResult.SUCCESS

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/in_memory_metrics_exporter.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/in_memory_metrics_exporter.py
@@ -16,7 +16,7 @@ import threading
 from typing import Sequence
 
 from opentelemetry.sdk.metrics.export import (
-    MetricRecord,
+    ExportRecord,
     MetricsExporter,
     MetricsExportResult,
 )
@@ -41,13 +41,13 @@ class InMemoryMetricsExporter(MetricsExporter):
             self._exported_metrics.clear()
 
     def export(
-        self, metric_records: Sequence[MetricRecord]
+        self, export_records: Sequence[ExportRecord]
     ) -> MetricsExportResult:
         if self._stopped:
             return MetricsExportResult.FAILURE
 
         with self._lock:
-            self._exported_metrics.extend(metric_records)
+            self._exported_metrics.extend(export_records)
         return MetricsExportResult.SUCCESS
 
     def get_exported_metrics(self):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/processor.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/processor.py
@@ -14,7 +14,7 @@
 
 from typing import Sequence
 
-from opentelemetry.sdk.metrics.export import MetricRecord
+from opentelemetry.sdk.metrics.export import ExportRecord
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.util import get_dict_as_key
 
@@ -36,22 +36,22 @@ class Processor:
         self.stateful = stateful
         self._resource = resource
 
-    def checkpoint_set(self) -> Sequence[MetricRecord]:
-        """Returns a list of MetricRecords used for exporting.
+    def checkpoint_set(self) -> Sequence[ExportRecord]:
+        """Returns a list of ExportRecords used for exporting.
 
-        The list of MetricRecords is a snapshot created from the current
+        The list of ExportRecords is a snapshot created from the current
         data in all of the aggregators in this processor.
         """
-        metric_records = []
+        export_records = []
         # pylint: disable=W0612
         for (
             (instrument, aggregator_type, _, labels),
             aggregator,
         ) in self._batch_map.items():
-            metric_records.append(
-                MetricRecord(instrument, labels, aggregator, self._resource)
+            export_records.append(
+                ExportRecord(instrument, labels, aggregator, self._resource)
             )
-        return metric_records
+        return export_records
 
     def finished_collection(self):
         """Performs certain post-export logic.

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -22,7 +22,7 @@ from opentelemetry.context import get_value
 from opentelemetry.sdk import metrics
 from opentelemetry.sdk.metrics.export import (
     ConsoleMetricsExporter,
-    MetricRecord,
+    ExportRecord,
 )
 from opentelemetry.sdk.metrics.export.aggregate import (
     LastValueAggregator,
@@ -52,7 +52,7 @@ class TestConsoleMetricsExporter(unittest.TestCase):
         )
         labels = {"environment": "staging"}
         aggregator = SumAggregator()
-        record = MetricRecord(
+        record = ExportRecord(
             metric, labels, aggregator, meter_provider.resource
         )
         result = '{}(data="{}", labels="{}", value={}, resource={})'.format(


### PR DESCRIPTION
# Description
Renaming all instances of MetricRecord to ExportRecord to adhere to [Metric Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/sdk.md)

Relates to issues #1345  and #1307 

## Type of change
- [x] Spec Compliance (non-breaking change which further complies sdk with spec)

# How Has This Been Tested?
I ran tox to make sure nothing had been accidentally broken while renaming.

# Checklist:
- [x] Followed the style guidelines of this project
- [x] Unit tests have been updated added
