### PR TITLE
improving the release process for maintainers

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,6 +3,7 @@ This document explains how to publish all OT modules at version x.y.z. Ensure th
 
 Release Process:
 * [Checkout a clean repo](#checkout-a-clean-repo)
+* [Update versions](#update-versions)
 * [Create a new branch](#create-a-new-branch)
 * [Open a Pull Request](#open-a-pull-request)
 * [Create a Release](#Create-a-Release)
@@ -13,28 +14,32 @@ Release Process:
 * [Troubleshooting](#troubleshooting)
 
 ## Checkout a clean repo
-- To avoid pushing untracked changes, check out the repo in a new dir
+To avoid pushing untracked changes, check out the repo in a new dir
+
+## Update versions
+The update of the version information relies on the information in eachdist.ini to identify which packages are stable, prerelease or
+experimental. Update the desired version there to begin the release process.
 
 ## Create a new branch
 The following script does the following:
 - update main locally
 - creates a new release branch `release/<version>`
 - updates version and changelog files
-- commits the change to a new branch `release/<version>-auto`
+- commits the change
 
 *NOTE: This script was run by a GitHub Action but required the Action bot to be excluded from the CLA check, which it currently is not.*
 
 ```bash
-./scripts/prepare_release.sh 0.7b0
+./scripts/prepare_release.sh
 ```
 
 ## Open a Pull Request
 
-The PR should be opened from the `release/<version>-auto` branch created as part of running `prepare_release.sh` in the steps above.
+The PR should be opened from the `release/<version>` branch created as part of running `prepare_release.sh` in the steps above.
 
 ## Create a Release
 
-- Create the GH release from the release branch, using a new tag for this micro version, e.g. `v0.7.0`
+- Create the GH release from the main branch, using a new tag for this micro version, e.g. `v0.7.0`
 - Copy the changelogs from all packages that changed into the release notes (and reformat to remove hard line wraps)
 
 
@@ -42,7 +47,7 @@ The PR should be opened from the `release/<version>-auto` branch created as part
 
 This should be handled automatically on release by the [publish action](https://github.com/open-telemetry/opentelemetry-python/blob/main/.github/workflows/publish.yml).
 
- - Check the [action logs](https://github.com/open-telemetry/opentelemetry-python/actions?query=workflow%3APublish) to make sure packages have been uploaded to PyPI
+- Check the [action logs](https://github.com/open-telemetry/opentelemetry-python/actions?query=workflow%3APublish) to make sure packages have been uploaded to PyPI
 - Check the release history (e.g. https://pypi.org/project/opentelemetry-api/#history) on PyPI
 
 If for some reason the action failed, see [Publish failed](#publish-failed) below
@@ -61,18 +66,12 @@ To validate this worked, ensure the stable build has run successfully: https://r
 
 ## Update main
 
-Ensure the version and changelog updates have been applied to main.
-
+Ensure the version and changelog updates have been applied to main. Update the versions in eachdist.ini once again this time to include the `.dev0` tag and
+run eachdist once again:
 ```bash
-# checkout a new branch from main
-git checkout -b v0.7b0-main-update
-# cherry pick the change from the release branch
-git cherry-pick $(git log -n 1 origin/release/0.7b0 --format="%H")
-# update the version number, make it a "dev" greater than release number, e.g. 0.8.dev0
-perl -i -p -e 's/0.7b0/0.8.dev0/' $(git grep -l "0.7b0" | grep -vi CHANGELOG)
-# open a PR targeting main see #331
-git commit -m
+./scripts/eachdist.py update_versions --versions stable,prerelease
 ```
+
 
 ## Update website docs
 

--- a/eachdist.ini
+++ b/eachdist.ini
@@ -12,6 +12,46 @@ sortfirst=
     tests/util
     exporter/*
 
+[stable]
+version=1.2.0.dev0
+
+packages=
+    opentelemetry-sdk
+    opentelemetry-proto
+    propagator/opentelemetry-propagator-jaeger
+    propagator/opentelemetry-propagator-b3
+    exporter/opentelemetry-exporter-zipkin-proto-http
+    exporter/opentelemetry-exporter-zipkin-json
+    exporter/opentelemetry-exporter-zipkin
+    exporter/opentelemetry-exporter-otlp-proto-grpc
+    exporter/opentelemetry-exporter-otlp
+    exporter/opentelemetry-exporter-jaeger-thrift
+    exporter/opentelemetry-exporter-jaeger-proto-grpc
+    exporter/opentelemetry-exporter-jaeger
+    opentelemetry-api
+
+[prerelease]
+version=0.21.dev0
+
+packages=
+    opentelemetry-opentracing-shim
+    exporter/opentelemetry-exporter-opencensus
+    opentelemetry-distro
+    opentelemetry-semantic-conventions
+    opentelemetry-test
+    opentelemetry-instrumentation
+
+[experimental]
+version=1.10a0
+
+packages=
+    exporter/opentelemetry-exporter-prometheus-remote-write
+    exporter/opentelemetry-exporter-prometheus
+    opentelemetry-api
+    opentelemetry-sdk
+    exporter/opentelemetry-exporter-otlp-proto-grpc
+    exporter/opentelemetry-exporter-otlp
+
 [lintroots]
 extraroots=examples/*,scripts/
 subglob=*.py,tests/,test/,src/*,examples/*

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -11,15 +11,9 @@
 #      triggering unnecessary pull requests
 #
 
-VERSION=`echo $1 | awk -F "/" '{print $NF}'`
+VERSION=$(./scripts/eachdist.py version --mode stable)-$(./scripts/eachdist.py version --mode prerelease)
 echo "Using version ${VERSION}"
 
-# check the version matches expected versioning e.g
-# 0.6, 0.6b, 0.6b0, 0.6.0
-if [[ ! "${VERSION}" =~ ^([0-9])(\.*[0-9]{1,5}[a-b]*){1,3}$ ]]; then
-    echo "Version number invalid: $VERSION"
-    exit 1
-fi
 
 # create the release branch
 git fetch origin main
@@ -28,7 +22,7 @@ git reset --hard origin/main
 git checkout -b release/${VERSION}
 git push origin release/${VERSION}
 
-./scripts/eachdist.py release --version ${VERSION}
+./scripts/eachdist.py update_versions --versions stable,prerelease
 rc=$?
 if [ $rc != 0 ]; then
     echo "::set-output name=version_updated::0"


### PR DESCRIPTION
# Description

The following changes update the release process for maintainers. The release versioning is now stored in eachdist.ini and is applied per release "group" (stable, prerelease, experimental). I think this will reduce the chances for accidentally changing the wrong version number in the process. See the updated RELEASING.md for the process.