### PR TITLE
Default to the current context when context is not given for B3 propagator extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adjust `B3Format` propagator to be spec compliant by not modifying context
   when propagation headers are not present/invalid/empty
   ([#1728](https://github.com/open-telemetry/opentelemetry-python/pull/1728))
-
+- `B3Format` propagator defaults to the current context when no context is given,
+   according to the `TextMapPropagator` interface
+  ([#1732](https://github.com/open-telemetry/opentelemetry-python/pull/1732))
 
 ## [1.0.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.0.0) - 2021-03-26
 ### Added

--- a/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
+++ b/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
@@ -16,7 +16,7 @@ import typing
 from re import compile as re_compile
 
 import opentelemetry.trace as trace
-from opentelemetry.context import Context
+from opentelemetry.context import Context, get_current
 from opentelemetry.propagators.textmap import (
     CarrierT,
     Getter,
@@ -50,6 +50,8 @@ class B3Format(TextMapPropagator):
         context: typing.Optional[Context] = None,
         getter: Getter = default_getter,
     ) -> Context:
+        if context is None:
+            context = get_current()
         trace_id = trace.INVALID_TRACE_ID
         span_id = trace.INVALID_SPAN_ID
         sampled = "0"


### PR DESCRIPTION
# Description

This is a follow up to https://github.com/open-telemetry/opentelemetry-python/pull/1728.

With the current design of the propagators pipeline every single propagator is responsible for defaulting to the current context in case the context is not provided as an input, which `TextMapPropagator` interface mandates: https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-api/src/opentelemetry/propagators/textmap.py#L153.

[Recent changes](https://github.com/open-telemetry/opentelemetry-python/pull/1728) to the B3 format propagator amplified this breach of contract, because there is a possibility that no context is given and in the case of an empty carrier, the context is returned as is, which then would result in a caller receiving `None` instead of `Context` promised in the signature (see [unit test](https://github.com/open-telemetry/opentelemetry-python/pull/1732/commits/39b79127942d034e416be0a0d59de087388721fc#diff-b97391ef2053a76fa0e904bb632df6ecdcc43adc7777f94633e3df96e090fd94R302)).
Previously this behavior was masked, because some `Context` was always returned (possibly invalid) even if it was not the current one, giving an impression that it is what is expected.

Contributes to #1727

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See implemented [unit test](https://github.com/open-telemetry/opentelemetry-python/pull/1732/commits/39b79127942d034e416be0a0d59de087388721fc#diff-b97391ef2053a76fa0e904bb632df6ecdcc43adc7777f94633e3df96e090fd94R302).

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
