### PR TITLE
Implement Span.from_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1668](https://github.com/open-telemetry/opentelemetry-python/pull/1668))
 - Add `udp_split_oversized_batches` support to jaeger exporter
   ([#1500](https://github.com/open-telemetry/opentelemetry-python/pull/1500))
+- Add `Span.from_json` method to create a span from a JSON string
+  ([#1713](https://github.com/open-telemetry/opentelemetry-python/pull/1713))
 
 ### Changed
 - remove `service_name` from constructor of jaeger and opencensus exporters and 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -51,7 +51,6 @@ from opentelemetry.sdk.trace.id_generator import IdGenerator, RandomIdGenerator
 from opentelemetry.sdk.util import BoundedDict, BoundedList
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
 from opentelemetry.trace import SpanContext
-from opentelemetry.trace.propagation import SPAN_KEY
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util import types
 from opentelemetry.util._time import _time_ns

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -50,6 +50,9 @@ from opentelemetry.sdk.trace import sampling
 from opentelemetry.sdk.trace.id_generator import IdGenerator, RandomIdGenerator
 from opentelemetry.sdk.util import BoundedDict, BoundedList
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
+from opentelemetry.trace import SpanContext
+from opentelemetry.trace.propagation import SPAN_KEY
+from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util import types
 from opentelemetry.util._time import _time_ns
 
@@ -415,8 +418,8 @@ class ReadableSpan:
         links: Sequence[trace_api.Link] = (),
         kind: trace_api.SpanKind = trace_api.SpanKind.INTERNAL,
         instrumentation_info: InstrumentationInfo = None,
-        status: trace_api.Status = trace_api.Status(
-            trace_api.StatusCode.UNSET
+        status: Status = Status(
+            StatusCode.UNSET
         ),
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
@@ -462,7 +465,7 @@ class ReadableSpan:
         return self._end_time
 
     @property
-    def status(self) -> trace_api.Status:
+    def status(self) -> Status:
         return self._status
 
     @property
@@ -794,7 +797,7 @@ class Span(trace_api.Span, ReadableSpan):
         return self._end_time is None
 
     @_check_span_ended
-    def set_status(self, status: trace_api.Status) -> None:
+    def set_status(self, status: Status) -> None:
         self._status = status
 
     def __exit__(
@@ -813,8 +816,8 @@ class Span(trace_api.Span, ReadableSpan):
             # i.e. with tracer.start_span() as span:
             if self._set_status_on_exception:
                 self.set_status(
-                    trace_api.Status(
-                        status_code=trace_api.StatusCode.ERROR,
+                    Status(
+                        status_code=StatusCode.ERROR,
                         description="{}: {}".format(
                             exc_type.__name__, exc_val
                         ),

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -50,8 +50,6 @@ from opentelemetry.sdk.trace import sampling
 from opentelemetry.sdk.trace.id_generator import IdGenerator, RandomIdGenerator
 from opentelemetry.sdk.util import BoundedDict, BoundedList
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
-from opentelemetry.trace import SpanContext
-from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util import types
 from opentelemetry.util._time import _time_ns
 
@@ -417,7 +415,7 @@ class ReadableSpan:
         links: Sequence[trace_api.Link] = (),
         kind: trace_api.SpanKind = trace_api.SpanKind.INTERNAL,
         instrumentation_info: InstrumentationInfo = None,
-        status: Status = Status(StatusCode.UNSET),
+        status: trace_api.Status = trace_api.Status(trace_api.StatusCode.UNSET),
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
     ) -> None:
@@ -491,7 +489,7 @@ class ReadableSpan:
             if isinstance(self.parent, Span):
                 ctx = self.parent.context
                 parent_id = trace_api.format_span_id(ctx.span_id)
-            elif isinstance(self.parent, SpanContext):
+            elif isinstance(self.parent, trace_api.SpanContext):
                 parent_id = trace_api.format_span_id(self.parent.span_id)
 
         start_time = None
@@ -813,8 +811,8 @@ class Span(trace_api.Span, ReadableSpan):
             # i.e. with tracer.start_span() as span:
             if self._set_status_on_exception:
                 self.set_status(
-                    Status(
-                        status_code=StatusCode.ERROR,
+                    trace_api.Status(
+                        status_code=trace_api.StatusCode.ERROR,
                         description="{}: {}".format(
                             exc_type.__name__, exc_val
                         ),

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -512,7 +512,7 @@ class ReadableSpan:
 
         f_span["name"] = self._name
         f_span["context"] = self._format_context(self._context)
-        f_span["kind"] = str(self.kind)
+        f_span["kind"] = self.kind.name
         f_span["parent_id"] = parent_id
         f_span["start_time"] = start_time
         f_span["end_time"] = end_time

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -418,9 +418,7 @@ class ReadableSpan:
         links: Sequence[trace_api.Link] = (),
         kind: trace_api.SpanKind = trace_api.SpanKind.INTERNAL,
         instrumentation_info: InstrumentationInfo = None,
-        status: Status = Status(
-            StatusCode.UNSET
-        ),
+        status: Status = Status(StatusCode.UNSET),
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
     ) -> None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -314,10 +314,10 @@ class Event(EventBase):
     @staticmethod
     def from_dict(data: Dict[str, str]) -> "EventBase":
         return Event(
-                name=data["name"],
-                timestamp=util.iso_str_to_ns(data["timestamp"]),
-                attributes=data["attributes"],
-            )
+            name=data["name"],
+            timestamp=util.iso_str_to_ns(data["timestamp"]),
+            attributes=data["attributes"],
+        )
 
 
 def _is_valid_attribute_value(value: types.AttributeValue) -> bool:
@@ -415,7 +415,9 @@ class ReadableSpan:
         links: Sequence[trace_api.Link] = (),
         kind: trace_api.SpanKind = trace_api.SpanKind.INTERNAL,
         instrumentation_info: InstrumentationInfo = None,
-        status: trace_api.Status = trace_api.Status(trace_api.StatusCode.UNSET),
+        status: trace_api.Status = trace_api.Status(
+            trace_api.StatusCode.UNSET
+        ),
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
     ) -> None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -19,8 +19,7 @@ from collections import OrderedDict, deque
 from collections.abc import MutableMapping, Sequence
 from typing import Dict, Sequence, Optional
 
-from opentelemetry.trace.status import Status, StatusCode
-from opentelemetry.trace import SpanKind, SpanContext, Link, TraceState
+from opentelemetry import trace as trace_api
 
 
 def ns_to_iso_str(nanoseconds):
@@ -43,12 +42,12 @@ def get_dict_as_key(labels):
     )
 
 
-def to_context(data: Dict[str, str]) -> SpanContext:
+def to_context(data: Dict[str, str]) -> trace_api.SpanContext:
     trace_state = None
     if data.get("trace_state", None):
-        trace_state = TraceState(entries=json.loads(data["trace_state"]))
+        trace_state = trace_api.TraceState(entries=json.loads(data["trace_state"]))
 
-    return SpanContext(
+    return trace_api.SpanContext(
         int(data.get("trace_id", "0x0"), 0),
         int(data.get("span_id", "0x0"), 0),
         is_remote=False,
@@ -63,26 +62,26 @@ def iso_str_to_ns(s: str) -> int:
     return int(datetime.datetime.fromisoformat(s).timestamp() * 1000000000)
 
 
-def to_span_kind(s: str) -> Optional[SpanKind]:
+def to_span_kind(s: str) -> Optional[trace_api.SpanKind]:
     if "." not in s:
         return None
-    return getattr(SpanKind, s.split(".")[1])
+    return getattr(trace_api.SpanKind, s.split(".")[1])
 
 
-def to_link(data: Dict[str, str]) -> Link:
+def to_link(data: Dict[str, str]) -> trace_api.Link:
     context = None
     if "context" in data:
         context = to_context(data["context"])
 
-    return Link(context, attributes=data.get("attributes", {}))
+    return trace_api.Link(context, attributes=data.get("attributes", {}))
 
 
-def to_status(data: Dict[str, Optional[str]]) -> Status:
+def to_status(data: Dict[str, Optional[str]]) -> trace_api.Status:
     status_code = None
     if "status_code" in data:
-        status_code = getattr(StatusCode, data["status_code"])
+        status_code = getattr(trace_api.StatusCode, data["status_code"])
 
-    return Status(
+    return trace_api.Status(
         status_code=status_code, description=data.get("description", None),
     )
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -14,19 +14,13 @@
 
 import datetime
 import json
-import re
 import threading
 from collections import OrderedDict, deque
 from collections.abc import MutableMapping, Sequence
-from types import MappingProxyType
-from typing import Dict, Sequence, List, Optional
+from typing import Dict, Sequence, Optional
 
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.trace import SpanKind, SpanContext, Link, TraceState
-from opentelemetry.util.types import Attributes
-
-
-_trace_state_regexp = re.compile("'\\{key=([^,]*), *value=([^}]*)\\}'")
 
 
 def ns_to_iso_str(nanoseconds):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -22,7 +22,7 @@ from typing import Dict, Optional
 
 from opentelemetry import trace as trace_api
 
-_tz_regexp = re.compile("([+-])(\\d{2}):(\d{2})$")
+_tz_regexp = re.compile("([+-])(\\d{2}):(\\d{2})$")
 
 
 def ns_to_iso_str(nanoseconds):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -14,12 +14,15 @@
 
 import datetime
 import json
+import re
 import threading
 from collections import OrderedDict, deque
 from collections.abc import MutableMapping, Sequence
 from typing import Dict, Optional
 
 from opentelemetry import trace as trace_api
+
+_tz_regexp = re.compile("([+-])(\\d{2}):(\d{2})$")
 
 
 def ns_to_iso_str(nanoseconds):
@@ -63,6 +66,8 @@ def iso_str_to_ns(dt_str: str) -> int:
             dt_str, "%Y-%m-%dT%H:%M:%S.%fZ"
         ).replace(tzinfo=datetime.timezone.utc)
     else:
+        # For python 3.6 support.
+        dt_str = _tz_regexp.sub("\\1\\2\\3", dt_str)
         dt = datetime.datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%f%z")
     return int(dt.timestamp() * 1000000000)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -17,7 +17,7 @@ import json
 import threading
 from collections import OrderedDict, deque
 from collections.abc import MutableMapping, Sequence
-from typing import Dict, Sequence, Optional
+from typing import Dict, Optional
 
 from opentelemetry import trace as trace_api
 
@@ -45,27 +45,31 @@ def get_dict_as_key(labels):
 def to_context(data: Dict[str, str]) -> trace_api.SpanContext:
     trace_state = None
     if data.get("trace_state", None):
-        trace_state = trace_api.TraceState(entries=json.loads(data["trace_state"]))
+        trace_state = trace_api.TraceState(
+            entries=json.loads(data["trace_state"])
+        )
 
     return trace_api.SpanContext(
         int(data.get("trace_id", "0x0"), 0),
         int(data.get("span_id", "0x0"), 0),
         is_remote=False,
-        trace_state=trace_state
+        trace_state=trace_state,
     )
 
 
-def iso_str_to_ns(s: str) -> int:
-    if s[-1] == "Z":
-        s = s[:-1] + "+00:00"
+def iso_str_to_ns(dt_str: str) -> int:
+    if dt_str[-1] == "Z":
+        dt_str = dt_str[:-1] + "+00:00"
 
-    return int(datetime.datetime.fromisoformat(s).timestamp() * 1000000000)
+    return int(
+        datetime.datetime.fromisoformat(dt_str).timestamp() * 1000000000
+    )
 
 
-def to_span_kind(s: str) -> Optional[trace_api.SpanKind]:
-    if "." not in s:
+def to_span_kind(span_kind_str: str) -> Optional[trace_api.SpanKind]:
+    if "." not in span_kind_str:
         return None
-    return getattr(trace_api.SpanKind, s.split(".")[1])
+    return getattr(trace_api.SpanKind, span_kind_str.split(".")[1])
 
 
 def to_link(data: Dict[str, str]) -> trace_api.Link:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -67,9 +67,10 @@ def iso_str_to_ns(dt_str: str) -> int:
 
 
 def to_span_kind(span_kind_str: str) -> Optional[trace_api.SpanKind]:
-    if "." not in span_kind_str:
-        return None
-    return getattr(trace_api.SpanKind, span_kind_str.split(".")[1])
+    for item in trace_api.SpanKind:
+        if item.name == span_kind_str:
+            return item
+    return None
 
 
 def to_link(data: Dict[str, str]) -> trace_api.Link:
@@ -83,7 +84,12 @@ def to_link(data: Dict[str, str]) -> trace_api.Link:
 def to_status(data: Dict[str, Optional[str]]) -> trace_api.Status:
     status_code = None
     if "status_code" in data:
-        status_code = getattr(trace_api.StatusCode, data["status_code"])
+        status_code = None
+        for item in trace_api.StatusCode:
+            if item.name == data["status_code"]:
+                status_code = item
+                break
+        return None
 
     return trace_api.Status(
         status_code=status_code, description=data.get("description", None),

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -61,10 +61,7 @@ def iso_str_to_ns(dt_str: str) -> int:
     if dt_str[-1] == "Z":
         dt_str = dt_str[:-1] + "+00:00"
 
-    try:
-        dt = datetime.datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%fZ")
-    except ValueError:
-        dt = datetime.datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%f%z")
+    dt = datetime.datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%f%z")
     return int(dt.timestamp() * 1000000000)
 
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -69,7 +69,9 @@ def iso_str_to_ns(s: str) -> int:
     return int(datetime.datetime.fromisoformat(s).timestamp() * 1000000000)
 
 
-def to_span_kind(s: str) -> SpanKind:
+def to_span_kind(s: str) -> Optional[SpanKind]:
+    if "." not in s:
+        return None
     return getattr(SpanKind, s.split(".")[1])
 
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -59,7 +59,9 @@ def to_context(data: Dict[str, str]) -> trace_api.SpanContext:
 
 def iso_str_to_ns(dt_str: str) -> int:
     if dt_str[-1] == "Z":
-        dt = datetime.datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+        dt = datetime.datetime.strptime(
+            dt_str, "%Y-%m-%dT%H:%M:%S.%fZ"
+        ).replace(tzinfo=datetime.timezone.utc)
     else:
         dt = datetime.datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%f%z")
     return int(dt.timestamp() * 1000000000)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -61,9 +61,11 @@ def iso_str_to_ns(dt_str: str) -> int:
     if dt_str[-1] == "Z":
         dt_str = dt_str[:-1] + "+00:00"
 
-    return int(
-        datetime.datetime.fromisoformat(dt_str).timestamp() * 1000000000
-    )
+    try:
+        dt = datetime.datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError:
+        dt = datetime.datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%f%z")
+    return int(dt.timestamp() * 1000000000)
 
 
 def to_span_kind(span_kind_str: str) -> Optional[trace_api.SpanKind]:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -89,7 +89,6 @@ def to_status(data: Dict[str, Optional[str]]) -> trace_api.Status:
             if item.name == data["status_code"]:
                 status_code = item
                 break
-        return None
 
     return trace_api.Status(
         status_code=status_code, description=data.get("description", None),

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -59,9 +59,9 @@ def to_context(data: Dict[str, str]) -> trace_api.SpanContext:
 
 def iso_str_to_ns(dt_str: str) -> int:
     if dt_str[-1] == "Z":
-        dt_str = dt_str[:-1] + "+00:00"
-
-    dt = datetime.datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%f%z")
+        dt = datetime.datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+    else:
+        dt = datetime.datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%f%z")
     return int(dt.timestamp() * 1000000000)
 
 

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -16,34 +16,47 @@ import collections
 import unittest
 
 from opentelemetry import trace as trace_api
-from opentelemetry.sdk.util import BoundedDict, BoundedList, to_context, iso_str_to_ns, to_span_kind, to_link, to_status
+from opentelemetry.sdk.util import (
+    BoundedDict,
+    BoundedList,
+    iso_str_to_ns,
+    to_context,
+    to_link,
+    to_span_kind,
+    to_status,
+)
 
 
 def test_to_context() -> None:
     expected_context = trace_api.SpanContext(
-        trace_id=0x1,
-        span_id=0x1,
-        is_remote=False,
-        trace_state={"foo": "bar"},
+        trace_id=0x1, span_id=0x1, is_remote=False, trace_state={"foo": "bar"},
     )
-    actual_context = to_context({
-        "trace_id": "0x1",
-        "span_id": "0x1",
-        "trace_state": "[[\"foo\", \"bar\"]]"
-    })
+    actual_context = to_context(
+        {
+            "trace_id": "0x1",
+            "span_id": "0x1",
+            "trace_state": '[["foo", "bar"]]',
+        }
+    )
     assert expected_context.trace_id == actual_context.trace_id
     assert expected_context.span_id == actual_context.span_id
     assert expected_context.trace_state == actual_context.trace_state
 
 
 def test_iso_str_to_ns() -> None:
-    assert 1614742496000000000 == iso_str_to_ns("2021-03-03T03:34:56.000000Z")
-    assert 1614742496000000000 == iso_str_to_ns("2021-03-03T03:34:56.000000+00:00")
-    assert 1614710096000000000 == iso_str_to_ns("2021-03-03T03:34:56.000000+09:00")
+    assert iso_str_to_ns("2021-03-03T03:34:56.000000Z") == 1614742496000000000
+    assert (
+        iso_str_to_ns("2021-03-03T03:34:56.000000+00:00")
+        == 1614742496000000000
+    )
+    assert (
+        iso_str_to_ns("2021-03-03T03:34:56.000000+09:00")
+        == 1614710096000000000
+    )
 
 
 def test_to_span_kind() -> None:
-    assert None == to_span_kind("foo")
+    assert to_span_kind("foo") is None
     assert trace_api.SpanKind.INTERNAL == to_span_kind("SpanKind.INTERNAL")
 
 
@@ -55,18 +68,18 @@ def test_to_link() -> None:
             is_remote=False,
             trace_state={"foo": "bar"},
         ),
-        {"link:foo": "link:bar"}
+        {"link:foo": "link:bar"},
     )
-    actual_link = to_link({
-        "context": {
-            "trace_id": "0x1",
-            "span_id": "0x1",
-            "trace_state": "[[\"foo\", \"bar\"]]"
-        },
-        "attributes": {
-            "link:foo": "link:bar"
-        },
-    })
+    actual_link = to_link(
+        {
+            "context": {
+                "trace_id": "0x1",
+                "span_id": "0x1",
+                "trace_state": '[["foo", "bar"]]',
+            },
+            "attributes": {"link:foo": "link:bar"},
+        }
+    )
     assert expected_link.context.trace_id == actual_link.context.trace_id
     assert expected_link.context.span_id == actual_link.context.span_id
     assert expected_link.context.trace_state == actual_link.context.trace_state
@@ -75,10 +88,7 @@ def test_to_link() -> None:
 
 def test_to_status() -> None:
     expected_status = trace_api.Status(trace_api.StatusCode.ERROR, "foo")
-    actual_status = to_status({
-        "status_code": "ERROR",
-        "description": "foo",
-    })
+    actual_status = to_status({"status_code": "ERROR", "description": "foo"})
     assert expected_status.status_code == actual_status.status_code
     assert expected_status.description == actual_status.description
 

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -44,7 +44,7 @@ def test_to_context() -> None:
 
 
 def test_iso_str_to_ns() -> None:
-    assert iso_str_to_ns("2021-03-03T03:34:56.000000Z") == 1614742496000000000
+    assert iso_str_to_ns("2021-03-03T03:34:56.000000Z") == 1614710096000000000
     assert (
         iso_str_to_ns("2021-03-03T03:34:56.000000+00:00")
         == 1614742496000000000

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -74,9 +74,9 @@ def test_to_link() -> None:
 
 
 def test_to_status() -> None:
-    expected_status = trace_api.Status(trace_api.StatusCode.UNSET, "foo")
+    expected_status = trace_api.Status(trace_api.StatusCode.ERROR, "foo")
     actual_status = to_status({
-        "status_code": "UNSET",
+        "status_code": "ERROR",
         "description": "foo",
     })
     assert expected_status.status_code == actual_status.status_code

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -57,7 +57,7 @@ def test_iso_str_to_ns() -> None:
 
 def test_to_span_kind() -> None:
     assert to_span_kind("foo") is None
-    assert trace_api.SpanKind.INTERNAL == to_span_kind("SpanKind.INTERNAL")
+    assert to_span_kind("INTERNAL") == trace_api.SpanKind.INTERNAL
 
 
 def test_to_link() -> None:

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -44,7 +44,7 @@ def test_to_context() -> None:
 
 
 def test_iso_str_to_ns() -> None:
-    assert iso_str_to_ns("2021-03-03T03:34:56.000000Z") == 1614710096000000000
+    assert iso_str_to_ns("2021-03-03T03:34:56.000000Z") == 1614742496000000000
     assert (
         iso_str_to_ns("2021-03-03T03:34:56.000000+00:00")
         == 1614742496000000000

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1276,6 +1276,34 @@ class TestSpanProcessor(unittest.TestCase):
             is_remote=False,
         )
         expected_span = trace._Span("span-name", context, resource=Resource({}))
+        actual_span = trace.Span.from_json({
+            "name": "span-name",
+            "context": {
+                "trace_id": "0x000000000000000000000000deadbeef",
+                "span_id": "0x00000000deadbef0",
+                "trace_state": "[]"
+            },
+            "kind": "SpanKind.INTERNAL",
+            "parent_id": None,
+            "start_time": None,
+            "end_time": None,
+            "status": {
+                "status_code": "UNSET"
+            },
+            "attributes": {},
+            "events": [],
+            "links": [],
+            "resource": {}
+        })
+        self.assertEqual(expected_span.to_json(), actual_span.to_json())
+
+    def test_from_json_with_str(self):
+        context = trace_api.SpanContext(
+            trace_id=0x000000000000000000000000DEADBEEF,
+            span_id=0x00000000DEADBEF0,
+            is_remote=False,
+        )
+        expected_span = trace._Span("span-name", context, resource=Resource({}))
         actual_span = trace.Span.from_json(
             """{
     "name": "span-name",
@@ -1334,45 +1362,43 @@ class TestSpanProcessor(unittest.TestCase):
             )
         )
         expected_span.end(datetime(2021, 3, 4, 10, 20, 30).timestamp() * 1000000000)
-        actual_span = trace.Span.from_json(
-            """{
-    "name": "span-name",
-    "context": {
-        "trace_id": "0x000000000000000000000000deadbeef",
-        "span_id": "0x00000000deadbef0",
-        "trace_state": "[[\\"foo\\", \\"bar\\"]]"
-    },
-    "kind": "SpanKind.INTERNAL",
-    "parent_id": null,
-    "start_time": "2021-03-03T03:34:56.000000Z",
-    "end_time": "2021-03-04T01:20:30.000000Z",
-    "status": {
-        "status_code": "ERROR",
-        "description": "Test description"
-    },
-    "attributes": {
-        "attr:foo": "attr:bar"
-    },
-    "events": [{
-        "name": "event",
-        "timestamp": "2021-03-03T11:20:20.000000Z",
-        "attributes": {
-            "event:foo": "event:bar"
-        }
-    }],
-    "links": [{
-        "context": {
-            "trace_id": "0x00000000000000000000000000000001",
-            "span_id": "0x0000000000000001",
-            "trace_state": "[[\\"foo\\", \\"bar\\"]]"
-        },
-        "attributes": {"link:foo": "link:bar"}
-    }],
-    "resource": {
-        "resource:foo": "resource:bar"
-    }
-}"""
-        )
+        actual_span = trace.Span.from_json({
+            "name": "span-name",
+            "context": {
+                "trace_id": "0x000000000000000000000000deadbeef",
+                "span_id": "0x00000000deadbef0",
+                "trace_state": "[[\"foo\", \"bar\"]]"
+            },
+            "kind": "SpanKind.INTERNAL",
+            "parent_id": None,
+            "start_time": "2021-03-03T03:34:56.000000Z",
+            "end_time": "2021-03-04T01:20:30.000000Z",
+            "status": {
+                "status_code": "ERROR",
+                "description": "Test description"
+            },
+            "attributes": {
+                "attr:foo": "attr:bar"
+            },
+            "events": [{
+                "name": "event",
+                "timestamp": "2021-03-03T11:20:20.000000Z",
+                "attributes": {
+                    "event:foo": "event:bar"
+                }
+            }],
+            "links": [{
+                "context": {
+                    "trace_id": "0x00000000000000000000000000000001",
+                    "span_id": "0x0000000000000001",
+                    "trace_state": "[[\"foo\", \"bar\"]]"
+                },
+                "attributes": {"link:foo": "link:bar"}
+            }],
+            "resource": {
+                "resource:foo": "resource:bar"
+            }
+        })
         self.assertEqual(expected_span.to_json(), actual_span.to_json())
 
 

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -16,7 +16,7 @@
 import shutil
 import subprocess
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib import reload
 from logging import ERROR, WARNING
 from typing import Optional
@@ -1359,12 +1359,14 @@ class TestSpanProcessor(unittest.TestCase):
             resource=Resource({"resource:foo": "resource:bar"},),
         )
         expected_span.start(
-            datetime(2021, 3, 3, 12, 34, 56).timestamp() * 1000000000
+            datetime(2021, 3, 3, 12, 34, 56, tzinfo=timezone.utc).timestamp()
+            * 1000000000
         )
         expected_span.add_event(
             "event",
             {"event:foo": "event:bar"},
-            datetime(2021, 3, 3, 20, 20, 20).timestamp() * 1000000000,
+            datetime(2021, 3, 3, 20, 20, 20, tzinfo=timezone.utc).timestamp()
+            * 1000000000,
         )
         expected_span.set_status(
             trace_api.status.Status(
@@ -1372,7 +1374,8 @@ class TestSpanProcessor(unittest.TestCase):
             )
         )
         expected_span.end(
-            datetime(2021, 3, 4, 10, 20, 30).timestamp() * 1000000000
+            datetime(2021, 3, 4, 10, 20, 30, tzinfo=timezone.utc).timestamp()
+            * 1000000000
         )
         actual_span = trace.Span.from_json(
             {

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1359,12 +1359,12 @@ class TestSpanProcessor(unittest.TestCase):
             resource=Resource({"resource:foo": "resource:bar"},),
         )
         expected_span.start(
-            datetime(2021, 3, 3, 12, 34, 56, tzinfo=None).timestamp() * 1000000000
+            datetime(2021, 3, 3, 12, 34, 56).timestamp() * 1000000000
         )
         expected_span.add_event(
             "event",
             {"event:foo": "event:bar"},
-            datetime(2021, 3, 3, 20, 20, 20, tzinfo=None).timestamp() * 1000000000,
+            datetime(2021, 3, 3, 20, 20, 20).timestamp() * 1000000000,
         )
         expected_span.set_status(
             trace_api.status.Status(
@@ -1372,7 +1372,7 @@ class TestSpanProcessor(unittest.TestCase):
             )
         )
         expected_span.end(
-            datetime(2021, 3, 4, 10, 20, 30, tzinfo=None).timestamp() * 1000000000
+            datetime(2021, 3, 4, 10, 20, 30).timestamp() * 1000000000
         )
         actual_span = trace.Span.from_json(
             {
@@ -1384,8 +1384,8 @@ class TestSpanProcessor(unittest.TestCase):
                 },
                 "kind": "INTERNAL",
                 "parent_id": None,
-                "start_time": "2021-03-03T03:34:56.000000Z",
-                "end_time": "2021-03-04T01:20:30.000000Z",
+                "start_time": "2021-03-03T12:34:56.000000Z",
+                "end_time": "2021-03-04T10:20:30.000000Z",
                 "status": {
                     "status_code": "ERROR",
                     "description": "Test description",
@@ -1394,7 +1394,7 @@ class TestSpanProcessor(unittest.TestCase):
                 "events": [
                     {
                         "name": "event",
-                        "timestamp": "2021-03-03T11:20:20.000000Z",
+                        "timestamp": "2021-03-03T20:20:20.000000Z",
                         "attributes": {"event:foo": "event:bar"},
                     }
                 ],

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1234,7 +1234,7 @@ class TestSpanProcessor(unittest.TestCase):
         "span_id": "0x00000000deadbef0",
         "trace_state": "[]"
     },
-    "kind": "SpanKind.INTERNAL",
+    "kind": "INTERNAL",
     "parent_id": null,
     "start_time": null,
     "end_time": null,
@@ -1249,7 +1249,7 @@ class TestSpanProcessor(unittest.TestCase):
         )
         self.assertEqual(
             span.to_json(indent=None),
-            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "[]"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "status": {"status_code": "UNSET"}, "attributes": {}, "events": [], "links": [], "resource": {}}',
+            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "[]"}, "kind": "INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "status": {"status_code": "UNSET"}, "attributes": {}, "events": [], "links": [], "resource": {}}',
         )
 
     def test_attributes_to_json(self):
@@ -1265,7 +1265,7 @@ class TestSpanProcessor(unittest.TestCase):
         date_str = ns_to_iso_str(123)
         self.assertEqual(
             span.to_json(indent=None),
-            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "[]"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "status": {"status_code": "UNSET"}, "attributes": {"key": "value"}, "events": [{"name": "event", "timestamp": "'
+            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "[]"}, "kind": "INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "status": {"status_code": "UNSET"}, "attributes": {"key": "value"}, "events": [{"name": "event", "timestamp": "'
             + date_str
             + '", "attributes": {"key2": "value2"}}], "links": [], "resource": {}}',
         )
@@ -1287,7 +1287,7 @@ class TestSpanProcessor(unittest.TestCase):
                     "span_id": "0x00000000deadbef0",
                     "trace_state": "[]",
                 },
-                "kind": "SpanKind.INTERNAL",
+                "kind": "INTERNAL",
                 "parent_id": None,
                 "start_time": None,
                 "end_time": None,
@@ -1317,7 +1317,7 @@ class TestSpanProcessor(unittest.TestCase):
         "span_id": "0x00000000deadbef0",
         "trace_state": "[]"
     },
-    "kind": "SpanKind.INTERNAL",
+    "kind": "INTERNAL",
     "parent_id": null,
     "start_time": null,
     "end_time": null,
@@ -1383,7 +1383,7 @@ class TestSpanProcessor(unittest.TestCase):
                     "span_id": "0x00000000deadbef0",
                     "trace_state": '[["foo", "bar"]]',
                 },
-                "kind": "SpanKind.INTERNAL",
+                "kind": "INTERNAL",
                 "parent_id": None,
                 "start_time": "2021-03-03T03:34:56.000000Z",
                 "end_time": "2021-03-04T01:20:30.000000Z",

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=too-many-lines
-from datetime import datetime
 import shutil
 import subprocess
 import unittest
+
+# pylint: disable=too-many-lines
+from datetime import datetime
 from importlib import reload
 from logging import ERROR, WARNING
 from typing import Optional
@@ -1275,26 +1276,28 @@ class TestSpanProcessor(unittest.TestCase):
             span_id=0x00000000DEADBEF0,
             is_remote=False,
         )
-        expected_span = trace._Span("span-name", context, resource=Resource({}))
-        actual_span = trace.Span.from_json({
-            "name": "span-name",
-            "context": {
-                "trace_id": "0x000000000000000000000000deadbeef",
-                "span_id": "0x00000000deadbef0",
-                "trace_state": "[]"
-            },
-            "kind": "SpanKind.INTERNAL",
-            "parent_id": None,
-            "start_time": None,
-            "end_time": None,
-            "status": {
-                "status_code": "UNSET"
-            },
-            "attributes": {},
-            "events": [],
-            "links": [],
-            "resource": {}
-        })
+        expected_span = trace._Span(
+            "span-name", context, resource=Resource({})
+        )
+        actual_span = trace.Span.from_json(
+            {
+                "name": "span-name",
+                "context": {
+                    "trace_id": "0x000000000000000000000000deadbeef",
+                    "span_id": "0x00000000deadbef0",
+                    "trace_state": "[]",
+                },
+                "kind": "SpanKind.INTERNAL",
+                "parent_id": None,
+                "start_time": None,
+                "end_time": None,
+                "status": {"status_code": "UNSET"},
+                "attributes": {},
+                "events": [],
+                "links": [],
+                "resource": {},
+            }
+        )
         self.assertEqual(expected_span.to_json(), actual_span.to_json())
 
     def test_from_json_with_str(self):
@@ -1303,7 +1306,9 @@ class TestSpanProcessor(unittest.TestCase):
             span_id=0x00000000DEADBEF0,
             is_remote=False,
         )
-        expected_span = trace._Span("span-name", context, resource=Resource({}))
+        expected_span = trace._Span(
+            "span-name", context, resource=Resource({})
+        )
         actual_span = trace.Span.from_json(
             """{
     "name": "span-name",
@@ -1342,7 +1347,7 @@ class TestSpanProcessor(unittest.TestCase):
                     is_remote=False,
                     trace_state={"foo": "bar"},
                 ),
-                {"link:foo": "link:bar"}
+                {"link:foo": "link:bar"},
             )
         ]
         expected_span = trace._Span(
@@ -1352,92 +1357,62 @@ class TestSpanProcessor(unittest.TestCase):
             parent=None,
             links=links,
             attributes={"attr:foo": "attr:bar"},
-            resource=Resource({"resource:foo": "resource:bar"},
-        ))
-        expected_span.start(datetime(2021, 3, 3, 12, 34, 56).timestamp() * 1000000000)
-        expected_span.add_event("event", {"event:foo": "event:bar"}, datetime(2021, 3, 3, 20, 20, 20).timestamp() * 1000000000)
+            resource=Resource({"resource:foo": "resource:bar"},),
+        )
+        expected_span.start(
+            datetime(2021, 3, 3, 12, 34, 56).timestamp() * 1000000000
+        )
+        expected_span.add_event(
+            "event",
+            {"event:foo": "event:bar"},
+            datetime(2021, 3, 3, 20, 20, 20).timestamp() * 1000000000,
+        )
         expected_span.set_status(
             trace_api.status.Status(
                 trace_api.StatusCode.ERROR, "Test description"
             )
         )
-        expected_span.end(datetime(2021, 3, 4, 10, 20, 30).timestamp() * 1000000000)
-        actual_span = trace.Span.from_json({
-            "name": "span-name",
-            "context": {
-                "trace_id": "0x000000000000000000000000deadbeef",
-                "span_id": "0x00000000deadbef0",
-                "trace_state": "[[\"foo\", \"bar\"]]"
-            },
-            "kind": "SpanKind.INTERNAL",
-            "parent_id": None,
-            "start_time": "2021-03-03T03:34:56.000000Z",
-            "end_time": "2021-03-04T01:20:30.000000Z",
-            "status": {
-                "status_code": "ERROR",
-                "description": "Test description"
-            },
-            "attributes": {
-                "attr:foo": "attr:bar"
-            },
-            "events": [{
-                "name": "event",
-                "timestamp": "2021-03-03T11:20:20.000000Z",
-                "attributes": {
-                    "event:foo": "event:bar"
-                }
-            }],
-            "links": [{
+        expected_span.end(
+            datetime(2021, 3, 4, 10, 20, 30).timestamp() * 1000000000
+        )
+        actual_span = trace.Span.from_json(
+            {
+                "name": "span-name",
                 "context": {
-                    "trace_id": "0x00000000000000000000000000000001",
-                    "span_id": "0x0000000000000001",
-                    "trace_state": "[[\"foo\", \"bar\"]]"
+                    "trace_id": "0x000000000000000000000000deadbeef",
+                    "span_id": "0x00000000deadbef0",
+                    "trace_state": '[["foo", "bar"]]',
                 },
-                "attributes": {"link:foo": "link:bar"}
-            }],
-            "resource": {
-                "resource:foo": "resource:bar"
+                "kind": "SpanKind.INTERNAL",
+                "parent_id": None,
+                "start_time": "2021-03-03T03:34:56.000000Z",
+                "end_time": "2021-03-04T01:20:30.000000Z",
+                "status": {
+                    "status_code": "ERROR",
+                    "description": "Test description",
+                },
+                "attributes": {"attr:foo": "attr:bar"},
+                "events": [
+                    {
+                        "name": "event",
+                        "timestamp": "2021-03-03T11:20:20.000000Z",
+                        "attributes": {"event:foo": "event:bar"},
+                    }
+                ],
+                "links": [
+                    {
+                        "context": {
+                            "trace_id": "0x00000000000000000000000000000001",
+                            "span_id": "0x0000000000000001",
+                            "trace_state": '[["foo", "bar"]]',
+                        },
+                        "attributes": {"link:foo": "link:bar"},
+                    }
+                ],
+                "resource": {"resource:foo": "resource:bar"},
             }
-        })
+        )
         self.assertEqual(expected_span.to_json(), actual_span.to_json())
-
-
-class TestSpanLimits(unittest.TestCase):
-    @mock.patch.dict(
-        "os.environ",
-        {
-            OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "10",
-            OTEL_SPAN_EVENT_COUNT_LIMIT: "20",
-            OTEL_SPAN_LINK_COUNT_LIMIT: "30",
-        },
-    )
-    def test_span_environment_limits(self):
-        reload(trace)
-        tracer = new_tracer()
-        id_generator = RandomIdGenerator()
-        some_links = [
-            trace_api.Link(
-                trace_api.SpanContext(
-                    trace_id=id_generator.generate_trace_id(),
-                    span_id=id_generator.generate_span_id(),
-                    is_remote=False,
-                )
-            )
-            for _ in range(100)
-        ]
-        with pytest.raises(ValueError):
-            with tracer.start_as_current_span("root", links=some_links):
-                pass
-
-        with tracer.start_as_current_span("root") as root:
-            for idx in range(100):
-                root.set_attribute("my_attribute_{}".format(idx), 0)
-                root.add_event("my_event_{}".format(idx))
-
-            self.assertEqual(len(root.attributes), 10)
-            self.assertEqual(len(root.events), 20)
-
-
 
 
 class TestSpanLimits(unittest.TestCase):

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=too-many-lines
 import shutil
 import subprocess
 import unittest
-
-# pylint: disable=too-many-lines
 from datetime import datetime
 from importlib import reload
 from logging import ERROR, WARNING

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1359,12 +1359,12 @@ class TestSpanProcessor(unittest.TestCase):
             resource=Resource({"resource:foo": "resource:bar"},),
         )
         expected_span.start(
-            datetime(2021, 3, 3, 12, 34, 56).timestamp() * 1000000000
+            datetime(2021, 3, 3, 12, 34, 56, tzinfo=None).timestamp() * 1000000000
         )
         expected_span.add_event(
             "event",
             {"event:foo": "event:bar"},
-            datetime(2021, 3, 3, 20, 20, 20).timestamp() * 1000000000,
+            datetime(2021, 3, 3, 20, 20, 20, tzinfo=None).timestamp() * 1000000000,
         )
         expected_span.set_status(
             trace_api.status.Status(
@@ -1372,7 +1372,7 @@ class TestSpanProcessor(unittest.TestCase):
             )
         )
         expected_span.end(
-            datetime(2021, 3, 4, 10, 20, 30).timestamp() * 1000000000
+            datetime(2021, 3, 4, 10, 20, 30, tzinfo=None).timestamp() * 1000000000
         )
         actual_span = trace.Span.from_json(
             {

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # pylint: disable=too-many-lines
+from datetime import datetime
 import shutil
 import subprocess
 import unittest
@@ -1267,6 +1268,150 @@ class TestSpanProcessor(unittest.TestCase):
             + date_str
             + '", "attributes": {"key2": "value2"}}], "links": [], "resource": {}}',
         )
+
+    def test_from_json(self):
+        context = trace_api.SpanContext(
+            trace_id=0x000000000000000000000000DEADBEEF,
+            span_id=0x00000000DEADBEF0,
+            is_remote=False,
+        )
+        expected_span = trace._Span("span-name", context, resource=Resource({}))
+        actual_span = trace.Span.from_json(
+            """{
+    "name": "span-name",
+    "context": {
+        "trace_id": "0x000000000000000000000000deadbeef",
+        "span_id": "0x00000000deadbef0",
+        "trace_state": "[]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": null,
+    "start_time": null,
+    "end_time": null,
+    "status": {
+        "status_code": "UNSET"
+    },
+    "attributes": {},
+    "events": [],
+    "links": [],
+    "resource": {}
+}"""
+        )
+        self.assertEqual(expected_span.to_json(), actual_span.to_json())
+
+    def test_from_json_with_full_contents(self):
+        context = trace_api.SpanContext(
+            trace_id=0x000000000000000000000000DEADBEEF,
+            span_id=0x00000000DEADBEF0,
+            is_remote=False,
+            trace_state={"foo": "bar"},
+        )
+        links = [
+            trace_api.Link(
+                trace_api.SpanContext(
+                    trace_id=0x00000000000000000000000000000001,
+                    span_id=0x0000000000000001,
+                    is_remote=False,
+                    trace_state={"foo": "bar"},
+                ),
+                {"link:foo": "link:bar"}
+            )
+        ]
+        expected_span = trace._Span(
+            "span-name",
+            context,
+            # The parent context cannot be recovered only from the ID.
+            parent=None,
+            links=links,
+            attributes={"attr:foo": "attr:bar"},
+            resource=Resource({"resource:foo": "resource:bar"},
+        ))
+        expected_span.start(datetime(2021, 3, 3, 12, 34, 56).timestamp() * 1000000000)
+        expected_span.add_event("event", {"event:foo": "event:bar"}, datetime(2021, 3, 3, 20, 20, 20).timestamp() * 1000000000)
+        expected_span.set_status(
+            trace_api.status.Status(
+                trace_api.StatusCode.ERROR, "Test description"
+            )
+        )
+        expected_span.end(datetime(2021, 3, 4, 10, 20, 30).timestamp() * 1000000000)
+        actual_span = trace.Span.from_json(
+            """{
+    "name": "span-name",
+    "context": {
+        "trace_id": "0x000000000000000000000000deadbeef",
+        "span_id": "0x00000000deadbef0",
+        "trace_state": "[[\\"foo\\", \\"bar\\"]]"
+    },
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": null,
+    "start_time": "2021-03-03T03:34:56.000000Z",
+    "end_time": "2021-03-04T01:20:30.000000Z",
+    "status": {
+        "status_code": "ERROR",
+        "description": "Test description"
+    },
+    "attributes": {
+        "attr:foo": "attr:bar"
+    },
+    "events": [{
+        "name": "event",
+        "timestamp": "2021-03-03T11:20:20.000000Z",
+        "attributes": {
+            "event:foo": "event:bar"
+        }
+    }],
+    "links": [{
+        "context": {
+            "trace_id": "0x00000000000000000000000000000001",
+            "span_id": "0x0000000000000001",
+            "trace_state": "[[\\"foo\\", \\"bar\\"]]"
+        },
+        "attributes": {"link:foo": "link:bar"}
+    }],
+    "resource": {
+        "resource:foo": "resource:bar"
+    }
+}"""
+        )
+        self.assertEqual(expected_span.to_json(), actual_span.to_json())
+
+
+class TestSpanLimits(unittest.TestCase):
+    @mock.patch.dict(
+        "os.environ",
+        {
+            OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "10",
+            OTEL_SPAN_EVENT_COUNT_LIMIT: "20",
+            OTEL_SPAN_LINK_COUNT_LIMIT: "30",
+        },
+    )
+    def test_span_environment_limits(self):
+        reload(trace)
+        tracer = new_tracer()
+        id_generator = RandomIdGenerator()
+        some_links = [
+            trace_api.Link(
+                trace_api.SpanContext(
+                    trace_id=id_generator.generate_trace_id(),
+                    span_id=id_generator.generate_span_id(),
+                    is_remote=False,
+                )
+            )
+            for _ in range(100)
+        ]
+        with pytest.raises(ValueError):
+            with tracer.start_as_current_span("root", links=some_links):
+                pass
+
+        with tracer.start_as_current_span("root") as root:
+            for idx in range(100):
+                root.set_attribute("my_attribute_{}".format(idx), 0)
+                root.add_event("my_event_{}".format(idx))
+
+            self.assertEqual(len(root.attributes), 10)
+            self.assertEqual(len(root.events), 20)
+
+
 
 
 class TestSpanLimits(unittest.TestCase):


### PR DESCRIPTION
# Description

I have an OTEL debugging code in a script as below.

```python
from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleExportSpanProcessor

if os.getenv("_OTEL_ENABLE_CONSOLE_EXPORTER", None):
    out = sys.stdout
    out_path = os.getenv("_OTEL_EXPORTER_CONSOLE_OUT_PATH", None)
    if out_path is not None:
        out = open(out_path, "a")

        def formatter(span: Span) -> str:
            return cast(str, span.to_json(indent=None)) + "\n"

        tracer_provider.add_span_processor(
            SimpleExportSpanProcessor(ConsoleSpanExporter(out=out, formatter=formatter))
        )
```

And want to import the JSON-serialized spans later into Jaeger just to confirm the spans as below.

```python
from opentelemetry.exporter.jaeger import JaegerSpanExporter

exporter = JaegerSpanExporter("something")

with open(filename, "r") as f:
    for line in f.readlines():
        span = some_method_to_deserialize_json_to_span(line)
        exporter.export([span])
```

However, there's no method for JSON-deserialization in the `Span` class so I needed to map the items by myself. I implemented the `Span.from_json` method so we can easily get back a span from a JSON string for debugging.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I added unit tests.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
