### PR TITLE
Recreate span on every run of a decorated function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `opentelemetry-exporter-zipkin` Updated zipkin exporter status code and error tag
   ([#1486](https://github.com/open-telemetry/opentelemetry-python/pull/1486))
+- Recreate span on every run of a `start_as_current_span`-decorated function
+  ([#1451](https://github.com/open-telemetry/opentelemetry-python/pull/1451))
 
 ## [0.16b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.16b1) - 2020-11-26
 ### Added

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -742,6 +742,7 @@ class Tracer(trace_api.Tracer):
         self.ids_generator = ids_generator
         self.instrumentation_info = instrumentation_info
 
+    @contextmanager
     def start_as_current_span(
         self,
         name: str,
@@ -763,7 +764,8 @@ class Tracer(trace_api.Tracer):
             record_exception=record_exception,
             set_status_on_exception=set_status_on_exception,
         )
-        return self.use_span(span, end_on_exit=True)
+        with self.use_span(span, end_on_exit=True) as span_context:
+            yield span_context
 
     def start_span(  # pylint: disable=too-many-locals
         self,

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -414,6 +414,37 @@ class TestSpanCreation(unittest.TestCase):
             self.assertIs(trace_api.get_current_span(), root)
             self.assertIsNotNone(child.end_time)
 
+    def test_start_as_current_span_decorator(self):
+        tracer = new_tracer()
+
+        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+
+        @tracer.start_as_current_span("root")
+        def func():
+            root = trace_api.get_current_span()
+
+            with tracer.start_as_current_span("child") as child:
+                self.assertIs(trace_api.get_current_span(), child)
+                self.assertIs(child.parent, root.get_span_context())
+
+            # After exiting the child's scope the parent should become the
+            # current span again.
+            self.assertIs(trace_api.get_current_span(), root)
+            self.assertIsNotNone(child.end_time)
+
+            return root
+
+        root1 = func()
+
+        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertIsNotNone(root1.end_time)
+
+        # Second call must create a new span
+        root2 = func()
+        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertIsNotNone(root2.end_time)
+        self.assertIsNot(root1, root2)
+
     def test_explicit_span_resource(self):
         resource = resources.Resource.create({})
         tracer_provider = trace.TracerProvider(resource=resource)


### PR DESCRIPTION
# Description

`start_as_current_span` could be used as decorator. But it works incorrectly in this case — a span is created only once on decoration time and it is reused for every run of function.

With that change it creates new span on every run.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test provided

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
