### PR TITLE
POC: support target dependencies for instrumentations

### DIFF
--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -26,7 +26,6 @@ from opentelemetry.environment_variables import (
 )
 from opentelemetry.instrumentation.resources import get_target_dependency_conflict
 
-logging.basicConfig(level=logging.DEBUG)
 logger = getLogger(__file__)
 
 
@@ -63,7 +62,7 @@ def _load_instrumentors():
                 logger.debug(conflict)
                 continue
 
-            entry_point.load()().instrument()  # type: ignore
+            entry_point.load()(run_dependency_checks=False).instrument()  # type: ignore
             logger.debug("Instrumented %s", entry_point.name)
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception("Instrumenting of %s failed", entry_point.name)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/instrumentor.py
@@ -18,7 +18,10 @@ OpenTelemetry Base Instrumentor
 """
 
 from abc import ABC, abstractmethod
+from pkg_resources import get_distribution
 from logging import getLogger
+
+from opentelemetry.instrumentation.resources import get_target_dependency_conflict
 
 _LOG = getLogger(__name__)
 
@@ -38,13 +41,21 @@ class BaseInstrumentor(ABC):
 
     _instance = None
     _is_instrumented = False
+    _run_dependency_checks = True
+    _dependency_check_result = None
 
     def __new__(cls, *args, **kwargs):
 
         if cls._instance is None:
+            run_checks = kwargs.pop('run_dependency_checks', True)
             cls._instance = object.__new__(cls, *args, **kwargs)
+            cls._instance._run_dependency_checks = run_checks
 
         return cls._instance
+
+    @abstractmethod
+    def package_name(self) -> str:
+        """"Return the Python package name"""
 
     @abstractmethod
     def _instrument(self, **kwargs):
@@ -53,6 +64,21 @@ class BaseInstrumentor(ABC):
     @abstractmethod
     def _uninstrument(self, **kwargs):
         """Uninstrument the library"""
+
+    def _has_dependency_conflicts(self) -> bool:
+        if not self._run_dependency_checks:
+            return False
+
+        if self._dependency_check_result is None:
+            name = self.package_name()
+            dist = get_distribution(name)
+            conflict = get_target_dependency_conflict(dist)
+            if conflict:
+                self._dependency_check_result = True
+                _LOG.warning('unable to instrument %s: %s', name, conflict)
+            else:
+                self._dependency_check_result = False
+        return self._dependency_check_result
 
     def instrument(self, **kwargs):
         """Instrument the library
@@ -64,6 +90,9 @@ class BaseInstrumentor(ABC):
         optional values should do the very same thing that the
         ``opentelemetry-instrument`` command does.
         """
+
+        if self._has_dependency_conflicts():
+            return
 
         if not self._is_instrumented:
             result = self._instrument(**kwargs)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/resources.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/resources.py
@@ -1,0 +1,32 @@
+from typing import Optional
+from pkg_resources import get_distribution, VersionConflict, DistributionNotFound
+
+
+class DependencyConflict:
+    required: str = None
+    found: Optional[str] = None
+
+    def __init__(self, required, found=None):
+        self.required = required
+        self.found = found
+
+    def __str__(self):
+        return 'DependencyConflict: requested: "{0}" but found: "{1}"'.format(self.required, self.found)
+
+
+def get_target_dependency_conflict(dist) -> Optional[DependencyConflict]:
+
+    # skip the check if the distribution has not specified any target dependencies
+    if 'target' not in dist.extras:
+        return
+
+    # figure out target dependencies
+    target_dependencies = [dep for dep in dist.requires(('target',)) if dep not in dist.requires()]
+    for dep in target_dependencies:
+        try:
+            get_distribution(str(dep))
+        except VersionConflict as exc:
+            return DependencyConflict(dep, exc.dist)
+        except DistributionNotFound as exc:
+            return DependencyConflict(dep)
+    return


### PR DESCRIPTION
# Description

This is a POC solution for the problem discussed in https://github.com/open-telemetry/opentelemetry-python/discussions/1729 and #1563 


### Details
Instead of specifying instrumented libraries (target dependencies) as regular dependencies, instrumentation packages can specify such dependencies as extras with the label `target`.  For example, `opentelemetry-instrumentation-aiohttp-client` can specify `aoihttp` as a target dependencies instead of a regular one:

```
[options.extras_require]
target = 
    aiohttp ~= 3.0
```

- This will make `opentelemetry-instrumentation-aiohttp-client` installable without automatically installing or updating  `aiohttp`.
- `opentelemetry-instrument` command will be able to tell that the instrumentor needs `aiohttp ~= 3.0`. It'll only load the instrumentor if this requirement is satisfied i.e, `aiohttp ~= 3.0` is installed as well.
- If the target package is not installed, the instrumentation package will not be loaded. This will prevent the instrumentor from running and causing import errors.
- This still allows users to automatically install the target dependencies if they want by suffixing `[target]` to the instrumentation package name `opentelemetry-instrumentation-aiohttp-client[target]`
~- Purely a packaging change. Does not require any interface or code changes to instrumentors.~
- Mostly a packaging change. Requires minimal code changes to instrumentations i.e adding a simple `package_name` method.

The instrument command will not require instrumentors to specify target dependencies. If an instrumentor does not specify any target dependencies, the instrument command will always load and apply the instrumentor. 

### Changes required to be made to instrumentations

Every instrumentation will need two changes. 

1. Move the target dependencies from regular deps to extra_require under label target.
2. Each instrumentor would need to define a `package_name() -> str` method.  This method would return the Python package name of the instrumentor. For example `RequestsInstrumentor().package_name()` would return `opentelemetry-instrumentation-requests`.

This demo contrib PR showcases what changes every instrumentation package would need: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/397/files

### Considerations
- Do we enforce all instrumentors to always specify "target" dependencies like this? Instrumentors that don't specify target dependencies can still be used manually but the opentelemetry-instrument command will ignore them. Can we think of any cases where specifying target dependencies may not be viable or desirable?
- I'm not sure about using the name `target` to represent instrumented libraries. I just picked something to allow me to move forward with the POC. What would be a better name for such deps?
- We need the package_name method in order to fetch the instrumentation distribution using pkg_resource and validate it's dependencies. Can we somehow automatically detect an instrumentation's package name without it having to explicitly specify it as a method? Such auto-detection needs to be highly reliable and have acceptable performance.
- Instead of making the instrumentors define a `package_name()` method that returns the Python package name of the instrumentor, we can have the instrumentors define a `package_name() -> str` method that just returns the package name of the instrumentor itself. We can implement it either way and it has almost no impact on the implementation. The question is what makes more sense for instrumentation authors.
- 

```python
class RequestsInstrumention:
    def package_name(self):
         return 'opentelemetry-instrumentation-requests'
```

vs


```python
class RequestsInstrumention:
    def target_dependencies(self):
         return ['requests ~= 2.0']
```

### Future iterations
- Evaluate lazily applying instrumentors as [suggested here](https://github.com/open-telemetry/opentelemetry-python/discussions/1729#discussioncomment-551596). This would require code changes to all instrumentors but can be built on top of this POC.
- Bootstrap command can be updated to support optionally installing target dependencies as well.
