### PR TITLE
Add support for span collection limit via env vars

### DIFF
--- a/exporter/opentelemetry-exporter-jaeger/tests/test_jaeger_exporter.py
+++ b/exporter/opentelemetry-exporter-jaeger/tests/test_jaeger_exporter.py
@@ -41,6 +41,12 @@ class TestJaegerSpanExporter(unittest.TestCase):
         self._test_span = trace._Span("test_span", context=context)
         self._test_span.start()
         self._test_span.end()
+        # pylint: disable=protected-access
+        Configuration._reset()
+
+    def tearDown(self):
+        # pylint: disable=protected-access
+        Configuration._reset()
 
     def test_constructor_default(self):
         """Test the default values assigned by constructor."""
@@ -141,8 +147,6 @@ class TestJaegerSpanExporter(unittest.TestCase):
         self.assertTrue(exporter.collector.auth is None)
 
         environ_patcher.stop()
-
-        Configuration._reset()
 
     def test_nsec_to_usec_round(self):
         # pylint: disable=protected-access

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([#1425](https://github.com/open-telemetry/opentelemetry-python/pull/1425))
 - Add `fields` to propagators
   ([#1374](https://github.com/open-telemetry/opentelemetry-python/pull/1374))
+- Add support for OTEL_SPAN_{ATTRIBUTE_COUNT_LIMIT,EVENT_COUNT_LIMIT,LINK_COUNT_LIMIT}
+  ([#1377](https://github.com/open-telemetry/opentelemetry-python/pull/1377))
 
 ## Version 0.16b0
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -37,6 +37,7 @@ from typing import (
 
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
+from opentelemetry.configuration import Configuration
 from opentelemetry.sdk import util
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import sampling
@@ -49,9 +50,11 @@ from opentelemetry.util import time_ns, types
 
 logger = logging.getLogger(__name__)
 
-MAX_NUM_ATTRIBUTES = 1000
-MAX_NUM_EVENTS = 1000
-MAX_NUM_LINKS = 1000
+SPAN_ATTRIBUTE_COUNT_LIMIT = Configuration().get(
+    "SPAN_ATTRIBUTE_COUNT_LIMIT", 1000
+)
+SPAN_EVENT_COUNT_LIMIT = Configuration().get("SPAN_EVENT_COUNT_LIMIT", 1000)
+SPAN_LINK_COUNT_LIMIT = Configuration().get("SPAN_LINK_COUNT_LIMIT", 1000)
 VALID_ATTR_VALUE_TYPES = (bool, str, int, float)
 
 
@@ -446,7 +449,7 @@ class Span(trace_api.Span):
             self.attributes = self._new_attributes()
         else:
             self.attributes = BoundedDict.from_map(
-                MAX_NUM_ATTRIBUTES, attributes
+                SPAN_ATTRIBUTE_COUNT_LIMIT, attributes
             )
 
         self.events = self._new_events()
@@ -462,7 +465,7 @@ class Span(trace_api.Span):
         if links is None:
             self.links = self._new_links()
         else:
-            self.links = BoundedList.from_seq(MAX_NUM_LINKS, links)
+            self.links = BoundedList.from_seq(SPAN_LINK_COUNT_LIMIT, links)
 
         self._end_time = None  # type: Optional[int]
         self._start_time = None  # type: Optional[int]
@@ -483,15 +486,15 @@ class Span(trace_api.Span):
 
     @staticmethod
     def _new_attributes():
-        return BoundedDict(MAX_NUM_ATTRIBUTES)
+        return BoundedDict(SPAN_ATTRIBUTE_COUNT_LIMIT)
 
     @staticmethod
     def _new_events():
-        return BoundedList(MAX_NUM_EVENTS)
+        return BoundedList(SPAN_EVENT_COUNT_LIMIT)
 
     @staticmethod
     def _new_links():
-        return BoundedList(MAX_NUM_LINKS)
+        return BoundedList(SPAN_LINK_COUNT_LIMIT)
 
     @staticmethod
     def _format_context(context):


### PR DESCRIPTION
This adds support for the following env variables:
* OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT (Maximum allowed span attribute count)
* OTEL_SPAN_EVENT_COUNT_LIMIT (Maximum allowed span event count)
* OTEL_SPAN_LINK_COUNT_LIMIT (Maximum allowed span link count)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #1364

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update  (not sure?)

# How Has This Been Tested?

Unit tests added

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated (Needed? If yes, where?)
