### PR TITLE
Explicitly install dependencies in lint env for tox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: b37945bdeaf49822b240281d493d053995cc2b7b
+  CONTRIB_REPO_SHA: master
 
 jobs:
   build:

--- a/tox.ini
+++ b/tox.ini
@@ -139,7 +139,17 @@ deps =
   httpretty
 
 commands_pre =
-  python scripts/eachdist.py install --editable --with-test-deps
+  python -m pip install -e {toxinidir}/opentelemetry-api[test]
+  python -m pip install -e {toxinidir}/opentelemetry-sdk[test]
+  python -m pip install -e {toxinidir}/opentelemetry-instrumentation[test]
+  python -m pip install -e {toxinidir}/opentelemetry-proto[test]
+  python -m pip install -e {toxinidir}/tests/util[test]
+  python -m pip install -e {toxinidir}/instrumentation/opentelemetry-instrumentation-opentracing-shim[test]
+  python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-jaeger[test]
+  python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-opencensus[test]
+  python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-otlp[test]
+  python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-prometheus[test]
+  python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-zipkin[test]
 
 commands =
   python scripts/eachdist.py lint --check-only


### PR DESCRIPTION
Builds are [failing](https://github.com/open-telemetry/opentelemetry-python/pull/1447/checks?check_run_id=1512422935) due to `python scripts/eachdist.py install --editable --with-test-deps` command in the lint env. Apparently appending all packages into one install statement is not working (`eachdist.py` constructs a large install statement like `python -m pip install -e '{toxinidir}/opentelemetry-api[test]' -e '{toxinidir}/opentelemetry-sdk[test]' ...`.

Splitting them up works for some reason. Also, `eachdist.py` is quite complicated, now that our packages are simpler (instrumentations are in the contrib), maybe we can refactor it to make it simpler.