### PR TITLE
Upgrade isort and enable black compat mode

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,6 +3,7 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=79
+profile=black
 
 ; 3 stands for Vertical Hanging Indent, e.g.
 ; from third_party import (
@@ -13,6 +14,6 @@ line_length=79
 ; docs: https://github.com/timothycrosley/isort#multi-line-output-modes
 multi_line_output=3
 skip=target
-skip_glob=**/gen/*,.venv*/*,venv*/*,**/proto/*,opentelemetry-python-contrib/*
+skip_glob=**/gen/*,.venv*/*,venv*/*,**/proto/*,opentelemetry-python-contrib/*,.tox/*
 known_first_party=opentelemetry,opentelemetry_example_app
 known_third_party=psutil,pytest,redis,redis_opentracing

--- a/.pylintrc
+++ b/.pylintrc
@@ -70,7 +70,11 @@ disable=missing-docstring,
       wrong-import-order, # Leave this up to isort
       bad-continuation, # Leave this up to black
       line-too-long, # Leave this up to black
-      exec-used
+      exec-used,
+      super-with-arguments, # temp-pylint-upgrade
+      isinstance-second-argument-not-valid-type, # temp-pylint-upgrade
+      raise-missing-from, # temp-pylint-upgrade 
+      unused-argument, # temp-pylint-upgrade 
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,8 @@
-pylint==2.4.4
+pylint==2.6.0
 flake8~=3.7
-isort~=4.3
+isort~=5.6
 black>=19.3b0,==19.*
+httpretty~=1.0
 mypy==0.790
 sphinx~=2.1
 sphinx-rtd-theme~=0.4

--- a/docs/examples/django/pages/views.py
+++ b/docs/examples/django/pages/views.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from django.http import HttpResponse
+
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (

--- a/docs/examples/opentracing/main.py
+++ b/docs/examples/opentracing/main.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
+from rediscache import RedisCache
+
 from opentelemetry import trace
 from opentelemetry.exporter.jaeger import JaegerSpanExporter
 from opentelemetry.instrumentation import opentracing_shim
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleExportSpanProcessor
-from rediscache import RedisCache
 
 # Configure the tracer using the default implementation
 trace.set_tracer_provider(TracerProvider())

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/exporter.py
@@ -123,8 +123,8 @@ def _get_resource_data(
 
 def _load_credential_from_file(filepath) -> ChannelCredentials:
     try:
-        with open(filepath, "rb") as f:
-            credential = f.read()
+        with open(filepath, "rb") as creds_file:
+            credential = creds_file.read()
             return ssl_channel_credentials(credential)
     except FileNotFoundError:
         logger.exception("Failed to read credential file")

--- a/opentelemetry-api/src/opentelemetry/util/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/util/__init__.py
@@ -21,8 +21,8 @@ from pkg_resources import iter_entry_points
 from opentelemetry.configuration import Configuration
 
 if TYPE_CHECKING:
-    from opentelemetry.trace import TracerProvider
     from opentelemetry.metrics import MeterProvider
+    from opentelemetry.trace import TracerProvider
 
 Provider = Union["TracerProvider", "MeterProvider"]
 

--- a/opentelemetry-api/tests/context/test_contextvars_context.py
+++ b/opentelemetry-api/tests/context/test_contextvars_context.py
@@ -21,6 +21,7 @@ from .base_context import ContextTestCases
 
 try:
     import contextvars  # pylint: disable=unused-import
+
     from opentelemetry.context.contextvars_context import (
         ContextVarsRuntimeContext,
     )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -17,12 +17,10 @@ from collections import OrderedDict, deque
 
 try:
     # pylint: disable=ungrouped-imports
-    from collections.abc import MutableMapping
-    from collections.abc import Sequence
+    from collections.abc import MutableMapping, Sequence
 except ImportError:
     # pylint: disable=no-name-in-module,ungrouped-imports
-    from collections import MutableMapping
-    from collections import Sequence
+    from collections import MutableMapping, Sequence
 
 
 def ns_to_iso_str(nanoseconds):

--- a/opentelemetry-sdk/tests/context/test_asyncio.py
+++ b/opentelemetry-sdk/tests/context/test_asyncio.py
@@ -25,6 +25,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 
 try:
     import contextvars  # pylint: disable=unused-import
+
     from opentelemetry.context.contextvars_context import (
         ContextVarsRuntimeContext,
     )

--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -509,7 +509,7 @@ def lint_args(args):
     )
     runsubprocess(
         args.dry_run,
-        ("isort", "--recursive", ".")
+        ("isort", ".")
         + (("--diff", "--check-only") if args.check_only else ()),
         cwd=rootdir,
         check=True,


### PR DESCRIPTION
isort and black can be incompatible. Often isort re-writes files in a
way black doesn't like. It takes quite some time and manual effort to
make changes that satisfy both isort and black.

Fortunately, newer versions of isort support a black compatibility mode by setting
isort profile to "black". This makes isort order imports in a way that
is compatible with how black formats Python code. This PR configures
isort to use the black profile by default.
