### PR TITLE
Release for 0.18b0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: 370afa618c30a9773b0594c2ea469518c8b2c274
+  CONTRIB_REPO_SHA: a8de87379a6930246ee5f2bf25efe19e147357cf
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.0.0rc1...HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v0.18b0...HEAD)
+
+## [0.18b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v0.18b0) - 2021-02-16
+
+### Added
+- Add urllib to opentelemetry-bootstrap target list
+  ([#1584])(https://github.com/open-telemetry/opentelemetry-python/pull/1584)
 
 ## [1.0.0rc1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.0.0rc1) - 2021-02-12
 

--- a/docs/examples/error_handler/error_handler_0/setup.cfg
+++ b/docs/examples/error_handler/error_handler_0/setup.cfg
@@ -37,7 +37,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/docs/examples/error_handler/error_handler_0/src/error_handler_0/version.py
+++ b/docs/examples/error_handler/error_handler_0/src/error_handler_0/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/docs/examples/error_handler/error_handler_1/setup.cfg
+++ b/docs/examples/error_handler/error_handler_1/setup.cfg
@@ -37,7 +37,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/docs/examples/error_handler/error_handler_1/src/error_handler_1/version.py
+++ b/docs/examples/error_handler/error_handler_1/src/error_handler_1/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/exporter/opentelemetry-exporter-jaeger/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger/setup.cfg
@@ -42,8 +42,8 @@ install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52.0
     thrift >= 0.10.0
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-opencensus/setup.cfg
+++ b/exporter/opentelemetry-exporter-opencensus/setup.cfg
@@ -42,8 +42,8 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     opencensus-proto >= 0.1.0, < 1.0.0
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
     protobuf >= 3.13.0
 
 [options.packages.find]

--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/exporter/opentelemetry-exporter-otlp/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp/setup.cfg
@@ -42,9 +42,9 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52.0
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-sdk == 1.0.0.dev0
-    opentelemetry-proto == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
+    opentelemetry-proto == 1.0.0rc1
     backoff ~= 1.10.0
 
 [options.extras_require]

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/version.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0.dev0"
+__version__ = "1.0.0rc1"

--- a/exporter/opentelemetry-exporter-zipkin/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin/setup.cfg
@@ -42,8 +42,8 @@ packages=find_namespace:
 install_requires =
     protobuf >= 3.12
     requests ~= 2.7
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/version.py
+++ b/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0.dev0"
+__version__ = "1.0.0rc1"

--- a/opentelemetry-api/src/opentelemetry/version.py
+++ b/opentelemetry-api/src/opentelemetry/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0.dev0"
+__version__ = "1.0.0rc1"

--- a/opentelemetry-distro/setup.cfg
+++ b/opentelemetry-distro/setup.cfg
@@ -41,8 +41,8 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.packages.find]
 where = src
@@ -56,4 +56,4 @@ opentelemetry_configurator =
 [options.extras_require]
 test =
 otlp =
-    opentelemetry-exporter-otlp == 1.0.0.dev0
+    opentelemetry-exporter-otlp == 1.0.0rc1

--- a/opentelemetry-distro/src/opentelemetry/distro/version.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/opentelemetry-instrumentation/setup.cfg
+++ b/opentelemetry-instrumentation/setup.cfg
@@ -42,7 +42,7 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
     wrapt >= 1.0.0, < 2.0.0
 
 [options.packages.find]

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/version.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/opentelemetry-proto/src/opentelemetry/proto/version.py
+++ b/opentelemetry-proto/src/opentelemetry/proto/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0.dev0"
+__version__ = "1.0.0rc1"

--- a/opentelemetry-sdk/setup.cfg
+++ b/opentelemetry-sdk/setup.cfg
@@ -42,7 +42,7 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.packages.find]
 where = src

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -122,6 +122,8 @@ class SpanProcessor:
         """
 
 
+# Temporary fix until https://github.com/PyCQA/pylint/issues/4098 is resolved
+# pylint:disable=no-member
 class SynchronousMultiSpanProcessor(SpanProcessor):
     """Implementation of class:`SpanProcessor` that forwards all received
     events to a list of span processors sequentially.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0.dev0"
+__version__ = "1.0.0rc1"

--- a/propagator/opentelemetry-propagator-b3/setup.cfg
+++ b/propagator/opentelemetry-propagator-b3/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =

--- a/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/version.py
+++ b/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0.dev0"
+__version__ = "1.0.0rc1"

--- a/propagator/opentelemetry-propagator-jaeger/setup.cfg
+++ b/propagator/opentelemetry-propagator-jaeger/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =

--- a/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/version.py
+++ b/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0.dev0"
+__version__ = "1.0.0rc1"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ DISTDIR=dist
   mkdir -p $DISTDIR
   rm -rf $DISTDIR/*
 
- for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-instrumentation/ opentelemetry-proto/ opentelemetry-distro/ exporter/*/ shim/*/ propagator/*/; do
+ for d in opentelemetry-instrumentation/ opentelemetry-distro/ exporter/opentelemetry-exporter-opencensus shim/*/ ; do
    (
      echo "building $d"
      cd "$d"

--- a/shim/opentelemetry-opentracing-shim/setup.cfg
+++ b/shim/opentelemetry-opentracing-shim/setup.cfg
@@ -42,11 +42,11 @@ packages=find_namespace:
 install_requires =
     Deprecated >= 1.2.6
     opentracing ~= 2.0
-    opentelemetry-api == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.18.dev0
+    opentelemetry-test == 0.18b0
     opentracing ~= 2.2.0
 
 [options.packages.find]

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/version.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"

--- a/tests/util/setup.cfg
+++ b/tests/util/setup.cfg
@@ -38,8 +38,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0.dev0
-    opentelemetry-sdk == 1.0.0.dev0
+    opentelemetry-api == 1.0.0rc1
+    opentelemetry-sdk == 1.0.0rc1
 
 [options.extras_require]
 test = flask~=1.0

--- a/tests/util/src/opentelemetry/test/version.py
+++ b/tests/util/src/opentelemetry/test/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.18.dev0"
+__version__ = "0.18b0"


### PR DESCRIPTION
Release for 0.18b0 which updates components to use 1.0.0rc1.
Would only target the below non-core opentelemetry packages:

`opentelemetry-distro`
`opentelemetry-exporter-opencensus`
`opentelemetry-instrumentation`
`opentelemetry-opentracing-shim`
