### PR TITLE
opentelemetry.sdk.util type stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ __pycache__
 venv*/
 .venv*/
 opentelemetry-python-contrib/
+# in case of symlink
+opentelemetry-python-contrib
 
 # Installer logs
 pip-log.txt

--- a/opentelemetry-api/src/opentelemetry/util/types.py
+++ b/opentelemetry-api/src/opentelemetry/util/types.py
@@ -13,17 +13,28 @@
 # limitations under the License.
 
 
-from typing import Callable, Mapping, Optional, Sequence, Union
+from typing import Callable, Mapping, Optional, Sequence, Tuple, Union
 
 AttributeValue = Union[
     str,
     bool,
     int,
     float,
-    Sequence[Union[None, str]],
-    Sequence[Union[None, bool]],
-    Sequence[Union[None, int]],
-    Sequence[Union[None, float]],
+    Sequence[Optional[str]],
+    Sequence[Optional[bool]],
+    Sequence[Optional[int]],
+    Sequence[Optional[float]],
+]
+AttributeValueAsKey = Union[
+    str,
+    bool,
+    int,
+    float,
+    Tuple[Optional[str], ...],
+    Tuple[Optional[bool], ...],
+    Tuple[Optional[int], ...],
+    Tuple[Optional[float], ...],
 ]
 Attributes = Optional[Mapping[str, AttributeValue]]
+AttributesAsKey = Tuple[Tuple[str, AttributeValueAsKey], ...]
 AttributesFormatter = Callable[[], Attributes]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -11,16 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import datetime
 import threading
 from collections import OrderedDict, deque
-
-try:
-    # pylint: disable=ungrouped-imports
-    from collections.abc import MutableMapping, Sequence
-except ImportError:
-    # pylint: disable=no-name-in-module,ungrouped-imports
-    from collections import MutableMapping, Sequence
+from collections.abc import MutableMapping, Sequence
 
 
 def ns_to_iso_str(nanoseconds):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.pyi
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.pyi
@@ -1,0 +1,71 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import (
+    Iterable,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    Sequence,
+    TypeVar,
+    overload,
+)
+
+from opentelemetry.util.types import AttributesAsKey, AttributeValue
+
+_T = TypeVar("_T")
+_KT = TypeVar("_KT")
+_VT = TypeVar("_VT")
+
+def ns_to_iso_str(nanoseconds: int) -> str: ...
+def get_dict_as_key(
+    labels: Mapping[str, AttributeValue]
+) -> AttributesAsKey: ...
+
+class BoundedList(Sequence[_T]):
+    """An append only list with a fixed max size.
+
+    Calls to `append` and `extend` will drop the oldest elements if there is
+    not enough room.
+    """
+
+    def __init__(self, maxlen: int): ...
+    def insert(self, index: int, value: _T) -> None: ...
+    @overload
+    def __getitem__(self, i: int) -> _T: ...
+    @overload
+    def __getitem__(self, s: slice) -> Sequence[_T]: ...
+    def __len__(self) -> int: ...
+    def append(self, item: _T): ...
+    def extend(self, seq: Sequence[_T]): ...
+    @classmethod
+    def from_seq(cls, maxlen: int, seq: Iterable[_T]) -> BoundedList[_T]: ...
+
+class BoundedDict(MutableMapping[_KT, _VT]):
+    """An ordered dict with a fixed max capacity.
+
+    Oldest elements are dropped when the dict is full and a new element is
+    added.
+    """
+
+    def __init__(self, maxlen: int): ...
+    def __getitem__(self, k: _KT) -> _VT: ...
+    def __setitem__(self, k: _KT, v: _VT) -> None: ...
+    def __delitem__(self, v: _KT) -> None: ...
+    def __iter__(self) -> Iterator[_KT]: ...
+    def __len__(self) -> int: ...
+    @classmethod
+    def from_map(
+        cls, maxlen: int, mapping: Mapping[_KT, _VT]
+    ) -> BoundedDict[_KT, _VT]: ...


### PR DESCRIPTION
# Description

Adds type stubs for `opentelemetry/sdk/util/__init__py`, most importantly `BoundedList` and `BoundedDict` which are pretty widely used. I could not put the annotations inline because you can't subclass `typing.Sequence` and `collections.abc.Sequence`, and you can't add generic parameters to `collections.abc.Sequence` either.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

These are typing changes only, so I tested only by running mypy on this module

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
