### PR TITLE
Remove unnecesary contrib packages from docs install

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -6,13 +6,7 @@ sphinx-autodoc-typehints~=1.10.2
 # doesn't work for pkg_resources.
 ./opentelemetry-api
 ./opentelemetry-sdk
--e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-exporter-datadog&subdirectory=exporter/opentelemetry-exporter-datadog"
--e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-instrumentation-grpc&subdirectory=instrumentation/opentelemetry-instrumentation-grpc"
 ./opentelemetry-instrumentation
--e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-instrumentation-requests&subdirectory=instrumentation/opentelemetry-instrumentation-requests"
--e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-instrumentation-wsgi&subdirectory=instrumentation/opentelemetry-instrumentation-wsgi"
--e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-instrumentation-django&subdirectory=instrumentation/opentelemetry-instrumentation-django"
--e "git+https://github.com/open-telemetry/opentelemetry-python-contrib.git#egg=opentelemetry-instrumentation-flask&subdirectory=instrumentation/opentelemetry-instrumentation-flask"
 
 # Required by ext packages
 asgiref~=3.0


### PR DESCRIPTION
# Description

As a follow up to #1464 I found that the docs tests pass just fine if there these packages are not installed.

Making this PR to mostly ask questions if anyone knows why these were needed!

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

`tox -e docs` passes and the sphinx build is created without a problem.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
