### PR TITLE
Add Zoom passcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ For information about contributing to OpenTelemetry Python, see [CONTRIBUTING.md
 
 We meet weekly on Thursdays at 9AM PST. The meeting is subject to change depending on contributors' availability. Check the [OpenTelemetry community calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com) for specific dates.
 
-Meetings take place via [Zoom video conference](https://zoom.us/j/6729396170).
+Meetings take place via [Zoom video conference](https://zoom.us/j/6729396170). The passcode is _77777_.
 
 Meeting notes are available as a public [Google doc](https://docs.google.com/document/d/1CIMGoIOZ-c3-igzbd6_Pnxx1SjAkjwqoYSUWxPY8XIs/edit). For edit access, get in touch on [Gitter](https://gitter.im/open-telemetry/opentelemetry-python).
 


### PR DESCRIPTION
# Description
Added the new passcode for Zoom meetings. This is a documentation-only change.
