### PR TITLE
Release for 1.0.0rc1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: 263adc5f7f524fae2c84571f656cef0896de0868
+  CONTRIB_REPO_SHA: e7041a7d94227a387246a02cbd57bdfe5047059c
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v0.17b0...HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.0.0rc1...HEAD)
+
+## [1.0.0rc1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.0.0rc1) - 2021-02-12
 
 ### Changed
 - Tracer and Meter provider environment variables are now consistent with the rest
@@ -23,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1545](https://github.com/open-telemetry/opentelemetry-python/pull/1545))
 - Add urllib to opentelemetry-bootstrap target list
   ([#1584])(https://github.com/open-telemetry/opentelemetry-python/pull/1584)
-
 
 ### Changed
 - Read-only Span attributes have been moved to ReadableSpan class

--- a/docs/examples/error_handler/error_handler_0/setup.cfg
+++ b/docs/examples/error_handler/error_handler_0/setup.cfg
@@ -37,7 +37,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-sdk == 0.18.dev0
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/docs/examples/error_handler/error_handler_0/src/error_handler_0/version.py
+++ b/docs/examples/error_handler/error_handler_0/src/error_handler_0/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/docs/examples/error_handler/error_handler_1/setup.cfg
+++ b/docs/examples/error_handler/error_handler_1/setup.cfg
@@ -37,7 +37,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-sdk == 0.18.dev0
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/docs/examples/error_handler/error_handler_1/src/error_handler_1/version.py
+++ b/docs/examples/error_handler/error_handler_1/src/error_handler_1/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/exporter/opentelemetry-exporter-jaeger/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger/setup.cfg
@@ -42,8 +42,8 @@ install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52.0
     thrift >= 0.10.0
-    opentelemetry-api == 0.18.dev0
-    opentelemetry-sdk == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/version.py
+++ b/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/exporter/opentelemetry-exporter-opencensus/setup.cfg
+++ b/exporter/opentelemetry-exporter-opencensus/setup.cfg
@@ -42,8 +42,8 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     opencensus-proto >= 0.1.0, < 1.0.0
-    opentelemetry-api == 0.18.dev0
-    opentelemetry-sdk == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
     protobuf >= 3.13.0
 
 [options.packages.find]

--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.17b0"

--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.17b0"
+__version__ = "0.18.dev0"

--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.17.b0"

--- a/exporter/opentelemetry-exporter-otlp/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp/setup.cfg
@@ -42,9 +42,9 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52.0
-    opentelemetry-api == 0.18.dev0
-    opentelemetry-sdk == 0.18.dev0
-    opentelemetry-proto == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
+    opentelemetry-proto == 1.0.0rc1
     backoff ~= 1.10.0
 
 [options.extras_require]

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/version.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/exporter/opentelemetry-exporter-zipkin/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin/setup.cfg
@@ -42,8 +42,8 @@ packages=find_namespace:
 install_requires =
     protobuf >= 3.12
     requests ~= 2.7
-    opentelemetry-api == 0.18.dev0
-    opentelemetry-sdk == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/version.py
+++ b/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/opentelemetry-api/src/opentelemetry/version.py
+++ b/opentelemetry-api/src/opentelemetry/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/opentelemetry-distro/setup.cfg
+++ b/opentelemetry-distro/setup.cfg
@@ -41,8 +41,8 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 0.18.dev0
-    opentelemetry-sdk == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src
@@ -56,4 +56,4 @@ opentelemetry_configurator =
 [options.extras_require]
 test =
 otlp =
-    opentelemetry-exporter-otlp == 0.18.dev0
+    opentelemetry-exporter-otlp == 1.0.0rc1

--- a/opentelemetry-distro/src/opentelemetry/distro/version.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.17b0"

--- a/opentelemetry-distro/src/opentelemetry/distro/version.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.17b0"
+__version__ = "0.18.dev0"

--- a/opentelemetry-distro/src/opentelemetry/distro/version.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.17.b0"

--- a/opentelemetry-instrumentation/setup.cfg
+++ b/opentelemetry-instrumentation/setup.cfg
@@ -42,7 +42,7 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
     wrapt >= 1.0.0, < 2.0.0
 
 [options.packages.find]

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/version.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.17b0"

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/version.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.17b0"
+__version__ = "0.18.dev0"

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/version.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.17.b0"

--- a/opentelemetry-proto/src/opentelemetry/proto/version.py
+++ b/opentelemetry-proto/src/opentelemetry/proto/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/opentelemetry-sdk/setup.cfg
+++ b/opentelemetry-sdk/setup.cfg
@@ -42,7 +42,7 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/propagator/opentelemetry-propagator-b3/setup.cfg
+++ b/propagator/opentelemetry-propagator-b3/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =

--- a/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/version.py
+++ b/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/propagator/opentelemetry-propagator-jaeger/setup.cfg
+++ b/propagator/opentelemetry-propagator-jaeger/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =

--- a/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/version.py
+++ b/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "1.0.0rc1"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ DISTDIR=dist
   mkdir -p $DISTDIR
   rm -rf $DISTDIR/*
 
- for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-instrumentation/ opentelemetry-proto/ opentelemetry-distro/ exporter/*/ shim/*/ propagator/*/; do
+ for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-proto/ exporter/opentelemetry-exporter-jaeger/ exporter/opentelemetry-exporter-otlp/ exporter/opentelemetry-exporter-zipkin/ propagator/*/; do
    (
      echo "building $d"
      cd "$d"

--- a/shim/opentelemetry-opentracing-shim/setup.cfg
+++ b/shim/opentelemetry-opentracing-shim/setup.cfg
@@ -42,11 +42,11 @@ packages=find_namespace:
 install_requires =
     Deprecated >= 1.2.6
     opentracing ~= 2.0
-    opentelemetry-api == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 1.0.0rc1
     opentracing ~= 2.2.0
 
 [options.packages.find]

--- a/shim/opentelemetry-opentracing-shim/setup.cfg
+++ b/shim/opentelemetry-opentracing-shim/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
 
 [options.extras_require]
 test =
-    opentelemetry-test == 1.0.0rc1
+    opentelemetry-test == 0.17.b0
     opentracing ~= 2.2.0
 
 [options.packages.find]

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/version.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.17b0"

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/version.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.17b0"
+__version__ = "0.18.dev0"

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/version.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.17.b0"

--- a/tests/util/setup.cfg
+++ b/tests/util/setup.cfg
@@ -38,8 +38,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.18.dev0
-    opentelemetry-sdk == 0.18.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.extras_require]
 test = flask~=1.0

--- a/tests/util/src/opentelemetry/test/version.py
+++ b/tests/util/src/opentelemetry/test/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.18.dev0"
+__version__ = "0.17.b0"


### PR DESCRIPTION
Will only be releasing:

opentelemetry-api
opentelemetry-sdk
opentelemetry-exporter-jaeger
opentelemetry-exporter-otlp
opentelemetry-exporter-zipkin
opentelemetry-proto
opentelemetry-propagator-b3
opentelemetry-propagator-jaeger

The build script (`build.sh`) has been modified to only create dists for these above packages.

Since it is only rc1, we will not be adding the `Development Status :: 5 - Production/Stable` classifier as of yet.

The packages that are not rcing will be kept at `0.17b0` and a separate release will be cut for those.