### PR TITLE
Only comment on benchmarks on alert

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Alert with a commit comment on possible performance regression
           alert-threshold: 200%
-          comment-always: true
           fail-on-alert: true
           # Make a commit on `gh-pages` with benchmarks from previous step
           auto-push: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
# Description

~After #1473, the GitHub action would try to fetch the `gh-pages` branch using the `secrets.GITHUB_TOKEN` of the pull request author. This will always fail, so we should skip this step using the undocumented `skip-fetch-gh-pages` flag of the GitHub action we use. See [source code that tries to pull gh-pages](https://github.com/rhysd/github-action-benchmark/blob/7cadfa13e55c8155d15ef0c2c6d0d2b112185dcb/src/write.ts#L374)~

We narrowed the problem to the `comment-always: true` flag being set. And further, it only happens when *multiple tests want to comment at the same time*.

To unblock the tests for now, we remove the feature which comments on the "new" benchmarks versus the "previous" benchmarks. We can come back and investigate later.

Example failed run: https://github.com/open-telemetry/opentelemetry-python/pull/1470/checks?check_run_id=1552050085#step:9:55

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

CI test should prove that this fix unblocks master tests.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
