### PR TITLE
Fix get exporter names condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1695](https://github.com/open-telemetry/opentelemetry-python/pull/1695))
 - Change Jaeger exporters to obtain service.name from span
   ([#1703](https://github.com/open-telemetry/opentelemetry-python/pull/1703))
-- Fixed a parse error on no `OTEL_TRACES_EXPORTER`
+- Fixed an unset `OTEL_TRACES_EXPORTER` resulting in an error
   ([#1707](https://github.com/open-telemetry/opentelemetry-python/pull/1707))
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1695](https://github.com/open-telemetry/opentelemetry-python/pull/1695))
 - Change Jaeger exporters to obtain service.name from span
   ([#1703](https://github.com/open-telemetry/opentelemetry-python/pull/1703))
+- Fixed a parse error on no `OTEL_TRACES_EXPORTER`
+  ([#1707](https://github.com/open-telemetry/opentelemetry-python/pull/1707))
 
 ### Removed
 - Removed unused `get_hexadecimal_trace_id` and `get_hexadecimal_span_id` methods.

--- a/opentelemetry-distro/src/opentelemetry/distro/__init__.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/__init__.py
@@ -50,10 +50,7 @@ def _get_exporter_names() -> Sequence[str]:
 
     exporters = set()
 
-    if (
-        trace_exporters
-        and trace_exporters.lower().strip() != "none"
-    ):
+    if trace_exporters and trace_exporters.lower().strip() != "none":
         exporters.update(
             {
                 trace_exporter.strip()

--- a/opentelemetry-distro/src/opentelemetry/distro/__init__.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/__init__.py
@@ -52,6 +52,7 @@ def _get_exporter_names() -> Sequence[str]:
 
     if (
         trace_exporters is not None
+        and trace_exporters != ''
         and trace_exporters.lower().strip() != "none"
     ):
         exporters.update(

--- a/opentelemetry-distro/src/opentelemetry/distro/__init__.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/__init__.py
@@ -52,7 +52,7 @@ def _get_exporter_names() -> Sequence[str]:
 
     if (
         trace_exporters is not None
-        or trace_exporters.lower().strip() != "none"
+        and trace_exporters.lower().strip() != "none"
     ):
         exporters.update(
             {

--- a/opentelemetry-distro/src/opentelemetry/distro/__init__.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/__init__.py
@@ -52,7 +52,7 @@ def _get_exporter_names() -> Sequence[str]:
 
     if (
         trace_exporters is not None
-        and trace_exporters != ''
+        and trace_exporters != ""
         and trace_exporters.lower().strip() != "none"
     ):
         exporters.update(

--- a/opentelemetry-distro/src/opentelemetry/distro/__init__.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/__init__.py
@@ -51,8 +51,7 @@ def _get_exporter_names() -> Sequence[str]:
     exporters = set()
 
     if (
-        trace_exporters is not None
-        and trace_exporters != ""
+        trace_exporters
         and trace_exporters.lower().strip() != "none"
     ):
         exporters.update(

--- a/opentelemetry-distro/tests/test_configurator.py
+++ b/opentelemetry-distro/tests/test_configurator.py
@@ -168,6 +168,10 @@ class TestExporterNames(TestCase):
     def test_multiple_exporters(self):
         self.assertEqual(sorted(_get_exporter_names()), ["jaeger", "zipkin"])
 
+    @patch.dict(environ, {OTEL_TRACES_EXPORTER: "none"})
+    def test_none_exporters(self):
+        self.assertEqual(sorted(_get_exporter_names()), [])
+
     @patch.dict(environ, {}, clear=True)
     def test_no_exporters(self):
         self.assertEqual(sorted(_get_exporter_names()), [])

--- a/opentelemetry-distro/tests/test_configurator.py
+++ b/opentelemetry-distro/tests/test_configurator.py
@@ -171,3 +171,7 @@ class TestExporterNames(TestCase):
     @patch.dict(environ, {}, clear=True)
     def test_no_exporters(self):
         self.assertEqual(sorted(_get_exporter_names()), [])
+
+    @patch.dict(environ, {OTEL_TRACES_EXPORTER: ""})
+    def test_empty_exporters(self):
+        self.assertEqual(sorted(_get_exporter_names()), [])

--- a/opentelemetry-distro/tests/test_configurator.py
+++ b/opentelemetry-distro/tests/test_configurator.py
@@ -167,3 +167,7 @@ class TestExporterNames(TestCase):
     @patch.dict(environ, {OTEL_TRACES_EXPORTER: "jaeger,zipkin"})
     def test_multiple_exporters(self):
         self.assertEqual(sorted(_get_exporter_names()), ["jaeger", "zipkin"])
+
+    @patch.dict(environ, {}, clear=True)
+    def test_no_exporters(self):
+        self.assertEqual(sorted(_get_exporter_names()), [])


### PR DESCRIPTION
# Description

With the current condition, `_get_exporter_names` always fails with no `OTEL_TRACES_EXPORTER`.

```
Python 3.8.2 (default, Apr 27 2020, 15:52:40)
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from opentelemetry.distro import Configurator
description should only be set when status_code is set to StatusCode.ERROR
>>> Configurator().configure()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/dtaniwaki/.pyenv/versions/3.8.2/lib/python3.8/site-packages/opentelemetry/instrumentation/configurator.py", line 50, in configure
    self._configure(**kwargs)
  File "/Users/dtaniwaki/github/opentelemetry-python/opentelemetry-distro/src/opentelemetry/distro/__init__.py", line 152, in _configure
    _initialize_components()
  File "/Users/dtaniwaki/github/opentelemetry-python/opentelemetry-distro/src/opentelemetry/distro/__init__.py", line 143, in _initialize_components
    exporter_names = _get_exporter_names()
  File "/Users/dtaniwaki/github/opentelemetry-python/opentelemetry-distro/src/opentelemetry/distro/__init__.py", line 55, in _get_exporter_names
    or trace_exporters.lower().strip() != "none"
AttributeError: 'NoneType' object has no attribute 'lower'
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tried to configure it with `Configurator().configure()` w/ and w/o `OTEL_TRACES_EXPORTER`.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
