### PR TITLE
Allow span limits to be unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added example for running Django with auto instrumentation.
   ([#1803](https://github.com/open-telemetry/opentelemetry-python/pull/1803))
+- Allow span limits (OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT, OTEL_SPAN_EVENT_COUNT_LIMIT, OTEL_SPAN_LINK_COUNT_LIMIT)
+  to be set to "none".
+  ([#1830](https://github.com/open-telemetry/opentelemetry-python/pull/1830))
 
 ### Changed
 - Fixed OTLP gRPC exporter silently failing if scheme is not specified in endpoint.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -58,12 +58,23 @@ from opentelemetry.util._time import _time_ns
 
 logger = logging.getLogger(__name__)
 
-SPAN_ATTRIBUTE_COUNT_LIMIT = int(
-    environ.get(OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT, 128)
+
+_DEFAULT_SPAN_LIMIT = "128"
+
+
+def _get_limit_from_env(limit_name) -> Optional[int]:
+    value = environ.get(limit_name, _DEFAULT_SPAN_LIMIT).strip().lower()
+    if value == "none":
+        return None
+    return int(value)
+
+
+SPAN_ATTRIBUTE_COUNT_LIMIT = _get_limit_from_env(
+    OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
 )
 
-_SPAN_EVENT_COUNT_LIMIT = int(environ.get(OTEL_SPAN_EVENT_COUNT_LIMIT, 128))
-_SPAN_LINK_COUNT_LIMIT = int(environ.get(OTEL_SPAN_LINK_COUNT_LIMIT, 128))
+_SPAN_EVENT_COUNT_LIMIT = _get_limit_from_env(OTEL_SPAN_EVENT_COUNT_LIMIT)
+_SPAN_LINK_COUNT_LIMIT = _get_limit_from_env(OTEL_SPAN_LINK_COUNT_LIMIT)
 _VALID_ATTR_VALUE_TYPES = (bool, str, int, float)
 # pylint: disable=protected-access
 _TRACE_SAMPLER = sampling._get_from_env_or_default()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -81,7 +81,7 @@ class BoundedList(Sequence):
     @classmethod
     def from_seq(cls, maxlen, seq):
         seq = tuple(seq)
-        if len(seq) > maxlen:
+        if maxlen is not None and len(seq) > maxlen:
             raise ValueError
         bounded_list = cls(maxlen)
         # pylint: disable=protected-access
@@ -97,10 +97,11 @@ class BoundedDict(MutableMapping):
     """
 
     def __init__(self, maxlen):
-        if not isinstance(maxlen, int):
-            raise ValueError
-        if maxlen < 0:
-            raise ValueError
+        if maxlen is not None:
+            if not isinstance(maxlen, int):
+                raise ValueError
+            if maxlen < 0:
+                raise ValueError
         self.maxlen = maxlen
         self.dropped = 0
         self._dict = OrderedDict()  # type: OrderedDict
@@ -122,7 +123,7 @@ class BoundedDict(MutableMapping):
 
             if key in self._dict:
                 del self._dict[key]
-            elif len(self._dict) == self.maxlen:
+            elif self.maxlen is not None and len(self._dict) == self.maxlen:
                 del self._dict[next(iter(self._dict.keys()))]
                 self.dropped += 1
             self._dict[key] = value
@@ -140,7 +141,7 @@ class BoundedDict(MutableMapping):
     @classmethod
     def from_map(cls, maxlen, mapping):
         mapping = OrderedDict(mapping)
-        if len(mapping) > maxlen:
+        if maxlen is not None and len(mapping) > maxlen:
             raise ValueError
         bounded_dict = cls(maxlen)
         # pylint: disable=protected-access

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -134,6 +134,14 @@ class TestBoundedList(unittest.TestCase):
         self.assertEqual(len(blist), list_len)
         self.assertEqual(blist.dropped, len(other_list))
 
+    def test_no_limit(self):
+        blist = BoundedList(maxlen=None)
+        for num in range(100):
+            blist.append(num)
+
+        for num in range(100):
+            self.assertEqual(blist[num], num)
+
 
 class TestBoundedDict(unittest.TestCase):
     base = collections.OrderedDict(
@@ -211,3 +219,11 @@ class TestBoundedDict(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             _ = bdict["new-name"]
+
+    def test_no_limit_code(self):
+        bdict = BoundedDict(maxlen=None)
+        for num in range(100):
+            bdict[num] = num
+
+        for num in range(100):
+            self.assertEqual(bdict[num], num)


### PR DESCRIPTION
# Description

Ths spec recommends most span limits to default to 128 and allow users
to change it via environment variables. It does not dictate that limits
should always be set though. So users should be able to remove these
limits. This commit accepts `"none"` as a valid value for the limit
config environment variables.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Added new tests

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
