### PR TITLE
Add __contains__ to TraceState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ProxyTracerProvider and ProxyTracer implementations to allow fetching provider
   and tracer instances before a global provider is set up.
   ([#1726](https://github.com/open-telemetry/opentelemetry-python/pull/1726))
+- Added `__contains__` to `opentelementry.trace.span.TraceState`.
+  ([#1773](https://github.com/open-telemetry/opentelemetry-python/pull/1773))
 
 
 ## [1.0.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.0.0) - 2021-03-26

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -231,7 +231,7 @@ class TraceState(typing.Mapping[str, str]):
                     "Invalid key/value pair (%s, %s) found.", key, value
                 )
 
-    def __contains__(self, item):
+    def __contains__(self, item: object) -> bool:
         return item in self._dict
 
     def __getitem__(self, key: str) -> typing.Optional[str]:  # type: ignore

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -235,7 +235,7 @@ class TraceState(typing.Mapping[str, str]):
         return item in self._dict
 
     def __getitem__(self, key: str) -> typing.Optional[str]:  # type: ignore
-        return self._dict.get(key)
+        return self._dict[key]
 
     def __iter__(self) -> typing.Iterator[str]:
         return iter(self._dict)

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -234,7 +234,7 @@ class TraceState(typing.Mapping[str, str]):
     def __contains__(self, item: object) -> bool:
         return item in self._dict
 
-    def __getitem__(self, key: str) -> typing.Optional[str]:  # type: ignore
+    def __getitem__(self, key: str) -> str:
         return self._dict[key]
 
     def __iter__(self) -> typing.Iterator[str]:

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -231,6 +231,9 @@ class TraceState(typing.Mapping[str, str]):
                     "Invalid key/value pair (%s, %s) found.", key, value
                 )
 
+    def __contains__(self, item):
+        return item in self._dict
+
     def __getitem__(self, key: str) -> typing.Optional[str]:  # type: ignore
         return self._dict.get(key)
 

--- a/opentelemetry-api/tests/trace/test_tracestate.py
+++ b/opentelemetry-api/tests/trace/test_tracestate.py
@@ -107,5 +107,5 @@ class TestTraceContextFormat(unittest.TestCase):
         header_list = [",".join(entries)]
         state = TraceState.from_header(header_list)
 
-        self.assertTrue('foo' in state)
-        self.assertFalse('bar' in state)
+        self.assertTrue("foo" in state)
+        self.assertFalse("bar" in state)

--- a/opentelemetry-api/tests/trace/test_tracestate.py
+++ b/opentelemetry-api/tests/trace/test_tracestate.py
@@ -96,3 +96,16 @@ class TestTraceContextFormat(unittest.TestCase):
         foo_place = entries.index(("foo", "bar33"))  # type: ignore
         prev_first_place = entries.index(("1a-2f@foo", "bar1"))  # type: ignore
         self.assertLessEqual(foo_place, prev_first_place)
+
+    def test_trace_contains(self):
+        entries = [
+            "1a-2f@foo=bar1",
+            "1a-_*/2b@foo=bar2",
+            "foo=bar3",
+            "foo-_*/bar=bar4",
+        ]
+        header_list = [",".join(entries)]
+        state = TraceState.from_header(header_list)
+
+        self.assertTrue('foo' in state)
+        self.assertFalse('bar' in state)

--- a/opentelemetry-api/tests/trace/test_tracestate.py
+++ b/opentelemetry-api/tests/trace/test_tracestate.py
@@ -109,3 +109,6 @@ class TestTraceContextFormat(unittest.TestCase):
 
         self.assertTrue("foo" in state)
         self.assertFalse("bar" in state)
+        self.assertIsNone(state.get("bar"))
+        with self.assertRaises(KeyError):
+            state["bar"]  # pylint:disable=W0104


### PR DESCRIPTION
# Description

Adds `__contains__` to `TraceState` - having this prevents accidentally assuming it's present and will work as expected.

This actually fixes a bug reported in the contrib repo: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/262 and possibly others.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] `TestTraceContextFormat.test_trace_contains`

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
