### PR TITLE
Update example collector-config.yaml

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -218,18 +218,20 @@ Start the Collector locally to see how the Collector works in practice. Write th
     # /tmp/otel-collector-config.yaml
     receivers:
         otlp:
+            protocols:
+                grpc:
+                http:
     exporters:
         logging:
             loglevel: debug
     processors:
         batch:
-        queued_retry:
     service:
         pipelines:
             traces:
                 receivers: [otlp]
                 exporters: [logging]
-                processors: [batch, queued_retry]
+                processors: [batch]
 
 Then start the Docker container:
 


### PR DESCRIPTION
# Description

It seems that there have been some changes to the open-telemetry collector image that cause issues in running this example. I updated the config file to avoid these, but an alternative would be to pin the image to a specific version rather than using the `latest` tag.

Anyway, the issues I ran into running the image with the given yaml file were:

1.  Empty configuration for the OLTP receiver
```Error: cannot load configuration: error reading receivers configuration for otlp: empty config for OTLP receiver```, which is fixed by adding the 
```
protocols:
    grpc:
    http:
```
bit.

2.  `unknown processors type "queued_retry" for queued_retry`. It looks like this processor was [removed](https://github.com/open-telemetry/opentelemetry-operator/issues/18) from the collector, so I just dropped the references to it.


# Checklist:

- [ x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ x] Documentation has been updated
