### PR TITLE
Fixes #1390 - Remove unexpected keyword argument in metrics_example

### DIFF
--- a/docs/getting_started/metrics_example.py
+++ b/docs/getting_started/metrics_example.py
@@ -32,7 +32,6 @@ requests_counter = meter.create_counter(
     description="number of requests",
     unit="1",
     value_type=int,
-    label_keys=("environment",),
 )
 
 requests_counter.add(25, staging_labels)

--- a/docs/getting_started/tests/test_metrics.py
+++ b/docs/getting_started/tests/test_metrics.py
@@ -1,0 +1,29 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import subprocess
+import sys
+import unittest
+
+
+class TestBasicMetricsExample(unittest.TestCase):
+    def test_basic_tracer(self):
+        dirpath = os.path.dirname(os.path.realpath(__file__))
+        test_script = "{}/../metrics_example.py".format(dirpath)
+        output = subprocess.check_output(
+            (sys.executable, test_script)
+        ).decode()
+
+        self.assertIn('name="requests"', output)
+        self.assertIn('description="number of requests"', output)

--- a/docs/getting_started/tests/test_metrics.py
+++ b/docs/getting_started/tests/test_metrics.py
@@ -18,7 +18,7 @@ import unittest
 
 
 class TestBasicMetricsExample(unittest.TestCase):
-    def test_basic_tracer(self):
+    def test_basic_meter(self):
         dirpath = os.path.dirname(os.path.realpath(__file__))
         test_script = "{}/../metrics_example.py".format(dirpath)
         output = subprocess.check_output(


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #1390 which is a minor bug introduced in #1254

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] New test file added `test_metrics.py`
- [x] A local test has been done, metrics_example.py code runs as expected:
`/home/yang/python-workspace/opentelemetry-python-example/metrics.py 
ConsoleMetricsExporter(data="Counter(name="requests", description="number of requests")", labels="(('environment', 'staging'),)", value=25, resource={'telemetry.sdk.language': 'python', 'telemetry.sdk.name': 'opentelemetry', 'telemetry.sdk.version': '0.16b1'})
ConsoleMetricsExporter(data="Counter(name="requests", description="number of requests")", labels="(('environment', 'staging'),)", value=45, resource={'telemetry.sdk.language': 'python', 'telemetry.sdk.name': 'opentelemetry', 'telemetry.sdk.version': '0.16b1'})`

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `opentelemetry-instrumentation/` have changed
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
