### PR TITLE
Fix OTLP exporter config tests

### DIFF
--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from collections import OrderedDict
 from unittest import TestCase
 from unittest.mock import patch
@@ -44,6 +45,8 @@ from opentelemetry.sdk.metrics.export import ExportRecord
 from opentelemetry.sdk.metrics.export.aggregate import SumAggregator
 from opentelemetry.sdk.resources import Resource as SDKResource
 
+THIS_DIR = os.path.dirname(__file__)
+
 
 class TestOTLPMetricExporter(TestCase):
     @patch("opentelemetry.sdk.metrics.export.aggregate.time_ns")
@@ -75,7 +78,8 @@ class TestOTLPMetricExporter(TestCase):
         "os.environ",
         {
             "OTEL_EXPORTER_OTLP_METRIC_ENDPOINT": "collector:55680",
-            "OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE": "fixtures/test.cert",
+            "OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE": THIS_DIR
+            + "/fixtures/test.cert",
             "OTEL_EXPORTER_OTLP_METRIC_HEADERS": "key1:value1;key2:value2",
             "OTEL_EXPORTER_OTLP_METRIC_TIMEOUT": "10",
         },

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from unittest import TestCase
@@ -52,6 +53,8 @@ from opentelemetry.sdk.trace.export import (
     SpanExportResult,
 )
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
+
+THIS_DIR = os.path.dirname(__file__)
 
 
 class TraceServiceServicerUNAVAILABLEDelay(TraceServiceServicer):
@@ -165,7 +168,8 @@ class TestOTLPSpanExporter(TestCase):
         "os.environ",
         {
             "OTEL_EXPORTER_OTLP_SPAN_ENDPOINT": "collector:55680",
-            "OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE": "fixtures/test.cert",
+            "OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE": THIS_DIR
+            + "/fixtures/test.cert",
             "OTEL_EXPORTER_OTLP_SPAN_HEADERS": "key1:value1;key2:value2",
             "OTEL_EXPORTER_OTLP_SPAN_TIMEOUT": "10",
         },


### PR DESCRIPTION
thests for the OTLP exporter failed when cwd pointed to something different than the test's directory because the file `fixtures/test.cert` could not be found.

## Type of change
- [x] unit test fix

