### PR TITLE
fix parent_id formatting inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Fixed OTLP gRPC exporter silently failing if scheme is not specified in endpoint.
   ([#1806](https://github.com/open-telemetry/opentelemetry-python/pull/1806))
+- Fixed inconsistency in parent_id formatting from the ConsoleSpanExporter
+  ([#1806](https://github.com/open-telemetry/opentelemetry-python/pull/1806))
 
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed OTLP gRPC exporter silently failing if scheme is not specified in endpoint.
   ([#1806](https://github.com/open-telemetry/opentelemetry-python/pull/1806))
 - Fixed inconsistency in parent_id formatting from the ConsoleSpanExporter
-  ([#1806](https://github.com/open-telemetry/opentelemetry-python/pull/1806))
+  ([#1833](https://github.com/open-telemetry/opentelemetry-python/pull/1833))
 
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -483,9 +483,13 @@ class ReadableSpan:
         if self.parent is not None:
             if isinstance(self.parent, Span):
                 ctx = self.parent.context
-                parent_id = trace_api.format_span_id(ctx.span_id)
+                parent_id = "0x{}".format(
+                    trace_api.format_span_id(ctx.span_id)
+                )
             elif isinstance(self.parent, SpanContext):
-                parent_id = trace_api.format_span_id(self.parent.span_id)
+                parent_id = "0x{}".format(
+                    trace_api.format_span_id(self.parent.span_id)
+                )
 
         start_time = None
         if self._start_time:

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1221,7 +1221,10 @@ class TestSpanProcessor(unittest.TestCase):
             is_remote=False,
             trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         )
-        span = trace._Span("span-name", context, resource=Resource({}))
+        parent = trace._Span("parent-name", context, resource=Resource({}))
+        span = trace._Span(
+            "span-name", context, resource=Resource({}), parent=parent
+        )
 
         self.assertEqual(
             span.to_json(),
@@ -1233,7 +1236,7 @@ class TestSpanProcessor(unittest.TestCase):
         "trace_state": "[]"
     },
     "kind": "SpanKind.INTERNAL",
-    "parent_id": null,
+    "parent_id": "0x00000000deadbef0",
     "start_time": null,
     "end_time": null,
     "status": {
@@ -1247,7 +1250,7 @@ class TestSpanProcessor(unittest.TestCase):
         )
         self.assertEqual(
             span.to_json(indent=None),
-            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "[]"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "status": {"status_code": "UNSET"}, "attributes": {}, "events": [], "links": [], "resource": {}}',
+            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "[]"}, "kind": "SpanKind.INTERNAL", "parent_id": "0x00000000deadbef0", "start_time": null, "end_time": null, "status": {"status_code": "UNSET"}, "attributes": {}, "events": [], "links": [], "resource": {}}',
         )
 
     def test_attributes_to_json(self):


### PR DESCRIPTION
# Description

Fixes #1832, funny enough the documentation was showing the parent_id with a leading `0x` which means it's likely this was working at some point.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been updated
- [ ] Documentation has been updated
