### PR TITLE
Updated release version for Python SDK

### DIFF
--- a/website_docs/_index.md
+++ b/website_docs/_index.md
@@ -19,7 +19,7 @@ is as follows:
 
 | Tracing | Metrics | Logging |
 | ------- | ------- | ------- |
-| Stable    | Alpha   | Not Yet Implemented |
+| 1.0    | Alpha   | Not Yet Implemented |
 
 The current release can be found [here](https://github.com/open-telemetry/opentelemetry-python/releases)
 


### PR DESCRIPTION
# Description

https://github.com/open-telemetry/opentelemetry.io/issues/520, as referenced in the following issue, the tracing version for python on the open telemetry website, is still beta, although the SDK has a 1.0 release. 
Since, the docs pages for the Python SDK are live here, making the change will lead to the change getting pulled in the open-telemetry.io repo and will update the same on the website.

# Changes Made
Updated the trace version to 1.0 in the website_docs, index.md

