### PR TITLE
adding note to check on the stable docs build

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,7 +56,7 @@ git tag stable
 git push origin stable
 ```
 
-To validate this worked, ensure the stable build has run successfully: https://readthedocs.org/projects/opentelemetry-python/builds/
+To validate this worked, ensure the stable build has run successfully: https://readthedocs.org/projects/opentelemetry-python/builds/. If the build has not run automatically, it can be manually trigger via the readthedocs interface.
 
 ## Update master
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,6 +56,8 @@ git tag stable
 git push origin stable
 ```
 
+To validate this worked, ensure the stable build has run successfully: https://readthedocs.org/projects/opentelemetry-python/builds/
+
 ## Update master
 
 Ensure the version and changelog updates have been applied to master.


### PR DESCRIPTION
# Description

The stable build *should* be fixed, but if not, added a note in the release doc to ensure maintainers check the state of the build and trigger it if it did not run.

Fixes #1352
