### PR TITLE
Use uppercase if testing in windows

### DIFF
--- a/opentelemetry-api/tests/configuration/test_configuration.py
+++ b/opentelemetry-api/tests/configuration/test_configuration.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # pylint: disable-all
 
+from sys import platform
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -35,7 +36,7 @@ class TestConfiguration(TestCase):
         {
             "OTEL_PYTHON_METER_PROVIDER": "meter_provider",
             "OTEL_PYTHON_TRACER_PROVIDER": "tracer_provider",
-            "OTEL_OThER": "other",
+            "OTEL_OTHER" if platform == "windows" else "OTEL_OThER": "other",
             "OTEL_OTHER_7": "other_7",
             "OPENTELEMETRY_PTHON_TRACEX_PROVIDER": "tracex_provider",
         },


### PR DESCRIPTION
Fixes #1419

# Description

Use only uppercase characters if testing in Windows.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] test_configuration

# Does This PR Require a Contrib Repo Change? no

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `opentelemetry-instrumentation/` have changed
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
