### PR TITLE
prepare 1.10a0 experimental release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: 18f5215f3418f369ac1d40ba493b4d141607fd8c
+  CONTRIB_REPO_SHA: e2bca7a3e8b60514122be277e9c4dc95b1085f5a
 
 jobs:
   build:
@@ -18,7 +18,7 @@ jobs:
       # We use these variables to convert between tox and GHA version literals
       py36: 3.6
       py37: 3.7
-      py38: 3.8
+    py38: 3.8
       py39: 3.9
       pypy3: pypy3
       RUN_MATRIX_COMBINATION: ${{ matrix.python-version }}-${{ matrix.package }}-${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: c64571e2b6adae22043902566f63ca6de5776e6d
+  CONTRIB_REPO_SHA: 18f5215f3418f369ac1d40ba493b4d141607fd8c
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: 4fc64a01c118c640e273f56d2afb1b4597b82f0f
+  CONTRIB_REPO_SHA: bd2dc1c1f40884279ec514e8f439963757580491
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: 5f16ad3be06c883ae8e7e21883eb918192fdab6d
+  CONTRIB_REPO_SHA: c64571e2b6adae22043902566f63ca6de5776e6d
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       # We use these variables to convert between tox and GHA version literals
       py36: 3.6
       py37: 3.7
-    py38: 3.8
+      py38: 3.8
       py39: 3.9
       pypy3: pypy3
       RUN_MATRIX_COMBINATION: ${{ matrix.python-version }}-${{ matrix.package }}-${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: bd2dc1c1f40884279ec514e8f439963757580491
+  CONTRIB_REPO_SHA: 5f16ad3be06c883ae8e7e21883eb918192fdab6d
 
 jobs:
   build:

--- a/docs/examples/error_hander/error_handler_0/setup.cfg
+++ b/docs/examples/error_hander/error_handler_0/setup.cfg
@@ -36,7 +36,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-sdk == 1.0.0
+    opentelemetry-sdk == 1.10a0
 
 [options.packages.find]
 where = src

--- a/docs/examples/error_hander/error_handler_1/setup.cfg
+++ b/docs/examples/error_hander/error_handler_1/setup.cfg
@@ -36,7 +36,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-sdk == 1.0.0
+    opentelemetry-sdk == 1.10a0
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.cfg
@@ -41,8 +41,8 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52.0
-    opentelemetry-api == 1.0.0
-    opentelemetry-sdk == 1.0.0
+    opentelemetry-api == 1.10a0
+    opentelemetry-sdk == 1.10a0
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-jaeger-thrift/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/setup.cfg
@@ -40,8 +40,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     thrift >= 0.10.0
-    opentelemetry-api == 1.0.0
-    opentelemetry-sdk == 1.0.0
+    opentelemetry-api == 1.10a0
+    opentelemetry-sdk == 1.10a0
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-opencensus/setup.cfg
+++ b/exporter/opentelemetry-exporter-opencensus/setup.cfg
@@ -41,8 +41,8 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     opencensus-proto >= 0.1.0, < 1.0.0
-    opentelemetry-api == 1.0.0
-    opentelemetry-sdk == 1.0.0
+    opentelemetry-api == 1.10a0
+    opentelemetry-sdk == 1.10a0
     protobuf >= 3.13.0
 
 [options.packages.find]

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
@@ -23,7 +23,7 @@ url = https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/
 platforms = any
 license = Apache-2.0
 classifiers =
-    Development Status :: 5 - Production/Stable
+    Development Status :: 3 - Alpha
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
@@ -41,8 +41,8 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52.0
-    opentelemetry-api == 1.0.0
-    opentelemetry-sdk == 1.0.0
+    opentelemetry-api == 1.10a0
+    opentelemetry-sdk == 1.10a0
     opentelemetry-proto == 1.0.0
     backoff ~= 1.10.0
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/version.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0"
+__version__ = "1.10a0"

--- a/exporter/opentelemetry-exporter-otlp/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp/setup.cfg
@@ -23,7 +23,7 @@ url = https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/
 platforms = any
 license = Apache-2.0
 classifiers =
-    Development Status :: 5 - Production/Stable
+    Development Status :: 3 - Alpha
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
@@ -37,4 +37,4 @@ classifiers =
 python_requires = >=3.6
 packages=find_namespace:
 install_requires =
-    opentelemetry-exporter-otlp-proto-grpc == 1.0.0
+    opentelemetry-exporter-otlp-proto-grpc == 1.10a0

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/version.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0"
+__version__ = "1.10a0"

--- a/exporter/opentelemetry-exporter-prometheus/setup.cfg
+++ b/exporter/opentelemetry-exporter-prometheus/setup.cfg
@@ -23,26 +23,25 @@ url = https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/
 platforms = any
 license = Apache-2.0
 classifiers =
-    Development Status :: 4 - Beta
+    Development Status :: 3 - Alpha
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.6
 package_dir=
     =src
 packages=find_namespace:
 install_requires =
     prometheus_client >= 0.5.0, < 1.0.0
-    opentelemetry-api == 1.0.0
-    opentelemetry-sdk == 1.0.0
+    opentelemetry-api == 1.10a0
+    opentelemetry-sdk == 1.10a0
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/version.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.19b0"
+__version__ = "1.10a0"

--- a/exporter/opentelemetry-exporter-zipkin-json/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin-json/setup.cfg
@@ -41,8 +41,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     requests ~= 2.7
-    opentelemetry-api == 1.0.0
-    opentelemetry-sdk == 1.0.0
+    opentelemetry-api == 1.10a0
+    opentelemetry-sdk == 1.10a0
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/setup.cfg
@@ -42,8 +42,8 @@ packages=find_namespace:
 install_requires =
     protobuf >= 3.12
     requests ~= 2.7
-    opentelemetry-api == 1.0.0
-    opentelemetry-sdk == 1.0.0
+    opentelemetry-api == 1.10a0
+    opentelemetry-sdk == 1.10a0
     opentelemetry-exporter-zipkin-json == 1.0.0
 
 [options.packages.find]

--- a/opentelemetry-api/setup.cfg
+++ b/opentelemetry-api/setup.cfg
@@ -23,7 +23,7 @@ url = https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelem
 platforms = any
 license = Apache-2.0
 classifiers =
-    Development Status :: 5 - Production/Stable
+    Development Status :: 3 - Alpha
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python

--- a/opentelemetry-api/src/opentelemetry/version.py
+++ b/opentelemetry-api/src/opentelemetry/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0"
+__version__ = "1.10a0"

--- a/opentelemetry-distro/setup.cfg
+++ b/opentelemetry-distro/setup.cfg
@@ -40,8 +40,8 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 1.0.0
-    opentelemetry-sdk == 1.0.0
+    opentelemetry-api == 1.10a0
+    opentelemetry-sdk == 1.10a0
 
 [options.packages.find]
 where = src
@@ -55,4 +55,4 @@ opentelemetry_configurator =
 [options.extras_require]
 test =
 otlp =
-    opentelemetry-exporter-otlp == 1.0.0
+    opentelemetry-exporter-otlp == 1.10a0

--- a/opentelemetry-distro/tests/test_configurator.py
+++ b/opentelemetry-distro/tests/test_configurator.py
@@ -162,7 +162,7 @@ class TestTraceInit(TestCase):
 class TestExporterNames(TestCase):
     def test_otlp_exporter_overwrite(self):
         with patch.dict(environ, {OTEL_TRACES_EXPORTER: EXPORTER_OTLP}):
-            self.assertEqual(
+            self.assertCountEqual(
                 _get_exporter_names(),
                 [EXPORTER_OTLP_SPAN, EXPORTER_OTLP_METRIC],
             )

--- a/opentelemetry-instrumentation/setup.cfg
+++ b/opentelemetry-instrumentation/setup.cfg
@@ -41,7 +41,7 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 1.0.0
+    opentelemetry-api == 1.10a0
     wrapt >= 1.0.0, < 2.0.0
 
 [options.packages.find]

--- a/opentelemetry-sdk/setup.cfg
+++ b/opentelemetry-sdk/setup.cfg
@@ -23,7 +23,7 @@ url = https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelem
 platforms = any
 license = Apache-2.0
 classifiers =
-    Development Status :: 5 - Production/Stable
+    Development Status :: 3 - Alpha
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
@@ -41,7 +41,7 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 1.0.0
+    opentelemetry-api == 1.10a0
 
 [options.packages.find]
 where = src

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0"
+__version__ = "1.10a0"

--- a/propagator/opentelemetry-propagator-b3/setup.cfg
+++ b/propagator/opentelemetry-propagator-b3/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0
+    opentelemetry-api == 1.10a0
 
 [options.extras_require]
 test =

--- a/propagator/opentelemetry-propagator-jaeger/setup.cfg
+++ b/propagator/opentelemetry-propagator-jaeger/setup.cfg
@@ -39,7 +39,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0
+    opentelemetry-api == 1.10a0
 
 [options.extras_require]
 test =

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,12 +11,20 @@ python3 -m pip install --upgrade pip setuptools wheel
 BASEDIR=$(dirname $(readlink -f $(dirname $0)))
 DISTDIR=dist
 
+PACKAGES=<<DIRS
+exporter/opentelemetry-exporter-prometheus
+opentelemetry-api
+opentelemetry-sdk
+exporter/opentelemetry-exporter-otlp-proto-grpc
+exporter/opentelemetry-exporter-otlp
+DIRS
+
 (
   cd $BASEDIR
   mkdir -p $DISTDIR
   rm -rf $DISTDIR/*
 
- for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-instrumentation/ opentelemetry-proto/ opentelemetry-distro/ exporter/*/ shim/*/ propagator/*/; do
+ for d in $PACKAGES; do
    (
      echo "building $d"
      cd "$d"

--- a/shim/opentelemetry-opentracing-shim/setup.cfg
+++ b/shim/opentelemetry-opentracing-shim/setup.cfg
@@ -41,7 +41,7 @@ packages=find_namespace:
 install_requires =
     Deprecated >= 1.2.6
     opentracing ~= 2.0
-    opentelemetry-api == 1.0.0
+    opentelemetry-api == 1.10a0
 
 [options.extras_require]
 test =

--- a/tests/util/setup.cfg
+++ b/tests/util/setup.cfg
@@ -37,8 +37,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.0.0
-    opentelemetry-sdk == 1.0.0
+    opentelemetry-api == 1.10a0
+    opentelemetry-sdk == 1.10a0
 
 [options.extras_require]
 test = flask~=1.0


### PR DESCRIPTION
# Description

Preparing 1.10a0 experimental release. This release adds the experimental metrics API/SDK and will include the following packages:

```
  opentelemetry-exporter-prometheus
  opentelemetry-api
  opentelemetry-sdk
  opentelemetry-exporter-otlp-proto-grpc
  opentelemetry-exporter-otlp
```
