### PR TITLE
[PROPOSAL] Add Performance Testing + SDK Span Performance Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       py38: 3.8
       py39: 3.9
       pypy3: pypy3
+      RUN_MATRIX_COMBINATION: ${{ matrix.python-version }}-${{ matrix.package }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
@@ -30,15 +31,6 @@ jobs:
         package: ["instrumentation", "core", "exporter"]
         os: [ ubuntu-latest ]
         include:
-          - python-version: py39
-            package: "tracecontext"
-            os: ubuntu-latest
-          - python-version: py39
-            package: "mypy"
-            os: ubuntu-latest
-          - python-version: py39
-            package: "mypyinstalled"
-            os: ubuntu-latest
           # py35-instrumentation segfaults on 18.04 so we instead run on 20.04
           - python-version: py35
             package: instrumentation
@@ -67,14 +59,38 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .tox
-          key: tox-cache-${{ matrix.python-version }}-${{ matrix.package }}-${{ matrix.os }}-${{ hashFiles('tox.ini', 'dev-requirements.txt') }}-core
+          key: tox-cache-${{ env.RUN_MATRIX_COMBINATION }}-${{ hashFiles('tox.ini', 'dev-requirements.txt') }}-core
       - name: run tox
-        run: tox -f ${{ matrix.python-version }}-${{ matrix.package }}
+        run: tox -f ${{ matrix.python-version }}-${{ matrix.package }} -- --benchmark-json=${{ env.RUN_MATRIX_COMBINATION }}-benchmark.json
+      - name: Find and merge benchmarks
+        # TODO: Add at least one benchmark to every package type to remove this
+        if: matrix.package == 'core'
+        run: >-
+          jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
+          | if .[0].benchmarks == null then null else .[0] end'
+          opentelemetry-*/tests/*${{ matrix.package }}*-benchmark.json > output.json
+      - name: Report on benchmark results
+        # TODO: Add at least one benchmark to every package type to remove this
+        if: matrix.package == 'core'
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package-group }}
+          tool: pytest
+          output-file-path: output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Alert with a commit comment on possible performance regression
+          alert-threshold: 200%
+          comment-always: true
+          fail-on-alert: true
+          # Make a commit on `gh-pages` with benchmarks from previous step
+          auto-push: ${{ github.ref == 'refs/heads/master' }}
+          gh-pages-branch: master
+          benchmark-data-dir-path: benchmarks
   misc:
     strategy:
       fail-fast: false
       matrix:
-        tox-environment: [ "docker-tests", "lint", "docs" ]
+        tox-environment: [ "docker-tests", "lint", "docs", "mypy", "mypyinstalled", "tracecontext" ]
     name: ${{ matrix.tox-environment }}
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,31 @@ See
 [`tox.ini`](https://github.com/open-telemetry/opentelemetry-python/blob/master/tox.ini)
 for more detail on available tox commands.
 
+### Benchmarks
+
+Performance progression of benchmarks for packages distributed by OpenTelemetry Python can be viewed as a [graph of throughput vs commit history](https://opentelemetry-python.readthedocs.io/en/latest/benchmarks/index.html). From this page, you can download a JSON file with the performance results.
+
+Running the `tox` tests also runs the performance tests if any are available. Benchmarking tests are done with `pytest-benchmark` and they output a table with results to the console.
+
+To write benchmarks, simply use the [pytest benchmark fixture](https://pytest-benchmark.readthedocs.io/en/latest/usage.html#usage) like the following:
+
+```python
+def test_simple_start_span(benchmark):
+    def benchmark_start_as_current_span(span_name, attribute_num):
+        span = tracer.start_span(
+            span_name,
+            attributes={"count": attribute_num},
+        )
+        span.end()
+
+    benchmark(benchmark_start_as_current_span, "benchmarkedSpan", 42)
+```
+
+Make sure the test file is under the `tests/performance/benchmarks/` folder of
+the package it is benchmarking and further has a path that corresponds to the
+file in the package it is testing. Make sure that the file name begins with
+`test_benchmark_`. (e.g. `opentelemetry-sdk/tests/performance/benchmarks/trace/propagation/test_benchmark_b3_format.py`)
+
 ## Pull Requests
 
 ### How to Send Pull Requests

--- a/opentelemetry-sdk/tests/performance/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/tests/performance/benchmarks/trace/test_benchmark_trace.py
@@ -1,0 +1,51 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import opentelemetry.sdk.trace as trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import sampling
+
+tracer = trace.TracerProvider(
+    sampler=sampling.DEFAULT_ON,
+    resource=Resource(
+        {
+            "service.name": "A123456789",
+            "service.version": "1.34567890",
+            "service.instance.id": "123ab456-a123-12ab-12ab-12340a1abc12",
+        }
+    ),
+).get_tracer("sdk_tracer_provider")
+
+
+def test_simple_start_span(benchmark):
+    def benchmark_start_as_current_span():
+        span = tracer.start_span(
+            "benchmarkedSpan",
+            attributes={"long.attribute": -10000000001000000000},
+        )
+        span.add_event("benchmarkEvent")
+        span.end()
+
+    benchmark(benchmark_start_as_current_span)
+
+
+def test_simple_start_as_current_span(benchmark):
+    def benchmark_start_as_current_span():
+        with tracer.start_as_current_span(
+            "benchmarkedSpan",
+            attributes={"long.attribute": -10000000001000000000},
+        ) as span:
+            span.add_event("benchmarkEvent")
+
+    benchmark(benchmark_start_as_current_span)

--- a/tox.ini
+++ b/tox.ini
@@ -49,8 +49,8 @@ envlist =
     pypy3-test-core-opentracing-shim
 
     lint
-    py39-tracecontext
-    py39-{mypy,mypyinstalled}
+    tracecontext
+    mypy,mypyinstalled
     docs
     docker-tests
 
@@ -58,6 +58,7 @@ envlist =
 deps =
   -c dev-requirements.txt
   test: pytest
+  test: pytest-benchmark
   coverage: pytest
   coverage: pytest-cov
   mypy,mypyinstalled: mypy
@@ -164,7 +165,7 @@ changedir = docs
 commands =
   sphinx-build -E -a -W -b html -T . _build/html
 
-[testenv:py39-tracecontext]
+[testenv:tracecontext]
 basepython: python3.9
 deps =
   # needed for tracecontext


### PR DESCRIPTION
# Description

Part of #335, this PR aims to include the `pytest-benchmark` library to get micro benching results on some key SDK operations.

Specifically, this follows the [OpenTelemetry Specifications on Performance Benchmarking](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/performance-benchmark.md) guidelines.

Regarding `pytest-benchmark`:

Pros:
- Easy to use (integrates with `pytest`
- Lots of features (it was easy to mock and pass parameters to functions under test)
- Nice ways to output (See [the pytest-benchmark Command Line Options](https://pytest-benchmark.readthedocs.io/en/latest/usage.html#commandline-options)
    - Table in Terminal
    - Histogram (Since all the .json logs will stay in `gh-pages`, people can create these or we can create these!)
    - Stats summary file
    - Detailed Stats summary file

Cons:
- No resource profiling (CPU/RAM/IO) (See the [open issue on resource profiling](https://github.com/ionelmc/pytest-benchmark/issues/28) for more information. Will mean we need a different profiler for these things?)

## Type of change

In this PR:
* Benchmarks for every python version are added
* The package tests will **FAIL** if during comparison. performance regresses by 200% from the most recent recorded test (To avoid flaky failing of tests)
* Benchmark results are printed to the workflow output (to know what happened + to update the current results if needed)
* Performance tests work locally too! (The first run fails because there are no benchmarks yet)
* It is easy to add more benchmarks by adding
  - The tests themselves
  - Updating `tox.ini` to print the tests using the added `tests/print_benchmarks.py` script
  - Added their most recent recorded results in the relevant package folder.
* All the history of the logs will be available in the `gh-pages` branch and at the link https://open-telemetry.github.io/opentelemetry-python/benchmarks/index.html

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Locally

Running `tox -e test-core-sdk` produces the following table:

```
test-core-sdk run-test: commands[0] | pytest
================================================================================================================================================= test session starts =================================================================================================================================================
platform darwin -- Python 3.8.2, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /Users/enowell/git/opentelemetry-python/.tox/test-core-sdk/bin/python
cachedir: .tox/test-core-sdk/.pytest_cache
benchmark: 3.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/enowell/git/opentelemetry-python, configfile: pyproject.toml
plugins: benchmark-3.2.3
collected 249 items

...

-------------------------------------------------------------------------------------------- benchmark: 2 tests --------------------------------------------------------------------------------------------
Name (time in us)                         Min                 Max               Mean             StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_simple_start_span                27.3250 (1.0)      223.2550 (1.0)      31.0913 (1.0)       9.2509 (1.0)      28.6885 (1.0)      1.5250 (1.55)     218;1017       32.1634 (1.0)        5320           1
test_simple_start_as_current_span     36.0340 (1.32)     251.3840 (1.13)     40.2968 (1.30)     11.7254 (1.27)     37.5900 (1.31)     0.9810 (1.0)      744;2070       24.8159 (0.77)      14010           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
=========================================================================================================================================== 249 passed, 1 warning in 8.83s ============================================================================================================================================
_______________________________________________________________________________________________________________________________________________________ summary _______________________________________________________________________________________________________________________________________________________
  test-core-sdk: commands succeeded
  congratulations :)
```

## Example Repo

I made [an example repo](https://github.com/NathanielRN/github-benchmarks-example) here to prove the json merging works

You can see the difference between [PRs that have different performance benchmarks](https://github.com/NathanielRN/github-benchmarks-example/pulls):
- [Worse Performance](https://github.com/NathanielRN/github-benchmarks-example/pull/3)
- [Better Performance](https://github.com/NathanielRN/github-benchmarks-example/pull/2)

This combines all the tests under `OpenTelemetry Python Benchmark` as [seen here](https://nathanielrn.github.io/github-benchmarks-example/benchmarks/index.html). The fluctuations are _on purpose_ because I made the test take longer.

![image](https://user-images.githubusercontent.com/23139455/101705562-08803200-3a3c-11eb-9e55-a372e07d03cf.png)

# Does This PR Require a Contrib Repo Change?

- [x] No. (But it will be a good follow up)

# Checklist:

- [x] Followed the style guidelines of this project
~- [] Changelogs have been updated~ (Not changing functionality, only adding tests
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
