### PR TITLE
Proxy tracer/provider to enable lazy setup of tracing pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: fbd7e07d0b3f9be37ddfdbc8b12b35f0a8d71ede
+  CONTRIB_REPO_SHA: 1064da4bf2afaa0fb84fa10f573b211efeba72bc
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1722](https://github.com/open-telemetry/opentelemetry-python/pull/1722))
 - Fix B3 propagator to never return None.
   ([#1750](https://github.com/open-telemetry/opentelemetry-python/pull/1750))
+- Added ProxyTracerProvider and ProxyTracer implementations to allow fetching provider
+  and tracer instances before a global provider is set up.
+  ([#1726](https://github.com/open-telemetry/opentelemetry-python/pull/1726))
 
 
 ## [1.0.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.0.0) - 2021-03-26

--- a/opentelemetry-api/tests/trace/test_proxy.py
+++ b/opentelemetry-api/tests/trace/test_proxy.py
@@ -1,0 +1,72 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=W0212,W0222,W0221
+
+import unittest
+
+from opentelemetry import trace
+from opentelemetry.trace.span import INVALID_SPAN_CONTEXT, NonRecordingSpan
+
+
+class TestProvider(trace._DefaultTracerProvider):
+    def get_tracer(
+        self, instrumentation_module_name, instrumentaiton_library_version=None
+    ):
+        return TestTracer()
+
+
+class TestTracer(trace._DefaultTracer):
+    def start_span(self, *args, **kwargs):
+        return TestSpan(INVALID_SPAN_CONTEXT)
+
+
+class TestSpan(NonRecordingSpan):
+    pass
+
+
+class TestProxy(unittest.TestCase):
+    def test_proxy_tracer(self):
+        original_provider = trace._TRACER_PROVIDER
+
+        provider = trace.get_tracer_provider()
+        # proxy provider
+        self.assertIsInstance(provider, trace.ProxyTracerProvider)
+
+        # provider returns proxy tracer
+        tracer = provider.get_tracer("proxy-test")
+        self.assertIsInstance(tracer, trace.ProxyTracer)
+
+        with tracer.start_span("span1") as span:
+            self.assertIsInstance(span, trace.NonRecordingSpan)
+
+        with tracer.start_as_current_span("span2") as span:
+            self.assertIsInstance(span, trace.NonRecordingSpan)
+
+        # set a real provider
+        trace.set_tracer_provider(TestProvider())
+
+        # tracer provider now returns real instance
+        self.assertIsInstance(trace.get_tracer_provider(), TestProvider)
+
+        # references to the old provider still work but return real tracer now
+        real_tracer = provider.get_tracer("proxy-test")
+        self.assertIsInstance(real_tracer, TestTracer)
+
+        # reference to old proxy tracer now delegates to a real tracer and
+        # creates real spans
+        with tracer.start_span("") as span:
+            self.assertIsInstance(span, TestSpan)
+
+        trace._TRACER_PROVIDER = original_provider


### PR DESCRIPTION
# Description

Introduces a proxy tracer provider and proxy tracer implementations. The proxies return noop implementations until a global tracer provider is set by the user. Once a global provider is set the proxies delegate to the real provider and tracer implementations.

Updated `get_tracer_provider()` to return a proxy tracer provider if a the user has not set a global provider via code or env vars.

Fixes #1159
Fixes #1276
Fixes https://github.com/open-telemetry/opentelemetry-python-contrib/issues/405

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Added new test case
- [x] Manually tested with https://github.com/owais/otel-django-test


# Does This PR Require a Contrib Repo Change?

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/399
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated

