### PR TITLE
fix wrong argument

### DIFF
--- a/docs/examples/auto-instrumentation/README.rst
+++ b/docs/examples/auto-instrumentation/README.rst
@@ -151,7 +151,7 @@ and run the following command instead:
 
 .. code:: sh
 
-    $ opentelemetry-instrument -e console_span python server_uninstrumented.py
+    $ opentelemetry-instrument --trace-exporter console_span python server_uninstrumented.py
 
 In the console where you previously executed ``client.py``, run the following
 command again:

--- a/opentelemetry-instrumentation/README.rst
+++ b/opentelemetry-instrumentation/README.rst
@@ -88,13 +88,13 @@ Examples
 
 ::
 
-    opentelemetry-instrument -e otlp flask run --port=3000
+    opentelemetry-instrument --trace-exporter otlp flask run --port=3000
 
-The above command will pass ``-e otlp`` to the instrument command and ``--port=3000`` to ``flask run``.
+The above command will pass ``--trace-exporter otlp`` to the instrument command and ``--port=3000`` to ``flask run``.
 
 ::
 
-    opentelemetry-instrument -e zipkin,otlp celery -A tasks worker --loglevel=info
+    opentelemetry-instrument --trace-exporter zipkin,otlp celery -A tasks worker --loglevel=info
 
 The above command will configure global trace provider, attach zipkin and otlp exporters to it and then
 start celery with the rest of the arguments. 


### PR DESCRIPTION
Fixing an issue reported by a user in Gitter. The arg used to be `-e`, it is now `--trace-exporter`