### PR TITLE
remove toumorokoshi from python-approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ Approvers ([@open-telemetry/python-approvers](https://github.com/orgs/open-telem
 - [Hector Hernandez](https://github.com/hectorhdzg), Microsoft
 - [Owais Lone](https://github.com/owais), Splunk
 - [Srikanth Chekuri](https://github.com/lonewolf3739)
-- [Yusuke Tsutsumi](https://github.com/toumorokoshi), Google
 
 *For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*
 


### PR DESCRIPTION
# Description

officially removing toumorokoshi as an approver.

With opentelemetry-python officially at 1.0, and my involvement in the project and awareness  changes waning significantly, I think it's a good time to remove myself as an approver.

It's been a fantastic journey, and thanks for having me! I hope I have the opportunity to get involved again in the future, but regardless it was great meeting and working with everyone.

Upon merge of this PR I'll remove myself from the GitHub group. 

# Does This PR Require a Contrib Repo Change?

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/404

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
