### PR TITLE
fix otlp grpc exporter bug when no scheme is passed in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.1.0...HEAD)
 
 ### Added
-- Added example for running Django with auto instrumentation
+- Added example for running Django with auto instrumentation.
   ([#1803](https://github.com/open-telemetry/opentelemetry-python/pull/1803))
 
+### Changed
+- Fixed OTLP gRPC exporter silently failing if scheme is not specified in endpoint.
+  ([#1806](https://github.com/open-telemetry/opentelemetry-python/pull/1806))
+
 ### Removed
-- Moved `opentelemetry-instrumentation` to contrib repository
+- Moved `opentelemetry-instrumentation` to contrib repository.
   ([#1797](https://github.com/open-telemetry/opentelemetry-python/pull/1797))
 
 ## [1.1.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.1.0) - 2021-04-20

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -207,7 +207,8 @@ class OTLPExporterMixin(
             else:
                 insecure = True
 
-        endpoint = parsed_url.netloc
+        if parsed_url.netloc:
+            endpoint = parsed_url.netloc
 
         self._headers = headers or environ.get(OTEL_EXPORTER_OTLP_HEADERS)
         if isinstance(self._headers, str):

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -239,6 +239,7 @@ class TestOTLPSpanExporter(TestCase):
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.secure_channel")
     def test_otlp_exporter_endpoint(self, mock_secure, mock_insecure):
         """Just OTEL_EXPORTER_OTLP_COMPRESSION should work"""
+        expected_endpoint = "localhost:4317"
         endpoints = [
             (
                 "http://localhost:4317",
@@ -273,6 +274,13 @@ class TestOTLPSpanExporter(TestCase):
                 mock_method.call_count,
                 "expected {} to be called for {} {}".format(
                     mock_method, endpoint, insecure
+                ),
+            )
+            self.assertEqual(
+                expected_endpoint,
+                mock_method.call_args[0][0],
+                "expected {} got {} {}".format(
+                    expected_endpoint, mock_method.call_args[0][0], endpoint
                 ),
             )
             mock_method.reset_mock()


### PR DESCRIPTION
# Description

When an endpoint without a protocol is passed in, urlparse sets the host as the scheme and leaves the net location empty. This changes catches that and skips setting the endpoint in that case.

Fixes #1801 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
