### PR TITLE
Renaming Meter to Accumulator in Metrics SDK context

### DIFF
--- a/opentelemetry-instrumentation/tests/test_metric.py
+++ b/opentelemetry-instrumentation/tests/test_metric.py
@@ -41,7 +41,7 @@ class TestMetricMixin(TestCase):
         mixin = MetricMixin()
         mixin.init_metrics("test", 1.0)
         meter = mixin.meter
-        self.assertTrue(isinstance(meter, metrics.Meter))
+        self.assertTrue(isinstance(meter, metrics.Accumulator))
         self.assertEqual(meter.instrumentation_info.name, "test")
         self.assertEqual(meter.instrumentation_info.version, 1.0)
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Update exception handling optional parameters, add escaped attribute to record_exception
   ([#1365](https://github.com/open-telemetry/opentelemetry-python/pull/1365))
 - Rename Record in Metrics SDK to Accumulation ([#1373](https://github.com/open-telemetry/opentelemetry-python/pull/1373))
+- Rename Meter class to Accumulator in Metrics SDK ([#1372](https://github.com/open-telemetry/opentelemetry-python/pull/1372))
 
 ## Version 0.15b0
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -8,8 +8,10 @@
   ([#1314](https://github.com/open-telemetry/opentelemetry-python/pull/1314))
 - Update exception handling optional parameters, add escaped attribute to record_exception
   ([#1365](https://github.com/open-telemetry/opentelemetry-python/pull/1365))
-- Rename Record in Metrics SDK to Accumulation ([#1373](https://github.com/open-telemetry/opentelemetry-python/pull/1373))
-- Rename Meter class to Accumulator in Metrics SDK ([#1372](https://github.com/open-telemetry/opentelemetry-python/pull/1372))
+- Rename Record in Metrics SDK to Accumulation
+  ([#1373](https://github.com/open-telemetry/opentelemetry-python/pull/1373))
+- Rename Meter class to Accumulator in Metrics SDK
+  ([#1372](https://github.com/open-telemetry/opentelemetry-python/pull/1372))
 
 ## Version 0.15b0
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -145,7 +145,7 @@ class Metric(metrics_api.Metric):
         description: str,
         unit: str,
         value_type: Type[metrics_api.ValueT],
-        meter: "Meter",
+        meter: "Accumulator",
         enabled: bool = True,
     ):
         self.name = name
@@ -339,7 +339,7 @@ class Accumulation:
         self.aggregator = aggregator
 
 
-class Meter(metrics_api.Meter):
+class Accumulator(metrics_api.Meter):
     """See `opentelemetry.metrics.Meter`.
 
     Args:
@@ -561,7 +561,7 @@ class MeterProvider(metrics_api.MeterProvider):
         if not instrumenting_module_name:  # Reject empty strings too.
             instrumenting_module_name = "ERROR:MISSING MODULE NAME"
             logger.error("get_meter called with missing module name.")
-        return Meter(
+        return Accumulator(
             self,
             InstrumentationInfo(
                 instrumenting_module_name, instrumenting_library_version

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/processor.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/processor.py
@@ -23,7 +23,7 @@ class Processor:
     """Base class for all processor types.
 
     The processor is responsible for storing the aggregators and aggregated
-    values received from updates from metrics in the meter. The stored values
+    values received from updates from metrics in the accumulator. The stored values
     will be sent to an exporter for exporting.
     """
 


### PR DESCRIPTION
# Description

This PR addresses Issue https://github.com/open-telemetry/opentelemetry-python/issues/1342 and issue https://github.com/open-telemetry/opentelemetry-python/issues/1307 by renaming the `Meter` class in the metrics sdk to `Accumulator`

## Summary of changes

1. rename `Meter` class to `Accumulator`
2. ~~rename all `meter = meter_provider.get_meter()` to `accumulator = meter_provider.get_meter()` for consistency~~

## Rationale behind changes
1. **rename Meter class to Accumulator**
* The [Meter Class](https://github.com/open-telemetry/opentelemetry-python/blob/master/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py#L341) does a lot of the same things as the [Accumulator in Go](https://github.com/open-telemetry/opentelemetry-go/blob/master/sdk/metric/sdk.go)

|Similarities|Meter class|Accumulator struct|
|----|----|----|
|collects all metrics|[def collect](https://github.com/open-telemetry/opentelemetry-python/blob/master/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py#L363)| [func collect](https://github.com/open-telemetry/opentelemetry-go/blob/master/sdk/metric/sdk.go#L348)|
| helper func to collect from sync instruments| [def _collect_metrics](https://github.com/open-telemetry/opentelemetry-python/blob/master/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py#L374)| [func collectSyncInstruments](https://github.com/open-telemetry/opentelemetry-go/blob/master/sdk/metric/sdk.go#L359)|
| helper func to collect from async instruments| [def _collect_observers](https://github.com/open-telemetry/opentelemetry-python/blob/master/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py#L397) | [func observeAsyncInstruments](https://github.com/open-telemetry/opentelemetry-go/blob/master/sdk/metric/sdk.go#L413)|
| record batch metric events | [def record_batch](https://github.com/open-telemetry/opentelemetry-python/blob/master/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py#L410) | [func RecordBatch](https://github.com/open-telemetry/opentelemetry-go/blob/master/sdk/metric/sdk.go#L480)|
| register sync instruments | create_counter, create_updowncounter etc | [func NewSyncInstrument](https://github.com/open-telemetry/opentelemetry-go/blob/master/sdk/metric/sdk.go#L317)|
| register async instruments | register_sumobserver, register_updownsumobserver etc | [func NewAsyncInstrument](https://github.com/open-telemetry/opentelemetry-go/blob/master/sdk/metric/sdk.go#L327) |

* The `Meter` class does all of what is defined for the`Accumulator` in the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/sdk.md#dataflow-diagram) 
    * extends the `Meter` interface
    * adds collection methods for Synchronous and Asynchronous instruments (which are metrics and observers respectively in Python)
    * registers records to concurrency update and aggregate records of metric data

2. ~~**rename all `meter = meter_provider.get_meter()` to `accumulator = meter_provider.get_meter()` for consistency**~~

*  ~~feels awkward to have an instance of a `meter` since a meter is an interface~~
*  ~~now that the metrics sdk meter_provider returns an accumulator, the usage in various tests and examples should reflect what is actually being returned~~

## Type of change

Please delete options that are not relevant.

- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Just made sure all the tests are passing post name changes.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] ~~Unit tests have been added~~
- [x] Documentation has been updated

cc - @ocelotl 