### PR TITLE
Trace SDK does not raise when Span attribute and link limits are exceeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1818](https://github.com/open-telemetry/opentelemetry-python/pull/1818))
 - Update transient errors retry timeout and retryable status codes
   ([#1842](https://github.com/open-telemetry/opentelemetry-python/pull/1842))
+- Fix start span behavior when excess links and attributes are included
+  ([#1856](https://github.com/open-telemetry/opentelemetry-python/pull/1856))
 
 ### Removed
 - Moved `opentelemetry-instrumentation` to contrib repository.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -81,11 +81,8 @@ class BoundedList(Sequence):
     @classmethod
     def from_seq(cls, maxlen, seq):
         seq = tuple(seq)
-        if len(seq) > maxlen:
-            raise ValueError
         bounded_list = cls(maxlen)
-        # pylint: disable=protected-access
-        bounded_list._dq = deque(seq, maxlen=maxlen)
+        bounded_list.extend(seq)
         return bounded_list
 
 
@@ -140,9 +137,7 @@ class BoundedDict(MutableMapping):
     @classmethod
     def from_map(cls, maxlen, mapping):
         mapping = OrderedDict(mapping)
-        if len(mapping) > maxlen:
-            raise ValueError
         bounded_dict = cls(maxlen)
-        # pylint: disable=protected-access
-        bounded_dict._dict = mapping
+        for key, value in mapping.items():
+            bounded_dict[key] = value
         return bounded_dict

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -61,8 +61,9 @@ class TestBoundedList(unittest.TestCase):
         self.assertEqual(len(tuple(blist)), list_len)
 
         # sequence too big
-        with self.assertRaises(ValueError):
-            BoundedList.from_seq(list_len / 2, self.base)
+        blist = BoundedList.from_seq(list_len // 2, base_copy)
+        self.assertEqual(len(blist), list_len // 2)
+        self.assertEqual(blist.dropped, list_len - (list_len // 2))
 
     def test_append_no_drop(self):
         """Append max capacity elements to the list without dropping elements."""
@@ -167,8 +168,10 @@ class TestBoundedDict(unittest.TestCase):
         self.assertEqual(len(tuple(bdict)), dic_len)
 
         # map too big
-        with self.assertRaises(ValueError):
-            BoundedDict.from_map(dic_len / 2, self.base)
+        half_len = dic_len // 2
+        bdict = BoundedDict.from_map(half_len, self.base)
+        self.assertEqual(len(tuple(bdict)), half_len)
+        self.assertEqual(bdict.dropped, dic_len - half_len)
 
     def test_bounded_dict(self):
         # create empty dict


### PR DESCRIPTION
# Description

Relevant Spec [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-limits).

We should not be raising `ValueError` when starting a span if the number of links or attributes exceeds the configured maxima. Surplus attributes and links can be discarded instead.

* `opentelemetry.sdk.util.BoundedList.from_seq(...)` behavior changes to not raise ValueError. Instead uses `BoundedList.extend` to fill the deque to capacity and preserve a dropped count for excess items.
*  `opentelemetry.sdk.util.BoundedDict.from_map(...)` behavior changes to not raise ValueError. Instead it iterates on the input mapping and inserts keys one by one relying on `BoundedDict.__setitem__` to discard excess items.

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/1844

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Just the `tox` test suite

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [X] No.

*I'm not positive - could use some help on this front*

# Checklist:

- [X] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
