### PR TITLE
Make span attributes inaccessible except when needed [WIP]

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -445,8 +445,7 @@ exclude-protected=_asdict,
                   _fields,
                   _replace,
                   _source,
-                  _make,
-                  _Span
+                  _make
 
 # List of valid names for the first argument in a class method.
 valid-classmethod-first-arg=cls

--- a/exporter/opentelemetry-exporter-jaeger/tests/test_jaeger_exporter.py
+++ b/exporter/opentelemetry-exporter-jaeger/tests/test_jaeger_exporter.py
@@ -22,8 +22,7 @@ import opentelemetry.exporter.jaeger as jaeger_exporter
 from opentelemetry import trace as trace_api
 from opentelemetry.configuration import Configuration
 from opentelemetry.exporter.jaeger.gen.jaeger import ttypes as jaeger
-from opentelemetry.sdk import trace
-from opentelemetry.sdk.trace import Resource
+from opentelemetry.sdk.trace import _ReadWriteSpan, Resource
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
 from opentelemetry.trace import SpanKind
 from opentelemetry.trace.status import Status, StatusCode
@@ -38,7 +37,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
             is_remote=False,
         )
 
-        self._test_span = trace._Span("test_span", context=context)
+        self._test_span = _ReadWriteSpan("test_span", context=context)
         self._test_span.start()
         self._test_span.end()
         # pylint: disable=protected-access
@@ -230,7 +229,7 @@ class TestJaegerSpanExporter(unittest.TestCase):
         ]
 
         otel_spans = [
-            trace._Span(
+            _ReadWriteSpan(
                 name=span_names[0],
                 context=span_context,
                 parent=parent_span_context,
@@ -238,10 +237,10 @@ class TestJaegerSpanExporter(unittest.TestCase):
                 links=(link,),
                 kind=trace_api.SpanKind.CLIENT,
             ),
-            trace._Span(
+            _ReadWriteSpan(
                 name=span_names[1], context=parent_span_context, parent=None
             ),
-            trace._Span(
+            _ReadWriteSpan(
                 name=span_names[2], context=other_context, parent=None
             ),
         ]

--- a/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_trace_exporter.py
@@ -25,7 +25,7 @@ from opentelemetry.exporter.opencensus.trace_exporter import (
     OpenCensusSpanExporter,
     translate_to_collector,
 )
-from opentelemetry.sdk import trace
+from opentelemetry.sdk.trace import _ReadWriteSpan, Event
 from opentelemetry.sdk.trace.export import SpanExportResult
 from opentelemetry.trace import TraceFlags
 
@@ -108,7 +108,7 @@ class TestCollectorSpanExporter(unittest.TestCase):
             "key_float": 0.3,
         }
         event_timestamp = base_time + 50 * 10 ** 6
-        event = trace.Event(
+        event = Event(
             name="event0",
             timestamp=event_timestamp,
             attributes=event_attributes,
@@ -120,7 +120,7 @@ class TestCollectorSpanExporter(unittest.TestCase):
         link_2 = trace_api.Link(
             context=parent_span_context, attributes=link_attributes
         )
-        span_1 = trace._Span(
+        span_1 = _ReadWriteSpan(
             name="test1",
             context=span_context,
             parent=parent_span_context,
@@ -128,13 +128,13 @@ class TestCollectorSpanExporter(unittest.TestCase):
             links=(link_1,),
             kind=trace_api.SpanKind.CLIENT,
         )
-        span_2 = trace._Span(
+        span_2 = _ReadWriteSpan(
             name="test2",
             context=parent_span_context,
             parent=None,
             kind=trace_api.SpanKind.SERVER,
         )
-        span_3 = trace._Span(
+        span_3 = _ReadWriteSpan(
             name="test3",
             context=other_context,
             links=(link_2,),
@@ -300,7 +300,7 @@ class TestCollectorSpanExporter(unittest.TestCase):
             trace_flags=TraceFlags(TraceFlags.SAMPLED),
         )
         otel_spans = [
-            trace._Span(
+            _ReadWriteSpan(
                 name="test1",
                 context=span_context,
                 kind=trace_api.SpanKind.CLIENT,

--- a/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_otlp_trace_exporter.py
@@ -47,7 +47,7 @@ from opentelemetry.proto.trace.v1.trace_pb2 import (
 from opentelemetry.proto.trace.v1.trace_pb2 import Span as OTLPSpan
 from opentelemetry.proto.trace.v1.trace_pb2 import Status
 from opentelemetry.sdk.resources import Resource as SDKResource
-from opentelemetry.sdk.trace import TracerProvider, _Span
+from opentelemetry.sdk.trace import _ReadWriteSpan, TracerProvider
 from opentelemetry.sdk.trace.export import (
     SimpleExportSpanProcessor,
     SpanExportResult,
@@ -127,7 +127,7 @@ class TestOTLPSpanExporter(TestCase):
 
         type(event_mock).name = PropertyMock(return_value="a")
 
-        self.span = _Span(
+        self.span = _ReadWriteSpan(
             "a",
             context=Mock(
                 **{

--- a/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
+++ b/exporter/opentelemetry-exporter-zipkin/tests/test_zipkin_exporter.py
@@ -28,8 +28,7 @@ from opentelemetry.exporter.zipkin import (
     nsec_to_usec_round,
 )
 from opentelemetry.exporter.zipkin.gen import zipkin_pb2
-from opentelemetry.sdk import trace
-from opentelemetry.sdk.trace import Resource
+from opentelemetry.sdk.trace import _ReadWriteSpan, Event, Resource
 from opentelemetry.sdk.trace.export import SpanExportResult
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
 from opentelemetry.trace import SpanKind, TraceFlags
@@ -51,7 +50,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
             is_remote=False,
         )
 
-        self._test_span = trace._Span("test_span", context=context)
+        self._test_span = _ReadWriteSpan("test_span", context=context)
         self._test_span.start()
         self._test_span.end()
 
@@ -166,7 +165,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
         }
 
         event_timestamp = base_time + 50 * 10 ** 6
-        event = trace.Event(
+        event = Event(
             name="event0",
             timestamp=event_timestamp,
             attributes=event_attributes,
@@ -179,20 +178,20 @@ class TestZipkinSpanExporter(unittest.TestCase):
         )
 
         otel_spans = [
-            trace._Span(
+            _ReadWriteSpan(
                 name=span_names[0],
                 context=span_context,
                 parent=parent_span_context,
                 events=(event,),
                 links=(link,),
             ),
-            trace._Span(
+            _ReadWriteSpan(
                 name=span_names[1], context=parent_span_context, parent=None
             ),
-            trace._Span(
+            _ReadWriteSpan(
                 name=span_names[2], context=other_context, parent=None
             ),
-            trace._Span(
+            _ReadWriteSpan(
                 name=span_names[3], context=other_context, parent=None
             ),
         ]
@@ -354,7 +353,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
             trace_id, parent_id, is_remote=False
         )
 
-        otel_span = trace._Span(
+        otel_span = _ReadWriteSpan(
             name=span_names[0],
             context=span_context,
             parent=parent_span_context,
@@ -415,7 +414,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
             trace_flags=TraceFlags(TraceFlags.SAMPLED),
         )
 
-        span = trace._Span(name="test-span", context=span_context,)
+        span = _ReadWriteSpan(name="test-span", context=span_context,)
 
         span.start()
         span.resource = Resource({})
@@ -686,7 +685,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
         }
 
         event_timestamp = base_time + 50 * 10 ** 6
-        event = trace.Event(
+        event = Event(
             name="event0",
             timestamp=event_timestamp,
             attributes=event_attributes,
@@ -699,20 +698,20 @@ class TestZipkinSpanExporter(unittest.TestCase):
         )
 
         otel_spans = [
-            trace._Span(
+            _ReadWriteSpan(
                 name=span_names[0],
                 context=span_context,
                 parent=parent_span_context,
                 events=(event,),
                 links=(link,),
             ),
-            trace._Span(
+            _ReadWriteSpan(
                 name=span_names[1], context=parent_span_context, parent=None
             ),
-            trace._Span(
+            _ReadWriteSpan(
                 name=span_names[2], context=other_context, parent=None
             ),
-            trace._Span(
+            _ReadWriteSpan(
                 name=span_names[3], context=other_context, parent=None
             ),
         ]
@@ -871,7 +870,7 @@ class TestZipkinSpanExporter(unittest.TestCase):
             trace_flags=TraceFlags(TraceFlags.SAMPLED),
         )
 
-        span = trace._Span(name="test-span", context=span_context,)
+        span = _ReadWriteSpan(name="test-span", context=span_context,)
 
         span.start()
         span.resource = Resource({})

--- a/instrumentation/opentelemetry-instrumentation-opentracing-shim/tests/test_shim.py
+++ b/instrumentation/opentelemetry-instrumentation-opentracing-shim/tests/test_shim.py
@@ -404,9 +404,9 @@ class TestShim(TestCase):
         tags = {"foo": "bar"}
         with self.shim.start_active_span("TestSetTag", tags=tags) as scope:
             scope.span.set_tag("baz", "qux")
-
-            self.assertEqual(scope.span.unwrap().attributes["foo"], "bar")
-            self.assertEqual(scope.span.unwrap().attributes["baz"], "qux")
+            span = scope.span.unwrap()._data  # pylint: disable=protected-access
+            self.assertEqual(span.attributes["foo"], "bar")
+            self.assertEqual(span.attributes["baz"], "qux")
 
     def test_span_tracer(self):
         """Test the `tracer` property on `Span` objects."""
@@ -479,7 +479,7 @@ class TestShim(TestCase):
                 raise Exception
 
         # Verify exception details have been added to span.
-        self.assertEqual(scope.span.unwrap().attributes["error"], True)
+        self.assertEqual(scope.span.unwrap()._data.attributes["error"], True)  # pylint: disable=protected-access
 
     def test_inject_http_headers(self):
         """Test `inject()` method for Format.HTTP_HEADERS."""

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -24,7 +24,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.configuration import Configuration
 from opentelemetry.context import Context
 from opentelemetry.sdk import trace
-from opentelemetry.sdk.trace import export
+from opentelemetry.sdk.trace import _ReadWriteSpan, export
 
 
 class MySpanExporter(export.SpanExporter):
@@ -140,7 +140,7 @@ class TestSimpleExportSpanProcessor(unittest.TestCase):
 
 
 def _create_start_and_end_span(name, span_processor):
-    span = trace._Span(
+    span = _ReadWriteSpan(
         name,
         trace_api.SpanContext(
             0xDEADBEEF,
@@ -481,7 +481,7 @@ class TestConsoleSpanExporter(unittest.TestCase):
         exporter = export.ConsoleSpanExporter()
         # Mocking stdout interferes with debugging and test reporting, mock on
         # the exporter instance instead.
-        span = trace._Span("span name", trace_api.INVALID_SPAN_CONTEXT)
+        span = _ReadWriteSpan("span name", trace_api.INVALID_SPAN_CONTEXT)
         with mock.patch.object(exporter, "out") as mock_stdout:
             exporter.export([span])
         mock_stdout.write.assert_called_once_with(span.to_json() + os.linesep)
@@ -500,5 +500,5 @@ class TestConsoleSpanExporter(unittest.TestCase):
         exporter = export.ConsoleSpanExporter(
             out=mock_stdout, formatter=formatter
         )
-        exporter.export([trace._Span("span name", mock.Mock())])
+        exporter.export([_ReadWriteSpan("span name", mock.Mock())])
         mock_stdout.write.assert_called_once_with(mock_span_str)

--- a/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
+++ b/opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py
@@ -17,7 +17,7 @@ from unittest import mock
 
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk import trace
-from opentelemetry.sdk.trace import export
+from opentelemetry.sdk.trace import _ReadWriteSpan, export
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
@@ -61,7 +61,7 @@ class TestInMemorySpanExporter(unittest.TestCase):
         self.assertEqual(len(span_list), 3)
 
     def test_return_code(self):
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = _ReadWriteSpan("name", mock.Mock(spec=trace_api.SpanContext))
         span_list = (span,)
         memory_exporter = InMemorySpanExporter()
 

--- a/opentelemetry-sdk/tests/trace/propagation/test_b3_format.py
+++ b/opentelemetry-sdk/tests/trace/propagation/test_b3_format.py
@@ -19,6 +19,7 @@ import opentelemetry.sdk.trace as trace
 import opentelemetry.sdk.trace.propagation.b3_format as b3_format
 import opentelemetry.trace as trace_api
 from opentelemetry.context import get_current
+from opentelemetry.sdk.trace import _ReadWriteSpan
 from opentelemetry.trace.propagation.textmap import DictGetter
 
 FORMAT = b3_format.B3Format()
@@ -32,8 +33,8 @@ def get_child_parent_new_carrier(old_carrier):
     ctx = FORMAT.extract(carrier_getter, old_carrier)
     parent_span_context = trace_api.get_current_span(ctx).get_span_context()
 
-    parent = trace._Span("parent", parent_span_context)
-    child = trace._Span(
+    parent = _ReadWriteSpan("parent", parent_span_context)
+    child = _ReadWriteSpan(
         "child",
         trace_api.SpanContext(
             parent_span_context.trace_id,

--- a/opentelemetry-sdk/tests/trace/propagation/test_jaeger_propagator.py
+++ b/opentelemetry-sdk/tests/trace/propagation/test_jaeger_propagator.py
@@ -16,6 +16,7 @@ import unittest
 from unittest.mock import Mock
 
 import opentelemetry.sdk.trace as trace
+from opentelemetry.sdk.trace import _ReadWriteSpan
 import opentelemetry.sdk.trace.propagation.jaeger_propagator as jaeger
 import opentelemetry.trace as trace_api
 from opentelemetry import baggage
@@ -35,8 +36,8 @@ def get_context_new_carrier(old_carrier, carrier_baggage=None):
             ctx = baggage.set_baggage(key, value, ctx)
     parent_span_context = trace_api.get_current_span(ctx).get_span_context()
 
-    parent = trace._Span("parent", parent_span_context)
-    child = trace._Span(
+    parent = _ReadWriteSpan("parent", parent_span_context)
+    child = _ReadWriteSpan(
         "child",
         trace_api.SpanContext(
             parent_span_context.trace_id,

--- a/opentelemetry-sdk/tests/trace/test_implementation.py
+++ b/opentelemetry-sdk/tests/trace/test_implementation.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from opentelemetry.sdk import trace
+from opentelemetry.sdk.trace import _ReadWriteSpan
 from opentelemetry.trace import INVALID_SPAN, INVALID_SPAN_CONTEXT
 
 
@@ -42,8 +42,8 @@ class TestTracerImplementation(unittest.TestCase):
     def test_span(self):
         with self.assertRaises(Exception):
             # pylint: disable=no-value-for-parameter
-            span = trace._Span()
+            span = _ReadWriteSpan()
 
-        span = trace._Span("name", INVALID_SPAN_CONTEXT)
+        span = _ReadWriteSpan("name", INVALID_SPAN_CONTEXT)
         self.assertEqual(span.get_span_context(), INVALID_SPAN_CONTEXT)
         self.assertIs(span.is_recording(), True)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -27,7 +27,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.configuration import Configuration
 from opentelemetry.context import Context
 from opentelemetry.sdk import resources, trace
-from opentelemetry.sdk.trace import Resource, sampling
+from opentelemetry.sdk.trace import _ReadWriteSpan, Resource, sampling
 from opentelemetry.sdk.util import ns_to_iso_str
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
 from opentelemetry.trace.status import StatusCode
@@ -297,7 +297,7 @@ class TestSpanCreation(unittest.TestCase):
     def test_start_span_explicit(self):
         tracer = new_tracer()
 
-        other_parent = trace._Span(
+        other_parent = _ReadWriteSpan(
             "name",
             trace_api.SpanContext(
                 trace_id=0x000000000000000000000000DEADBEEF,
@@ -378,7 +378,7 @@ class TestSpanCreation(unittest.TestCase):
     def test_start_as_current_span_explicit(self):
         tracer = new_tracer()
 
-        other_parent = trace._Span(
+        other_parent = _ReadWriteSpan(
             "name",
             trace_api.SpanContext(
                 trace_id=0x000000000000000000000000DEADBEEF,
@@ -447,7 +447,7 @@ class TestSpan(unittest.TestCase):
         self.tracer = new_tracer()
 
     def test_basic_span(self):
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = _ReadWriteSpan("name", mock.Mock(spec=trace_api.SpanContext))
         self.assertEqual(span.name, "name")
 
     def test_attributes(self):
@@ -726,7 +726,7 @@ class TestSpan(unittest.TestCase):
 
     def test_start_span(self):
         """Start twice, end a not started"""
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = _ReadWriteSpan("name", mock.Mock(spec=trace_api.SpanContext))
 
         # end not started span
         self.assertRaises(RuntimeError, span.end)
@@ -755,7 +755,7 @@ class TestSpan(unittest.TestCase):
     def test_start_accepts_context(self):
         # pylint: disable=no-self-use
         span_processor = mock.Mock(spec=trace.SpanProcessor)
-        span = trace._Span(
+        span = _ReadWriteSpan(
             "name",
             mock.Mock(spec=trace_api.SpanContext),
             span_processor=span_processor,
@@ -768,7 +768,7 @@ class TestSpan(unittest.TestCase):
 
     def test_span_override_start_and_end_time(self):
         """Span sending custom start_time and end_time values"""
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = _ReadWriteSpan("name", mock.Mock(spec=trace_api.SpanContext))
         start_time = 123
         span.start(start_time)
         self.assertEqual(start_time, span.start_time)
@@ -860,7 +860,7 @@ class TestSpan(unittest.TestCase):
         )
 
     def test_record_exception(self):
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = _ReadWriteSpan("name", mock.Mock(spec=trace_api.SpanContext))
         try:
             raise ValueError("invalid")
         except ValueError as err:
@@ -879,7 +879,7 @@ class TestSpan(unittest.TestCase):
         )
 
     def test_record_exception_with_attributes(self):
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = _ReadWriteSpan("name", mock.Mock(spec=trace_api.SpanContext))
         try:
             raise RuntimeError("error")
         except RuntimeError as err:
@@ -908,7 +908,7 @@ class TestSpan(unittest.TestCase):
         )
 
     def test_record_exception_escaped(self):
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = _ReadWriteSpan("name", mock.Mock(spec=trace_api.SpanContext))
         try:
             raise RuntimeError("error")
         except RuntimeError as err:
@@ -930,7 +930,7 @@ class TestSpan(unittest.TestCase):
         )
 
     def test_record_exception_with_timestamp(self):
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = _ReadWriteSpan("name", mock.Mock(spec=trace_api.SpanContext))
         try:
             raise RuntimeError("error")
         except RuntimeError as err:
@@ -953,7 +953,7 @@ class TestSpan(unittest.TestCase):
         )
 
     def test_record_exception_with_attributes_and_timestamp(self):
-        span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))
+        span = _ReadWriteSpan("name", mock.Mock(spec=trace_api.SpanContext))
         try:
             raise RuntimeError("error")
         except RuntimeError as err:
@@ -1138,7 +1138,7 @@ class TestSpanProcessor(unittest.TestCase):
             is_remote=False,
             trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         )
-        span = trace._Span("span-name", context)
+        span = _ReadWriteSpan("span-name", context)
         span.resource = Resource({})
 
         self.assertEqual(
@@ -1175,7 +1175,7 @@ class TestSpanProcessor(unittest.TestCase):
             is_remote=False,
             trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         )
-        span = trace._Span("span-name", context)
+        span = _ReadWriteSpan("span-name", context)
         span.resource = Resource({})
         span.set_attribute("key", "value")
         span.add_event("event", {"key2": "value2"}, 123)


### PR DESCRIPTION
# Description
Attempting to discourage accessing Span Attributes outside the SDK using the method suggested by @Oberon00.

Fixes #1001 

# How Has This Been Tested?
This is currently failing tests and is a work in progress. The pull request has only been opened as a draft for feedback on the method.