### PR TITLE
Include parent span in Jaeger gRPC export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.1.0...HEAD)
 
+### Changed
+- Include span parent in Jaeger gRPC export as `CHILD_OF` reference
+  ([#1809])(https://github.com/open-telemetry/opentelemetry-python/pull/1809)
+
 ### Added
 - Added example for running Django with auto instrumentation
   ([#1803](https://github.com/open-telemetry/opentelemetry-python/pull/1803))

--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/translate/__init__.py
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/translate/__init__.py
@@ -318,10 +318,18 @@ class ProtobufTranslator(Translator):
     def _extract_refs(
         self, span: ReadableSpan
     ) -> Optional[Sequence[model_pb2.SpanRef]]:
-        if not span.links:
-            return None
 
         refs = []
+        if span.parent:
+            ctx = span.get_span_context()
+            parent_id = span.parent.span_id
+            parent_ref = model_pb2.SpanRef(
+                ref_type=model_pb2.SpanRefType.CHILD_OF,
+                trace_id=_trace_id_to_bytes(ctx.trace_id),
+                span_id=_span_id_to_bytes(parent_id),
+            )
+            refs.append(parent_ref)
+
         for link in span.links:
             trace_id = link.context.trace_id
             span_id = link.context.span_id

--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/tests/test_jaeger_exporter_protobuf.py
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/tests/test_jaeger_exporter_protobuf.py
@@ -288,10 +288,15 @@ class TestJaegerExporter(unittest.TestCase):
                 ],
                 references=[
                     model_pb2.SpanRef(
+                        ref_type=model_pb2.SpanRefType.CHILD_OF,
+                        trace_id=pb_translator._trace_id_to_bytes(trace_id),
+                        span_id=pb_translator._span_id_to_bytes(parent_id),
+                    ),
+                    model_pb2.SpanRef(
                         ref_type=model_pb2.SpanRefType.FOLLOWS_FROM,
                         trace_id=pb_translator._trace_id_to_bytes(trace_id),
                         span_id=pb_translator._span_id_to_bytes(other_id),
-                    )
+                    ),
                 ],
                 logs=[
                     model_pb2.Log(


### PR DESCRIPTION
# Description

This extracts the parent span and adds it as a CHILD_OF reference in the
gRPC export, so that we get the expected hierarchy of spans.

Fixes #1808

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- I have manually tested this by exporting to a Jaeger collector via gRPC and inspecting the exported data to ensure it has the correct hierarchy.
- I have updated a unit test and the expected data conforms to my expectations, test suite passes!

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project (I believe so, it's very simple Python in this case)
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] ~~Documentation has been updated~~ (no docs update for a bug fix)