### PR TITLE
Add Contrib repo checkout for docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,12 +10,20 @@ on:
     - 'instrumentation/**'
     - 'opentelemetry-python/opentelemetry-api/src/opentelemetry/**'
     - 'opentelemetry-python/opentelemetry-sdk/src/opentelemetry/sdk/**'
+env:
+  CONTRIB_REPO_SHA: master
 
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Checkout Contrib Repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
+        uses: actions/checkout@v2
+        with:
+          repository: open-telemetry/opentelemetry-python-contrib
+          ref: ${{ env.CONTRIB_REPO_SHA }}
+          path: opentelemetry-python-contrib
     - name: Set up Python py38
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
# Description

This fixes the issue with the docs build which is failing because the Contrib repo is not checked out as part of the `docs.yml` workflow.

The failure can be seen here: https://github.com/open-telemetry/opentelemetry-python/runs/1379941084

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No tests, but the errors logs say it's because the `opentelemetry-python-contrib` repo directory does not exist which makes sense.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
