### PR TITLE
Allow customizing instrumentation loading 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `py.typed` file to every package. This should resolve a bunch of mypy
   errors for users.
   ([#1720](https://github.com/open-telemetry/opentelemetry-python/pull/1720))
+- Distros can now implement `load_instrumentor(EntryPoint)` method to customize instrumentor
+  loading behaviour.
+  ([#1751](https://github.com/open-telemetry/opentelemetry-python/pull/1751))
 
 ### Changed
 - Adjust `B3Format` propagator to be spec compliant by not modifying context

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/distro.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/distro.py
@@ -20,6 +20,10 @@ OpenTelemetry Base Distribution (Distro)
 from abc import ABC, abstractmethod
 from logging import getLogger
 
+from pkg_resources import EntryPoint
+
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+
 _LOG = getLogger(__name__)
 
 
@@ -43,5 +47,25 @@ class BaseDistro(ABC):
         """Configure the distribution"""
         self._configure(**kwargs)
 
+    def load_instrumentor(  # pylint: disable=no-self-use
+        self, entry_point: EntryPoint
+    ):
+        """Takes a collection of instrumentation entry points
+        and activates them by instantiating and calling instrument()
+        on each one.
 
-__all__ = ["BaseDistro"]
+        Distros can override this method to customize the behavior by
+        inspecting each entry point and configuring them in special ways,
+        passing additional arguments, load a replacement/fork instead,
+        skip loading entirely, etc.
+        """
+        instrumentor: BaseInstrumentor = entry_point.load()
+        instrumentor().instrument()
+
+
+class DefaultDistro(BaseDistro):
+    def _configure(self, **kwargs):
+        pass
+
+
+__all__ = ["BaseDistro", "DefaultDistro"]

--- a/opentelemetry-instrumentation/tests/test_distro.py
+++ b/opentelemetry-instrumentation/tests/test_distro.py
@@ -1,0 +1,55 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# type: ignore
+
+from unittest import TestCase
+
+from pkg_resources import EntryPoint
+
+from opentelemetry.instrumentation.distro import BaseDistro
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+
+
+class MockInstrumetor(BaseInstrumentor):
+    def _instrument(self, **kwargs):
+        pass
+
+    def _uninstrument(self, **kwargs):
+        pass
+
+
+class MockEntryPoint(EntryPoint):
+    def __init__(self, obj):  # pylint: disable=super-init-not-called
+        self._obj = obj
+
+    def load(self, *args, **kwargs):  # pylint: disable=signature-differs
+        return self._obj
+
+
+class MockDistro(BaseDistro):
+    def _configure(self, **kwargs):
+        pass
+
+
+class TestDistro(TestCase):
+    def test_load_instrumentor(self):
+        # pylint: disable=protected-access
+        distro = MockDistro()
+
+        instrumentor = MockInstrumetor()
+        entry_point = MockEntryPoint(MockInstrumetor)
+
+        self.assertFalse(instrumentor._is_instrumented)
+        distro.load_instrumentor(entry_point)
+        self.assertTrue(instrumentor._is_instrumented)


### PR DESCRIPTION
# Description

This feature allows distros to customize instrumentation initialization when using automatically instrumenting with the `opentelemetry-instrument` command. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested manually
- [x] Added test for newly introduced method 

# Does This PR Require a Contrib Repo Change?

- [ ] Yes.
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
