### PR TITLE
Add __getnewargs__ to SpanContext class

### DIFF
--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add optional parameter to `record_exception` method ([#1314](https://github.com/open-telemetry/opentelemetry-python/pull/1314))
+- Add pickle support to SpanContext class ([#1380](https://github.com/open-telemetry/opentelemetry-python/pull/1380))
 
 ## Version 0.15b0
 

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -199,7 +199,7 @@ class SpanContext(
             self.trace_flags,
             self.trace_state,
         )
-        
+
     @property
     def trace_id(self) -> int:
         return self[0]  # pylint: disable=unsubscriptable-object

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -189,6 +189,17 @@ class SpanContext(
             (trace_id, span_id, is_remote, trace_flags, trace_state, is_valid),
         )
 
+    def __getnewargs__(
+        self,
+    ) -> typing.Tuple[int, int, bool, "TraceFlags", "TraceState"]:
+        return (
+            self.trace_id,
+            self.span_id,
+            self.is_remote,
+            self.trace_flags,
+            self.trace_state,
+        )
+        
     @property
     def trace_id(self) -> int:
         return self[0]  # pylint: disable=unsubscriptable-object

--- a/opentelemetry-api/tests/trace/test_span_context.py
+++ b/opentelemetry-api/tests/trace/test_span_context.py
@@ -30,3 +30,4 @@ class TestSpanContext(unittest.TestCase):
         pickle_sc = pickle.loads(pickle.dumps(sc))
         self.assertEqual(sc.trace_id, pickle_sc.trace_id)
         self.assertEqual(sc.span_id, pickle_sc.span_id)
+  

--- a/opentelemetry-api/tests/trace/test_span_context.py
+++ b/opentelemetry-api/tests/trace/test_span_context.py
@@ -1,0 +1,34 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import pickle
+
+from opentelemetry import trace
+
+class TestSpanContext(unittest.TestCase):
+    def test_span_context_pickle(self):
+
+        sc = trace.SpanContext(
+            1,
+            2,
+            is_remote=False,
+            trace_flags=trace.DEFAULT_TRACE_OPTIONS,
+            trace_state=trace.DEFAULT_TRACE_STATE,
+        )
+
+        pickle_sc = pickle.loads(pickle.dumps(sc))
+
+        self.assertEqual(sc.trace_id, pickle_sc.trace_id)
+        self.assertEqual(sc.span_id, pickle_sc.span_id)

--- a/opentelemetry-api/tests/trace/test_span_context.py
+++ b/opentelemetry-api/tests/trace/test_span_context.py
@@ -20,6 +20,10 @@ from opentelemetry import trace
 
 class TestSpanContext(unittest.TestCase):
     def test_span_context_pickle(self):
+        """
+        SpanContext needs to be pickleable to support multiprocessing
+        so span can start as parent from the new spawned process
+        """
         sc = trace.SpanContext(
             1,
             2,

--- a/opentelemetry-api/tests/trace/test_span_context.py
+++ b/opentelemetry-api/tests/trace/test_span_context.py
@@ -17,9 +17,9 @@ import pickle
 
 from opentelemetry import trace
 
+
 class TestSpanContext(unittest.TestCase):
     def test_span_context_pickle(self):
-
         sc = trace.SpanContext(
             1,
             2,
@@ -27,8 +27,6 @@ class TestSpanContext(unittest.TestCase):
             trace_flags=trace.DEFAULT_TRACE_OPTIONS,
             trace_state=trace.DEFAULT_TRACE_STATE,
         )
-
         pickle_sc = pickle.loads(pickle.dumps(sc))
-
         self.assertEqual(sc.trace_id, pickle_sc.trace_id)
         self.assertEqual(sc.span_id, pickle_sc.span_id)

--- a/opentelemetry-api/tests/trace/test_span_context.py
+++ b/opentelemetry-api/tests/trace/test_span_context.py
@@ -30,4 +30,3 @@ class TestSpanContext(unittest.TestCase):
         pickle_sc = pickle.loads(pickle.dumps(sc))
         self.assertEqual(sc.trace_id, pickle_sc.trace_id)
         self.assertEqual(sc.span_id, pickle_sc.span_id)
-  

--- a/opentelemetry-api/tests/trace/test_span_context.py
+++ b/opentelemetry-api/tests/trace/test_span_context.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import pickle
+import unittest
 
 from opentelemetry import trace
 


### PR DESCRIPTION
# Description

SpanContext does not support pickle due to missing getnewargs function. Add function to SpanContext.

Fixes # (issue)
#1375 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Tor

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated