### PR TITLE
Add dependency ordering for lint tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -146,8 +146,12 @@ deps =
 
 commands_pre =
   ; The example app depends on instrumentation packages. It should be moved to the Contrib repo. Remove in #1391.
-  pip install -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests
-              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask
+  pip install -e {toxinidir}/opentelemetry-api \
+              -e {toxinidir}/opentelemetry-sdk \
+              -e {toxinidir}/opentelemetry-instrumentation \
+              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests \
+              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi \
+              -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask \
               -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc
   python scripts/eachdist.py install --editable --with-test-deps
 


### PR DESCRIPTION
# Description

Follow up to #1408 which adds additional missing dependencies.