### PR TITLE
Make propagators conform to spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added example for running Django with auto instrumentation
   ([#1803](https://github.com/open-telemetry/opentelemetry-python/pull/1803))
 
+### Changed
+- Propagators use the root context as default for `extract` and do not modify
+  the context if extracting from carrier does not work.
+  ([#1811](https://github.com/open-telemetry/opentelemetry-python/pull/1811))
+
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository
   ([#1797](https://github.com/open-telemetry/opentelemetry-python/pull/1797))

--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -96,7 +96,7 @@ def extract(
             used to construct a Context. This object
             must be paired with an appropriate getter
             which understands how to extract a value from it.
-        context: an optional Context to use. Defaults to current
+        context: an optional Context to use. Defaults to root
             context if not set.
     """
     return get_global_textmap().extract(carrier, context, getter=getter)

--- a/opentelemetry-api/src/opentelemetry/propagators/textmap.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/textmap.py
@@ -150,7 +150,7 @@ class TextMapPropagator(abc.ABC):
                 used to construct a Context. This object
                 must be paired with an appropriate getter
                 which understands how to extract a value from it.
-            context: an optional Context to use. Defaults to current
+            context: an optional Context to use. Defaults to root
                 context if not set.
         Returns:
             A Context with configuration found in the carrier.

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py
@@ -43,14 +43,17 @@ class TraceContextTextMapPropagator(textmap.TextMapPropagator):
 
         See `opentelemetry.propagators.textmap.TextMapPropagator.extract`
         """
+        if context is None:
+            context = Context()
+
         header = getter.get(carrier, self._TRACEPARENT_HEADER_NAME)
 
         if not header:
-            return trace.set_span_in_context(trace.INVALID_SPAN, context)
+            return context
 
         match = re.search(self._TRACEPARENT_HEADER_FORMAT_RE, header[0])
         if not match:
-            return trace.set_span_in_context(trace.INVALID_SPAN, context)
+            return context
 
         version = match.group(1)
         trace_id = match.group(2)
@@ -58,13 +61,13 @@ class TraceContextTextMapPropagator(textmap.TextMapPropagator):
         trace_flags = match.group(4)
 
         if trace_id == "0" * 32 or span_id == "0" * 16:
-            return trace.set_span_in_context(trace.INVALID_SPAN, context)
+            return context
 
         if version == "00":
             if match.group(5):
-                return trace.set_span_in_context(trace.INVALID_SPAN, context)
+                return context
         if version == "ff":
-            return trace.set_span_in_context(trace.INVALID_SPAN, context)
+            return context
 
         tracestate_headers = getter.get(carrier, self._TRACESTATE_HEADER_NAME)
         if tracestate_headers is None:

--- a/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
+++ b/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/__init__.py
@@ -50,6 +50,8 @@ class B3Format(TextMapPropagator):
         context: typing.Optional[Context] = None,
         getter: Getter = default_getter,
     ) -> Context:
+        if context is None:
+            context = Context()
         trace_id = trace.INVALID_TRACE_ID
         span_id = trace.INVALID_SPAN_ID
         sampled = "0"
@@ -97,8 +99,6 @@ class B3Format(TextMapPropagator):
             or self._trace_id_regex.fullmatch(trace_id) is None
             or self._span_id_regex.fullmatch(span_id) is None
         ):
-            if context is None:
-                return trace.set_span_in_context(trace.INVALID_SPAN, context)
             return context
 
         trace_id = int(trace_id, 16)


### PR DESCRIPTION
# Description

Propagators use the root context as default value for the `extract` operation. Additionally avoid modifying the context in case there is nothing to extract or the carrier does not hold valid data.

Fixes #1765

Fixes also an issue in the `jaeger` propagator where trace/span id validity was comparing str with int values.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (behavioral change since root context is now the default value for extract)

# How Has This Been Tested?
additional unit tests have been added

# Does This PR Require a Contrib Repo Change?
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
