### PR TITLE
Public symbols cleanup

### DIFF
--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.py
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.py
@@ -11,23 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR,
-    "src",
-    "opentelemetry",
-    "exporter",
-    "jaeger",
-    "proto",
-    "grpc",
-    "version.py",
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "exporter",
+        "jaeger",
+        "proto",
+        "grpc",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/translate/__init__.py
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/translate/__init__.py
@@ -25,7 +25,7 @@ from opentelemetry.trace import SpanKind
 from opentelemetry.util import types
 
 
-OTLP_JAEGER_SPAN_KIND = {
+_otlp_jaeger_span_kind = {
     SpanKind.CLIENT: "client",
     SpanKind.SERVER: "server",
     SpanKind.CONSUMER: "consumer",
@@ -33,8 +33,8 @@ OTLP_JAEGER_SPAN_KIND = {
     SpanKind.INTERNAL: "internal",
 }
 
-NAME_KEY = "otel.library.name"
-VERSION_KEY = "otel.library.version"
+_name_key = "otel.library.name"
+_version_key = "otel.library.version"
 
 
 def _nsec_to_usec_round(nsec: int) -> int:
@@ -295,17 +295,17 @@ class ProtobufTranslator(Translator):
                 )
         translated.append(
             _get_string_key_value(
-                "span.kind", OTLP_JAEGER_SPAN_KIND[span.kind]
+                "span.kind", _otlp_jaeger_span_kind[span.kind]
             )
         )
 
         # Instrumentation info KeyValues
         if span.instrumentation_info:
             name = _get_string_key_value(
-                NAME_KEY, span.instrumentation_info.name
+                _name_key, span.instrumentation_info.name
             )
             version = _get_string_key_value(
-                VERSION_KEY, span.instrumentation_info.version
+                _version_key, span.instrumentation_info.version
             )
             translated.extend([name, version])
 

--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/tests/test_jaeger_exporter_protobuf.py
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/tests/test_jaeger_exporter_protobuf.py
@@ -24,9 +24,9 @@ import opentelemetry.exporter.jaeger.proto.grpc.translate as pb_translator
 from opentelemetry import trace as trace_api
 from opentelemetry.exporter.jaeger.proto.grpc import JaegerExporter
 from opentelemetry.exporter.jaeger.proto.grpc.translate import (
-    NAME_KEY,
-    VERSION_KEY,
     Translate,
+    _name_key,
+    _version_key,
 )
 from opentelemetry.sdk import trace
 from opentelemetry.sdk.environment_variables import (
@@ -362,12 +362,12 @@ class TestJaegerExporter(unittest.TestCase):
                         v_str="internal",
                     ),
                     model_pb2.KeyValue(
-                        key=NAME_KEY,
+                        key=_name_key,
                         v_type=model_pb2.ValueType.STRING,
                         v_str="name",
                     ),
                     model_pb2.KeyValue(
-                        key=VERSION_KEY,
+                        key=_version_key,
                         v_type=model_pb2.ValueType.STRING,
                         v_str="version",
                     ),

--- a/exporter/opentelemetry-exporter-jaeger-thrift/setup.py
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/setup.py
@@ -11,22 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR,
-    "src",
-    "opentelemetry",
-    "exporter",
-    "jaeger",
-    "thrift",
-    "version.py",
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "exporter",
+        "jaeger",
+        "thrift",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/exporter/opentelemetry-exporter-jaeger-thrift/src/opentelemetry/exporter/jaeger/thrift/translate/__init__.py
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/src/opentelemetry/exporter/jaeger/thrift/translate/__init__.py
@@ -22,7 +22,7 @@ from opentelemetry.sdk.trace import ReadableSpan, StatusCode
 from opentelemetry.trace import SpanKind
 from opentelemetry.util import types
 
-OTLP_JAEGER_SPAN_KIND = {
+_otlp_jaeger_span_kind = {
     SpanKind.CLIENT: "client",
     SpanKind.SERVER: "server",
     SpanKind.CONSUMER: "consumer",
@@ -30,8 +30,8 @@ OTLP_JAEGER_SPAN_KIND = {
     SpanKind.INTERNAL: "internal",
 }
 
-NAME_KEY = "otel.library.name"
-VERSION_KEY = "otel.library.version"
+_name_key = "otel.library.name"
+_version_key = "otel.library.version"
 
 
 def _nsec_to_usec_round(nsec: int) -> int:
@@ -211,14 +211,14 @@ class ThriftTranslator(Translator):
                 )
 
         translated.append(
-            _get_string_tag("span.kind", OTLP_JAEGER_SPAN_KIND[span.kind])
+            _get_string_tag("span.kind", _otlp_jaeger_span_kind[span.kind])
         )
 
         # Instrumentation info tags
         if span.instrumentation_info:
-            name = _get_string_tag(NAME_KEY, span.instrumentation_info.name)
+            name = _get_string_tag(_name_key, span.instrumentation_info.name)
             version = _get_string_tag(
-                VERSION_KEY, span.instrumentation_info.version
+                _version_key, span.instrumentation_info.version
             )
             translated.extend([name, version])
 

--- a/exporter/opentelemetry-exporter-jaeger-thrift/tests/test_jaeger_exporter_thrift.py
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/tests/test_jaeger_exporter_thrift.py
@@ -198,7 +198,7 @@ class TestJaegerExporter(unittest.TestCase):
     def test_all_otlp_span_kinds_are_mapped(self):
         for kind in SpanKind:
             self.assertIn(
-                kind, jaeger_exporter.translate.OTLP_JAEGER_SPAN_KIND
+                kind, jaeger_exporter.translate._otlp_jaeger_span_kind
             )
 
     # pylint: disable=too-many-locals
@@ -436,12 +436,12 @@ class TestJaegerExporter(unittest.TestCase):
                         vStr="internal",
                     ),
                     jaeger.Tag(
-                        key=jaeger_exporter.translate.NAME_KEY,
+                        key=jaeger_exporter.translate._name_key,
                         vType=jaeger.TagType.STRING,
                         vStr="name",
                     ),
                     jaeger.Tag(
-                        key=jaeger_exporter.translate.VERSION_KEY,
+                        key=jaeger_exporter.translate._version_key,
                         vType=jaeger.TagType.STRING,
                         vStr="version",
                     ),

--- a/exporter/opentelemetry-exporter-jaeger/setup.py
+++ b/exporter/opentelemetry-exporter-jaeger/setup.py
@@ -11,16 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR, "src", "opentelemetry", "exporter", "jaeger", "version.py"
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "exporter",
+        "jaeger",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/exporter/opentelemetry-exporter-opencensus/setup.py
+++ b/exporter/opentelemetry-exporter-opencensus/setup.py
@@ -11,16 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR, "src", "opentelemetry", "exporter", "opencensus", "version.py"
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "exporter",
+        "opencensus",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/trace_exporter/__init__.py
@@ -14,7 +14,6 @@
 
 """OpenCensus Span Exporter."""
 
-import logging
 from typing import Sequence
 
 import grpc
@@ -30,10 +29,6 @@ from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
-DEFAULT_ENDPOINT = "localhost:55678"
-
-logger = logging.getLogger(__name__)
-
 
 # pylint: disable=no-member
 class OpenCensusSpanExporter(SpanExporter):
@@ -46,10 +41,7 @@ class OpenCensusSpanExporter(SpanExporter):
     """
 
     def __init__(
-        self,
-        endpoint=DEFAULT_ENDPOINT,
-        host_name=None,
-        client=None,
+        self, endpoint="localhost:55678", host_name=None, client=None,
     ):
         tracer_provider = trace.get_tracer_provider()
         service_name = (
@@ -85,7 +77,7 @@ class OpenCensusSpanExporter(SpanExporter):
         pass
 
     def generate_span_requests(self, spans):
-        collector_spans = translate_to_collector(spans)
+        collector_spans = _translate_to_collector(spans)
         service_request = trace_service_pb2.ExportTraceServiceRequest(
             node=self.node, spans=collector_spans
         )
@@ -93,7 +85,7 @@ class OpenCensusSpanExporter(SpanExporter):
 
 
 # pylint: disable=too-many-branches
-def translate_to_collector(spans: Sequence[ReadableSpan]):
+def _translate_to_collector(spans: Sequence[ReadableSpan]):
     collector_spans = []
     for span in spans:
         status = None

--- a/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-opencensus/tests/test_otcollector_trace_exporter.py
@@ -23,7 +23,7 @@ import opentelemetry.exporter.opencensus.util as utils
 from opentelemetry import trace as trace_api
 from opentelemetry.exporter.opencensus.trace_exporter import (
     OpenCensusSpanExporter,
-    translate_to_collector,
+    _translate_to_collector,
 )
 from opentelemetry.sdk import trace
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
@@ -79,7 +79,7 @@ class TestCollectorSpanExporter(unittest.TestCase):
 
     # pylint: disable=too-many-locals
     # pylint: disable=too-many-statements
-    def test_translate_to_collector(self):
+    def test__translate_to_collector(self):
         trace_id = 0x6E0C63257DE34C926F9EFCD03927272E
         span_id = 0x34BF92DEEFC58C92
         parent_id = 0x1111111111111111
@@ -164,7 +164,7 @@ class TestCollectorSpanExporter(unittest.TestCase):
         otel_spans[1].end(end_time=end_times[1])
         otel_spans[2].start(start_time=start_times[2])
         otel_spans[2].end(end_time=end_times[2])
-        output_spans = translate_to_collector(otel_spans)
+        output_spans = _translate_to_collector(otel_spans)
 
         self.assertEqual(len(output_spans), 3)
         self.assertEqual(

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.py
@@ -11,23 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR,
-    "src",
-    "opentelemetry",
-    "exporter",
-    "otlp",
-    "proto",
-    "grpc",
-    "version.py",
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "exporter",
+        "otlp",
+        "proto",
+        "grpc",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
@@ -50,7 +50,7 @@ from opentelemetry.sdk.trace import Span as ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.trace import StatusCode
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 # pylint: disable=no-member
@@ -164,7 +164,7 @@ class OTLPSpanExporter(
                         _translate_key_values(key, value)
                     )
                 except Exception as error:  # pylint: disable=broad-except
-                    logger.exception(error)
+                    _logger.exception(error)
 
     def _translate_events(self, sdk_span: ReadableSpan) -> None:
         if sdk_span.events:
@@ -184,7 +184,7 @@ class OTLPSpanExporter(
                         )
                     # pylint: disable=broad-except
                     except Exception as error:
-                        logger.exception(error)
+                        _logger.exception(error)
 
                 self._collector_span_kwargs["events"].append(
                     collector_span_event
@@ -210,7 +210,7 @@ class OTLPSpanExporter(
                         )
                     # pylint: disable=broad-except
                     except Exception as error:
-                        logger.exception(error)
+                        _logger.exception(error)
 
                 self._collector_span_kwargs["links"].append(
                     collector_span_link

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/performance/benchmarks/test_benchmark_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/performance/benchmarks/test_benchmark_trace_exporter.py
@@ -27,8 +27,7 @@ from opentelemetry.sdk.trace.export import (
 def get_tracer_with_processor(span_processor_class):
     span_processor = span_processor_class(OTLPSpanExporter())
     tracer = TracerProvider(
-        active_span_processor=span_processor,
-        sampler=sampling.DEFAULT_ON,
+        active_span_processor=span_processor, sampler=sampling.default_on,
     ).get_tracer("pipeline_benchmark_tracer")
     return tracer
 

--- a/exporter/opentelemetry-exporter-otlp/setup.py
+++ b/exporter/opentelemetry-exporter-otlp/setup.py
@@ -11,16 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR, "src", "opentelemetry", "exporter", "otlp", "version.py"
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "exporter",
+        "otlp",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/exporter/opentelemetry-exporter-zipkin-json/setup.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/setup.py
@@ -11,22 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR,
-    "src",
-    "opentelemetry",
-    "exporter",
-    "zipkin",
-    "json",
-    "version.py",
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "exporter",
+        "zipkin",
+        "json",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/encoder/__init__.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/encoder/__init__.py
@@ -35,11 +35,11 @@ from opentelemetry.trace import (
 
 EncodedLocalEndpointT = TypeVar("EncodedLocalEndpointT")
 
-DEFAULT_MAX_TAG_VALUE_LENGTH = 128
-NAME_KEY = "otel.library.name"
-VERSION_KEY = "otel.library.version"
+_DEFAULT_MAX_TAG_VALUE_LENGTH = 128
+_name_key = "otel.library.name"
+_version_key = "otel.library.version"
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class Protocol(Enum):
@@ -64,7 +64,7 @@ class Encoder(abc.ABC):
     """
 
     def __init__(
-        self, max_tag_value_length: int = DEFAULT_MAX_TAG_VALUE_LENGTH
+        self, max_tag_value_length: int = _DEFAULT_MAX_TAG_VALUE_LENGTH
     ):
         self.max_tag_value_length = max_tag_value_length
 
@@ -137,10 +137,12 @@ class Encoder(abc.ABC):
                     attribute_value
                 )
                 if not value:
-                    logger.warning("Could not serialize tag %s", attribute_key)
+                    _logger.warning(
+                        "Could not serialize tag %s", attribute_key
+                    )
                     continue
             else:
-                logger.warning("Could not serialize tag %s", attribute_key)
+                _logger.warning("Could not serialize tag %s", attribute_key)
                 continue
 
             if (
@@ -199,8 +201,8 @@ class Encoder(abc.ABC):
         if span.instrumentation_info is not None:
             tags.update(
                 {
-                    NAME_KEY: span.instrumentation_info.name,
-                    VERSION_KEY: span.instrumentation_info.version,
+                    _name_key: span.instrumentation_info.name,
+                    _version_key: span.instrumentation_info.version,
                 }
             )
         if span.status.status_code is not StatusCode.UNSET:

--- a/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/json/__init__.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/json/__init__.py
@@ -75,11 +75,7 @@ from typing import Optional, Sequence
 
 import requests
 
-from opentelemetry.exporter.zipkin.encoder import (
-    DEFAULT_MAX_TAG_VALUE_LENGTH,
-    Encoder,
-    Protocol,
-)
+from opentelemetry.exporter.zipkin.encoder import Protocol
 from opentelemetry.exporter.zipkin.json.v1 import JsonV1Encoder
 from opentelemetry.exporter.zipkin.json.v2 import JsonV2Encoder
 from opentelemetry.exporter.zipkin.node_endpoint import IpInput, NodeEndpoint

--- a/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/common_tests.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/common_tests.py
@@ -19,7 +19,7 @@ from typing import Dict, List
 
 from opentelemetry import trace as trace_api
 from opentelemetry.exporter.zipkin.encoder import (
-    DEFAULT_MAX_TAG_VALUE_LENGTH,
+    _DEFAULT_MAX_TAG_VALUE_LENGTH,
     Encoder,
 )
 from opentelemetry.exporter.zipkin.node_endpoint import NodeEndpoint
@@ -85,7 +85,7 @@ class CommonEncoderTestCases:
             encoder = self.get_encoder()
 
             self.assertEqual(
-                DEFAULT_MAX_TAG_VALUE_LENGTH, encoder.max_tag_value_length
+                _DEFAULT_MAX_TAG_VALUE_LENGTH, encoder.max_tag_value_length
             )
 
         def test_constructor_max_tag_value_length(self):

--- a/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/test_v1_json.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/test_v1_json.py
@@ -14,7 +14,7 @@
 import json
 
 from opentelemetry import trace as trace_api
-from opentelemetry.exporter.zipkin.encoder import NAME_KEY, VERSION_KEY
+from opentelemetry.exporter.zipkin.encoder import _name_key, _version_key
 from opentelemetry.exporter.zipkin.json.v1 import JsonV1Encoder
 from opentelemetry.exporter.zipkin.node_endpoint import NodeEndpoint
 from opentelemetry.sdk import trace
@@ -152,12 +152,12 @@ class TestV1JsonEncoder(CommonEncoderTestCases.CommonJsonEncoderTest):
                 - (otel_spans[3].start_time // 10 ** 3),
                 "binaryAnnotations": [
                     {
-                        "key": NAME_KEY,
+                        "key": _name_key,
                         "value": "name",
                         "endpoint": local_endpoint,
                     },
                     {
-                        "key": VERSION_KEY,
+                        "key": _version_key,
                         "value": "version",
                         "endpoint": local_endpoint,
                     },

--- a/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/test_v2_json.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/test_v2_json.py
@@ -14,7 +14,7 @@
 import json
 
 from opentelemetry import trace as trace_api
-from opentelemetry.exporter.zipkin.encoder import NAME_KEY, VERSION_KEY
+from opentelemetry.exporter.zipkin.encoder import _name_key, _version_key
 from opentelemetry.exporter.zipkin.json.v2 import JsonV2Encoder
 from opentelemetry.exporter.zipkin.node_endpoint import NodeEndpoint
 from opentelemetry.sdk import trace
@@ -121,7 +121,7 @@ class TestV2JsonEncoder(CommonEncoderTestCases.CommonJsonEncoderTest):
                 - (otel_spans[3].start_time // 10 ** 3),
                 "localEndpoint": local_endpoint,
                 "kind": span_kind,
-                "tags": {NAME_KEY: "name", VERSION_KEY: "version"},
+                "tags": {_name_key: "name", _version_key: "version"},
             },
         ]
 

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/setup.py
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/setup.py
@@ -11,23 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR,
-    "src",
-    "opentelemetry",
-    "exporter",
-    "zipkin",
-    "proto",
-    "http",
-    "version.py",
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "exporter",
+        "zipkin",
+        "proto",
+        "http",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/tests/encoder/common_tests.py
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/tests/encoder/common_tests.py
@@ -19,7 +19,7 @@ from typing import Dict, List
 
 from opentelemetry import trace as trace_api
 from opentelemetry.exporter.zipkin.encoder import (
-    DEFAULT_MAX_TAG_VALUE_LENGTH,
+    _DEFAULT_MAX_TAG_VALUE_LENGTH,
     Encoder,
 )
 from opentelemetry.exporter.zipkin.node_endpoint import NodeEndpoint
@@ -85,7 +85,7 @@ class CommonEncoderTestCases:
             encoder = self.get_encoder()
 
             self.assertEqual(
-                DEFAULT_MAX_TAG_VALUE_LENGTH, encoder.max_tag_value_length
+                _DEFAULT_MAX_TAG_VALUE_LENGTH, encoder.max_tag_value_length
             )
 
         def test_constructor_max_tag_value_length(self):

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/tests/encoder/test_v2_protobuf.py
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/tests/encoder/test_v2_protobuf.py
@@ -14,7 +14,7 @@
 import ipaddress
 import json
 
-from opentelemetry.exporter.zipkin.encoder import NAME_KEY, VERSION_KEY
+from opentelemetry.exporter.zipkin.encoder import _name_key, _version_key
 from opentelemetry.exporter.zipkin.node_endpoint import NodeEndpoint
 from opentelemetry.exporter.zipkin.proto.http.v2 import ProtobufEncoder
 from opentelemetry.exporter.zipkin.proto.http.v2.gen import zipkin_pb2
@@ -180,7 +180,7 @@ class TestProtobufEncoder(CommonEncoderTestCases.CommonEncoderTest):
                     ),
                     local_endpoint=local_endpoint,
                     kind=span_kind,
-                    tags={NAME_KEY: "name", VERSION_KEY: "version"},
+                    tags={_name_key: "name", _version_key: "version"},
                     debug=False,
                 ),
             ],

--- a/exporter/opentelemetry-exporter-zipkin/setup.py
+++ b/exporter/opentelemetry-exporter-zipkin/setup.py
@@ -11,16 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR, "src", "opentelemetry", "exporter", "zipkin", "version.py"
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "zipkin",
+        "version.py"
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/opentelemetry-api/setup.py
+++ b/opentelemetry-api/setup.py
@@ -16,12 +16,12 @@ import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(BASE_DIR, "src", "opentelemetry", "version.py")
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__), "src", "opentelemetry", "version.py"
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(
-    version=PACKAGE_INFO["__version__"],
-)
+setuptools.setup(version=package_info["__version__"],)

--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -78,7 +78,7 @@ from opentelemetry.context.context import Context
 from opentelemetry.environment_variables import OTEL_PROPAGATORS
 from opentelemetry.propagators import composite, textmap
 
-logger = getLogger(__name__)
+_logger = getLogger(__name__)
 
 
 def extract(
@@ -139,7 +139,7 @@ try:
         )
 
 except Exception:  # pylint: disable=broad-except
-    logger.exception("Failed to load configured propagators")
+    _logger.exception("Failed to load configured propagators")
     raise
 
 _HTTP_TEXT_FORMAT = composite.CompositeHTTPPropagator(propagators)  # type: ignore

--- a/opentelemetry-api/src/opentelemetry/propagators/composite.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/composite.py
@@ -11,13 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
 import typing
 
 from opentelemetry.context.context import Context
 from opentelemetry.propagators import textmap
-
-logger = logging.getLogger(__name__)
 
 
 class CompositeHTTPPropagator(textmap.TextMapPropagator):

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -86,23 +86,11 @@ from opentelemetry.context.context import Context
 from opentelemetry.environment_variables import OTEL_PYTHON_TRACER_PROVIDER
 from opentelemetry.trace.propagation import (
     SPAN_KEY,
-    get_current_span,
-    set_span_in_context,
 )
 from opentelemetry.trace.span import (
-    DEFAULT_TRACE_OPTIONS,
-    DEFAULT_TRACE_STATE,
-    INVALID_SPAN,
-    INVALID_SPAN_CONTEXT,
-    INVALID_SPAN_ID,
-    INVALID_TRACE_ID,
-    NonRecordingSpan,
     Span,
     SpanContext,
-    TraceFlags,
-    TraceState,
-    format_span_id,
-    format_trace_id,
+    invalid_span,
 )
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util import types
@@ -417,7 +405,7 @@ class _DefaultTracer(Tracer):
         set_status_on_exception: bool = True,
     ) -> "Span":
         # pylint: disable=unused-argument,no-self-use
-        return INVALID_SPAN
+        return invalid_span
 
     @contextmanager  # type: ignore
     def start_as_current_span(
@@ -433,7 +421,7 @@ class _DefaultTracer(Tracer):
         end_on_exit: bool = True,
     ) -> Iterator["Span"]:
         # pylint: disable=unused-argument,no-self-use
-        yield INVALID_SPAN
+        yield invalid_span
 
 
 _TRACER_PROVIDER = None
@@ -542,32 +530,3 @@ def use_span(
     finally:
         if end_on_exit:
             span.end()
-
-
-__all__ = [
-    "DEFAULT_TRACE_OPTIONS",
-    "DEFAULT_TRACE_STATE",
-    "INVALID_SPAN",
-    "INVALID_SPAN_CONTEXT",
-    "INVALID_SPAN_ID",
-    "INVALID_TRACE_ID",
-    "NonRecordingSpan",
-    "Link",
-    "Span",
-    "SpanContext",
-    "SpanKind",
-    "TraceFlags",
-    "TraceState",
-    "TracerProvider",
-    "Tracer",
-    "format_span_id",
-    "format_trace_id",
-    "get_current_span",
-    "get_tracer",
-    "get_tracer_provider",
-    "set_tracer_provider",
-    "set_span_in_context",
-    "use_span",
-    "Status",
-    "StatusCode",
-]

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/__init__.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 from opentelemetry.context import get_value, set_value
 from opentelemetry.context.context import Context
-from opentelemetry.trace.span import INVALID_SPAN, Span
+from opentelemetry.trace.span import Span, invalid_span
 
 SPAN_KEY = "current-span"
 
@@ -42,9 +42,9 @@ def get_current_span(context: Optional[Context] = None) -> Span:
             default current context is used instead.
 
     Returns:
-        The Span set in the context if it exists. INVALID_SPAN otherwise.
+        The Span set in the context if it exists. invalid_span otherwise.
     """
     span = get_value(SPAN_KEY, context=context)
     if span is None or not isinstance(span, Span):
-        return INVALID_SPAN
+        return invalid_span
     return span

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py
@@ -46,11 +46,11 @@ class TraceContextTextMapPropagator(textmap.TextMapPropagator):
         header = getter.get(carrier, self._TRACEPARENT_HEADER_NAME)
 
         if not header:
-            return trace.set_span_in_context(trace.INVALID_SPAN, context)
+            return trace.set_span_in_context(trace.invalid_span, context)
 
         match = re.search(self._TRACEPARENT_HEADER_FORMAT_RE, header[0])
         if not match:
-            return trace.set_span_in_context(trace.INVALID_SPAN, context)
+            return trace.set_span_in_context(trace.invalid_span, context)
 
         version = match.group(1)
         trace_id = match.group(2)
@@ -58,13 +58,13 @@ class TraceContextTextMapPropagator(textmap.TextMapPropagator):
         trace_flags = match.group(4)
 
         if trace_id == "0" * 32 or span_id == "0" * 16:
-            return trace.set_span_in_context(trace.INVALID_SPAN, context)
+            return trace.set_span_in_context(trace.invalid_span, context)
 
         if version == "00":
             if match.group(5):
-                return trace.set_span_in_context(trace.INVALID_SPAN, context)
+                return trace.set_span_in_context(trace.invalid_span, context)
         if version == "ff":
-            return trace.set_span_in_context(trace.INVALID_SPAN, context)
+            return trace.set_span_in_context(trace.invalid_span, context)
 
         tracestate_headers = getter.get(carrier, self._TRACESTATE_HEADER_NAME)
         if tracestate_headers is None:
@@ -95,7 +95,7 @@ class TraceContextTextMapPropagator(textmap.TextMapPropagator):
         """
         span = trace.get_current_span(context)
         span_context = span.get_span_context()
-        if span_context == trace.INVALID_SPAN_CONTEXT:
+        if span_context == trace.invalid_span_context:
             return
         traceparent_string = "00-{trace_id}-{span_id}-{:02x}".format(
             span_context.trace_flags,

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -540,14 +540,14 @@ class NonRecordingSpan(Span):
 
 INVALID_SPAN_ID = 0x0000000000000000
 INVALID_TRACE_ID = 0x00000000000000000000000000000000
-INVALID_SPAN_CONTEXT = SpanContext(
+invalid_span_context = SpanContext(
     trace_id=INVALID_TRACE_ID,
     span_id=INVALID_SPAN_ID,
     is_remote=False,
     trace_flags=DEFAULT_TRACE_OPTIONS,
     trace_state=DEFAULT_TRACE_STATE,
 )
-INVALID_SPAN = NonRecordingSpan(INVALID_SPAN_CONTEXT)
+invalid_span = NonRecordingSpan(invalid_span_context)
 
 
 def format_trace_id(trace_id: int) -> str:

--- a/opentelemetry-api/tests/test_implementation.py
+++ b/opentelemetry-api/tests/test_implementation.py
@@ -38,15 +38,15 @@ class TestAPIOnlyImplementation(unittest.TestCase):
         tracer = tracer_provider.get_tracer(__name__)
         with tracer.start_span("test") as span:
             self.assertEqual(
-                span.get_span_context(), trace.INVALID_SPAN_CONTEXT
+                span.get_span_context(), trace.invalid_span_context
             )
-            self.assertEqual(span, trace.INVALID_SPAN)
+            self.assertEqual(span, trace.invalid_span)
             self.assertIs(span.is_recording(), False)
             with tracer.start_span("test2") as span2:
                 self.assertEqual(
-                    span2.get_span_context(), trace.INVALID_SPAN_CONTEXT
+                    span2.get_span_context(), trace.invalid_span_context
                 )
-                self.assertEqual(span2, trace.INVALID_SPAN)
+                self.assertEqual(span2, trace.invalid_span)
                 self.assertIs(span2.is_recording(), False)
 
     def test_span(self):
@@ -55,6 +55,6 @@ class TestAPIOnlyImplementation(unittest.TestCase):
             trace.Span()  # type:ignore
 
     def test_default_span(self):
-        span = trace.NonRecordingSpan(trace.INVALID_SPAN_CONTEXT)
-        self.assertEqual(span.get_span_context(), trace.INVALID_SPAN_CONTEXT)
+        span = trace.NonRecordingSpan(trace.invalid_span_context)
+        self.assertEqual(span.get_span_context(), trace.invalid_span_context)
         self.assertIs(span.is_recording(), False)

--- a/opentelemetry-api/tests/trace/propagation/test_tracecontexthttptextformat.py
+++ b/opentelemetry-api/tests/trace/propagation/test_tracecontexthttptextformat.py
@@ -104,7 +104,7 @@ class TestTraceContextFormat(unittest.TestCase):
                 },
             )
         )
-        self.assertEqual(span.get_span_context(), trace.INVALID_SPAN_CONTEXT)
+        self.assertEqual(span.get_span_context(), trace.invalid_span_context)
 
     def test_invalid_parent_id(self):
         """If the parent id is invalid, we must ignore the full traceparent
@@ -134,7 +134,7 @@ class TestTraceContextFormat(unittest.TestCase):
                 },
             )
         )
-        self.assertEqual(span.get_span_context(), trace.INVALID_SPAN_CONTEXT)
+        self.assertEqual(span.get_span_context(), trace.invalid_span_context)
 
     def test_no_send_empty_tracestate(self):
         """If the tracestate is empty, do not set the header.
@@ -172,12 +172,12 @@ class TestTraceContextFormat(unittest.TestCase):
                 },
             )
         )
-        self.assertEqual(span.get_span_context(), trace.INVALID_SPAN_CONTEXT)
+        self.assertEqual(span.get_span_context(), trace.invalid_span_context)
 
     def test_propagate_invalid_context(self):
         """Do not propagate invalid trace context."""
         output = {}  # type:typing.Dict[str, str]
-        ctx = trace.set_span_in_context(trace.INVALID_SPAN)
+        ctx = trace.set_span_in_context(trace.invalid_span)
         FORMAT.inject(output, context=ctx)
         self.assertFalse("traceparent" in output)
 
@@ -241,7 +241,7 @@ class TestTraceContextFormat(unittest.TestCase):
             span.get_span_context().trace_state["foo-_*/bar"], "bar4"
         )
 
-    @patch("opentelemetry.trace.INVALID_SPAN_CONTEXT")
+    @patch("opentelemetry.trace.invalid_span_context")
     @patch("opentelemetry.trace.get_current_span")
     def test_fields(self, mock_get_current_span, mock_invalid_span_context):
 

--- a/opentelemetry-api/tests/trace/test_defaultspan.py
+++ b/opentelemetry-api/tests/trace/test_defaultspan.py
@@ -30,6 +30,6 @@ class TestNonRecordingSpan(unittest.TestCase):
         self.assertEqual(context, span.get_span_context())
 
     def test_invalid_span(self):
-        self.assertIsNotNone(trace.INVALID_SPAN)
-        self.assertIsNotNone(trace.INVALID_SPAN.get_span_context())
-        self.assertFalse(trace.INVALID_SPAN.get_span_context().is_valid)
+        self.assertIsNotNone(trace.invalid_span)
+        self.assertIsNotNone(trace.invalid_span.get_span_context())
+        self.assertFalse(trace.invalid_span.get_span_context().is_valid)

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -51,28 +51,28 @@ class TestTracer(unittest.TestCase):
         """_DefaultTracer's start_span will also
         be retrievable via get_current_span
         """
-        self.assertEqual(trace.get_current_span(), trace.INVALID_SPAN)
-        span = trace.NonRecordingSpan(trace.INVALID_SPAN_CONTEXT)
+        self.assertEqual(trace.get_current_span(), trace.invalid_span)
+        span = trace.NonRecordingSpan(trace.invalid_span_context)
         ctx = trace.set_span_in_context(span)
         token = context.attach(ctx)
         try:
             self.assertIs(trace.get_current_span(), span)
         finally:
             context.detach(token)
-        self.assertEqual(trace.get_current_span(), trace.INVALID_SPAN)
+        self.assertEqual(trace.get_current_span(), trace.invalid_span)
 
 
 class TestUseTracer(unittest.TestCase):
     def test_use_span(self):
-        self.assertEqual(trace.get_current_span(), trace.INVALID_SPAN)
-        span = trace.NonRecordingSpan(trace.INVALID_SPAN_CONTEXT)
+        self.assertEqual(trace.get_current_span(), trace.invalid_span)
+        span = trace.NonRecordingSpan(trace.invalid_span_context)
         with trace.use_span(span):
             self.assertIs(trace.get_current_span(), span)
-        self.assertEqual(trace.get_current_span(), trace.INVALID_SPAN)
+        self.assertEqual(trace.get_current_span(), trace.invalid_span)
 
     def test_use_span_end_on_exit(self):
 
-        test_span = TestSpan(trace.INVALID_SPAN_CONTEXT)
+        test_span = TestSpan(trace.invalid_span_context)
 
         with trace.use_span(test_span):
             pass
@@ -86,7 +86,7 @@ class TestUseTracer(unittest.TestCase):
         class TestUseSpanException(Exception):
             pass
 
-        test_span = TestSpan(trace.INVALID_SPAN_CONTEXT)
+        test_span = TestSpan(trace.invalid_span_context)
         exception = TestUseSpanException("test exception")
         with self.assertRaises(TestUseSpanException):
             with trace.use_span(test_span):
@@ -98,7 +98,7 @@ class TestUseTracer(unittest.TestCase):
         class TestUseSpanException(Exception):
             pass
 
-        test_span = TestSpan(trace.INVALID_SPAN_CONTEXT)
+        test_span = TestSpan(trace.invalid_span_context)
         with self.assertRaises(TestUseSpanException):
             with trace.use_span(test_span):
                 raise TestUseSpanException("test error")

--- a/opentelemetry-api/tests/trace/test_proxy.py
+++ b/opentelemetry-api/tests/trace/test_proxy.py
@@ -17,7 +17,7 @@
 import unittest
 
 from opentelemetry import trace
-from opentelemetry.trace.span import INVALID_SPAN_CONTEXT, NonRecordingSpan
+from opentelemetry.trace.span import NonRecordingSpan, invalid_span_context
 
 
 class TestProvider(trace._DefaultTracerProvider):
@@ -29,7 +29,7 @@ class TestProvider(trace._DefaultTracerProvider):
 
 class TestTracer(trace._DefaultTracer):
     def start_span(self, *args, **kwargs):
-        return TestSpan(INVALID_SPAN_CONTEXT)
+        return TestSpan(invalid_span_context)
 
 
 class TestSpan(NonRecordingSpan):

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -33,5 +33,5 @@ class TestTracer(unittest.TestCase):
     def test_get_current_span(self):
         with self.tracer.start_as_current_span("test") as span:
             trace.get_current_span().set_attribute("test", "test")
-            self.assertEqual(span, trace.INVALID_SPAN)
+            self.assertEqual(span, trace.invalid_span)
             self.assertFalse(hasattr("span", "attributes"))

--- a/opentelemetry-distro/setup.py
+++ b/opentelemetry-distro/setup.py
@@ -16,14 +16,16 @@ import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR, "src", "opentelemetry", "distro", "version.py"
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "distro",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(
-    version=PACKAGE_INFO["__version__"],
-)
+setuptools.setup(version=package_info["__version__"],)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py
@@ -1,0 +1,109 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from logging import getLogger
+from os import environ, path
+from os.path import abspath, dirname, pathsep
+from re import sub
+
+from pkg_resources import iter_entry_points
+
+from opentelemetry.environment_variables import (
+    OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
+)
+
+_logger = getLogger(__file__)
+
+
+def _load_distros():
+    for entry_point in iter_entry_points("opentelemetry_distro"):
+        try:
+            entry_point.load()().configure()  # type: ignore
+            _logger.debug("Distribution %s configured", entry_point.name)
+        except Exception as exc:  # pylint: disable=broad-except
+            _logger.exception(
+                "Distribution %s configuration failed", entry_point.name
+            )
+            raise exc
+
+
+def _load_instrumentors():
+    package_to_exclude = environ.get(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, [])
+    if isinstance(package_to_exclude, str):
+        package_to_exclude = package_to_exclude.split(",")
+        # to handle users entering "requests , flask" or "requests, flask" with spaces
+        package_to_exclude = [x.strip() for x in package_to_exclude]
+
+    for entry_point in iter_entry_points("opentelemetry_instrumentor"):
+        try:
+            if entry_point.name in package_to_exclude:
+                _logger.debug(
+                    "Instrumentation skipped for library %s", entry_point.name
+                )
+                continue
+            entry_point.load()().instrument()  # type: ignore
+            _logger.debug("Instrumented %s", entry_point.name)
+        except Exception as exc:  # pylint: disable=broad-except
+            _logger.exception("Instrumenting of %s failed", entry_point.name)
+            raise exc
+
+
+def _load_configurators():
+    configured = None
+    for entry_point in iter_entry_points("opentelemetry_configurator"):
+        if configured is not None:
+            _logger.warning(
+                "Configuration of %s not loaded, %s already loaded",
+                entry_point.name,
+                configured,
+            )
+            continue
+        try:
+            entry_point.load()().configure()  # type: ignore
+            configured = entry_point.name
+        except Exception as exc:  # pylint: disable=broad-except
+            _logger.exception("Configuration of %s failed", entry_point.name)
+            raise exc
+
+
+def _initialize():
+    try:
+        _load_distros()
+        _load_configurators()
+        _load_instrumentors()
+    except Exception:  # pylint: disable=broad-except
+        _logger.exception("Failed to auto initialize opentelemetry")
+    finally:
+        environ["PYTHONPATH"] = sub(
+            r"{}{}?".format(dirname(abspath(__file__)), pathsep),
+            "",
+            environ["PYTHONPATH"],
+        )
+
+
+if (
+    hasattr(sys, "argv")
+    and sys.argv[0].split(path.sep)[-1] == "celery"
+    and "worker" in sys.argv[1:]
+):
+    from celery.signals import worker_process_init  # pylint:disable=E0401
+
+    @worker_process_init.connect(weak=False)
+    def init_celery(*args, **kwargs):
+        _initialize()
+
+
+else:
+    _initialize()

--- a/opentelemetry-proto/setup.py
+++ b/opentelemetry-proto/setup.py
@@ -16,14 +16,16 @@ import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR, "src", "opentelemetry", "proto", "version.py"
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "proto",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(
-    version=PACKAGE_INFO["__version__"],
-)
+setuptools.setup(version=package_info["__version__"],)

--- a/opentelemetry-sdk/setup.py
+++ b/opentelemetry-sdk/setup.py
@@ -16,14 +16,12 @@ import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR, "src", "opentelemetry", "sdk", "version.py"
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__), "src", "opentelemetry", "sdk", "version.py"
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(
-    version=PACKAGE_INFO["__version__"],
-)
+setuptools.setup(version=package_info["__version__"],)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/error_handler/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/error_handler/__init__.py
@@ -33,14 +33,14 @@ handler that handles ``ZeroDivisionError``:
     from opentelemetry.sdk.error_handler import ErrorHandler
     from logging import getLogger
 
-    logger = getLogger(__name__)
+    _logger = getLogger(__name__)
 
 
     class ErrorHandler0(ErrorHandler, ZeroDivisionError):
 
         def _handle(self, error: Exception, *args, **kwargs):
 
-            logger.exception("ErrorHandler0 handling a ZeroDivisionError")
+            _logger.exception("ErrorHandler0 handling a ZeroDivisionError")
 
 To use the global error handler, just instantiate it as a context manager where
 you want exceptions to be handled:
@@ -64,7 +64,7 @@ from logging import getLogger
 
 from pkg_resources import iter_entry_points
 
-logger = getLogger(__name__)
+_logger = getLogger(__name__)
 
 
 class ErrorHandler(ABC):
@@ -85,7 +85,7 @@ class _DefaultErrorHandler(ErrorHandler):
     # pylint: disable=useless-return
     def _handle(self, error: Exception, *args, **kwargs):
 
-        logger.exception("Error handled by default error handler: ")
+        _logger.exception("Error handled by default error handler: ")
         return None
 
 
@@ -134,7 +134,7 @@ class GlobalErrorHandler:
                 # pylint: disable=broad-except
                 except Exception as error_handling_error:
 
-                    logger.exception(
+                    _logger.exception(
                         "%s error while handling error"
                         " %s by error handler %s",
                         error_handling_error.__class__.__name__,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -69,7 +69,7 @@ from opentelemetry.semconv.resource import ResourceAttributes
 
 LabelValue = typing.Union[str, bool, int, float]
 Attributes = typing.Dict[str, LabelValue]
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 CLOUD_PROVIDER = ResourceAttributes.CLOUD_PROVIDER
@@ -152,7 +152,7 @@ class Resource:
         """
         if not attributes:
             attributes = {}
-        resource = _DEFAULT_RESOURCE.merge(
+        resource = _default_resource.merge(
             OTELResourceDetector().detect()
         ).merge(Resource(attributes))
         if not resource.attributes.get(SERVICE_NAME, None):
@@ -169,7 +169,7 @@ class Resource:
 
     @staticmethod
     def get_empty() -> "Resource":
-        return _EMPTY_RESOURCE
+        return _empty_resource
 
     @property
     def attributes(self) -> Attributes:
@@ -200,8 +200,8 @@ class Resource:
         return hash(dumps(self._attributes, sort_keys=True))
 
 
-_EMPTY_RESOURCE = Resource({})
-_DEFAULT_RESOURCE = Resource(
+_empty_resource = Resource({})
+_default_resource = Resource(
     {
         TELEMETRY_SDK_LANGUAGE: "python",
         TELEMETRY_SDK_NAME: "opentelemetry",
@@ -246,7 +246,7 @@ def get_aggregated_resources(
     :param timeout: Number of seconds to wait for each detector to return
     :return:
     """
-    final_resource = initial_resource or _EMPTY_RESOURCE
+    final_resource = initial_resource or _empty_resource
     detectors = [OTELResourceDetector()] + detectors
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
@@ -259,10 +259,10 @@ def get_aggregated_resources(
             except Exception as ex:
                 if detector.raise_on_error:
                     raise ex
-                logger.warning(
+                _logger.warning(
                     "Exception %s in detector %s, ignoring", ex, detector
                 )
-                detected_resources = _EMPTY_RESOURCE
+                detected_resources = _empty_resource
             finally:
                 final_resource = final_resource.merge(detected_resources)
     return final_resource

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -22,8 +22,8 @@ OpenTelemetry provides two types of samplers:
 
 A `StaticSampler` always returns the same sampling result regardless of the conditions. Both possible StaticSamplers are already created:
 
-- Always sample spans: ALWAYS_ON
-- Never sample spans: ALWAYS_OFF
+- Always sample spans: always_on
+- Never sample spans: always_off
 
 A `TraceIdRatioBased` sampler makes a random sampling result based on the sampling probability given.
 
@@ -105,7 +105,6 @@ from logging import getLogger
 from types import MappingProxyType
 from typing import Optional, Sequence
 
-# pylint: disable=unused-import
 from opentelemetry.context import Context
 from opentelemetry.sdk.environment_variables import (
     OTEL_TRACES_SAMPLER,
@@ -152,8 +151,8 @@ class SamplingResult:
     def __init__(
         self,
         decision: Decision,
-        attributes: "Attributes" = None,
-        trace_state: "TraceState" = None,
+        attributes: Attributes = None,
+        trace_state: TraceState = None,
     ) -> None:
         self.decision = decision
         if attributes is None:
@@ -167,13 +166,13 @@ class Sampler(abc.ABC):
     @abc.abstractmethod
     def should_sample(
         self,
-        parent_context: Optional["Context"],
+        parent_context: Optional[Context],
         trace_id: int,
         name: str,
         kind: SpanKind = None,
         attributes: Attributes = None,
-        links: Sequence["Link"] = None,
-        trace_state: "TraceState" = None,
+        links: Sequence[Link] = None,
+        trace_state: TraceState = None,
     ) -> "SamplingResult":
         pass
 
@@ -190,13 +189,13 @@ class StaticSampler(Sampler):
 
     def should_sample(
         self,
-        parent_context: Optional["Context"],
+        parent_context: Optional[Context],
         trace_id: int,
         name: str,
         kind: SpanKind = None,
         attributes: Attributes = None,
-        links: Sequence["Link"] = None,
-        trace_state: "TraceState" = None,
+        links: Sequence[Link] = None,
+        trace_state: TraceState = None,
     ) -> "SamplingResult":
         if self._decision is Decision.DROP:
             attributes = None
@@ -212,10 +211,10 @@ class StaticSampler(Sampler):
         return "AlwaysOnSampler"
 
 
-ALWAYS_OFF = StaticSampler(Decision.DROP)
+always_off = StaticSampler(Decision.DROP)
 """Sampler that never samples spans, regardless of the parent span's sampling decision."""
 
-ALWAYS_ON = StaticSampler(Decision.RECORD_AND_SAMPLE)
+always_on = StaticSampler(Decision.RECORD_AND_SAMPLE)
 """Sampler that always samples spans, regardless of the parent span's sampling decision."""
 
 
@@ -252,13 +251,13 @@ class TraceIdRatioBased(Sampler):
 
     def should_sample(
         self,
-        parent_context: Optional["Context"],
+        parent_context: Optional[Context],
         trace_id: int,
         name: str,
         kind: SpanKind = None,
         attributes: Attributes = None,
-        links: Sequence["Link"] = None,
-        trace_state: "TraceState" = None,
+        links: Sequence[Link] = None,
+        trace_state: TraceState = None,
     ) -> "SamplingResult":
         decision = Decision.DROP
         if trace_id & self.TRACE_ID_LIMIT < self.bound:
@@ -294,10 +293,10 @@ class ParentBased(Sampler):
     def __init__(
         self,
         root: Sampler,
-        remote_parent_sampled: Sampler = ALWAYS_ON,
-        remote_parent_not_sampled: Sampler = ALWAYS_OFF,
-        local_parent_sampled: Sampler = ALWAYS_ON,
-        local_parent_not_sampled: Sampler = ALWAYS_OFF,
+        remote_parent_sampled: Sampler = always_on,
+        remote_parent_not_sampled: Sampler = always_off,
+        local_parent_sampled: Sampler = always_on,
+        local_parent_not_sampled: Sampler = always_off,
     ):
         self._root = root
         self._remote_parent_sampled = remote_parent_sampled
@@ -307,13 +306,13 @@ class ParentBased(Sampler):
 
     def should_sample(
         self,
-        parent_context: Optional["Context"],
+        parent_context: Optional[Context],
         trace_id: int,
         name: str,
         kind: SpanKind = None,
         attributes: Attributes = None,
-        links: Sequence["Link"] = None,
-        trace_state: "TraceState" = None,
+        links: Sequence[Link] = None,
+        trace_state: TraceState = None,
     ) -> "SamplingResult":
         parent_span_context = get_current_span(
             parent_context
@@ -352,10 +351,10 @@ class ParentBased(Sampler):
         )
 
 
-DEFAULT_OFF = ParentBased(ALWAYS_OFF)
+default_off = ParentBased(always_off)
 """Sampler that respects its parent span's sampling decision, but otherwise never samples."""
 
-DEFAULT_ON = ParentBased(ALWAYS_ON)
+default_on = ParentBased(always_on)
 """Sampler that respects its parent span's sampling decision, but otherwise always samples."""
 
 
@@ -371,10 +370,10 @@ class ParentBasedTraceIdRatio(ParentBased):
 
 
 _KNOWN_SAMPLERS = {
-    "always_on": ALWAYS_ON,
-    "always_off": ALWAYS_OFF,
-    "parentbased_always_on": DEFAULT_ON,
-    "parentbased_always_off": DEFAULT_OFF,
+    "always_on": always_on,
+    "always_off": always_off,
+    "parentbased_always_on": default_on,
+    "parentbased_always_off": default_off,
     "traceidratio": TraceIdRatioBased,
     "parentbased_traceidratio": ParentBasedTraceIdRatio,
 }

--- a/opentelemetry-sdk/tests/error_handler/test_error_handler.py
+++ b/opentelemetry-sdk/tests/error_handler/test_error_handler.py
@@ -20,7 +20,7 @@ from unittest.mock import Mock, patch
 from opentelemetry.sdk.error_handler import (
     ErrorHandler,
     GlobalErrorHandler,
-    logger,
+    _logger,
 )
 
 
@@ -28,7 +28,7 @@ class TestErrorHandler(TestCase):
     @patch("opentelemetry.sdk.error_handler.iter_entry_points")
     def test_default_error_handler(self, mock_iter_entry_points):
 
-        with self.assertLogs(logger, ERROR):
+        with self.assertLogs(_logger, ERROR):
             with GlobalErrorHandler():
                 raise Exception("some exception")
 
@@ -97,7 +97,7 @@ class TestErrorHandler(TestCase):
 
         error = ZeroDivisionError()
 
-        with self.assertLogs(logger, ERROR):
+        with self.assertLogs(_logger, ERROR):
             with GlobalErrorHandler():
                 raise error
 

--- a/opentelemetry-sdk/tests/performance/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/tests/performance/benchmarks/trace/test_benchmark_trace.py
@@ -17,7 +17,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import sampling
 
 tracer = trace.TracerProvider(
-    sampler=sampling.DEFAULT_ON,
+    sampler=sampling.default_on,
     resource=Resource(
         {
             "service.name": "A123456789",

--- a/opentelemetry-sdk/tests/performance/resource-usage/trace/profile_resource_usage_batch_export.py
+++ b/opentelemetry-sdk/tests/performance/resource-usage/trace/profile_resource_usage_batch_export.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import time
-from unittest.mock import patch
 
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
     OTLPSpanExporter,
@@ -35,8 +34,7 @@ OTLPSpanExporter._stub = MockTraceServiceStub
 
 simple_span_processor = BatchSpanProcessor(OTLPSpanExporter())
 tracer = TracerProvider(
-    active_span_processor=simple_span_processor,
-    sampler=sampling.DEFAULT_ON,
+    active_span_processor=simple_span_processor, sampler=sampling.default_on,
 ).get_tracer("resource_usage_tracer")
 
 starttime = time.time()

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -60,12 +60,12 @@ class TestResources(unittest.TestCase):
         os.environ[resources.OTEL_RESOURCE_ATTRIBUTES] = ""
 
         resource = resources.Resource.get_empty()
-        self.assertEqual(resource, resources._EMPTY_RESOURCE)
+        self.assertEqual(resource, resources._empty_resource)
 
         resource = resources.Resource.create(None)
         self.assertEqual(
             resource,
-            resources._DEFAULT_RESOURCE.merge(
+            resources._default_resource.merge(
                 resources.Resource({resources.SERVICE_NAME: "unknown_service"})
             ),
         )
@@ -73,7 +73,7 @@ class TestResources(unittest.TestCase):
         resource = resources.Resource.create({})
         self.assertEqual(
             resource,
-            resources._DEFAULT_RESOURCE.merge(
+            resources._default_resource.merge(
                 resources.Resource({resources.SERVICE_NAME: "unknown_service"})
             ),
         )

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -124,7 +124,7 @@ class TestSimpleSpanProcessor(unittest.TestCase):
 
     def test_simple_span_processor_not_sampled(self):
         tracer_provider = trace.TracerProvider(
-            sampler=trace.sampling.ALWAYS_OFF
+            sampler=trace.sampling.always_off
         )
         tracer = tracer_provider.get_tracer(__name__)
 
@@ -333,7 +333,7 @@ class TestBatchSpanProcessor(unittest.TestCase):
 
     def test_batch_span_processor_not_sampled(self):
         tracer_provider = trace.TracerProvider(
-            sampler=trace.sampling.ALWAYS_OFF
+            sampler=trace.sampling.always_off
         )
         tracer = tracer_provider.get_tracer(__name__)
         spans_names_list = []
@@ -481,7 +481,7 @@ class TestConsoleSpanExporter(unittest.TestCase):
         exporter = export.ConsoleSpanExporter()
         # Mocking stdout interferes with debugging and test reporting, mock on
         # the exporter instance instead.
-        span = trace._Span("span name", trace_api.INVALID_SPAN_CONTEXT)
+        span = trace._Span("span name", trace_api.invalid_span_context)
         with mock.patch.object(exporter, "out") as mock_stdout:
             exporter.export([span])
         mock_stdout.write.assert_called_once_with(span.to_json() + os.linesep)

--- a/opentelemetry-sdk/tests/trace/test_implementation.py
+++ b/opentelemetry-sdk/tests/trace/test_implementation.py
@@ -15,7 +15,7 @@
 import unittest
 
 from opentelemetry.sdk import trace
-from opentelemetry.trace import INVALID_SPAN, INVALID_SPAN_CONTEXT
+from opentelemetry.trace import invalid_span, invalid_span_context
 
 
 class TestTracerImplementation(unittest.TestCase):
@@ -29,14 +29,14 @@ class TestTracerImplementation(unittest.TestCase):
     def test_tracer(self):
         tracer = trace.TracerProvider().get_tracer(__name__)
         with tracer.start_span("test") as span:
-            self.assertNotEqual(span.get_span_context(), INVALID_SPAN_CONTEXT)
-            self.assertNotEqual(span, INVALID_SPAN)
+            self.assertNotEqual(span.get_span_context(), invalid_span_context)
+            self.assertNotEqual(span, invalid_span)
             self.assertIs(span.is_recording(), True)
             with tracer.start_span("test2") as span2:
                 self.assertNotEqual(
-                    span2.get_span_context(), INVALID_SPAN_CONTEXT
+                    span2.get_span_context(), invalid_span_context
                 )
-                self.assertNotEqual(span2, INVALID_SPAN)
+                self.assertNotEqual(span2, invalid_span)
                 self.assertIs(span2.is_recording(), True)
 
     def test_span(self):
@@ -44,6 +44,6 @@ class TestTracerImplementation(unittest.TestCase):
             # pylint: disable=no-value-for-parameter
             span = trace._Span()
 
-        span = trace._Span("name", INVALID_SPAN_CONTEXT)
-        self.assertEqual(span.get_span_context(), INVALID_SPAN_CONTEXT)
+        span = trace._Span("name", invalid_span_context)
+        self.assertEqual(span.get_span_context(), invalid_span_context)
         self.assertIs(span.is_recording(), True)

--- a/opentelemetry-sdk/tests/trace/test_sampling.py
+++ b/opentelemetry-sdk/tests/trace/test_sampling.py
@@ -95,7 +95,7 @@ class TestSampler(unittest.TestCase):
         for trace_flags in test_data:
             with self.subTest(trace_flags=trace_flags):
                 context = self._create_parent(trace_flags, False, trace_state)
-                sample_result = sampling.ALWAYS_ON.should_sample(
+                sample_result = sampling.always_on.should_sample(
                     context,
                     0xDEADBEF1,
                     "sampling on",
@@ -118,7 +118,7 @@ class TestSampler(unittest.TestCase):
         for trace_flags in test_data:
             with self.subTest(trace_flags=trace_flags):
                 context = self._create_parent(trace_flags, False, trace_state)
-                sample_result = sampling.ALWAYS_OFF.should_sample(
+                sample_result = sampling.always_off.should_sample(
                     context,
                     0xDEADBEF1,
                     "sampling off",
@@ -135,7 +135,7 @@ class TestSampler(unittest.TestCase):
     def test_default_on(self):
         trace_state = trace.TraceState([("key", "value")])
         context = self._create_parent(TO_DEFAULT, False, trace_state)
-        sample_result = sampling.DEFAULT_ON.should_sample(
+        sample_result = sampling.default_on.should_sample(
             context,
             0xDEADBEF1,
             "unsampled parent, sampling on",
@@ -147,7 +147,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(sample_result.trace_state, trace_state)
 
         context = self._create_parent(TO_SAMPLED, False, trace_state)
-        sample_result = sampling.DEFAULT_ON.should_sample(
+        sample_result = sampling.default_on.should_sample(
             context,
             0xDEADBEF1,
             "sampled parent, sampling on",
@@ -158,7 +158,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(sample_result.attributes, {"sampled.expect": "true"})
         self.assertEqual(sample_result.trace_state, trace_state)
 
-        sample_result = sampling.DEFAULT_ON.should_sample(
+        sample_result = sampling.default_on.should_sample(
             None,
             0xDEADBEF1,
             "no parent, sampling on",
@@ -172,7 +172,7 @@ class TestSampler(unittest.TestCase):
     def test_default_off(self):
         trace_state = trace.TraceState([("key", "value")])
         context = self._create_parent(TO_DEFAULT, False, trace_state)
-        sample_result = sampling.DEFAULT_OFF.should_sample(
+        sample_result = sampling.default_off.should_sample(
             context,
             0xDEADBEF1,
             "unsampled parent, sampling off",
@@ -184,7 +184,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(sample_result.trace_state, trace_state)
 
         context = self._create_parent(TO_SAMPLED, False, trace_state)
-        sample_result = sampling.DEFAULT_OFF.should_sample(
+        sample_result = sampling.default_off.should_sample(
             context,
             0xDEADBEF1,
             "sampled parent, sampling on",
@@ -195,7 +195,7 @@ class TestSampler(unittest.TestCase):
         self.assertEqual(sample_result.attributes, {"sampled.expect": "true"})
         self.assertEqual(sample_result.trace_state, trace_state)
 
-        default_off = sampling.DEFAULT_OFF.should_sample(
+        default_off = sampling.default_off.should_sample(
             None,
             0xDEADBEF1,
             "unsampled parent, sampling off",
@@ -322,7 +322,7 @@ class TestSampler(unittest.TestCase):
     # pylint:disable=too-many-statements
     def exec_parent_based(self, parent_sampling_context):
         trace_state = trace.TraceState([("key", "value")])
-        sampler = sampling.ParentBased(sampling.ALWAYS_ON)
+        sampler = sampling.ParentBased(sampling.always_on)
         # Check that the sampling decision matches the parent context if given
         with parent_sampling_context(
             self._create_parent_span(
@@ -349,8 +349,8 @@ class TestSampler(unittest.TestCase):
             )
         ) as context:
             sampler = sampling.ParentBased(
-                root=sampling.ALWAYS_OFF,
-                local_parent_not_sampled=sampling.ALWAYS_ON,
+                root=sampling.always_off,
+                local_parent_not_sampled=sampling.always_on,
             )
             # local, not sampled -> opposite sampler
             sampled_result = sampler.should_sample(
@@ -370,7 +370,7 @@ class TestSampler(unittest.TestCase):
                 trace_state=trace_state,
             )
         ) as context:
-            sampler = sampling.ParentBased(sampling.ALWAYS_OFF)
+            sampler = sampling.ParentBased(sampling.always_off)
             # local, sampled
             sampled_result = sampler.should_sample(
                 context,
@@ -391,8 +391,8 @@ class TestSampler(unittest.TestCase):
             )
         ) as context:
             sampler = sampling.ParentBased(
-                root=sampling.ALWAYS_ON,
-                local_parent_sampled=sampling.ALWAYS_OFF,
+                root=sampling.always_on,
+                local_parent_sampled=sampling.always_off,
             )
             # local, sampled -> opposite sampler
             not_sampled_result = sampler.should_sample(
@@ -414,7 +414,7 @@ class TestSampler(unittest.TestCase):
                 trace_state=trace_state,
             )
         ) as context:
-            sampler = sampling.ParentBased(sampling.ALWAYS_ON)
+            sampler = sampling.ParentBased(sampling.always_on)
             # remote, not sampled
             not_sampled_result = sampler.should_sample(
                 context,
@@ -436,8 +436,8 @@ class TestSampler(unittest.TestCase):
             )
         ) as context:
             sampler = sampling.ParentBased(
-                root=sampling.ALWAYS_OFF,
-                remote_parent_not_sampled=sampling.ALWAYS_ON,
+                root=sampling.always_off,
+                remote_parent_not_sampled=sampling.always_on,
             )
             # remote, not sampled -> opposite sampler
             sampled_result = sampler.should_sample(
@@ -458,7 +458,7 @@ class TestSampler(unittest.TestCase):
                 trace_state=trace_state,
             )
         ) as context:
-            sampler = sampling.ParentBased(sampling.ALWAYS_OFF)
+            sampler = sampling.ParentBased(sampling.always_off)
             # remote, sampled
             sampled_result = sampler.should_sample(
                 context,
@@ -479,8 +479,8 @@ class TestSampler(unittest.TestCase):
             )
         ) as context:
             sampler = sampling.ParentBased(
-                root=sampling.ALWAYS_ON,
-                remote_parent_sampled=sampling.ALWAYS_OFF,
+                root=sampling.always_on,
+                remote_parent_sampled=sampling.always_off,
             )
             # remote, sampled -> opposite sampler
             not_sampled_result = sampler.should_sample(
@@ -495,8 +495,8 @@ class TestSampler(unittest.TestCase):
             self.assertEqual(not_sampled_result.trace_state, trace_state)
 
         # for root span follow decision of root sampler
-        with parent_sampling_context(trace.INVALID_SPAN) as context:
-            sampler = sampling.ParentBased(sampling.ALWAYS_OFF)
+        with parent_sampling_context(trace.invalid_span) as context:
+            sampler = sampling.ParentBased(sampling.always_off)
             not_sampled_result = sampler.should_sample(
                 context,
                 0x8000000000000000,
@@ -508,8 +508,8 @@ class TestSampler(unittest.TestCase):
             self.assertEqual(not_sampled_result.attributes, {})
             self.assertIsNone(not_sampled_result.trace_state)
 
-        with parent_sampling_context(trace.INVALID_SPAN) as context:
-            sampler = sampling.ParentBased(sampling.ALWAYS_ON)
+        with parent_sampling_context(trace.invalid_span) as context:
+            sampler = sampling.ParentBased(sampling.always_on)
             sampled_result = sampler.should_sample(
                 context,
                 0x8000000000000000,

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -162,10 +162,10 @@ class TestTracerSampling(unittest.TestCase):
         tracer_provider = trace.TracerProvider()
         self.assertIsInstance(tracer_provider.sampler, sampling.ParentBased)
         # pylint: disable=protected-access
-        self.assertEqual(tracer_provider.sampler._root, sampling.ALWAYS_ON)
+        self.assertEqual(tracer_provider.sampler._root, sampling.always_on)
 
     def test_sampler_no_sampling(self):
-        tracer_provider = trace.TracerProvider(sampling.ALWAYS_OFF)
+        tracer_provider = trace.TracerProvider(sampling.always_off)
         tracer = tracer_provider.get_tracer(__name__)
 
         # Check that the default tracer creates no-op spans if the sampler
@@ -225,7 +225,7 @@ class TestSpanCreation(unittest.TestCase):
         """
         tracer = new_tracer()
         parent_context = trace_api.set_span_in_context(
-            trace_api.INVALID_SPAN_CONTEXT
+            trace_api.invalid_span_context
         )
         new_span = tracer.start_span("root", context=parent_context)
         self.assertTrue(new_span.context.is_valid)
@@ -288,7 +288,7 @@ class TestSpanCreation(unittest.TestCase):
     def test_start_span_implicit(self):
         tracer = new_tracer()
 
-        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertEqual(trace_api.get_current_span(), trace_api.invalid_span)
 
         root = tracer.start_span("root")
         self.assertIsNotNone(root.start_time)
@@ -327,7 +327,7 @@ class TestSpanCreation(unittest.TestCase):
 
             self.assertIsNotNone(child.end_time)
 
-        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertEqual(trace_api.get_current_span(), trace_api.invalid_span)
         self.assertIsNotNone(root.end_time)
 
     def test_start_span_explicit(self):
@@ -345,7 +345,7 @@ class TestSpanCreation(unittest.TestCase):
 
         other_parent_context = trace_api.set_span_in_context(other_parent)
 
-        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertEqual(trace_api.get_current_span(), trace_api.invalid_span)
 
         root = tracer.start_span("root")
         self.assertIsNotNone(root.start_time)
@@ -394,7 +394,7 @@ class TestSpanCreation(unittest.TestCase):
     def test_start_as_current_span_implicit(self):
         tracer = new_tracer()
 
-        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertEqual(trace_api.get_current_span(), trace_api.invalid_span)
 
         with tracer.start_as_current_span("root") as root:
             self.assertIs(trace_api.get_current_span(), root)
@@ -408,7 +408,7 @@ class TestSpanCreation(unittest.TestCase):
             self.assertIs(trace_api.get_current_span(), root)
             self.assertIsNotNone(child.end_time)
 
-        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertEqual(trace_api.get_current_span(), trace_api.invalid_span)
         self.assertIsNotNone(root.end_time)
 
     def test_start_as_current_span_explicit(self):
@@ -425,7 +425,7 @@ class TestSpanCreation(unittest.TestCase):
         )
         other_parent_ctx = trace_api.set_span_in_context(other_parent)
 
-        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertEqual(trace_api.get_current_span(), trace_api.invalid_span)
 
         # Test with the implicit root span
         with tracer.start_as_current_span("root") as root:
@@ -453,7 +453,7 @@ class TestSpanCreation(unittest.TestCase):
     def test_start_as_current_span_decorator(self):
         tracer = new_tracer()
 
-        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertEqual(trace_api.get_current_span(), trace_api.invalid_span)
 
         @tracer.start_as_current_span("root")
         def func():
@@ -472,12 +472,12 @@ class TestSpanCreation(unittest.TestCase):
 
         root1 = func()
 
-        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertEqual(trace_api.get_current_span(), trace_api.invalid_span)
         self.assertIsNotNone(root1.end_time)
 
         # Second call must create a new span
         root2 = func()
-        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertEqual(trace_api.get_current_span(), trace_api.invalid_span)
         self.assertIsNotNone(root2.end_time)
         self.assertIsNot(root1, root2)
 
@@ -697,7 +697,7 @@ class TestSpan(unittest.TestCase):
             )
 
     def test_events(self):
-        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertEqual(trace_api.get_current_span(), trace_api.invalid_span)
 
         with self.tracer.start_as_current_span("root") as root:
             # only event name
@@ -766,7 +766,7 @@ class TestSpan(unittest.TestCase):
                 event.attributes["name"] = "hello"
 
     def test_invalid_event_attributes(self):
-        self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
+        self.assertEqual(trace_api.get_current_span(), trace_api.invalid_span)
 
         with self.tracer.start_as_current_span("root") as root:
             root.add_event("event0", {"attr1": True, "attr2": ["hi", False]})

--- a/opentelemetry-semantic-conventions/setup.py
+++ b/opentelemetry-semantic-conventions/setup.py
@@ -16,14 +16,16 @@ import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR, "src", "opentelemetry", "semconv", "version.py"
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "semcov",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(
-    version=PACKAGE_INFO["__version__"],
-)
+setuptools.setup(version=package_info["__version__"],)

--- a/propagator/opentelemetry-propagator-b3/setup.py
+++ b/propagator/opentelemetry-propagator-b3/setup.py
@@ -11,16 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR, "src", "opentelemetry", "propagators", "b3", "version.py"
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "propagators",
+        "b3",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
+++ b/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
@@ -98,7 +98,7 @@ class B3Format(TextMapPropagator):
             or self._span_id_regex.fullmatch(span_id) is None
         ):
             if context is None:
-                return trace.set_span_in_context(trace.INVALID_SPAN, context)
+                return trace.set_span_in_context(trace.invalid_span, context)
             return context
 
         trace_id = int(trace_id, 16)
@@ -134,7 +134,7 @@ class B3Format(TextMapPropagator):
         span = trace.get_current_span(context=context)
 
         span_context = span.get_span_context()
-        if span_context == trace.INVALID_SPAN_CONTEXT:
+        if span_context == trace.invalid_span_context:
             return
 
         sampled = (trace.TraceFlags.SAMPLED & span_context.trace_flags) != 0

--- a/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
+++ b/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
@@ -369,4 +369,4 @@ class TestB3Format(unittest.TestCase):
         carrier = {}
         new_ctx = FORMAT.extract(carrier, old_ctx)
         self.assertIsNotNone(new_ctx)
-        self.assertEqual(new_ctx["current-span"], trace_api.INVALID_SPAN)
+        self.assertEqual(new_ctx["current-span"], trace_api.invalid_span)

--- a/propagator/opentelemetry-propagator-jaeger/setup.py
+++ b/propagator/opentelemetry-propagator-jaeger/setup.py
@@ -11,16 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR, "src", "opentelemetry", "propagators", "jaeger", "version.py"
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "opentelemetry",
+        "propagators",
+        "jaeger",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
+++ b/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
@@ -50,19 +50,19 @@ class JaegerPropagator(TextMapPropagator):
             context = get_current()
         header = getter.get(carrier, self.TRACE_ID_KEY)
         if not header:
-            return trace.set_span_in_context(trace.INVALID_SPAN, context)
+            return trace.set_span_in_context(trace.invalid_span, context)
         fields = _extract_first_element(header).split(":")
 
         context = self._extract_baggage(getter, carrier, context)
         if len(fields) != 4:
-            return trace.set_span_in_context(trace.INVALID_SPAN, context)
+            return trace.set_span_in_context(trace.invalid_span, context)
 
         trace_id, span_id, _parent_id, flags = fields
         if (
             trace_id == trace.INVALID_TRACE_ID
             or span_id == trace.INVALID_SPAN_ID
         ):
-            return trace.set_span_in_context(trace.INVALID_SPAN, context)
+            return trace.set_span_in_context(trace.invalid_span, context)
 
         span = trace.NonRecordingSpan(
             trace.SpanContext(
@@ -84,7 +84,7 @@ class JaegerPropagator(TextMapPropagator):
     ) -> None:
         span = trace.get_current_span(context=context)
         span_context = span.get_span_context()
-        if span_context == trace.INVALID_SPAN_CONTEXT:
+        if span_context == trace.invalid_span_context:
             return
 
         span_parent_id = span.parent.span_id if span.parent else 0

--- a/result.json
+++ b/result.json
@@ -1,0 +1,207 @@
+{
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-api/src/opentelemetry/baggage/__init__.py": [
+        "get_all",
+        "get_baggage",
+        "set_baggage",
+        "remove_baggage",
+        "clear"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py": [
+        "W3CBaggagePropagator"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-api/src/opentelemetry/util/types.py": [
+        "AttributeValue",
+        "Attributes",
+        "AttributesAsKey"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-api/src/opentelemetry/environment_variables/__init__.py": [
+        "OTEL_PROPAGATORS",
+        "OTEL_PYTHON_CONTEXT",
+        "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS",
+        "OTEL_PYTHON_ID_GENERATOR",
+        "OTEL_TRACES_EXPORTER",
+        "OTEL_PYTHON_TRACER_PROVIDER"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-api/src/opentelemetry/trace/span.py": [
+        "Span",
+        "TraceFlags",
+        "DEFAULT_TRACE_OPTIONS",
+        "TraceState",
+        "DEFAULT_TRACE_STATE",
+        "SpanContext",
+        "NonRecordingSpan",
+        "INVALID_SPAN_ID",
+        "INVALID_TRACE_ID",
+        "invalid_span_context",
+        "invalid_span",
+        "format_trace_id",
+        "format_span_id"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py": [
+        "TraceContextTextMapPropagator"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-api/src/opentelemetry/propagators/composite.py": [
+        "CompositeHTTPPropagator"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-api/src/opentelemetry/propagate/__init__.py": [
+        "extract",
+        "inject",
+        "get_global_textmap",
+        "set_global_textmap"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/translate/__init__.py": [
+        "Translator",
+        "Translate",
+        "ProtobufTranslator"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/trace_exporter/__init__.py": [
+        "OpenCensusSpanExporter"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/exporter/opentelemetry-exporter-zipkin-proto-http/src/opentelemetry/exporter/zipkin/proto/http/v2/__init__.py": [
+        "ProtobufEncoder"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/node_endpoint.py": [
+        "IpInput",
+        "NodeEndpoint"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/encoder/__init__.py": [
+        "EncodedLocalEndpointT",
+        "Protocol",
+        "Encoder",
+        "JsonEncoder"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/json/v2/__init__.py": [
+        "JsonV2Encoder"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/json/v1/__init__.py": [
+        "V1Encoder",
+        "JsonV1Encoder"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py": [
+        "OTLPSpanExporter"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/exporter/opentelemetry-exporter-jaeger-thrift/src/opentelemetry/exporter/jaeger/thrift/translate/__init__.py": [
+        "Translator",
+        "Translate",
+        "ThriftTranslator"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py": [
+        "LabelValue",
+        "Attributes",
+        "CLOUD_PROVIDER",
+        "CLOUD_ACCOUNT_ID",
+        "CLOUD_REGION",
+        "CLOUD_ZONE",
+        "CONTAINER_NAME",
+        "CONTAINER_ID",
+        "CONTAINER_IMAGE_NAME",
+        "CONTAINER_IMAGE_TAG",
+        "DEPLOYMENT_ENVIRONMENT",
+        "FAAS_NAME",
+        "FAAS_ID",
+        "FAAS_VERSION",
+        "FAAS_INSTANCE",
+        "HOST_NAME",
+        "HOST_TYPE",
+        "HOST_IMAGE_NAME",
+        "HOST_IMAGE_ID",
+        "HOST_IMAGE_VERSION",
+        "KUBERNETES_CLUSTER_NAME",
+        "KUBERNETES_NAMESPACE_NAME",
+        "KUBERNETES_POD_UID",
+        "KUBERNETES_POD_NAME",
+        "KUBERNETES_CONTAINER_NAME",
+        "KUBERNETES_REPLICA_SET_UID",
+        "KUBERNETES_REPLICA_SET_NAME",
+        "KUBERNETES_DEPLOYMENT_UID",
+        "KUBERNETES_DEPLOYMENT_NAME",
+        "KUBERNETES_STATEFUL_SET_UID",
+        "KUBERNETES_STATEFUL_SET_NAME",
+        "KUBERNETES_DAEMON_SET_UID",
+        "KUBERNETES_DAEMON_SET_NAME",
+        "KUBERNETES_JOB_UID",
+        "KUBERNETES_JOB_NAME",
+        "KUBERNETES_CRON_JOB_UID",
+        "KUBERNETES_CRON_JOB_NAME",
+        "OS_TYPE",
+        "OS_DESCRIPTION",
+        "PROCESS_PID",
+        "PROCESS_EXECUTABLE_NAME",
+        "PROCESS_EXECUTABLE_PATH",
+        "PROCESS_COMMAND",
+        "PROCESS_COMMAND_LINE",
+        "PROCESS_COMMAND_ARGS",
+        "PROCESS_OWNER",
+        "PROCESS_RUNTIME_NAME",
+        "PROCESS_RUNTIME_VERSION",
+        "PROCESS_RUNTIME_DESCRIPTION",
+        "SERVICE_NAME",
+        "SERVICE_NAMESPACE",
+        "SERVICE_INSTANCE_ID",
+        "SERVICE_VERSION",
+        "TELEMETRY_SDK_NAME",
+        "TELEMETRY_SDK_VERSION",
+        "TELEMETRY_AUTO_VERSION",
+        "TELEMETRY_SDK_LANGUAGE",
+        "Resource",
+        "ResourceDetector",
+        "OTELResourceDetector",
+        "get_aggregated_resources"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-sdk/src/opentelemetry/sdk/util/instrumentation.py": [
+        "InstrumentationInfo"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py": [
+        "OTEL_RESOURCE_ATTRIBUTES",
+        "OTEL_LOG_LEVEL",
+        "OTEL_TRACES_SAMPLER",
+        "OTEL_TRACES_SAMPLER_ARG",
+        "OTEL_BSP_SCHEDULE_DELAY",
+        "OTEL_BSP_EXPORT_TIMEOUT",
+        "OTEL_BSP_MAX_QUEUE_SIZE",
+        "OTEL_BSP_MAX_EXPORT_BATCH_SIZE",
+        "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT",
+        "OTEL_SPAN_EVENT_COUNT_LIMIT",
+        "OTEL_SPAN_LINK_COUNT_LIMIT",
+        "OTEL_EXPORTER_JAEGER_AGENT_HOST",
+        "OTEL_EXPORTER_JAEGER_AGENT_PORT",
+        "OTEL_EXPORTER_JAEGER_ENDPOINT",
+        "OTEL_EXPORTER_JAEGER_USER",
+        "OTEL_EXPORTER_JAEGER_PASSWORD",
+        "OTEL_EXPORTER_ZIPKIN_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_HEADERS",
+        "OTEL_EXPORTER_OTLP_COMPRESSION",
+        "OTEL_EXPORTER_OTLP_TIMEOUT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE",
+        "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+        "OTEL_EXPORTER_OTLP_TRACES_COMPRESSION",
+        "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
+        "OTEL_EXPORTER_JAEGER_CERTIFICATE",
+        "OTEL_EXPORTER_JAEGER_AGENT_SPLIT_OVERSIZED_BATCHES"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-sdk/src/opentelemetry/sdk/error_handler/__init__.py": [
+        "ErrorHandler",
+        "GlobalErrorHandler"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py": [
+        "Decision",
+        "SamplingResult",
+        "Sampler",
+        "StaticSampler",
+        "always_off",
+        "always_on",
+        "TraceIdRatioBased",
+        "ParentBased",
+        "default_off",
+        "default_on",
+        "ParentBasedTraceIdRatio"
+    ],
+    "/home/ocelotl/github/ocelotl/opentelemetry-python/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/in_memory_span_exporter.py": [
+        "InMemorySpanExporter"
+    ]
+}

--- a/scripts/public_api_searcher.py
+++ b/scripts/public_api_searcher.py
@@ -1,0 +1,68 @@
+from json import dumps
+from os import getcwd, walk
+from os.path import join
+from re import match
+
+parsed_files = {}
+
+for dirpath, dirnames, filenames in walk(getcwd()):
+
+    dirnames_to_remove = []
+
+    for dirname in ["opentelemetry-python-contrib", "docs", "scripts"]:
+
+        if dirname in dirnames:
+            dirnames_to_remove.append(dirname)
+
+    for dirname in dirnames:
+        if (
+            dirname.startswith(".") or
+            dirname.endswith("tests") or
+            dirname.endswith("examples") or
+            dirname.endswith("gen")
+        ):
+            dirnames_to_remove.append(dirname)
+
+    for dirname_to_remove in dirnames_to_remove:
+        dirnames.remove(dirname_to_remove)
+
+    filenames_to_remove = []
+
+    for filename in filenames:
+
+        if not filename.endswith(".py") or "pb2" in filename:
+            filenames_to_remove.append(filename)
+
+    for filename_to_remove in filenames_to_remove:
+        filenames.remove(filename_to_remove)
+
+    if filenames:
+
+        for filename in filenames:
+
+            public_symbols = []
+
+            file_path = join(dirpath, filename)
+
+            with open(file_path) as file_:
+                for line in file_.readlines():
+
+                    symbol = r"[a-zA-Z][_\w]+"
+
+                    matching_line = match(
+                        r"({symbol})\s=\s.+|"
+                        r"def\s({symbol})|"
+                        r"class\s({symbol})".format(symbol=symbol),
+                        line
+                    )
+
+                    if matching_line is not None:
+
+                        public_symbols.append(
+                            next(filter(bool, matching_line.groups()))
+                        )
+
+        if public_symbols:
+            parsed_files[file_path] = public_symbols
+
+print(dumps(parsed_files, indent=4))

--- a/shim/opentelemetry-opentracing-shim/setup.py
+++ b/shim/opentelemetry-opentracing-shim/setup.py
@@ -11,21 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import setuptools
 
-BASE_DIR = os.path.dirname(__file__)
-VERSION_FILENAME = os.path.join(
-    BASE_DIR,
-    "src",
-    "opentelemetry",
-    "shim",
-    "opentracing_shim",
-    "version.py",
-)
-PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
-    exec(f.read(), PACKAGE_INFO)
+package_info = {}
+with open(
+    os.path.join(
+        os.path.dirname(__file__),
+        "src",
+        "shim",
+        "opentelemetry",
+        "shim",
+        "opentracing_shim",
+        "version.py",
+    )
+) as f:
+    exec(f.read(), package_info)
 
-setuptools.setup(version=PACKAGE_INFO["__version__"])
+setuptools.setup(version=package_info["__version__"],)

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
@@ -104,12 +104,13 @@ from opentelemetry.context import Context, attach, detach, get_value, set_value
 from opentelemetry.propagate import get_global_textmap
 from opentelemetry.shim.opentracing_shim import util
 from opentelemetry.shim.opentracing_shim.version import __version__
-from opentelemetry.trace import INVALID_SPAN_CONTEXT, Link, NonRecordingSpan
+from opentelemetry.trace import Link, NonRecordingSpan
 from opentelemetry.trace import SpanContext as OtelSpanContext
 from opentelemetry.trace import Tracer as OtelTracer
 from opentelemetry.trace import (
     TracerProvider,
     get_current_span,
+    invalid_span_context,
     set_span_in_context,
     use_span,
 )
@@ -473,7 +474,7 @@ class ScopeManagerShim(ScopeManager):
         """
 
         span = get_current_span()
-        if span.get_span_context() == INVALID_SPAN_CONTEXT:
+        if span.get_span_context() == invalid_span_context:
             return None
 
         try:
@@ -575,7 +576,7 @@ class TracerShim(Tracer):
 
         current_span = get_current_span()
 
-        if child_of is None and current_span is not INVALID_SPAN_CONTEXT:
+        if child_of is None and current_span is not invalid_span_context:
             child_of = SpanShim(None, None, current_span)
 
         span = self.start_span(
@@ -719,6 +720,6 @@ class TracerShim(Tracer):
         if span is not None:
             otel_context = span.get_span_context()
         else:
-            otel_context = INVALID_SPAN_CONTEXT
+            otel_context = invalid_span_context
 
         return SpanContextShim(otel_context)

--- a/shim/opentelemetry-opentracing-shim/tests/test_shim.py
+++ b/shim/opentelemetry-opentracing-shim/tests/test_shim.py
@@ -549,7 +549,7 @@ class TestShim(TestCase):
             carrier = {}
 
             ctx = self.shim.extract(opentracing.Format.HTTP_HEADERS, carrier)
-            self.assertEqual(ctx.unwrap(), trace.INVALID_SPAN_CONTEXT)
+            self.assertEqual(ctx.unwrap(), trace.invalid_span_context)
         finally:
             set_global_textmap(_old_propagator)
 

--- a/tests/util/src/opentelemetry/test/mock_textmap.py
+++ b/tests/util/src/opentelemetry/test/mock_textmap.py
@@ -70,7 +70,7 @@ class MockTextMapPropagator(TextMapPropagator):
         span_id_list = getter.get(carrier, self.SPAN_ID_KEY)
 
         if not trace_id_list or not span_id_list:
-            return trace.set_span_in_context(trace.INVALID_SPAN)
+            return trace.set_span_in_context(trace.invalid_span)
 
         return trace.set_span_in_context(
             trace.NonRecordingSpan(


### PR DESCRIPTION
# Description

Right now we have some issues with our public API, mostly these:

1. Some public symbols don't need to be. This is a problem because it adds to our burden of keeping them compatible between versions when they are implementation details.
2. Some public symbols do not follow [PEP8](https://www.python.org/dev/peps/pep-0008/#constants).

Now, regarding the second point: I have intentionally tried to be as strict as possible when writing this PR. I have considered constants to be only numeric types, strings, booleans and `None`, that should be the kind of things that always return the same result from `id` when passed as an argument:

```python
>>> none_0 = None
>>> id(none_0)
94865325304416
>>> none_1 = None
>>> id(none_1)
94865325304416
>>> true_0 = True
>>> id(true_0)
94865325415904
>>> true_1 = True
>>> id(true_1)
94865325415904
>>> string_0 = "string"
>>> id(string_0)
140069704282416
>>> string_1 = "string"
>>> id(string_1)
140069704282416
>>> class Test:
...     pass
... 
>>> 
>>> test_0 = Test()
>>> id(test_0)
140069704320384
>>> test_1 = Test()
>>> id(test_1)
140069704648064
```

I have not been able to find anywhere that says this is the "official" definition of a constant anywhere, so I understand any argument against these (constants being what I just defined) kind of changes considering that these should be breaking changes.

I have also added a [script](https://github.com/open-telemetry/opentelemetry-python/pull/1768/files#diff-c98843160fef598c6a3200eb8cf39a1ca8b0756fba1e171424ec1a4e578cbfdf) that looks through our code and finds what should be public symbols. [This](https://github.com/open-telemetry/opentelemetry-python/pull/1768/files#diff-c9571d90d0c1dda483c76249db49e78e626aee0fa4cfb4103f52a1e46b93a076) is the result of running it right now.

Adding the execution of this script as part of our review process should be a good idea because it should alert us of any non-necessary public symbol being added to the API.

Before I continue to the changes for the contrib repo, I would like for your thoughts on this, I'll bring this to the next SIG.

Fixes #1710 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `opentelemetry-instrumentation/` have changed
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
