### PR TITLE
rename instrumentation to shim

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ DISTDIR=dist
   mkdir -p $DISTDIR
   rm -rf $DISTDIR/*
 
- for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-instrumentation/ opentelemetry-proto/ opentelemetry-distro/ exporter/*/ instrumentation/*/ propagator/*/; do
+ for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-instrumentation/ opentelemetry-proto/ opentelemetry-distro/ exporter/*/ shim/*/ propagator/*/; do
    (
      echo "building $d"
      cd "$d"


### PR DESCRIPTION
# Description

The opentracing shim was moved from `instrumentation` to `shim`, this build script was not updated as part of that change. This fixes that.
