### PR TITLE
Use gh-pages to save performance benchmarks results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
           fail-on-alert: true
           # Make a commit on `gh-pages` with benchmarks from previous step
           auto-push: ${{ github.ref == 'refs/heads/master' }}
-          gh-pages-branch: master
+          gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmarks
   misc:
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ for more detail on available tox commands.
 
 ### Benchmarks
 
-Performance progression of benchmarks for packages distributed by OpenTelemetry Python can be viewed as a [graph of throughput vs commit history](https://opentelemetry-python.readthedocs.io/en/latest/benchmarks/index.html). From this page, you can download a JSON file with the performance results.
+Performance progression of benchmarks for packages distributed by OpenTelemetry Python can be viewed as a [graph of throughput vs commit history](https://opentelemetry-python.readthedocs.io/en/latest/performance/benchmarks.html). From the linked page, you can download a JSON file with the performance results.
 
 Running the `tox` tests also runs the performance tests if any are available. Benchmarking tests are done with `pytest-benchmark` and they output a table with results to the console.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,6 +93,14 @@ install <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>
 
 .. toctree::
     :maxdepth: 1
+    :caption: OpenTelemetry Python Performance
+    :name: performance-tests
+    :glob:
+
+    performance/**
+
+.. toctree::
+    :maxdepth: 1
     :caption: Examples
     :name: examples
     :glob:

--- a/docs/performance/benchmarks.rst
+++ b/docs/performance/benchmarks.rst
@@ -1,0 +1,4 @@
+Performance Tests - Benchmarks
+==============================
+
+Click `here <https://open-telemetry.github.io/opentelemetry-python/benchmarks/index.html>`_ to view the latest performance benchmarks for packages in this repo.


### PR DESCRIPTION
# Description

As a follow up to #1443 we found out that the GitHub action [will fetch the branch even if it on that branch which produces an error](https://github.com/rhysd/github-action-benchmark/issues/51).

This PR goes back to using `gh-pages` and adds a link in the ReadTheDocs directory to point to the benchmarks graphs which will live on the `gh-pages` branch.

This is also a good idea to reduce the noise on the `master` branch.

This will fix the current Core Repo Tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See [my example repo](https://github.com/NathanielRN/github-benchmarks-example/runs/1532810344?check_suite_focus=true#step:8:25) which uses `gh-pages` correctly to publish to https://nathanielrn.github.io/github-benchmarks-example/benchmarks/index.html

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Documentation has been updated
