### PR TITLE
Fix syntax for Docs Build Workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,24 +17,24 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Checkout Contrib Repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
+      - uses: actions/checkout@v2
+      - name: Checkout Contrib Repo @ SHA - ${{ env.CONTRIB_REPO_SHA }}
         uses: actions/checkout@v2
         with:
           repository: open-telemetry/opentelemetry-python-contrib
           ref: ${{ env.CONTRIB_REPO_SHA }}
           path: opentelemetry-python-contrib
-    - name: Set up Python py38
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Build docs
-      run: |
-        pip install --upgrade tox
-        tox -e docs
-    - name: Publish to gh-pages
-      uses: JamesIves/github-pages-deploy-action@2.0.2
-      env:
-        ACCESS_TOKEN: ${{ secrets.DocsPushToken }}
-        BRANCH: gh-pages
-        FOLDER: docs/_build/html/
+      - name: Set up Python py38
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Build docs
+        run: |
+          pip install --upgrade tox
+          tox -e docs
+      - name: Publish to gh-pages
+        uses: JamesIves/github-pages-deploy-action@2.0.2
+        env:
+          ACCESS_TOKEN: ${{ secrets.DocsPushToken }}
+          BRANCH: gh-pages
+          FOLDER: docs/_build/html/

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -6,6 +6,13 @@ sphinx-autodoc-typehints~=1.10.2
 # doesn't work for pkg_resources.
 ./opentelemetry-api
 ./opentelemetry-sdk
+./opentelemetry-python-contrib/exporter/opentelemetry-exporter-datadog
+./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc
+./opentelemetry-instrumentation
+./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests
+./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi
+./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-django
+./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask
 
 # Required by ext packages
 asgiref~=3.0

--- a/tox.ini
+++ b/tox.ini
@@ -154,18 +154,8 @@ commands =
 
 [testenv:docs]
 deps =
-  -e {toxinidir}/opentelemetry-python-contrib/exporter/opentelemetry-exporter-datadog
-  -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc
-  -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask
-  -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-django
-  -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests
-  -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi
   -c {toxinidir}/dev-requirements.txt
   -r {toxinidir}/docs-requirements.txt
-
-commands_pre =
-  pip install -e {toxinidir}/opentelemetry-api \ 
-              -e {toxinidir}/opentelemetry-sdk
 
 changedir = docs
 


### PR DESCRIPTION
# Description

Follow up to #1371 

I had a syntax error in my YAML which meant the docs build still didn't work. Further, I realized it's better and simpler to put the docs dependencies in the `docs-requirements.txt` file, so I've moved it out of tox and into there.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To fully test it this time, I temporarily disable the "only on push to `master`" condition and saw that the build succeeded on my fork.

It only failed on the publish command as expected. See the run here: https://github.com/NathanielRN/opentelemetry-python/runs/1420741830?check_suite_focus=true

# Checklist:

- [x] Followed the style guidelines of this project
