### PR TITLE
Include parent span in Jaeger thrift export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed inconsistency in parent_id formatting from the ConsoleSpanExporter
   ([#1833](https://github.com/open-telemetry/opentelemetry-python/pull/1833))
 - Include span parent in Jaeger thrift export as `CHILD_OF` reference
-  ([#1835])(https://github.com/open-telemetry/opentelemetry-python/pull/1835)
+  ([#1836])(https://github.com/open-telemetry/opentelemetry-python/pull/1836)
 
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.1.0...HEAD)
 
-### Changed
-- Include span parent in Jaeger gRPC export as `CHILD_OF` reference
-  ([#1809])(https://github.com/open-telemetry/opentelemetry-python/pull/1809)
-
 ### Added
 - Added example for running Django with auto instrumentation.
   ([#1803](https://github.com/open-telemetry/opentelemetry-python/pull/1803))
@@ -28,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1810](https://github.com/open-telemetry/opentelemetry-python/pull/1810))
 - Fixed inconsistency in parent_id formatting from the ConsoleSpanExporter
   ([#1833](https://github.com/open-telemetry/opentelemetry-python/pull/1833))
+- Include span parent in Jaeger gRPC export as `CHILD_OF` reference
+  ([#1809])(https://github.com/open-telemetry/opentelemetry-python/pull/1809)
 - Include span parent in Jaeger thrift export as `CHILD_OF` reference
   ([#1836])(https://github.com/open-telemetry/opentelemetry-python/pull/1836)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1810](https://github.com/open-telemetry/opentelemetry-python/pull/1810))
 - Fixed inconsistency in parent_id formatting from the ConsoleSpanExporter
   ([#1833](https://github.com/open-telemetry/opentelemetry-python/pull/1833))
+- Include span parent in Jaeger thrift export as `CHILD_OF` reference
+  ([#1835])(https://github.com/open-telemetry/opentelemetry-python/pull/1835)
 
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.

--- a/exporter/opentelemetry-exporter-jaeger-thrift/src/opentelemetry/exporter/jaeger/thrift/translate/__init__.py
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/src/opentelemetry/exporter/jaeger/thrift/translate/__init__.py
@@ -231,10 +231,18 @@ class ThriftTranslator(Translator):
     def _extract_refs(
         self, span: ReadableSpan
     ) -> Optional[Sequence[TCollector.SpanRef]]:
-        if not span.links:
-            return None
 
         refs = []
+        if span.parent:
+            ctx = span.get_span_context()
+            parent_id = span.parent.span_id
+            parent_ref = TCollector.SpanRef(
+                refType=TCollector.SpanRefType.CHILD_OF,
+                traceIdHigh=_get_trace_id_high(ctx.trace_id),
+                traceIdLow=_get_trace_id_low(ctx.trace_id),
+                spanId=_convert_int_to_i64(parent_id),
+            )
+            refs.append(parent_ref)
         for link in span.links:
             trace_id = link.context.trace_id
             span_id = link.context.span_id

--- a/exporter/opentelemetry-exporter-jaeger-thrift/tests/test_jaeger_exporter_thrift.py
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/tests/test_jaeger_exporter_thrift.py
@@ -370,11 +370,17 @@ class TestJaegerExporter(unittest.TestCase):
                 ],
                 references=[
                     jaeger.SpanRef(
+                        refType=jaeger.SpanRefType.CHILD_OF,
+                        traceIdHigh=trace_id_high,
+                        traceIdLow=trace_id_low,
+                        spanId=parent_id,
+                    ),
+                    jaeger.SpanRef(
                         refType=jaeger.SpanRefType.FOLLOWS_FROM,
                         traceIdHigh=trace_id_high,
                         traceIdLow=trace_id_low,
                         spanId=other_id,
-                    )
+                    ),
                 ],
                 logs=[
                     jaeger.Log(
@@ -414,6 +420,7 @@ class TestJaegerExporter(unittest.TestCase):
                 duration=durations[1] // 10 ** 3,
                 flags=0,
                 tags=default_tags,
+                references=[],
             ),
             jaeger.Span(
                 operationName=span_names[2],
@@ -446,6 +453,7 @@ class TestJaegerExporter(unittest.TestCase):
                         vStr="version",
                     ),
                 ],
+                references=[],
             ),
         ]
 


### PR DESCRIPTION
# Description

Follow up to https://github.com/open-telemetry/opentelemetry-python/pull/1809 to add the same logic to the thrift exporter

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been updated
- [ ] Documentation has been updated
