### PR TITLE
Fix eachdist.py not printing invoked commands.

### DIFF
--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -343,7 +343,7 @@ def runsubprocess(dry_run, params, *args, **kwargs):
 
     check = kwargs.pop("check")  # Enforce specifying check
 
-    print(">>>", cmdstr, file=sys.stderr)
+    print(">>>", cmdstr, file=sys.stderr, flush=True)
 
     # This is a workaround for subprocess.run(['python']) leaving the virtualenv on Win32.
     # The cause for this is that when running the python.exe in a virtualenv,
@@ -356,7 +356,7 @@ def runsubprocess(dry_run, params, *args, **kwargs):
     # Only this would find the "correct" python.exe.
 
     params = list(params)
-    executable = shutil.which(params[0])  # On Win32, pytho
+    executable = shutil.which(params[0])
     if executable:
         params[0] = executable
     try:


### PR DESCRIPTION
# Description

I observed the following pattern:

```
<output of cmd 1>
<output of cmd 2>
>>> cmd1
>>> cmd2
```

The `>>> cmd` header should come immediately before the command output to facilitate debugging & progress reporting.

Also remove a leftover comment fragment.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Only locally.

# Does This PR Require a Contrib Repo Change?

- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated: No, IMHO too minor but can do if requested
- [ ] Unit tests have been added: N/A
- [ ] Documentation has been updated: N/A
