### PR TITLE
Simplify `Span.set_status` - allow to pass `StatusCode` or enum name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1285](https://github.com/open-telemetry/opentelemetry-python/pull/1285))
 - Added `__repr__` for `DefaultSpan`, added `trace_flags` to `__repr__` of
   `SpanContext` ([#1485](https://github.com/open-telemetry/opentelemetry-python/pull/1485)])
+- `Span.set_status` accepts `StatusCode` instance or string Enum name
 ### Changed
 - `opentelemetry-exporter-zipkin` Updated zipkin exporter status code and error tag
   ([#1486](https://github.com/open-telemetry/opentelemetry-python/pull/1486))

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -3,7 +3,7 @@ import logging
 import types as python_types
 import typing
 
-from opentelemetry.trace.status import Status
+from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util import types
 
 _logger = logging.getLogger(__name__)
@@ -75,7 +75,9 @@ class Span(abc.ABC):
         """
 
     @abc.abstractmethod
-    def set_status(self, status: Status) -> None:
+    def set_status(
+        self, status: typing.Union[str, StatusCode, Status]
+    ) -> None:
         """Sets the Status of the Span. If used, this will override the default
         Span status.
         """
@@ -280,7 +282,9 @@ class DefaultSpan(Span):
     def update_name(self, name: str) -> None:
         pass
 
-    def set_status(self, status: Status) -> None:
+    def set_status(
+        self, status: typing.Union[str, StatusCode, Status]
+    ) -> None:
         pass
 
     def record_exception(

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -76,7 +76,9 @@ class Span(abc.ABC):
 
     @abc.abstractmethod
     def set_status(
-        self, status: typing.Union[str, StatusCode, Status]
+        self,
+        status: typing.Union[str, StatusCode, Status],
+        description: typing.Optional[str] = None,
     ) -> None:
         """Sets the Status of the Span. If used, this will override the default
         Span status.
@@ -283,7 +285,9 @@ class DefaultSpan(Span):
         pass
 
     def set_status(
-        self, status: typing.Union[str, StatusCode, Status]
+        self,
+        status: typing.Union[str, StatusCode, Status],
+        description: typing.Optional[str] = None,
     ) -> None:
         pass
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -655,7 +655,15 @@ class Span(trace_api.Span):
         return self._end_time is None
 
     @_check_span_ended
-    def set_status(self, status: trace_api.Status) -> None:
+    def set_status(
+        self, status: Union[str, StatusCode, trace_api.Status]
+    ) -> None:
+        if isinstance(status, str):
+            status = StatusCode[status]
+
+        if isinstance(status, StatusCode):
+            status = Status(status_code=status)
+
         self.status = status
 
     def __exit__(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -656,13 +656,18 @@ class Span(trace_api.Span):
 
     @_check_span_ended
     def set_status(
-        self, status: Union[str, StatusCode, trace_api.Status]
+        self,
+        status: Union[str, StatusCode, trace_api.Status],
+        description: Optional[str] = None,
     ) -> None:
         if isinstance(status, str):
-            status = StatusCode[status]
+            try:
+                status = StatusCode[status]
+            except KeyError:
+                return
 
         if isinstance(status, StatusCode):
-            status = Status(status_code=status)
+            status = Status(status_code=status, description=description)
 
         self.status = status
 

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -760,26 +760,28 @@ class TestSpan(unittest.TestCase):
         status = trace_api.status.Status(
             trace_api.status.StatusCode.ERROR, "Test description"
         )
-        span1.set_status(status)
+        span1.set_status(status, "Ignore description")
 
         self.assertIs(span1.status.status_code, StatusCode.ERROR)
         self.assertEqual(span1.status.description, "Test description")
 
         span2 = self.tracer.start_span("span2")
-        span2.set_status(trace_api.status.StatusCode.ERROR)
+        span2.set_status(trace_api.status.StatusCode.ERROR, "Test description")
 
         self.assertIs(span2.status.status_code, StatusCode.ERROR)
-        self.assertIsNone(span2.status.description)
+        self.assertEqual(span2.status.description, "Test description")
 
         span3 = self.tracer.start_span("span3")
-        span3.set_status("ERROR")
+        span3.set_status("ERROR", "Test description")
 
         self.assertIs(span3.status.status_code, StatusCode.ERROR)
-        self.assertIsNone(span3.status.description)
+        self.assertEqual(span3.status.description, "Test description")
 
         span4 = self.tracer.start_span("span4")
-        with self.assertRaises(KeyError):
-            span4.set_status("Unknown")
+        span4.set_status("err", "Test description")
+
+        self.assertIs(span4.status.status_code, StatusCode.UNSET)
+        self.assertIsNone(span4.status.description)
 
     def test_start_span(self):
         """Start twice, end a not started"""

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -755,6 +755,32 @@ class TestSpan(unittest.TestCase):
             root.update_name("toor")
             self.assertEqual(root.name, "toor")
 
+    def test_set_status(self):
+        span1 = self.tracer.start_span("span1")
+        status = trace_api.status.Status(
+            trace_api.status.StatusCode.ERROR, "Test description"
+        )
+        span1.set_status(status)
+
+        self.assertIs(span1.status.status_code, StatusCode.ERROR)
+        self.assertEqual(span1.status.description, "Test description")
+
+        span2 = self.tracer.start_span("span2")
+        span2.set_status(trace_api.status.StatusCode.ERROR)
+
+        self.assertIs(span2.status.status_code, StatusCode.ERROR)
+        self.assertIsNone(span2.status.description)
+
+        span3 = self.tracer.start_span("span3")
+        span3.set_status("ERROR")
+
+        self.assertIs(span3.status.status_code, StatusCode.ERROR)
+        self.assertIsNone(span3.status.description)
+
+        span4 = self.tracer.start_span("span4")
+        with self.assertRaises(KeyError):
+            span4.set_status("Unknown")
+
     def test_start_span(self):
         """Start twice, end a not started"""
         span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))


### PR DESCRIPTION
# Description

Current implementation requires to import 2 classes (`Status` and `StatusCode`) from rather arbitrary location and requires 5 lines of code for that simple action every time:
```py
span.set_status(
    trace.status.Status(
        status_code=trace.status.StatusCode.OK,
    )
)
```

That is not convenient and not a python way to do things.

With this PR I'm simplifying `Span.set_status` interface to accept `StatusCode` or enum name. With that simple action becomes simple in code:
```py
span.set_status('OK')
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests updated respectively

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `opentelemetry-instrumentation/` have changed
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
