### PR TITLE
Instrumentation Package depends on the OTel SDK

### DIFF
--- a/opentelemetry-instrumentation/CHANGELOG.md
+++ b/opentelemetry-instrumentation/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added support for `OTEL_EXPORTER` to the `opentelemetry-instrument` command ([#1036](https://github.com/open-telemetry/opentelemetry-python/pull/1036))
 - Add missing references to instrumented packages
   ([#1416](https://github.com/open-telemetry/opentelemetry-python/pull/1416))
+- Instrumentation Package depends on the OTel SDK
+  ([#1405](https://github.com/open-telemetry/opentelemetry-python/pull/1405))
 
 ## Version 0.14b0
 

--- a/opentelemetry-instrumentation/setup.cfg
+++ b/opentelemetry-instrumentation/setup.cfg
@@ -42,6 +42,7 @@ zip_safe = False
 include_package_data = True
 install_requires =
     opentelemetry-api == 0.16.dev0
+    opentelemetry-sdk == 0.16.dev0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.packages.find]


### PR DESCRIPTION
# Description

As a follow up to https://github.com/open-telemetry/opentelemetry-python/pull/1036, with the new configurability, the instrumentation package takes a dependency on `opentelemetry.sdk` because of its use in `opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/components.py`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
~- [ ] Unit tests have been added~
~- [] Documentation has been updated~
