### PR TITLE
pin version of pip installed

### DIFF
--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -444,7 +444,7 @@ def install_args(args):
                 "pip",
                 "install",
                 "--upgrade",
-                "pip",
+                "pip==20.2.4",
                 "setuptools",
                 "wheel",
             ]

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ changedir =
 
 commands_pre =
 ; Install without -e to test the actual installation
-  py3{5,6,7,8}: python -m pip install -U pip setuptools wheel
+  py3{5,6,7,8}: python -m pip install -U pip==20.2.4 setuptools wheel
 ; Install common packages for all the tests. These are not needed in all the
 ; cases but it saves a lot of boilerplate in this file.
   test: pip install {toxinidir}/opentelemetry-api {toxinidir}/opentelemetry-sdk {toxinidir}/tests/util

--- a/tox.ini
+++ b/tox.ini
@@ -139,6 +139,7 @@ deps =
   httpretty
 
 commands_pre =
+  python -m pip install -U pip==20.2.4
   python scripts/eachdist.py install --editable --with-test-deps
 
 commands =


### PR DESCRIPTION
# Description

To unblock the build, pinning the version of pip to 20.2.4. It appears there's an [issue](https://github.com/pypa/pip/issues/8785) causing trouble in the 20.3.x release. 

## Type of change

Please delete options that are not relevant.

- [x] Infrastructure change

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `opentelemetry-instrumentation/` have changed
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
