### PR TITLE
Update gettracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed sequence values in OTLP exporter not translating
   ([#1818](https://github.com/open-telemetry/opentelemetry-python/pull/1818))
 - Update get_tracer to return an empty string when passed an invalid name
-  (TBD)
+  ([#1854](https://github.com/open-telemetry/opentelemetry-python/pull/1854))
 
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
 
+- Updated get_tracer to return an empty string when passed an invalid name
+  ([#1854](https://github.com/open-telemetry/opentelemetry-python/pull/1854))
+
 ## [1.2.0, 0.21b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.2.0-0.21b0) - 2021-05-11
 
 ### Added
@@ -36,8 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1809])(https://github.com/open-telemetry/opentelemetry-python/pull/1809)
 - Fixed sequence values in OTLP exporter not translating
   ([#1818](https://github.com/open-telemetry/opentelemetry-python/pull/1818))
-- Update get_tracer to return an empty string when passed an invalid name
-  ([#1854](https://github.com/open-telemetry/opentelemetry-python/pull/1854))
 
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
 
+### Changed
 - Updated get_tracer to return an empty string when passed an invalid name
   ([#1854](https://github.com/open-telemetry/opentelemetry-python/pull/1854))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1809])(https://github.com/open-telemetry/opentelemetry-python/pull/1809)
 - Fixed sequence values in OTLP exporter not translating
   ([#1818](https://github.com/open-telemetry/opentelemetry-python/pull/1818))
+- Update get_tracer to return an empty string when passed an invalid name
+  (TBD)
 
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -997,7 +997,7 @@ class TracerProvider(trace_api.TracerProvider):
         instrumenting_library_version: str = "",
     ) -> "trace_api.Tracer":
         if not instrumenting_module_name:  # Reject empty strings too.
-            instrumenting_module_name = "ERROR:MISSING MODULE NAME"
+            instrumenting_module_name = ""
             logger.error("get_tracer called with missing module name.")
         return Tracer(
             self.sampler,

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -277,7 +277,7 @@ class TestSpanCreation(unittest.TestCase):
         self.assertEqual(
             tracer1.instrumentation_info, tracer2.instrumentation_info
         )
-        
+
     def test_span_processor_for_source(self):
         tracer_provider = trace.TracerProvider()
         tracer1 = tracer_provider.get_tracer("instr1")

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -260,15 +260,22 @@ class TestSpanCreation(unittest.TestCase):
         self.assertEqual(
             tracer1.instrumentation_info, tracer2.instrumentation_info
         )
+
         self.assertIsInstance(
             tracer1.instrumentation_info, InstrumentationInfo
         )
         span1 = tracer1.start_span("foo")
         self.assertTrue(span1.is_recording())
         self.assertEqual(tracer1.instrumentation_info.version, "")
-        self.assertEqual(
-            tracer1.instrumentation_info.name, "ERROR:MISSING MODULE NAME"
+        self.assertEqual(tracer1.instrumentation_info.name, "")
+
+        self.assertIsInstance(
+            tracer2.instrumentation_info, InstrumentationInfo
         )
+        span2 = tracer2.start_span("bar")
+        self.assertTrue(span2.is_recording())
+        self.assertEqual(tracer2.instrumentation_info.version, "")
+        self.assertEqual(tracer2.instrumentation_info.name, "")
 
     def test_span_processor_for_source(self):
         tracer_provider = trace.TracerProvider()

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -257,9 +257,6 @@ class TestSpanCreation(unittest.TestCase):
             tracer1 = tracer_provider.get_tracer("")
         with self.assertLogs(level=ERROR):
             tracer2 = tracer_provider.get_tracer(None)
-        self.assertEqual(
-            tracer1.instrumentation_info, tracer2.instrumentation_info
-        )
 
         self.assertIsInstance(
             tracer1.instrumentation_info, InstrumentationInfo
@@ -277,6 +274,10 @@ class TestSpanCreation(unittest.TestCase):
         self.assertEqual(tracer2.instrumentation_info.version, "")
         self.assertEqual(tracer2.instrumentation_info.name, "")
 
+        self.assertEqual(
+            tracer1.instrumentation_info, tracer2.instrumentation_info
+        )
+        
     def test_span_processor_for_source(self):
         tracer_provider = trace.TracerProvider()
         tracer1 = tracer_provider.get_tracer("instr1")


### PR DESCRIPTION
# Description

[Specification change #1654](https://github.com/open-telemetry/opentelemetry-specification/pull/1654) requires invalid names to be converted to an empty string, as described in the tracer specification below. Passing `None` or the empty string `""` as the `name` parameter to `trace.get_tracer(name, version)` will now return a tracer with an empty string for `tracer.instrumentation_info.name`. Full details available in the [Trace API specifications](https://github.com/carlosalberto/opentelemetry-specification/blob/e4bea087ae84e343e400bae20e87fb08ce8aee5b/specification/trace/api.md#get-a-tracer).

Fixes [#1849](https://github.com/open-telemetry/opentelemetry-python/issues/1849)

# How Has This Been Tested?

- [x] The test_invalid_instrumentation_info unit test has been updated to expect an empty string output of `get_tracer` for the given invalid inputs, and the `tox -e test-core-sdk` tests passed.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been updated

Hooray for my first PR!