### PR TITLE
Fixed B3 Propagator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1721](https://github.com/open-telemetry/opentelemetry-python/pull/1721))
 - Update bootstrap cmd to use exact version when installing instrumentation packages. 
   ([#1722](https://github.com/open-telemetry/opentelemetry-python/pull/1722))
+- Fix B3 propagator to never return None.
+  ([#1750](https://github.com/open-telemetry/opentelemetry-python/pull/1750))
 
 
 ## [1.0.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.0.0) - 2021-03-26

--- a/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
+++ b/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
@@ -97,6 +97,8 @@ class B3Format(TextMapPropagator):
             or self._trace_id_regex.fullmatch(trace_id) is None
             or self._span_id_regex.fullmatch(span_id) is None
         ):
+            if context is None:
+                return trace.set_span_in_context(trace.INVALID_SPAN, context)
             return context
 
         trace_id = int(trace_id, 16)
@@ -119,7 +121,8 @@ class B3Format(TextMapPropagator):
                     trace_flags=trace.TraceFlags(options),
                     trace_state=trace.TraceState(),
                 )
-            )
+            ),
+            context,
         )
 
     def inject(


### PR DESCRIPTION
# Description

B3 propagator was returning `None` instead of invalid context after last
change. This resulted in many apps crashing when B3 failed to extract a
valid context from carrier. This PR patches it to not make apps crash
and return an invalid context when one cannot be extracted from the
carrier.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test case

# Does This PR Require a Contrib Repo Change?

- [ ] Yes.
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
