### PR TITLE
Add "Typing :: Typed" tags to all packages with py.types

### DIFF
--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6

--- a/exporter/opentelemetry-exporter-jaeger-thrift/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6

--- a/exporter/opentelemetry-exporter-jaeger/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6

--- a/exporter/opentelemetry-exporter-opencensus/setup.cfg
+++ b/exporter/opentelemetry-exporter-opencensus/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6

--- a/exporter/opentelemetry-exporter-otlp/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6

--- a/exporter/opentelemetry-exporter-zipkin-json/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin-json/setup.cfg
@@ -33,6 +33,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.5

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/setup.cfg
@@ -33,6 +33,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.5

--- a/exporter/opentelemetry-exporter-zipkin/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6

--- a/opentelemetry-api/setup.cfg
+++ b/opentelemetry-api/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6

--- a/opentelemetry-distro/setup.cfg
+++ b/opentelemetry-distro/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6

--- a/opentelemetry-sdk/setup.cfg
+++ b/opentelemetry-sdk/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6

--- a/propagator/opentelemetry-propagator-b3/setup.cfg
+++ b/propagator/opentelemetry-propagator-b3/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6

--- a/propagator/opentelemetry-propagator-jaeger/setup.cfg
+++ b/propagator/opentelemetry-propagator-jaeger/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6

--- a/shim/opentelemetry-opentracing-shim/setup.cfg
+++ b/shim/opentelemetry-opentracing-shim/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Typing :: Typed
 
 [options]
 python_requires = >=3.6


### PR DESCRIPTION
Pypi defines a typed classifer (https://pypi.org/classifiers/) that we can use
for all packages that contain types and the py.types file.

Fixes #979.