### PR TITLE
Add throughput performance tests for OTLP exporter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           | if .[0].benchmarks == null then null else .[0] end'
           `find . -name '*${{ matrix.package }}*-benchmark.json'` > output.json
       - name: Report on benchmark results
-        if: [ `cat output.json` == null ]
+        if: `cat output.json` == null
         uses: rhysd/github-action-benchmark@v1
         with:
           name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,15 +63,15 @@ jobs:
       - name: run tox
         run: tox -f ${{ matrix.python-version }}-${{ matrix.package }} -- --benchmark-json=${{ env.RUN_MATRIX_COMBINATION }}-benchmark.json
       - name: Find and merge benchmarks
-        # TODO: Add at least one benchmark to every package type to remove this
-        if: matrix.package == 'core'
+        # TODO: Add at least one benchmark to the instrumentation package type to remove this
+        if: matrix.package != 'instrumentation'
         run: >-
           jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
           | if .[0].benchmarks == null then null else .[0] end'
-          opentelemetry-*/tests/*${{ matrix.package }}*-benchmark.json > output.json
+          `find . -name '*${{ matrix.package }}*-benchmark.json'` > output.json
       - name: Report on benchmark results
-        # TODO: Add at least one benchmark to every package type to remove this
-        if: matrix.package == 'core'
+        # TODO: Add at least one benchmark to the instrumentation package type to remove this
+        if: matrix.package != 'instrumentation'
         uses: rhysd/github-action-benchmark@v1
         with:
           name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,12 +63,14 @@ jobs:
       - name: run tox
         run: tox -f ${{ matrix.python-version }}-${{ matrix.package }} -- --benchmark-json=${{ env.RUN_MATRIX_COMBINATION }}-benchmark.json
       - name: Find and merge benchmarks
+        id: find_and_merge_benchmarks
         run: >-
           jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
           | if .[0].benchmarks == null then null else .[0] end'
-          `find . -name '*${{ matrix.package }}*-benchmark.json'` > output.json
+          $(find . -name '*${{ matrix.package }}*-benchmark.json') > output.json
+          && echo "::set-output name=json_plaintext::$(cat output.json)"
       - name: Report on benchmark results
-        if: `cat output.json` == null
+        if: steps.find_and_merge_benchmarks.outputs.json_plaintext != 'null'
         uses: rhysd/github-action-benchmark@v1
         with:
           name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,15 +63,12 @@ jobs:
       - name: run tox
         run: tox -f ${{ matrix.python-version }}-${{ matrix.package }} -- --benchmark-json=${{ env.RUN_MATRIX_COMBINATION }}-benchmark.json
       - name: Find and merge benchmarks
-        # TODO: Add at least one benchmark to the instrumentation package type to remove this
-        if: matrix.package != 'instrumentation'
         run: >-
           jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
           | if .[0].benchmarks == null then null else .[0] end'
           `find . -name '*${{ matrix.package }}*-benchmark.json'` > output.json
       - name: Report on benchmark results
-        # TODO: Add at least one benchmark to the instrumentation package type to remove this
-        if: matrix.package != 'instrumentation'
+        if: [ `cat output.json` == null ]
         uses: rhysd/github-action-benchmark@v1
         with:
           name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package }}

--- a/exporter/opentelemetry-exporter-otlp/tests/performance/benchmarks/test_benchmark_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/performance/benchmarks/test_benchmark_trace_exporter.py
@@ -1,0 +1,74 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from opentelemetry.exporter.otlp.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider, sampling
+from opentelemetry.sdk.trace.export import (
+    BatchExportSpanProcessor,
+    SimpleExportSpanProcessor,
+)
+
+
+def get_tracer_with_processor(span_processor_class):
+    simple_span_processor = span_processor_class(OTLPSpanExporter())
+    tracer = TracerProvider(
+        active_span_processor=simple_span_processor,
+        sampler=sampling.DEFAULT_ON,
+    ).get_tracer("pipeline_benchmark_tracer")
+    return tracer
+
+
+class MockTraceServiceStub(object):
+    def __init__(self, channel):
+        self.Export = lambda *args, **kwargs: None
+
+
+@patch(
+    "opentelemetry.exporter.otlp.trace_exporter.OTLPSpanExporter._stub",
+    new=MockTraceServiceStub,
+)
+def test_simple_span_processor(benchmark):
+    tracer = get_tracer_with_processor(SimpleExportSpanProcessor)
+
+    def create_spans_to_be_exported():
+        span = tracer.start_span("benchmarkedSpan",)
+        for i in range(10):
+            span.set_attribute(
+                "benchmarkAttribute_{}".format(i),
+                "benchmarkAttrValue_{}".format(i),
+            )
+        span.end()
+
+    benchmark(create_spans_to_be_exported)
+
+
+@patch(
+    "opentelemetry.exporter.otlp.trace_exporter.OTLPSpanExporter._stub",
+    new=MockTraceServiceStub,
+)
+def test_batch_span_processor(benchmark):
+    tracer = get_tracer_with_processor(BatchExportSpanProcessor)
+
+    def create_spans_to_be_exported():
+        span = tracer.start_span("benchmarkedSpan",)
+        for i in range(10):
+            span.set_attribute(
+                "benchmarkAttribute_{}".format(i),
+                "benchmarkAttrValue_{}".format(i),
+            )
+        span.end()
+
+    benchmark(create_spans_to_be_exported)

--- a/exporter/opentelemetry-exporter-otlp/tests/performance/benchmarks/test_benchmark_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/performance/benchmarks/test_benchmark_trace_exporter.py
@@ -60,6 +60,13 @@ def test_simple_span_processor(benchmark):
     new=MockTraceServiceStub,
 )
 def test_batch_span_processor(benchmark):
+    """Runs benchmark tests using BatchExportSpanProcessor.
+
+    NOTE: One particular call by pytest-benchmark will be much more expensive since
+    the batch export thread will activate and consume a lot of CPU to process
+    all the spans. For this reason, focus on the average measurement. Do not
+    focus on the min/max measurements which will be misleading.
+    """
     tracer = get_tracer_with_processor(BatchExportSpanProcessor)
 
     def create_spans_to_be_exported():

--- a/exporter/opentelemetry-exporter-otlp/tests/performance/benchmarks/test_benchmark_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/performance/benchmarks/test_benchmark_trace_exporter.py
@@ -25,8 +25,7 @@ from opentelemetry.sdk.trace.export import (
 def get_tracer_with_processor(span_processor_class):
     span_processor = span_processor_class(OTLPSpanExporter())
     tracer = TracerProvider(
-        active_span_processor=span_processor,
-        sampler=sampling.DEFAULT_ON,
+        active_span_processor=span_processor, sampler=sampling.DEFAULT_ON,
     ).get_tracer("pipeline_benchmark_tracer")
     return tracer
 

--- a/exporter/opentelemetry-exporter-otlp/tests/performance/benchmarks/test_benchmark_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/performance/benchmarks/test_benchmark_trace_exporter.py
@@ -23,9 +23,9 @@ from opentelemetry.sdk.trace.export import (
 
 
 def get_tracer_with_processor(span_processor_class):
-    simple_span_processor = span_processor_class(OTLPSpanExporter())
+    span_processor = span_processor_class(OTLPSpanExporter())
     tracer = TracerProvider(
-        active_span_processor=simple_span_processor,
+        active_span_processor=span_processor,
         sampler=sampling.DEFAULT_ON,
     ).get_tracer("pipeline_benchmark_tracer")
     return tracer
@@ -62,7 +62,7 @@ def test_simple_span_processor(benchmark):
 def test_batch_span_processor(benchmark):
     """Runs benchmark tests using BatchExportSpanProcessor.
 
-    NOTE: One particular call by pytest-benchmark will be much more expensive since
+    One particular call by pytest-benchmark will be much more expensive since
     the batch export thread will activate and consume a lot of CPU to process
     all the spans. For this reason, focus on the average measurement. Do not
     focus on the min/max measurements which will be misleading.


### PR DESCRIPTION
# Description

According to the [Performance testing Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/performance-benchmark.md#throughput-measurement), we should have performance tests to test the throughput of the OTLP Exporter.

In the [Java equivalent tests](https://github.com/open-telemetry/opentelemetry-java/pull/2214), they actually run the Collector.

However, for these tests, I thought it would be sufficient to turn the gRPC export command into a No-op. We can then say that these tests test how much the SDK side exporter can export in a second.

I think it is possible that some spans won't be exported before the benchmark finishes, but it looks like that was not a concern for the Java tests, should we be concerned with that?

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Running `tox -e test-exporter-otlp` runs these benchmarking tests

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
