### PR TITLE
Change `should_sample` parameters to be spec compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `py.typed` file to every package. This should resolve a bunch of mypy
   errors for users.
   ([#1720](https://github.com/open-telemetry/opentelemetry-python/pull/1720))
-- Added `SpanKind` to `should_sample` parameters
+- Added `SpanKind` to `should_sample` parameters, suggest using parent span context's tracestate
+  instead of manually passed in tracestate in `should_sample`
   ([#1764](https://github.com/open-telemetry/opentelemetry-python/pull/1764))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `py.typed` file to every package. This should resolve a bunch of mypy
   errors for users.
   ([#1720](https://github.com/open-telemetry/opentelemetry-python/pull/1720))
+- Added `SpanKind` to `should_sample` parameters
+  ([#1764](https://github.com/open-telemetry/opentelemetry-python/pull/1764))
 
 ### Changed
 - Adjust `B3Format` propagator to be spec compliant by not modifying context

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -918,7 +918,7 @@ class Tracer(trace_api.Tracer):
         # The sampler may also add attributes to the newly-created span, e.g.
         # to include information about the sampling result.
         sampling_result = self.sampler.should_sample(
-            context, trace_id, name, attributes, links, trace_state
+            context, trace_id, name, kind, attributes, links, trace_state
         )
 
         trace_flags = (

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -905,20 +905,17 @@ class Tracer(trace_api.Tracer):
         if parent_span_context is None or not parent_span_context.is_valid:
             parent_span_context = None
             trace_id = self.id_generator.generate_trace_id()
-            trace_flags = None
-            trace_state = None
         else:
             trace_id = parent_span_context.trace_id
-            trace_flags = parent_span_context.trace_flags
-            trace_state = parent_span_context.trace_state
 
         # The sampler decides whether to create a real or no-op span at the
         # time of span creation. No-op spans do not record events, and are not
         # exported.
         # The sampler may also add attributes to the newly-created span, e.g.
         # to include information about the sampling result.
+        # The sampler may also modify the parent span context's tracestate
         sampling_result = self.sampler.should_sample(
-            context, trace_id, name, kind, attributes, links, trace_state
+            context, trace_id, name, kind, attributes, links
         )
 
         trace_flags = (

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -27,13 +27,13 @@ A `StaticSampler` always returns the same sampling result regardless of the cond
 
 A `TraceIdRatioBased` sampler makes a random sampling result based on the sampling probability given.
 
-If the span being sampled has a parent, `ParentBased` will respect the parent delegate sampler. Otherwise, it returns the sampling result from the given root sampler. 
+If the span being sampled has a parent, `ParentBased` will respect the parent delegate sampler. Otherwise, it returns the sampling result from the given root sampler.
 
 Currently, sampling results are always made during the creation of the span. However, this might not always be the case in the future (see `OTEP #115 <https://github.com/open-telemetry/oteps/pull/115>`_).
 
 Custom samplers can be created by subclassing `Sampler` and implementing `Sampler.should_sample` as well as `Sampler.get_description`.
 
-Samplers are able to modify the `TraceState` of the parent of the span being created. For custom samplers, it is suggested to implement `Sampler.should_sample` to utilize the
+Samplers are able to modify the TraceState of the parent of the span being created. For custom samplers, it is suggested to implement `Sampler.should_sample` to utilize the
 parent span context's `TraceState` and pass into the `SamplingResult` instead of the explicit `trace_state` field passed into the parameter of `should_sample`.
 
 To use a sampler, pass it into the tracer provider constructor. For example:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -108,7 +108,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_TRACES_SAMPLER,
     OTEL_TRACES_SAMPLER_ARG,
 )
-from opentelemetry.trace import SpanKind, Link, get_current_span
+from opentelemetry.trace import Link, SpanKind, get_current_span
 from opentelemetry.trace.span import TraceState
 from opentelemetry.util.types import Attributes
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -34,7 +34,7 @@ Currently, sampling results are always made during the creation of the span. How
 Custom samplers can be created by subclassing `Sampler` and implementing `Sampler.should_sample` as well as `Sampler.get_description`.
 
 Samplers are able to modify the `opentelemetry.trace.span.TraceState` of the parent of the span being created. For custom samplers, it is suggested to implement `Sampler.should_sample` to utilize the
-parent span context's `opentelemetry.trace.span.TraceState` and pass into the `SamplingResult` instead of the explicit trace_state field passed into the parameter of `should_sample`.
+parent span context's `opentelemetry.trace.span.TraceState` and pass into the `SamplingResult` instead of the explicit trace_state field passed into the parameter of `Sampler.should_sample`.
 
 To use a sampler, pass it into the tracer provider constructor. For example:
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -34,7 +34,7 @@ Currently, sampling results are always made during the creation of the span. How
 Custom samplers can be created by subclassing `Sampler` and implementing `Sampler.should_sample` as well as `Sampler.get_description`.
 
 Samplers are able to modify the `opentelemetry.trace.span.TraceState` of the parent of the span being created. For custom samplers, it is suggested to implement `Sampler.should_sample` to utilize the
-parent span context's `opentelemetry.trace.span.TraceState` and pass into the `SamplingResult` instead of the explicit `trace_state` field passed into the parameter of `should_sample`.
+parent span context's `opentelemetry.trace.span.TraceState` and pass into the `SamplingResult` instead of the explicit trace_state field passed into the parameter of `should_sample`.
 
 To use a sampler, pass it into the tracer provider constructor. For example:
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -108,7 +108,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_TRACES_SAMPLER,
     OTEL_TRACES_SAMPLER_ARG,
 )
-from opentelemetry.trace import Link, get_current_span
+from opentelemetry.trace import SpanKind, Link, get_current_span
 from opentelemetry.trace.span import TraceState
 from opentelemetry.util.types import Attributes
 
@@ -167,6 +167,7 @@ class Sampler(abc.ABC):
         parent_context: Optional["Context"],
         trace_id: int,
         name: str,
+        kind: SpanKind = None,
         attributes: Attributes = None,
         links: Sequence["Link"] = None,
         trace_state: "TraceState" = None,
@@ -189,6 +190,7 @@ class StaticSampler(Sampler):
         parent_context: Optional["Context"],
         trace_id: int,
         name: str,
+        kind: SpanKind = None,
         attributes: Attributes = None,
         links: Sequence["Link"] = None,
         trace_state: "TraceState" = None,
@@ -246,6 +248,7 @@ class TraceIdRatioBased(Sampler):
         parent_context: Optional["Context"],
         trace_id: int,
         name: str,
+        kind: SpanKind = None,
         attributes: Attributes = None,
         links: Sequence["Link"] = None,
         trace_state: "TraceState" = None,
@@ -296,6 +299,7 @@ class ParentBased(Sampler):
         parent_context: Optional["Context"],
         trace_id: int,
         name: str,
+        kind: SpanKind = None,
         attributes: Attributes = None,
         links: Sequence["Link"] = None,
         trace_state: "TraceState" = None,
@@ -322,6 +326,7 @@ class ParentBased(Sampler):
             parent_context=parent_context,
             trace_id=trace_id,
             name=name,
+            kind=kind,
             attributes=attributes,
             links=links,
             trace_state=trace_state,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -33,8 +33,8 @@ Currently, sampling results are always made during the creation of the span. How
 
 Custom samplers can be created by subclassing `Sampler` and implementing `Sampler.should_sample` as well as `Sampler.get_description`.
 
-Samplers are able to modify the TraceState of the parent of the span being created. For custom samplers, it is suggested to implement `Sampler.should_sample` to utilize the
-parent span context's `TraceState` and pass into the `SamplingResult` instead of the explicit `trace_state` field passed into the parameter of `should_sample`.
+Samplers are able to modify the `opentelemetry.trace.span.TraceState` of the parent of the span being created. For custom samplers, it is suggested to implement `Sampler.should_sample` to utilize the
+parent span context's `opentelemetry.trace.span.TraceState` and pass into the `SamplingResult` instead of the explicit `trace_state` field passed into the parameter of `should_sample`.
 
 To use a sampler, pass it into the tracer provider constructor. For example:
 
@@ -400,9 +400,8 @@ def _get_from_env_or_default() -> Sampler:
     return _KNOWN_SAMPLERS[trace_sampler]
 
 
-def _get_parent_trace_state(parent_context) -> "TraceState":
+def _get_parent_trace_state(parent_context) -> Optional["TraceState"]:
     parent_span_context = get_current_span(parent_context).get_span_context()
     if parent_span_context is None or not parent_span_context.is_valid:
         return None
-    else:
-        return parent_span_context.trace_state
+    return parent_span_context.trace_state

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -266,9 +266,7 @@ class TraceIdRatioBased(Sampler):
         if decision is Decision.DROP:
             attributes = None
         return SamplingResult(
-            decision,
-            attributes,
-            _get_parent_trace_state(parent_context),
+            decision, attributes, _get_parent_trace_state(parent_context),
         )
 
     def get_description(self) -> str:
@@ -402,10 +400,8 @@ def _get_from_env_or_default() -> Sampler:
     return _KNOWN_SAMPLERS[trace_sampler]
 
 
-def _get_parent_trace_state(parent_context) -> TraceState:
-    parent_span_context = get_current_span(
-        parent_context
-    ).get_span_context()
+def _get_parent_trace_state(parent_context) -> "TraceState":
+    parent_span_context = get_current_span(parent_context).get_span_context()
     if parent_span_context is None or not parent_span_context.is_valid:
         return None
     else:

--- a/opentelemetry-sdk/tests/trace/test_sampling.py
+++ b/opentelemetry-sdk/tests/trace/test_sampling.py
@@ -98,6 +98,7 @@ class TestSampler(unittest.TestCase):
                     context,
                     0xDEADBEF1,
                     "sampling on",
+                    trace.SpanKind.INTERNAL,
                     attributes={"sampled.expect": "true"},
                     trace_state=trace_state,
                 )
@@ -118,6 +119,7 @@ class TestSampler(unittest.TestCase):
                     context,
                     0xDEADBEF1,
                     "sampling off",
+                    trace.SpanKind.INTERNAL,
                     attributes={"sampled.expect": "false"},
                     trace_state=trace_state,
                 )
@@ -132,6 +134,7 @@ class TestSampler(unittest.TestCase):
             context,
             0xDEADBEF1,
             "unsampled parent, sampling on",
+            trace.SpanKind.INTERNAL,
             attributes={"sampled.expect": "false"},
             trace_state=trace_state,
         )
@@ -144,6 +147,7 @@ class TestSampler(unittest.TestCase):
             context,
             0xDEADBEF1,
             "sampled parent, sampling on",
+            trace.SpanKind.INTERNAL,
             attributes={"sampled.expect": "true"},
             trace_state=trace_state,
         )
@@ -155,6 +159,7 @@ class TestSampler(unittest.TestCase):
             None,
             0xDEADBEF1,
             "no parent, sampling on",
+            trace.SpanKind.INTERNAL,
             attributes={"sampled.expect": "true"},
             trace_state=trace_state,
         )
@@ -169,6 +174,7 @@ class TestSampler(unittest.TestCase):
             context,
             0xDEADBEF1,
             "unsampled parent, sampling off",
+            trace.SpanKind.INTERNAL,
             attributes={"sampled.expect", "false"},
             trace_state=trace_state,
         )
@@ -181,6 +187,7 @@ class TestSampler(unittest.TestCase):
             context,
             0xDEADBEF1,
             "sampled parent, sampling on",
+            trace.SpanKind.INTERNAL,
             attributes={"sampled.expect": "true"},
             trace_state=trace_state,
         )
@@ -192,6 +199,7 @@ class TestSampler(unittest.TestCase):
             None,
             0xDEADBEF1,
             "unsampled parent, sampling off",
+            trace.SpanKind.INTERNAL,
             attributes={"sampled.expect": "false"},
             trace_state=trace_state,
         )
@@ -209,6 +217,7 @@ class TestSampler(unittest.TestCase):
             None,
             0x7FFFFFFFFFFFFFFF,
             "sampled true",
+            trace.SpanKind.INTERNAL,
             attributes={"sampled.expect": "true"},
             trace_state=trace_state,
         )
@@ -220,6 +229,7 @@ class TestSampler(unittest.TestCase):
             None,
             0x8000000000000000,
             "sampled false",
+            trace.SpanKind.INTERNAL,
             attributes={"sampled.expect": "false"},
             trace_state=trace_state,
         )
@@ -324,6 +334,7 @@ class TestSampler(unittest.TestCase):
                 context,
                 0x7FFFFFFFFFFFFFFF,
                 "unsampled parent, sampling on",
+                trace.SpanKind.INTERNAL,
                 attributes={"sampled": "false"},
                 trace_state=trace_state,
             )
@@ -343,6 +354,7 @@ class TestSampler(unittest.TestCase):
                 context,
                 0x7FFFFFFFFFFFFFFF,
                 "unsampled parent, sampling on",
+                trace.SpanKind.INTERNAL,
                 attributes={"sampled": "false"},
                 trace_state=trace_state,
             )
@@ -359,6 +371,7 @@ class TestSampler(unittest.TestCase):
                 context,
                 0x8000000000000000,
                 "sampled parent, sampling off",
+                trace.SpanKind.INTERNAL,
                 attributes={"sampled": "true"},
                 trace_state=trace_state,
             )
@@ -378,6 +391,7 @@ class TestSampler(unittest.TestCase):
                 context,
                 0x7FFFFFFFFFFFFFFF,
                 "unsampled parent, sampling on",
+                trace.SpanKind.INTERNAL,
                 attributes={"sampled": "false"},
                 trace_state=trace_state,
             )
@@ -394,6 +408,7 @@ class TestSampler(unittest.TestCase):
                 context,
                 0x7FFFFFFFFFFFFFFF,
                 "unsampled parent, sampling on",
+                trace.SpanKind.INTERNAL,
                 attributes={"sampled": "false"},
                 trace_state=trace_state,
             )
@@ -413,6 +428,7 @@ class TestSampler(unittest.TestCase):
                 context,
                 0x7FFFFFFFFFFFFFFF,
                 "unsampled parent, sampling on",
+                trace.SpanKind.INTERNAL,
                 attributes={"sampled": "false"},
                 trace_state=trace_state,
             )
@@ -429,6 +445,7 @@ class TestSampler(unittest.TestCase):
                 context,
                 0x8000000000000000,
                 "sampled parent, sampling off",
+                trace.SpanKind.INTERNAL,
                 attributes={"sampled": "true"},
                 trace_state=trace_state,
             )
@@ -448,6 +465,7 @@ class TestSampler(unittest.TestCase):
                 context,
                 0x7FFFFFFFFFFFFFFF,
                 "unsampled parent, sampling on",
+                trace.SpanKind.INTERNAL,
                 attributes={"sampled": "false"},
                 trace_state=trace_state,
             )
@@ -462,6 +480,7 @@ class TestSampler(unittest.TestCase):
                 context,
                 0x8000000000000000,
                 "parent, sampling off",
+                trace.SpanKind.INTERNAL,
                 attributes={"sampled": "false"},
                 trace_state=trace_state,
             )
@@ -475,6 +494,7 @@ class TestSampler(unittest.TestCase):
                 context,
                 0x8000000000000000,
                 "no parent, sampling on",
+                trace.SpanKind.INTERNAL,
                 attributes={"sampled": "true"},
                 trace_state=trace_state,
             )

--- a/opentelemetry-sdk/tests/trace/test_sampling.py
+++ b/opentelemetry-sdk/tests/trace/test_sampling.py
@@ -107,7 +107,7 @@ class TestSampler(unittest.TestCase):
                 self.assertEqual(
                     sample_result.attributes, {"sampled.expect": "true"}
                 )
-                if context:
+                if context is not None:
                     self.assertEqual(sample_result.trace_state, trace_state)
                 else:
                     self.assertIsNone(sample_result.trace_state)
@@ -127,7 +127,7 @@ class TestSampler(unittest.TestCase):
                 )
                 self.assertFalse(sample_result.decision.is_sampled())
                 self.assertEqual(sample_result.attributes, {})
-                if context:
+                if context is not None:
                     self.assertEqual(sample_result.trace_state, trace_state)
                 else:
                     self.assertIsNone(sample_result.trace_state)
@@ -221,7 +221,7 @@ class TestSampler(unittest.TestCase):
         )
         self.assertTrue(sampled_result.decision.is_sampled())
         self.assertEqual(sampled_result.attributes, {"sampled.expect": "true"})
-        self.assertFalse(sampled_result.trace_state)
+        self.assertIsNone(sampled_result.trace_state)
 
         not_sampled_result = sampler.should_sample(
             None,
@@ -232,7 +232,7 @@ class TestSampler(unittest.TestCase):
         )
         self.assertFalse(not_sampled_result.decision.is_sampled())
         self.assertEqual(not_sampled_result.attributes, {})
-        self.assertFalse(not_sampled_result.trace_state)
+        self.assertIsNone(sampled_result.trace_state)
 
     def test_probability_sampler_zero(self):
         default_off = sampling.TraceIdRatioBased(0.0)

--- a/opentelemetry-sdk/tests/trace/test_sampling.py
+++ b/opentelemetry-sdk/tests/trace/test_sampling.py
@@ -207,7 +207,6 @@ class TestSampler(unittest.TestCase):
         self.assertIsNone(default_off.trace_state)
 
     def test_probability_sampler(self):
-        trace_state = trace.TraceState([("key", "value")])
         sampler = sampling.TraceIdRatioBased(0.5)
 
         # Check that we sample based on the trace ID if the parent context is

--- a/opentelemetry-sdk/tests/trace/test_sampling.py
+++ b/opentelemetry-sdk/tests/trace/test_sampling.py
@@ -326,8 +326,7 @@ class TestSampler(unittest.TestCase):
         # Check that the sampling decision matches the parent context if given
         with parent_sampling_context(
             self._create_parent_span(
-                trace_flags=TO_DEFAULT,
-                trace_state=trace_state,
+                trace_flags=TO_DEFAULT, trace_state=trace_state,
             )
         ) as context:
             # local, not sampled
@@ -344,8 +343,7 @@ class TestSampler(unittest.TestCase):
 
         with parent_sampling_context(
             self._create_parent_span(
-                trace_flags=TO_DEFAULT,
-                trace_state=trace_state,
+                trace_flags=TO_DEFAULT, trace_state=trace_state,
             )
         ) as context:
             sampler = sampling.ParentBased(
@@ -366,8 +364,7 @@ class TestSampler(unittest.TestCase):
 
         with parent_sampling_context(
             self._create_parent_span(
-                trace_flags=TO_SAMPLED,
-                trace_state=trace_state,
+                trace_flags=TO_SAMPLED, trace_state=trace_state,
             )
         ) as context:
             sampler = sampling.ParentBased(sampling.ALWAYS_OFF)
@@ -386,8 +383,7 @@ class TestSampler(unittest.TestCase):
 
         with parent_sampling_context(
             self._create_parent_span(
-                trace_flags=TO_SAMPLED,
-                trace_state=trace_state,
+                trace_flags=TO_SAMPLED, trace_state=trace_state,
             )
         ) as context:
             sampler = sampling.ParentBased(


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-python/issues/1763

1. Adds `SpanKind` to `should_sample`
2. `should_sample` uses `trace_state` from the passed in `Context` 's `SpanContext` 's `TraceState` instead of the explicitly passed in `TraceState`.