### PR TITLE
rename CompositeHTTPPropagator, add deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added example for running Django with auto instrumentation
   ([#1803](https://github.com/open-telemetry/opentelemetry-python/pull/1803))
 
+### Changed
+- Rename CompositeHTTPPropagator to CompositePropagator as per specification.
+  ([#1807](https://github.com/open-telemetry/opentelemetry-python/pull/1807))
+
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository
   ([#1797](https://github.com/open-telemetry/opentelemetry-python/pull/1797))

--- a/docs/examples/datadog_exporter/server.py
+++ b/docs/examples/datadog_exporter/server.py
@@ -21,7 +21,7 @@ from opentelemetry.exporter.datadog import (
 )
 from opentelemetry.exporter.datadog.propagator import DatadogFormat
 from opentelemetry.propagate import get_global_textmap, set_global_textmap
-from opentelemetry.propagators.composite import CompositeHTTPPropagator
+from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk.trace import TracerProvider
 
 app = Flask(__name__)
@@ -38,13 +38,11 @@ trace.get_tracer_provider().add_span_processor(
 
 # append Datadog format for propagation to and from Datadog instrumented services
 global_textmap = get_global_textmap()
-if isinstance(global_textmap, CompositeHTTPPropagator) and not any(
+if isinstance(global_textmap, CompositePropagator) and not any(
     isinstance(p, DatadogFormat) for p in global_textmap._propagators
 ):
     set_global_textmap(
-        CompositeHTTPPropagator(
-            global_textmap._propagators + [DatadogFormat()]
-        )
+        CompositePropagator(global_textmap._propagators + [DatadogFormat()])
     )
 else:
     set_global_textmap(DatadogFormat())

--- a/opentelemetry-api/setup.cfg
+++ b/opentelemetry-api/setup.cfg
@@ -42,6 +42,7 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
+    Deprecated >= 1.2.6
     aiocontextvars; python_version<'3.7'
 
 [options.packages.find]

--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -16,13 +16,13 @@
 API for propagation of context.
 
 The propagators for the
-``opentelemetry.propagators.composite.CompositeHTTPPropagator`` can be defined
+``opentelemetry.propagators.composite.CompositePropagator`` can be defined
 via configuration in the ``OTEL_PROPAGATORS`` environment variable. This
 variable should be set to a comma-separated string of names of values for the
 ``opentelemetry_propagator`` entry point. For example, setting
 ``OTEL_PROPAGATORS`` to ``tracecontext,baggage`` (which is the default value)
 would instantiate
-``opentelemetry.propagators.composite.CompositeHTTPPropagator`` with 2
+``opentelemetry.propagators.composite.CompositePropagator`` with 2
 propagators, one of type
 ``opentelemetry.trace.propagation.tracecontext.TraceContextTextMapPropagator``
 and other of type ``opentelemetry.baggage.propagation.W3CBaggagePropagator``.
@@ -142,7 +142,7 @@ except Exception:  # pylint: disable=broad-except
     logger.exception("Failed to load configured propagators")
     raise
 
-_HTTP_TEXT_FORMAT = composite.CompositeHTTPPropagator(propagators)  # type: ignore
+_HTTP_TEXT_FORMAT = composite.CompositePropagator(propagators)  # type: ignore
 
 
 def get_global_textmap() -> textmap.TextMapPropagator:

--- a/opentelemetry-api/src/opentelemetry/propagators/composite.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/composite.py
@@ -84,6 +84,6 @@ class CompositePropagator(textmap.TextMapPropagator):
         return composite_fields
 
 
-@deprecated(version="1.2.0", reason="You should use CompositePropagator")
+@deprecated(version="1.2.0", reason="You should use CompositePropagator")  # type: ignore
 class CompositeHTTPPropagator(CompositePropagator):
     """Alias for CompositePropagator"""

--- a/opentelemetry-api/src/opentelemetry/propagators/composite.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/composite.py
@@ -86,4 +86,5 @@ class CompositePropagator(textmap.TextMapPropagator):
 
 @deprecated(version="1.2.0", reason="You should use CompositePropagator")  # type: ignore
 class CompositeHTTPPropagator(CompositePropagator):
-    """Alias for CompositePropagator"""
+    """CompositeHTTPPropagator provides a mechanism for combining multiple
+    propagators into a single one.

--- a/opentelemetry-api/src/opentelemetry/propagators/composite.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/composite.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import typing
+from deprecated import deprecated
 
 from opentelemetry.context.context import Context
 from opentelemetry.propagators import textmap
@@ -20,8 +21,8 @@ from opentelemetry.propagators import textmap
 logger = logging.getLogger(__name__)
 
 
-class CompositeHTTPPropagator(textmap.TextMapPropagator):
-    """CompositeHTTPPropagator provides a mechanism for combining multiple
+class CompositePropagator(textmap.TextMapPropagator):
+    """CompositePropagator provides a mechanism for combining multiple
     propagators into a single one.
 
     Args:
@@ -80,3 +81,8 @@ class CompositeHTTPPropagator(textmap.TextMapPropagator):
                 composite_fields.add(field)
 
         return composite_fields
+
+
+@deprecated(version="1.2.0", reason="You should use CompositePropagator")
+class CompositeHTTPPropagator(CompositePropagator):
+    """Alias for CompositePropagator"""

--- a/opentelemetry-api/src/opentelemetry/propagators/composite.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/composite.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import typing
+
 from deprecated import deprecated
 
 from opentelemetry.context.context import Context

--- a/opentelemetry-api/src/opentelemetry/propagators/composite.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/composite.py
@@ -88,3 +88,4 @@ class CompositePropagator(textmap.TextMapPropagator):
 class CompositeHTTPPropagator(CompositePropagator):
     """CompositeHTTPPropagator provides a mechanism for combining multiple
     propagators into a single one.
+    """

--- a/opentelemetry-api/tests/propagators/test_composite.py
+++ b/opentelemetry-api/tests/propagators/test_composite.py
@@ -17,7 +17,7 @@
 import unittest
 from unittest.mock import Mock
 
-from opentelemetry.propagators.composite import CompositeHTTPPropagator
+from opentelemetry.propagators.composite import CompositePropagator
 
 
 def get_as_list(dict_object, key):
@@ -67,7 +67,7 @@ class TestCompositePropagator(unittest.TestCase):
         )
 
     def test_no_propagators(self):
-        propagator = CompositeHTTPPropagator([])
+        propagator = CompositePropagator([])
         new_carrier = {}
         propagator.inject(new_carrier)
         self.assertEqual(new_carrier, {})
@@ -78,7 +78,7 @@ class TestCompositePropagator(unittest.TestCase):
         self.assertEqual(context, {})
 
     def test_single_propagator(self):
-        propagator = CompositeHTTPPropagator([self.mock_propagator_0])
+        propagator = CompositePropagator([self.mock_propagator_0])
 
         new_carrier = {}
         propagator.inject(new_carrier)
@@ -90,7 +90,7 @@ class TestCompositePropagator(unittest.TestCase):
         self.assertEqual(context, {"mock-0": "context"})
 
     def test_multiple_propagators(self):
-        propagator = CompositeHTTPPropagator(
+        propagator = CompositePropagator(
             [self.mock_propagator_0, self.mock_propagator_1]
         )
 
@@ -106,7 +106,7 @@ class TestCompositePropagator(unittest.TestCase):
     def test_multiple_propagators_same_key(self):
         # test that when multiple propagators extract/inject the same
         # key, the later propagator values are extracted/injected
-        propagator = CompositeHTTPPropagator(
+        propagator = CompositePropagator(
             [self.mock_propagator_0, self.mock_propagator_2]
         )
 
@@ -120,7 +120,7 @@ class TestCompositePropagator(unittest.TestCase):
         self.assertEqual(context, {"mock-0": "context2"})
 
     def test_fields(self):
-        propagator = CompositeHTTPPropagator(
+        propagator = CompositePropagator(
             [
                 self.mock_propagator_0,
                 self.mock_propagator_1,

--- a/opentelemetry-api/tests/propagators/test_propagators.py
+++ b/opentelemetry-api/tests/propagators/test_propagators.py
@@ -27,7 +27,7 @@ from opentelemetry.trace.propagation.tracecontext import (
 
 
 class TestPropagators(TestCase):
-    @patch("opentelemetry.propagators.composite.CompositeHTTPPropagator")
+    @patch("opentelemetry.propagators.composite.CompositePropagator")
     def test_default_composite_propagators(self, mock_compositehttppropagator):
         def test_propagators(propagators):
 
@@ -48,7 +48,7 @@ class TestPropagators(TestCase):
         reload(opentelemetry.propagate)
 
     @patch.dict(environ, {OTEL_PROPAGATORS: "a,b,c"})
-    @patch("opentelemetry.propagators.composite.CompositeHTTPPropagator")
+    @patch("opentelemetry.propagators.composite.CompositePropagator")
     @patch("pkg_resources.iter_entry_points")
     def test_non_default_propagators(
         self, mock_iter_entry_points, mock_compositehttppropagator


### PR DESCRIPTION
# Description

Renaming CompositeHTTPPropagator to CompositePropagator. Note this change adds the dependency on the `Deprecated` package to the API, we may or may not want this, would love some feedback from reviewers. The following is what users will see when using `CompositeHTTPPropagator`:

```
>>> from opentelemetry.propagators.composite import CompositeHTTPPropagator
>>> CompositeHTTPPropagator([])
<stdin>:1: DeprecationWarning: Call to deprecated class CompositeHTTPPropagator. (You should use CompositePropagator) -- Deprecated since version 1.2.0.
<opentelemetry.propagators.composite.CompositeHTTPPropagator object at 0x108712be0>
```

Fixes #1775 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been updated
