### PR TITLE
Allow users to "unset" SDK limits and evaluate default limits lazily instead of on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1823](https://github.com/open-telemetry/opentelemetry-python/pull/1823))
 - Added support for OTEL_SERVICE_NAME.
   ([#1829](https://github.com/open-telemetry/opentelemetry-python/pull/1829))
+- Lazily read/configure limits and allow limits to be unset.
+  ([#1839](https://github.com/open-telemetry/opentelemetry-python/pull/1839))
 
 ### Changed
 - Fixed OTLP gRPC exporter silently failing if scheme is not specified in endpoint.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -872,10 +872,6 @@ class Tracer(trace_api.Tracer):
         self.instrumentation_info = instrumentation_info
         self._limits = None
 
-    def _with_limits(self, limits: _Limits) -> "Tracer":
-        self._limits = limits
-        return self
-
     @contextmanager
     def start_as_current_span(
         self,
@@ -1023,7 +1019,7 @@ class TracerProvider(trace_api.TracerProvider):
         if not instrumenting_module_name:  # Reject empty strings too.
             instrumenting_module_name = ""
             logger.error("get_tracer called with missing module name.")
-        return Tracer(
+        tracer = Tracer(
             self.sampler,
             self.resource,
             self._active_span_processor,
@@ -1031,7 +1027,9 @@ class TracerProvider(trace_api.TracerProvider):
             InstrumentationInfo(
                 instrumenting_module_name, instrumenting_library_version
             ),
-        )._with_limits(self._limits)
+        )
+        tracer._limits = self._limits
+        return tracer
 
     def add_span_processor(self, span_processor: SpanProcessor) -> None:
         """Registers a new :class:`SpanProcessor` for this `TracerProvider`.

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -135,6 +135,14 @@ class TestBoundedList(unittest.TestCase):
         self.assertEqual(len(blist), list_len)
         self.assertEqual(blist.dropped, len(other_list))
 
+    def test_no_limit(self):
+        blist = BoundedList(maxlen=None)
+        for num in range(100):
+            blist.append(num)
+
+        for num in range(100):
+            self.assertEqual(blist[num], num)
+
 
 class TestBoundedDict(unittest.TestCase):
     base = collections.OrderedDict(
@@ -214,3 +222,11 @@ class TestBoundedDict(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             _ = bdict["new-name"]
+
+    def test_no_limit_code(self):
+        bdict = BoundedDict(maxlen=None)
+        for num in range(100):
+            bdict[num] = num
+
+        for num in range(100):
+            self.assertEqual(bdict[num], num)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -18,6 +18,7 @@ import subprocess
 import unittest
 from importlib import reload
 from logging import ERROR, WARNING
+from random import randint
 from typing import Optional
 from unittest import mock
 
@@ -538,7 +539,7 @@ class TestSpanCreation(unittest.TestCase):
 
     def test_surplus_span_links(self):
         # pylint: disable=protected-access
-        max_links = trace._SPAN_LINK_COUNT_LIMIT
+        max_links = trace._Limits().max_links
         links = [
             trace_api.Link(trace_api.SpanContext(0x1, idx, is_remote=False))
             for idx in range(0, 16 + max_links)
@@ -548,7 +549,7 @@ class TestSpanCreation(unittest.TestCase):
             self.assertEqual(len(root.links), max_links)
 
     def test_surplus_span_attributes(self):
-        max_attrs = trace.SPAN_ATTRIBUTE_COUNT_LIMIT
+        max_attrs = trace._Limits().max_attributes
         attributes = {str(idx): idx for idx in range(0, 16 + max_attrs)}
         tracer = new_tracer()
         with tracer.start_as_current_span(
@@ -1270,6 +1271,50 @@ class TestSpanProcessor(unittest.TestCase):
 
 
 class TestSpanLimits(unittest.TestCase):
+    # pylint: disable=protected-access
+
+    def test_limits_defaults(self):
+        limits = trace._Limits()
+        self.assertEqual(
+            limits.max_attributes, trace._DEFAULT_SPAN_ATTRIBUTES_LIMIT
+        )
+        self.assertEqual(limits.max_events, trace._DEFAULT_SPAN_EVENTS_LIMIT)
+        self.assertEqual(limits.max_links, trace._DEFAULT_SPAN_LINKS_LIMIT)
+
+    def test_limits_values_code(self):
+        max_attributes, max_events, max_links = (
+            randint(0, 10000),
+            randint(0, 10000),
+            randint(0, 10000),
+        )
+        limits = trace._Limits(
+            max_attributes=max_attributes,
+            max_events=max_events,
+            max_links=max_links,
+        )
+        self.assertEqual(limits.max_attributes, max_attributes)
+        self.assertEqual(limits.max_events, max_events)
+        self.assertEqual(limits.max_links, max_links)
+
+    def test_limits_values_env(self):
+        max_attributes, max_events, max_links = (
+            randint(0, 10000),
+            randint(0, 10000),
+            randint(0, 10000),
+        )
+        with mock.patch.dict(
+            "os.environ",
+            {
+                OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: str(max_attributes),
+                OTEL_SPAN_EVENT_COUNT_LIMIT: str(max_events),
+                OTEL_SPAN_LINK_COUNT_LIMIT: str(max_links),
+            },
+        ):
+            limits = trace._Limits()
+            self.assertEqual(limits.max_attributes, max_attributes)
+            self.assertEqual(limits.max_events, max_events)
+            self.assertEqual(limits.max_links, max_links)
+
     @mock.patch.dict(
         "os.environ",
         {
@@ -1278,8 +1323,7 @@ class TestSpanLimits(unittest.TestCase):
             OTEL_SPAN_LINK_COUNT_LIMIT: "30",
         },
     )
-    def test_span_environment_limits(self):
-        reload(trace)
+    def test_span_limits_env(self):
         tracer = new_tracer()
         id_generator = RandomIdGenerator()
         some_links = [
@@ -1307,3 +1351,45 @@ class TestSpanLimits(unittest.TestCase):
 
             self.assertEqual(len(root.attributes), 10)
             self.assertEqual(len(root.events), 20)
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "unset",
+            OTEL_SPAN_EVENT_COUNT_LIMIT: "unset",
+            OTEL_SPAN_LINK_COUNT_LIMIT: "unset",
+        },
+    )
+    def test_span_no_limits_env(self):
+        num_links = int(trace._DEFAULT_SPAN_LINKS_LIMIT) + randint(1, 100)
+
+        tracer = new_tracer()
+        id_generator = RandomIdGenerator()
+        some_links = [
+            trace_api.Link(
+                trace_api.SpanContext(
+                    trace_id=id_generator.generate_trace_id(),
+                    span_id=id_generator.generate_span_id(),
+                    is_remote=False,
+                )
+            )
+            for _ in range(num_links)
+        ]
+        with tracer.start_as_current_span("root", links=some_links) as root:
+            self.assertEqual(len(root.links), num_links)
+
+        num_events = int(trace._DEFAULT_SPAN_EVENTS_LIMIT) + randint(1, 100)
+        with tracer.start_as_current_span("root") as root:
+            for idx in range(num_events):
+                root.add_event("my_event_{}".format(idx))
+
+            self.assertEqual(len(root.events), num_events)
+
+        num_attributes = int(trace._DEFAULT_SPAN_ATTRIBUTES_LIMIT) + randint(
+            1, 100
+        )
+        with tracer.start_as_current_span("root") as root:
+            for idx in range(num_attributes):
+                root.set_attribute("my_attribute_{}".format(idx), 0)
+
+            self.assertEqual(len(root.attributes), num_attributes)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -549,6 +549,7 @@ class TestSpanCreation(unittest.TestCase):
             self.assertEqual(len(root.links), max_links)
 
     def test_surplus_span_attributes(self):
+        # pylint: disable=protected-access
         max_attrs = trace._Limits().max_attributes
         attributes = {str(idx): idx for idx in range(0, 16 + max_attrs)}
         tracer = new_tracer()


### PR DESCRIPTION
# Description


- Added SpanLimits class
- TracerProvider now optionally accepts an instance of SpanLimits which is passed all the way down to Spans.
- Spans use the limits to created bounded lists or dicts for different fields.

fixes #1838 

# Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added tests

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
