### PR TITLE
Update transient errors retry timeout and retryable status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1810](https://github.com/open-telemetry/opentelemetry-python/pull/1810))
 - Fixed inconsistency in parent_id formatting from the ConsoleSpanExporter
   ([#1833](https://github.com/open-telemetry/opentelemetry-python/pull/1833))
+- Update transient errors retry timeout and retryable status codes
+  ([#1842](https://github.com/open-telemetry/opentelemetry-python/pull/1842))
 
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -262,14 +262,11 @@ class OTLPExporterMixin(
         pass
 
     def _export(self, data: TypingSequence[SDKDataT]) -> ExportResultT:
+
+        max_value = 64
         # expo returns a generator that yields delay values which grow
         # exponentially. Once delay is greater than max_value, the yielded
         # value will remain constant.
-        # max_value is set to 900 (900 seconds is 15 minutes) to use the same
-        # value as used in the Go implementation.
-
-        max_value = 900
-
         for delay in expo(max_value=max_value):
 
             if delay == max_value:
@@ -289,8 +286,6 @@ class OTLPExporterMixin(
                 if error.code() in [
                     StatusCode.CANCELLED,
                     StatusCode.DEADLINE_EXCEEDED,
-                    StatusCode.PERMISSION_DENIED,
-                    StatusCode.UNAUTHENTICATED,
                     StatusCode.RESOURCE_EXHAUSTED,
                     StatusCode.ABORTED,
                     StatusCode.OUT_OF_RANGE,


### PR DESCRIPTION
# Description

We agreed that OTLP exporter transient error retry timeout is way to high and change it to some reasonable number. This also updates the retryable codes list for grpc; `PERMISSION_DENIED` and `UNAUTHENTICATED` do not belong to that list.

Fixes #1670 
