### PR TITLE
Allow to override global `tracer_provider` after `tracer`s creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding `opentelemetry-distro` package to add default configuration for
   span exporter to OTLP
   ([#1482](https://github.com/open-telemetry/opentelemetry-python/pull/1482))
+- Allow to override global `tracer_provider` after `tracer`s creation
 
 ### Changed
 - `opentelemetry-exporter-zipkin` Updated zipkin exporter status code and error tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding `opentelemetry-distro` package to add default configuration for
   span exporter to OTLP
   ([#1482](https://github.com/open-telemetry/opentelemetry-python/pull/1482))
-- Allow to override global `tracer_provider` after `tracer`s creation
+- Allow to set global `tracer_provider` after `tracer`s creation
+  ([#1445](https://github.com/open-telemetry/opentelemetry-python/pull/1445))
 
 ### Changed
 - `opentelemetry-exporter-zipkin` Updated zipkin exporter status code and error tag

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -527,7 +527,6 @@ def set_tracer_provider(tracer_provider: TracerProvider) -> None:
 
 def get_tracer_provider() -> TracerProvider:
     """Gets the current global :class:`~.TracerProvider` object."""
-    global _TRACER_PROVIDER  # pylint: disable=global-statement
 
     if _TRACER_PROVIDER is None:
         return _load_trace_provider("tracer_provider")

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -477,7 +477,7 @@ class ProxyTracer(Tracer):
 _TRACER_PROVIDER = None
 
 
-@functools.lru_cache(maxsize=128)  # type: ignore
+@functools.lru_cache(maxsize=None)  # type: ignore
 def _get_current_tracer(*args: typing.Any, **kwargs: typing.Any) -> "Tracer":
     tracer_provider = get_tracer_provider()
     return tracer_provider.get_tracer(*args, **kwargs)  # type: ignore

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -492,7 +492,7 @@ def get_tracer(
 ) -> "Tracer":
     """Returns a `Tracer` for use by the given instrumentation library.
 
-    If tracer_provider is ommited it returns a _ProxyTracer
+    If tracer_provider is omitted it returns a _ProxyTracer
     which redirects calls to a current instrumentation library.
     """
     if tracer_provider is None:

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -515,6 +515,10 @@ def set_tracer_provider(tracer_provider: TracerProvider) -> None:
     """
     global _TRACER_PROVIDER  # pylint: disable=global-statement
 
+    if _TRACER_PROVIDER is not None:
+        logger.warning("Overriding of current TracerProvider is not allowed")
+        return
+
     _TRACER_PROVIDER = tracer_provider
     _get_current_tracer.cache_clear()  # pylint: disable=no-member
 
@@ -524,7 +528,7 @@ def get_tracer_provider() -> TracerProvider:
     global _TRACER_PROVIDER  # pylint: disable=global-statement
 
     if _TRACER_PROVIDER is None:
-        _TRACER_PROVIDER = _load_trace_provider("tracer_provider")
+        return _load_trace_provider("tracer_provider")
 
     return _TRACER_PROVIDER
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -409,7 +409,7 @@ class DefaultTracer(Tracer):
         yield
 
 
-class ProxyTracer(Tracer):
+class _ProxyTracer(Tracer):
     """Proxies all calls to current TracerProvider
     """
 
@@ -490,11 +490,11 @@ def get_tracer(
 ) -> "Tracer":
     """Returns a `Tracer` for use by the given instrumentation library.
 
-    If tracer_provider is ommited it returns a ProxyTracer
+    If tracer_provider is ommited it returns a _ProxyTracer
     which redirects calls to a current instrumentation library.
     """
     if tracer_provider is None:
-        return ProxyTracer(
+        return _ProxyTracer(
             functools.partial(
                 _get_current_tracer,
                 instrumenting_module_name=instrumenting_module_name,

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -490,10 +490,8 @@ def get_tracer(
 ) -> "Tracer":
     """Returns a `Tracer` for use by the given instrumentation library.
 
-    This function is a convenience wrapper for
-    opentelemetry.trace.TracerProvider.get_tracer.
-
-    If tracer_provider is ommited the current configured one is used.
+    If tracer_provider is ommited it returns a ProxyTracer
+    which redirects calls to a current instrumentation library.
     """
     if tracer_provider is None:
         return ProxyTracer(

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from opentelemetry import context, trace
 
@@ -13,12 +13,76 @@ class TestGlobals(unittest.TestCase):
         self._patcher.stop()
 
     def test_get_tracer(self):
-        """trace.get_tracer should proxy to the global tracer provider."""
-        trace.get_tracer("foo", "var")
-        self._mock_tracer_provider.get_tracer.assert_called_with("foo", "var")
+        """trace.get_tracer should create a proxy to the global tracer provider."""
+        tracer = trace.get_tracer("foo", "var")
+        self._mock_tracer_provider.get_tracer.assert_not_called()
+        self.assertIsInstance(tracer, trace.ProxyTracer)
+
+        tracer.start_span("one")
+        tracer.start_span("two")
+        self._mock_tracer_provider.get_tracer.assert_called_once_with(
+            instrumenting_module_name="foo",
+            instrumenting_library_version="var",
+        )
+
         mock_provider = unittest.mock.Mock()
         trace.get_tracer("foo", "var", mock_provider)
         mock_provider.get_tracer.assert_called_with("foo", "var")
+
+    def test_set_tracer_provider(self):
+        """trace.get_tracer should update global tracer provider."""
+        self.assertIs(
+            trace._TRACER_PROVIDER,  # pylint: disable=protected-access
+            self._mock_tracer_provider,
+        )
+
+        tracer_provider1 = trace.DefaultTracerProvider()
+        trace.set_tracer_provider(tracer_provider1)
+        self.assertIs(
+            trace._TRACER_PROVIDER,  # pylint: disable=protected-access
+            tracer_provider1,
+        )
+
+        tracer_provider2 = trace.DefaultTracerProvider()
+        trace.set_tracer_provider(tracer_provider2)
+        self.assertIs(
+            trace._TRACER_PROVIDER,  # pylint: disable=protected-access
+            tracer_provider2,
+        )
+
+    @patch("opentelemetry.trace._load_trace_provider")
+    def test_get_tracer_provider(self, load_trace_provider_mock: "MagicMock"):  # type: ignore
+        """trace.get_tracer should get or create a global tracer provider."""
+        load_trace_provider_mock.assert_not_called()
+
+        tracer_provider = trace.get_tracer_provider()
+        self.assertIs(
+            trace._TRACER_PROVIDER,  # pylint: disable=protected-access
+            tracer_provider,
+        )
+        load_trace_provider_mock.assert_not_called()
+
+        trace._TRACER_PROVIDER = None  # pylint: disable=protected-access
+        tracer_provider1 = trace.get_tracer_provider()
+        self.assertIsNotNone(
+            trace._TRACER_PROVIDER  # pylint: disable=protected-access
+        )
+        self.assertIs(
+            trace._TRACER_PROVIDER,  # pylint: disable=protected-access
+            tracer_provider1,
+        )
+        load_trace_provider_mock.assert_called_once_with("tracer_provider")
+
+        tracer_provider2 = trace.get_tracer_provider()
+        self.assertIsNotNone(
+            trace._TRACER_PROVIDER  # pylint: disable=protected-access
+        )
+        self.assertIs(
+            trace._TRACER_PROVIDER,  # pylint: disable=protected-access
+            tracer_provider2,
+        )
+        self.assertIs(tracer_provider1, tracer_provider2)
+        load_trace_provider_mock.assert_called_once_with("tracer_provider")
 
 
 class TestTracer(unittest.TestCase):
@@ -38,3 +102,109 @@ class TestTracer(unittest.TestCase):
         finally:
             context.detach(token)
         self.assertEqual(trace.get_current_span(), trace.INVALID_SPAN)
+
+
+class TestProxyTracer(unittest.TestCase):
+    def setUp(self):
+        self._patcher = patch("opentelemetry.trace._TRACER_PROVIDER")
+        self._patcher.start()
+
+        self.proxy_tracer = trace.get_tracer("foo", "var")
+        self.inner_tracer = MagicMock(wraps=trace.DefaultTracer())
+
+        tracer_provider = MagicMock(wraps=trace.DefaultTracerProvider())
+        tracer_provider.get_tracer.return_value = self.inner_tracer
+        trace.set_tracer_provider(tracer_provider)
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_start_span(self):
+        """ProxyTracer should call `start_span` on a real `Tracer`
+        """
+        self.inner_tracer.start_span.assert_not_called()
+
+        span = self.proxy_tracer.start_span("span1")
+        self.assertIs(span, trace.INVALID_SPAN)
+        self.inner_tracer.start_span.assert_called_once_with(
+            name="span1",
+            context=None,
+            kind=trace.SpanKind.INTERNAL,
+            attributes=None,
+            links=(),
+            start_time=None,
+            record_exception=True,
+            set_status_on_exception=True,
+        )
+
+    def test_start_as_current_span(self):
+        """ProxyTracer should call `start_as_current_span` on a real `Tracer`
+        """
+        self.inner_tracer.start_as_current_span.assert_not_called()
+
+        with self.proxy_tracer.start_as_current_span("span1") as span:
+            self.assertIs(span, trace.INVALID_SPAN)
+            self.inner_tracer.start_as_current_span.assert_called_once_with(
+                name="span1",
+                context=None,
+                kind=trace.SpanKind.INTERNAL,
+                attributes=None,
+                links=(),
+                start_time=None,
+                record_exception=True,
+                set_status_on_exception=True,
+            )
+
+        self.inner_tracer.start_as_current_span.reset_mock()
+
+        @self.proxy_tracer.start_as_current_span("span1")
+        def func(arg: str, kwarg: str) -> str:
+            self.assertEqual(arg, "argval")
+            self.assertEqual(kwarg, "kwargval")
+            return "retval"
+
+        self.inner_tracer.start_as_current_span.assert_not_called()
+
+        result = func("argval", kwarg="kwargval")
+        self.assertEqual(result, "retval")
+
+        self.inner_tracer.start_as_current_span.assert_called_once_with(
+            name="span1",
+            context=None,
+            kind=trace.SpanKind.INTERNAL,
+            attributes=None,
+            links=(),
+            start_time=None,
+            record_exception=True,
+            set_status_on_exception=True,
+        )
+
+    def test_use_span(self):
+        """ProxyTracer should call `use_span` on a real `Tracer`
+        """
+        self.inner_tracer.use_span.assert_not_called()
+
+        span = self.proxy_tracer.start_span("span1")
+
+        with self.proxy_tracer.use_span(span) as current_context:
+            self.assertIsNone(current_context)
+            self.inner_tracer.use_span.assert_called_once_with(
+                span=span, end_on_exit=False,
+            )
+
+        self.inner_tracer.use_span.reset_mock()
+
+        @self.proxy_tracer.use_span(span)
+        def func(arg: str, kwarg: str) -> str:
+            self.assertEqual(arg, "argval")
+            self.assertEqual(kwarg, "kwargval")
+            return "retval"
+
+        self.inner_tracer.use_span.assert_not_called()
+
+        result = func("argval", kwarg="kwargval")
+        self.assertEqual(result, "retval")
+
+        self.inner_tracer.use_span.assert_called_once_with(
+            span=span, end_on_exit=False,
+        )

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -16,7 +16,7 @@ class TestGlobals(unittest.TestCase):
         """trace.get_tracer should create a proxy to the global tracer provider."""
         tracer = trace.get_tracer("foo", "var")
         self._mock_tracer_provider.get_tracer.assert_not_called()
-        self.assertIsInstance(tracer, trace.ProxyTracer)
+        self.assertIsInstance(tracer, trace._ProxyTracer)
 
         tracer.start_span("one")
         tracer.start_span("two")

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -56,7 +56,7 @@ class TestGlobals(unittest.TestCase):
 
     @patch("opentelemetry.trace._load_trace_provider")
     def test_get_tracer_provider(self, load_trace_provider_mock: "MagicMock"):  # type: ignore
-        """trace.get_tracer should get or create a global tracer provider."""
+        """trace.get_tracer_provider should get or create a global tracer provider."""
 
         # Get before set
         load_trace_provider_mock.return_value = trace.DefaultTracerProvider()

--- a/opentelemetry-sdk/tests/trace/test_globals.py
+++ b/opentelemetry-sdk/tests/trace/test_globals.py
@@ -14,4 +14,4 @@ class TestGlobals(unittest.TestCase):
 
         new_tracer_provider = TracerProvider()
         trace.set_tracer_provider(new_tracer_provider)
-        self.assertIs(new_tracer_provider, trace.get_tracer_provider())
+        self.assertIs(tracer_provider, trace.get_tracer_provider())

--- a/opentelemetry-sdk/tests/trace/test_globals.py
+++ b/opentelemetry-sdk/tests/trace/test_globals.py
@@ -1,25 +1,17 @@
 # type:ignore
 import unittest
-from logging import WARNING
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider  # type:ignore
 
 
 class TestGlobals(unittest.TestCase):
-    def test_tracer_provider_override_warning(self):
-        """trace.set_tracer_provider should throw a warning when overridden"""
-        trace.set_tracer_provider(TracerProvider())
-        tracer_provider = trace.get_tracer_provider()
-        with self.assertLogs(level=WARNING) as test:
-            trace.set_tracer_provider(TracerProvider())
-            self.assertEqual(
-                test.output,
-                [
-                    (
-                        "WARNING:opentelemetry.trace:Overriding of current "
-                        "TracerProvider is not allowed"
-                    )
-                ],
-            )
+    def test_tracer_provider_override(self):
+        """trace.set_tracer_provider should override global tracer"""
+        tracer_provider = TracerProvider()
+        trace.set_tracer_provider(tracer_provider)
         self.assertIs(tracer_provider, trace.get_tracer_provider())
+
+        new_tracer_provider = TracerProvider()
+        trace.set_tracer_provider(new_tracer_provider)
+        self.assertIs(new_tracer_provider, trace.get_tracer_provider())


### PR DESCRIPTION
# Description

Allow to override global `tracer_provider` after `tracer`s creation.

With this change any module may do
```python
from opentelemetry import trace

tracer = trace.get_tracer(__name__)
````
and wire that tracer to its code (e.g. by applying `start_as_current_span` decorator).

And such modules may be safely imported to a main app before initializing/configuring real tracer provider. All tracers created before (on import time) will use that provider.

Fixes # (issue)
https://github.com/open-telemetry/opentelemetry-python/issues/1159
https://github.com/open-telemetry/opentelemetry-python/issues/1276
https://gitter.im/open-telemetry/opentelemetry-python?at=5fc8be67f46e246609860465

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

submodule.py
```python
from opentelemetry import trace

tracer = trace.get_tracer(__name__)


@tracer.start_as_current_span("submodule decorator created before configuration")
def echo(text):
    with tracer.start_as_current_span("submodule context manager"):
        print(text)
```

main.py
```python
import submodule

from opentelemetry import trace
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import (
    ConsoleSpanExporter,
    SimpleExportSpanProcessor,
)

tracer = trace.get_tracer("__main__")


@tracer.start_as_current_span("another decorator created before configuration")
def main():
    with tracer.start_as_current_span("submodule context manager"):
        submodule.echo("Hello world from OpenTelemetry Python!")

def init():
    trace.set_tracer_provider(TracerProvider())
    trace.get_tracer_provider().add_span_processor(
        SimpleExportSpanProcessor(ConsoleSpanExporter())
    )

init()
main()
```

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `opentelemetry-instrumentation/` have changed
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
