### PR TITLE
add otlp grpc exporter test

### DIFF
--- a/tests/opentelemetry-docker-tests/tests/docker-compose.yml
+++ b/tests/opentelemetry-docker-tests/tests/docker-compose.yml
@@ -7,3 +7,7 @@ services:
     ports:
         - "8888:8888"
         - "55678:55678"
+  otcollector:
+    image: otel/opentelemetry-collector:0.22.0
+    ports:
+        - "4317:4317"

--- a/tests/opentelemetry-docker-tests/tests/otlpexporter/test_otlp_grpc_exporter_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/otlpexporter/test_otlp_grpc_exporter_functional.py
@@ -1,0 +1,56 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opentelemetry import trace
+from opentelemetry.context import attach, detach, set_value
+from opentelemetry.exporter.otlp.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.test.test_base import TestBase
+
+
+class ExportStatusSpanProcessor(SimpleSpanProcessor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.export_status = []
+
+    def on_end(self, span):
+        token = attach(set_value("suppress_instrumentation", True))
+        self.export_status.append(self.span_exporter.export((span,)))
+        detach(token)
+
+
+class TestOTLPExporter(TestBase):
+    def setUp(self):
+        super().setUp()
+
+        trace.set_tracer_provider(TracerProvider())
+        self.tracer = trace.get_tracer(__name__)
+        self.span_processor = ExportStatusSpanProcessor(
+            OTLPSpanExporter(insecure=True, timeout=1)
+        )
+
+        trace.get_tracer_provider().add_span_processor(self.span_processor)
+
+    def test_export(self):
+        with self.tracer.start_as_current_span("foo"):
+            with self.tracer.start_as_current_span("bar"):
+                with self.tracer.start_as_current_span("baz"):
+                    pass
+
+        self.assertTrue(len(self.span_processor.export_status), 3)
+
+        for export_status in self.span_processor.export_status:
+            self.assertEqual(export_status.name, "SUCCESS")
+            self.assertEqual(export_status.value, 0)

--- a/tox.ini
+++ b/tox.ini
@@ -214,7 +214,9 @@ commands_pre =
               -e {toxinidir}/opentelemetry-instrumentation \
               -e {toxinidir}/opentelemetry-sdk \
               -e {toxinidir}/tests/util \
-              -e {toxinidir}/exporter/opentelemetry-exporter-opencensus
+              -e {toxinidir}/exporter/opentelemetry-exporter-opencensus \
+              -e {toxinidir}/opentelemetry-proto \
+              -e {toxinidir}/exporter/opentelemetry-exporter-otlp
   docker-compose up -d	
 commands =
   pytest {posargs}


### PR DESCRIPTION
# Description

Adding an OpenTelemetry collector as part of the docker tests to ensure the OTLP exporter works w/ it.

Fixes #472 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
