### PR TITLE
Rename Record class in Metrics SDK to Accumulation to follow spec

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -8,6 +8,7 @@
   ([#1314](https://github.com/open-telemetry/opentelemetry-python/pull/1314))
 - Update exception handling optional parameters, add escaped attribute to record_exception
   ([#1365](https://github.com/open-telemetry/opentelemetry-python/pull/1365))
+- Rename Record in Metrics SDK to Accumulation ([#1373](https://github.com/open-telemetry/opentelemetry-python/pull/1373))
 
 ## Version 0.15b0
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -325,7 +325,7 @@ class ValueObserver(Observer, metrics_api.ValueObserver):
     """See `opentelemetry.metrics.ValueObserver`."""
 
 
-class Record:
+class Accumulation:
     """Container class used for processing in the `Processor`"""
 
     def __init__(
@@ -382,10 +382,10 @@ class Meter(metrics_api.Meter):
                     bound_instrument,
                 ) in metric.bound_instruments.items():
                     for view_data in bound_instrument.view_datas:
-                        record = Record(
+                        accumulation = Accumulation(
                             metric, view_data.labels, view_data.aggregator
                         )
-                        self.processor.process(record)
+                        self.processor.process(accumulation)
 
                     if bound_instrument.ref_count() == 0:
                         to_remove.append(labels)
@@ -404,8 +404,8 @@ class Meter(metrics_api.Meter):
                     continue
 
                 for labels, aggregator in observer.aggregators.items():
-                    record = Record(observer, labels, aggregator)
-                    self.processor.process(record)
+                    accumulation = Accumulation(observer, labels, aggregator)
+                    self.processor.process(accumulation)
 
     def record_batch(
         self,

--- a/opentelemetry-sdk/tests/metrics/export/test_export.py
+++ b/opentelemetry-sdk/tests/metrics/export/test_export.py
@@ -139,8 +139,8 @@ class TestProcessor(unittest.TestCase):
         _batch_map[batch_key] = aggregator
         aggregator2.update(1.0)
         processor._batch_map = _batch_map
-        record = metrics.Record(metric, labels, aggregator2)
-        processor.process(record)
+        accumulation = metrics.Accumulation(metric, labels, aggregator2)
+        processor.process(accumulation)
         self.assertEqual(len(processor._batch_map), 1)
         self.assertIsNotNone(processor._batch_map.get(batch_key))
         self.assertEqual(processor._batch_map.get(batch_key).current, 0)
@@ -159,8 +159,8 @@ class TestProcessor(unittest.TestCase):
         batch_key = (metric, SumAggregator, tuple(), labels)
         aggregator.update(1.0)
         processor._batch_map = _batch_map
-        record = metrics.Record(metric, labels, aggregator)
-        processor.process(record)
+        accumulation = metrics.Accumulation(metric, labels, aggregator)
+        processor.process(accumulation)
         self.assertEqual(len(processor._batch_map), 1)
         self.assertIsNotNone(processor._batch_map.get(batch_key))
         self.assertEqual(processor._batch_map.get(batch_key).current, 0)
@@ -182,8 +182,8 @@ class TestProcessor(unittest.TestCase):
         batch_key = (metric, SumAggregator, tuple(), labels)
         aggregator.update(1.0)
         processor._batch_map = _batch_map
-        record = metrics.Record(metric, labels, aggregator)
-        processor.process(record)
+        accumulation = metrics.Accumulation(metric, labels, aggregator)
+        processor.process(accumulation)
         self.assertEqual(len(processor._batch_map), 1)
         self.assertIsNotNone(processor._batch_map.get(batch_key))
         self.assertEqual(processor._batch_map.get(batch_key).current, 0)


### PR DESCRIPTION
# Description

This PR addresses Issue https://github.com/open-telemetry/opentelemetry-python/issues/1343 and issue https://github.com/open-telemetry/opentelemetry-python/issues/1307 by renaming the `Record` class in the metrics sdk to `Accumulation`

related to PR https://github.com/open-telemetry/opentelemetry-python/pull/1372 and issue https://github.com/open-telemetry/opentelemetry-python/issues/1342

## Summary of Changes

1. rename `Record` class to `Accumulation`
2. rename all `record = metrics.Accumulation()` to `accumulation = metrics.Accumulation()` for consistency

## Rationale behind changes

**1. rename `Record` class to `Accumulation`**
* PR https://github.com/open-telemetry/opentelemetry-python/pull/1372 showed that the `Meter` class should be renamed to `Accumulator`
* According to the [Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/sdk.md#accumulator-collect-function), the type computed/collected by the Accumulator must be named Accumulation

**2. rename all `record = metrics.Accumulation()` to `accumulation = metrics.Accumulation()` for consistency**

* cleaning up vestigial naming scheme from when Accumulation used to be called Record. 
* variable name should reflect what is actually behind returned

## Type of change

Please delete options that are not relevant.

- ~~[ ] Bug fix (non-breaking change which fixes an issue)~~
- ~~[ ] New feature (non-breaking change which adds functionality)~~
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Just made sure all the tests are passing post naming change

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] ~~Unit tests have been added~~
- [ ] ~~Documentation has been updated~~

cc - @ocelotl 