### PR TITLE
Example app dependecies needed to pass lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -145,6 +145,10 @@ deps =
   httpretty
 
 commands_pre =
+  ; The example app depends on instrumentation packages. It should be moved to the Contrib repo. Remove in #1391.
+  pip install -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests
+              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask
+              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc
   python scripts/eachdist.py install --editable --with-test-deps
 
 commands =


### PR DESCRIPTION
# Description

Adding to the strength of the argument in https://github.com/open-telemetry/opentelemetry-python/issues/1391, the Example App is causing `linting` errors in the Core repo unless the instrumentation packages are downloaded _explicitly_. These errors are valid because they say that this Example App only makes sense if the instrumentations are present, which they are not because they are in the Contrib repo.

As a quick fix to unblock the release, we add the instrumentations specifically, but the solution to https://github.com/open-telemetry/opentelemetry-python/issues/1391 should also remove these lines.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

CI tests will confirm it worked.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
