### PR TITLE
Ex app tests use dev grpc instrumentation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ commands_pre =
   test-core-proto: pip install {toxinidir}/opentelemetry-proto
   instrumentation: pip install {toxinidir}/opentelemetry-instrumentation
 
-  example-app: pip install {toxinidir}/opentelemetry-instrumentation {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask {toxinidir}/docs/examples/opentelemetry-example-app
+  example-app: pip install {toxinidir}/opentelemetry-instrumentation {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc {toxinidir}/docs/examples/opentelemetry-example-app
 
   getting-started: pip install -e {toxinidir}/opentelemetry-instrumentation -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask
 


### PR DESCRIPTION
# Description

In light of #1406, it was discovered that the Example App is using published packages instead of dev packages. This PR adds the **development** version of the `opentelemetry-instrumentation-grpc` package to the required install dependencies

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Covered by CI

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
