### PR TITLE
Set max number of commits in performance graph

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
           tool: pytest
           output-file-path: output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          max-items-in-chart: 100
           # Alert with a commit comment on possible performance regression
           alert-threshold: 200%
           fail-on-alert: true


### PR DESCRIPTION
# Description

As a follow up to #1443, this PR adds a limit to the number of commits saved and displayed in the performance graph.

By default [there is no limit](https://github.com/rhysd/github-action-benchmark#max-items-in-chart-optional) so I thought this would be a good preemptative measure to avoid a noisy (and maybe unreadable?) graph.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

N/A

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
~- [ ] Changelogs have been updated~
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
