### PR TITLE
OTLP exporter use grpc runtime cert if not set

### DIFF
--- a/exporter/opentelemetry-exporter-otlp/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-otlp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 0.16b1
+
+Released 2020-11-26
+
 - Add meter reference to observers
   ([#1425](https://github.com/open-telemetry/opentelemetry-python/pull/1425))
 

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/exporter.py
@@ -208,11 +208,12 @@ class OTLPExporterMixin(
             credentials is None
             and Configuration().EXPORTER_OTLP_CERTIFICATE is None
         ):
-            raise ValueError("No credentials set in secure mode.")
-
-        credentials = credentials or _load_credential_from_file(
-            Configuration().EXPORTER_OTLP_CERTIFICATE
-        )
+            # use the default location chosen by gRPC runtime
+            credentials = ssl_channel_credentials()
+        else:
+            credentials = credentials or _load_credential_from_file(
+                Configuration().EXPORTER_OTLP_CERTIFICATE
+            )
         self._client = self._stub(
             secure_channel(
                 endpoint, credentials, compression=compression_algorithm

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
@@ -90,9 +90,10 @@ class TestOTLPMetricExporter(TestCase):
         self.assertIsNotNone(kwargs["credentials"])
         self.assertIsInstance(kwargs["credentials"], ChannelCredentials)
 
-    def test_no_credentials_error(self):
-        with self.assertRaises(ValueError):
-            OTLPMetricsExporter()
+    @patch("grpc.ssl_channel_credentials")
+    def test_no_credentials_error(self, mock_ssl_channel):
+        OTLPMetricsExporter(insecure=False)
+        mock_ssl_channel.assert_called_with()
 
     @patch("opentelemetry.sdk.metrics.export.aggregate.time_ns")
     def test_translate_counter_export_record(self, mock_time_ns):

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
@@ -90,10 +90,16 @@ class TestOTLPMetricExporter(TestCase):
         self.assertIsNotNone(kwargs["credentials"])
         self.assertIsInstance(kwargs["credentials"], ChannelCredentials)
 
-    @patch("grpc.ssl_channel_credentials")
-    def test_no_credentials_error(self, mock_ssl_channel):
+    @patch("opentelemetry.exporter.otlp.exporter.ssl_channel_credentials")
+    @patch("opentelemetry.exporter.otlp.exporter.secure_channel")
+    @patch(
+        "opentelemetry.exporter.otlp.metrics_exporter.OTLPMetricsExporter._stub"
+    )
+    def test_no_credentials_error(
+        self, mock_ssl_channel, mock_secure, mock_stub
+    ):
         OTLPMetricsExporter(insecure=False)
-        mock_ssl_channel.assert_called_with()
+        self.assertTrue(mock_ssl_channel.called)
 
     @patch("opentelemetry.sdk.metrics.export.aggregate.time_ns")
     def test_translate_counter_export_record(self, mock_time_ns):

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_metric_exporter.py
@@ -95,6 +95,7 @@ class TestOTLPMetricExporter(TestCase):
     @patch(
         "opentelemetry.exporter.otlp.metrics_exporter.OTLPMetricsExporter._stub"
     )
+    # pylint: disable=unused-argument
     def test_no_credentials_error(
         self, mock_ssl_channel, mock_secure, mock_stub
     ):

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
@@ -187,9 +187,10 @@ class TestOTLPSpanExporter(TestCase):
         self.assertIsNotNone(kwargs["credentials"])
         self.assertIsInstance(kwargs["credentials"], ChannelCredentials)
 
-    def test_no_credentials_error(self):
-        with self.assertRaises(ValueError):
-            OTLPSpanExporter()
+    @patch("grpc.ssl_channel_credentials")
+    def test_no_credentials_error(self, mock_ssl_channel):
+        OTLPSpanExporter(insecure=False)
+        mock_ssl_channel.assert_called_with()
 
     @patch("opentelemetry.exporter.otlp.exporter.expo")
     @patch("opentelemetry.exporter.otlp.exporter.sleep")

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
@@ -187,10 +187,14 @@ class TestOTLPSpanExporter(TestCase):
         self.assertIsNotNone(kwargs["credentials"])
         self.assertIsInstance(kwargs["credentials"], ChannelCredentials)
 
-    @patch("grpc.ssl_channel_credentials")
-    def test_no_credentials_error(self, mock_ssl_channel):
+    @patch("opentelemetry.exporter.otlp.exporter.ssl_channel_credentials")
+    @patch("opentelemetry.exporter.otlp.exporter.secure_channel")
+    @patch("opentelemetry.exporter.otlp.trace_exporter.OTLPSpanExporter._stub")
+    def test_no_credentials_error(
+        self, mock_ssl_channel, mock_secure, mock_stub
+    ):
         OTLPSpanExporter(insecure=False)
-        mock_ssl_channel.assert_called_with()
+        self.assertTrue(mock_ssl_channel.called)
 
     @patch("opentelemetry.exporter.otlp.exporter.expo")
     @patch("opentelemetry.exporter.otlp.exporter.sleep")

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
@@ -190,6 +190,7 @@ class TestOTLPSpanExporter(TestCase):
     @patch("opentelemetry.exporter.otlp.exporter.ssl_channel_credentials")
     @patch("opentelemetry.exporter.otlp.exporter.secure_channel")
     @patch("opentelemetry.exporter.otlp.trace_exporter.OTLPSpanExporter._stub")
+    # pylint: disable=unused-argument
     def test_no_credentials_error(
         self, mock_ssl_channel, mock_secure, mock_stub
     ):


### PR DESCRIPTION
# Description

Prior to this change, the OTLP exporter raises an error if the user doesn't configure a certificate file for setting up a secure channel for grpc. This is unnecessary, because the implementation of gRPC can use a default location if none is specified.

Fixes #1429 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been updated
- [ ] Documentation has been updated
