### PR TITLE
Release for 1.0.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v0.17b0...HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.0.0rc1...HEAD)
+
+## [1.0.0rc1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.0.0rc1) - 2021-02-12
 
 ### Changed
 - Tracer and Meter provider environment variables are now consistent with the rest
@@ -23,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1545](https://github.com/open-telemetry/opentelemetry-python/pull/1545))
 - Add urllib to opentelemetry-bootstrap target list
   ([#1584])(https://github.com/open-telemetry/opentelemetry-python/pull/1584)
-
 
 ### Changed
 - Read-only Span attributes have been moved to ReadableSpan class

--- a/docs/examples/error_handler/error_handler_0/setup.cfg
+++ b/docs/examples/error_handler/error_handler_0/setup.cfg
@@ -37,7 +37,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-sdk == 0.18.dev0
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/docs/examples/error_handler/error_handler_0/src/error_handler_0/version.py
+++ b/docs/examples/error_handler/error_handler_0/src/error_handler_0/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/docs/examples/error_handler/error_handler_1/setup.cfg
+++ b/docs/examples/error_handler/error_handler_1/setup.cfg
@@ -37,7 +37,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-sdk == 0.18.dev0
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/docs/examples/error_handler/error_handler_1/src/error_handler_1/version.py
+++ b/docs/examples/error_handler/error_handler_1/src/error_handler_1/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/exporter/opentelemetry-exporter-jaeger/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger/setup.cfg
@@ -42,8 +42,8 @@ install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52.0
     thrift >= 0.10.0
-    opentelemetry-api == 0.18.dev0
-    opentelemetry-sdk == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/version.py
+++ b/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/exporter/opentelemetry-exporter-otlp/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp/setup.cfg
@@ -42,9 +42,9 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52.0
-    opentelemetry-api == 0.18.dev0
-    opentelemetry-sdk == 0.18.dev0
-    opentelemetry-proto == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
+    opentelemetry-proto == 1.0.0rc1
     backoff ~= 1.10.0
 
 [options.extras_require]

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/version.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/exporter/opentelemetry-exporter-zipkin/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin/setup.cfg
@@ -42,8 +42,8 @@ packages=find_namespace:
 install_requires =
     protobuf >= 3.12
     requests ~= 2.7
-    opentelemetry-api == 0.18.dev0
-    opentelemetry-sdk == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/version.py
+++ b/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/opentelemetry-api/src/opentelemetry/version.py
+++ b/opentelemetry-api/src/opentelemetry/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/opentelemetry-proto/src/opentelemetry/proto/version.py
+++ b/opentelemetry-proto/src/opentelemetry/proto/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/opentelemetry-sdk/setup.cfg
+++ b/opentelemetry-sdk/setup.cfg
@@ -42,7 +42,7 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/propagator/opentelemetry-propagator-b3/setup.cfg
+++ b/propagator/opentelemetry-propagator-b3/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =

--- a/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/version.py
+++ b/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/propagator/opentelemetry-propagator-jaeger/setup.cfg
+++ b/propagator/opentelemetry-propagator-jaeger/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =

--- a/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/version.py
+++ b/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ DISTDIR=dist
   mkdir -p $DISTDIR
   rm -rf $DISTDIR/*
 
- for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-instrumentation/ opentelemetry-proto/ opentelemetry-distro/ exporter/*/ shim/*/ propagator/*/; do
+ for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-proto/ exporter/opentelemetry-exporter-jaeger/ exporter/opentelemetry-exporter-otlp/ exporter/opentelemetry-exporter-zipkin/ propagator/*/; do
    (
      echo "building $d"
      cd "$d"


### PR DESCRIPTION
Will only be releasing:

opentelemetry-api
opentelemetry-sdk
opentelemetry-exporter-jaeger
opentelemetry-exporter-otlp
opentelemetry-exporter-zipkin
opentelemetry-proto
opentelemetry-propagator-b3
opentelemetry-propagator-jaeger

The build script (`build.sh`) has been modified to only create dists for these above packages.

Since it is only rc1, we will not be adding the `Development Status :: 5 - Production/Stable` classifier as of yet.