### PR TITLE
Update docs

### DIFF
--- a/docs/examples/basic_tracer/README.rst
+++ b/docs/examples/basic_tracer/README.rst
@@ -18,6 +18,7 @@ Installation
 
     pip install opentelemetry-api
     pip install opentelemetry-sdk
+    pip install opentelemetry-tools-google-cloud
 
 Run the Example
 ---------------

--- a/docs/examples/basic_tracer/README.rst
+++ b/docs/examples/basic_tracer/README.rst
@@ -7,7 +7,7 @@ There are two different examples:
 
 * basic_trace: Shows how to configure a SpanProcessor and Exporter, and how to create a tracer and span.
 
-* resources: Shows how to add resource information to a Provider. Note that this must be run on a Google Compute Engine instance.
+* resources: Shows how to add resource information to a Provider.
 
 The source files of these examples are available :scm_web:`here <docs/examples/basic_tracer/>`.
 
@@ -18,7 +18,6 @@ Installation
 
     pip install opentelemetry-api
     pip install opentelemetry-sdk
-    pip install opentelemetry-tools-google-cloud
 
 Run the Example
 ---------------

--- a/docs/examples/basic_tracer/resources.py
+++ b/docs/examples/basic_tracer/resources.py
@@ -1,15 +1,14 @@
 from opentelemetry import trace
-from opentelemetry.sdk.resources import get_aggregated_resources
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     ConsoleSpanExporter,
     SimpleExportSpanProcessor,
 )
-from opentelemetry.tools.resource_detector import GoogleCloudResourceDetector
 
-resources = get_aggregated_resources([GoogleCloudResourceDetector()])
+resource = Resource.create({"service.name": "basic_service"})
 
-trace.set_tracer_provider(TracerProvider(resource=resources))
+trace.set_tracer_provider(TracerProvider(resource=resource))
 
 trace.get_tracer_provider().add_span_processor(
     SimpleExportSpanProcessor(ConsoleSpanExporter())


### PR DESCRIPTION
# Description

The example mentioned in basic resource needs a dependency `opentelemetry-tools-google-cloud` to work.  https://github.com/open-telemetry/opentelemetry-python/blob/ca8c0970f88b083b57c85322c997595d0ffc3702/docs/examples/basic_tracer/resources.py#L1-L19


Based on discussion https://github.com/open-telemetry/opentelemetry-python/pull/1548#discussion_r563560194 removed the GCP resource detector and added simple resource creation.