### PR TITLE
Add __getnewargs__ to SpanContext class to support pickle

### DIFF
--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add optional parameter to `record_exception` method ([#1314](https://github.com/open-telemetry/opentelemetry-python/pull/1314))
+- Add pickle support to SpanContext class ([#1379](https://github.com/open-telemetry/opentelemetry-python/pull/1379))
 
 ## Version 0.15b0
 

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -200,23 +200,6 @@ class SpanContext(
             self.trace_state,
         )
 
-    def __reduce__(
-        self,
-    ) -> typing.Tuple[
-        typing.Type.SpanContext, 
-        typing.Tuple[int, int, bool, "TraceFlags", "TraceState"],
-    ]:
-        return (
-            SpanContext, 
-            (
-                self.trace_id,
-                self.span_id,
-                self.is_remote,
-                self.trace_flags,
-                self.trace_state,
-            ),
-        )
-
     @property
     def trace_id(self) -> int:
         return self[0]  # pylint: disable=unsubscriptable-object

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -189,11 +189,26 @@ class SpanContext(
             (trace_id, span_id, is_remote, trace_flags, trace_state, is_valid),
         )
 
-    def __getnewargs__(self):
-        return self.trace_id, self.span_id, self.is_remote, self.trace_flags, self.trace_state
+    def __getnewargs__(self) -> typing.Tuple[int, int, bool, "TraceFlags", "TraceState"]:
+        return (
+            self.trace_id, 
+            self.span_id, 
+            self.is_remote, 
+            self.trace_flags, 
+            self.trace_state,
+        )
 
-    def __reduce__(self):
-        return (SpanContext, (self.trace_id, self.span_id, self.is_remote, self.trace_flags, self.trace_state))        
+    def __reduce__(self) -> "SpanContext":
+        return (
+            SpanContext, 
+            (
+                self.trace_id, 
+                self.span_id, 
+                self.is_remote, 
+                self.trace_flags, 
+                self.trace_state,
+            ),
+        )        
 
     @property
     def trace_id(self) -> int:

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -189,26 +189,17 @@ class SpanContext(
             (trace_id, span_id, is_remote, trace_flags, trace_state, is_valid),
         )
 
-    def __getnewargs__(self) -> typing.Tuple[int, int, bool, "TraceFlags", "TraceState"]:
-        return (
-            self.trace_id, 
-            self.span_id, 
-            self.is_remote, 
-            self.trace_flags, 
-            self.trace_state,
-        )
+    def __getnewargs__(
+        self,
+    ) -> typing.Tuple[int, int, bool, "TraceFlags", "TraceState"]:
+        return (self.trace_id, self.span_id, self.is_remote, self.trace_flags, self.trace_state)
 
-    def __reduce__(self) -> "SpanContext":
-        return (
-            SpanContext, 
-            (
-                self.trace_id, 
-                self.span_id, 
-                self.is_remote, 
-                self.trace_flags, 
-                self.trace_state,
-            ),
-        )        
+    def __reduce__(
+        self,
+    ) -> typing.Tuple[
+        "SpanContext", typing.Tuple[int, int, bool, "TraceFlags", "TraceState"]
+    ]:
+        return (SpanContext, (self.trace_id, self.span_id, self.is_remote, self.trace_flags, self.trace_state))
 
     @property
     def trace_id(self) -> int:

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -189,6 +189,12 @@ class SpanContext(
             (trace_id, span_id, is_remote, trace_flags, trace_state, is_valid),
         )
 
+    def __getnewargs__(self):
+        return self.trace_id, self.span_id, self.is_remote, self.trace_flags, self.trace_state
+
+    def __reduce__(self):
+        return (SpanContext, (self.trace_id, self.span_id, self.is_remote, self.trace_flags, self.trace_state))        
+
     @property
     def trace_id(self) -> int:
         return self[0]  # pylint: disable=unsubscriptable-object

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -203,16 +203,16 @@ class SpanContext(
     def __reduce__(
         self,
     ) -> typing.Tuple[
-        typing.Type.SpanContext, typing.Tuple[int,
-                                              int, bool, "TraceFlags", "TraceState"]
+        typing.Type.SpanContext, 
+        typing.Tuple[int, int, bool, "TraceFlags", "TraceState"],
     ]:
         return (
             SpanContext, 
             (
-                self.trace_id, 
-                self.span_id, 
-                self.is_remote, 
-                self.trace_flags, 
+                self.trace_id,
+                self.span_id,
+                self.is_remote,
+                self.trace_flags,
                 self.trace_state,
             ),
         )

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -192,14 +192,30 @@ class SpanContext(
     def __getnewargs__(
         self,
     ) -> typing.Tuple[int, int, bool, "TraceFlags", "TraceState"]:
-        return (self.trace_id, self.span_id, self.is_remote, self.trace_flags, self.trace_state)
+        return (
+            self.trace_id,
+            self.span_id,
+            self.is_remote,
+            self.trace_flags,
+            self.trace_state,
+        )
 
     def __reduce__(
         self,
     ) -> typing.Tuple[
-        "SpanContext", typing.Tuple[int, int, bool, "TraceFlags", "TraceState"]
+        typing.Type.SpanContext, typing.Tuple[int,
+                                              int, bool, "TraceFlags", "TraceState"]
     ]:
-        return (SpanContext, (self.trace_id, self.span_id, self.is_remote, self.trace_flags, self.trace_state))
+        return (
+            SpanContext, 
+            (
+                self.trace_id, 
+                self.span_id, 
+                self.is_remote, 
+                self.trace_flags, 
+                self.trace_state,
+            ),
+        )
 
     @property
     def trace_id(self) -> int:


### PR DESCRIPTION
# Description

SpanContext does not support pickle due to missing __getnewargs__. Add it to the SpanContext class

Fixes # (issue)

#1375 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Create SpanContext class and use pickle.dumps and pickle.loads without issue

- [X] Tor

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
