### PR TITLE
Clone the contrib repo for every docs dependency install to fix docs build

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -6,13 +6,13 @@ sphinx-autodoc-typehints~=1.10.2
 # doesn't work for pkg_resources.
 ./opentelemetry-api
 ./opentelemetry-sdk
-./opentelemetry-python-contrib/exporter/opentelemetry-exporter-datadog
-./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-grpc
+-e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-exporter-datadog&subdirectory=exporter/opentelemetry-exporter-datadog"
+-e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-instrumentation-grpc&subdirectory=instrumentation/opentelemetry-instrumentation-grpc"
 ./opentelemetry-instrumentation
-./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests
-./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi
-./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-django
-./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask
+-e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-instrumentation-requests&subdirectory=instrumentation/opentelemetry-instrumentation-requests"
+-e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-instrumentation-wsgi&subdirectory=instrumentation/opentelemetry-instrumentation-wsgi"
+-e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-instrumentation-django&subdirectory=instrumentation/opentelemetry-instrumentation-django"
+-e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-instrumentation-flask&subdirectory=instrumentation/opentelemetry-instrumentation-flask"
 
 # Required by ext packages
 asgiref~=3.0


### PR DESCRIPTION
# Description

In the linked issue, it was pointed out that the [readTheDocs build is failing](https://readthedocs.org/projects/opentelemetry-python/builds/12515452/) with the following error message:

```
ERROR: Invalid requirement: './opentelemetry-python-contrib/exporter/opentelemetry-exporter-datadog' (from line 9 of docs-requirements.txt)
Hint: It looks like a path. File './opentelemetry-python-contrib/exporter/opentelemetry-exporter-datadog' does not exist.
```

I've seen this error before and hope that this PR has the solution :smile:

Related to: #1352

## Solution Explanation

Initially I was hoping to take advantage of `pip`'s [--src](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-src) or [--target](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-t) options to have the repo cloned to the directory I wanted (i.e. `./opentelemtry-python-contrib`) but [pip does not allow certain options in its requirements.txt file](https://stackoverflow.com/a/60372140/7460739) :confused:

Next, I read how the [readTheDocs configuration file](https://docs.readthedocs.io/en/stable/config-file/v2.html#supported-settings) works.
* The submodule option seemed possible but in contradiction to splitting the repos.
* `readTheDocs` supports [using conda enviornment variables](https://docs.readthedocs.io/en/stable/config-file/v2.html#conda-environment) but new versions of Conda have [an issue that means environment variables are not passed to pip correctly](https://github.com/conda/conda/issues/6805) so we again can't do `--src`

So no luck on readTheDocs.

If we knew the path to the virtual env then we could expect the first `-e` install and clone the repo at the path `<venv_path>/src` [as in the docs](https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support) but the build says the venv name is `python3.8 -mvirtualenv /home/docs/checkouts/readthedocs.org/user_builds/opentelemetry-python/envs/latest` so I don't know what would happen if it went to `.... /stable` 😕 

Finally I decided to just go with cloning the repo every time for these packages. The Contrib repo is 40MB large, and there is a 3GB limit for readTheDocs. We should be fine to merge this, but I think a good follow up would be to remove all the references in docs that need these Contrib packages 😄 

But if we merge this at least the build will be fixed 😄 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I wasn't able to get a local build of readTheDocs working... but hopefully we can try this first and I'll follow up with additional fixes if needed :smile:

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
