### PR TITLE
Add schema_url attribute to Resource

### DIFF
--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/tests/test_jaeger_exporter_protobuf.py
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/tests/test_jaeger_exporter_protobuf.py
@@ -159,20 +159,20 @@ class TestJaegerExporter(unittest.TestCase):
                 links=(link,),
                 kind=trace_api.SpanKind.CLIENT,
                 resource=Resource(
-                    attributes={"key_resource": "some_resource"}
+                    attributes={"key_resource": "some_resource"}, schema_url=""
                 ),
             ),
             trace._Span(
                 name=span_names[1],
                 context=parent_span_context,
                 parent=None,
-                resource=Resource({}),
+                resource=Resource({}, ""),
             ),
             trace._Span(
                 name=span_names[2],
                 context=other_context,
                 parent=None,
-                resource=Resource({}),
+                resource=Resource({}, ""),
                 instrumentation_info=InstrumentationInfo(
                     name="name", version="version"
                 ),
@@ -399,7 +399,8 @@ class TestJaegerExporter(unittest.TestCase):
             resource=Resource(
                 attributes={
                     "key_resource": "some_resource some_resource some_more_resource"
-                }
+                },
+                schema_url="",
             ),
             context=trace_api.SpanContext(
                 trace_id=0x000000000000000000000000DEADBEEF,

--- a/exporter/opentelemetry-exporter-jaeger-thrift/tests/test_jaeger_exporter_thrift.py
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/tests/test_jaeger_exporter_thrift.py
@@ -273,20 +273,20 @@ class TestJaegerExporter(unittest.TestCase):
                 links=(link,),
                 kind=trace_api.SpanKind.CLIENT,
                 resource=Resource(
-                    attributes={"key_resource": "some_resource"}
+                    attributes={"key_resource": "some_resource"}, schema_url=""
                 ),
             ),
             trace._Span(
                 name=span_names[1],
                 context=parent_span_context,
                 parent=None,
-                resource=Resource({}),
+                resource=Resource({}, ""),
             ),
             trace._Span(
                 name=span_names[2],
                 context=other_context,
                 parent=None,
-                resource=Resource({}),
+                resource=Resource({}, ""),
                 instrumentation_info=InstrumentationInfo(
                     name="name", version="version"
                 ),
@@ -536,7 +536,8 @@ class TestJaegerExporter(unittest.TestCase):
             resource=Resource(
                 attributes={
                     "key_resource": "some_resource some_resource some_more_resource"
-                }
+                },
+                schema_url="",
             ),
             context=trace_api.SpanContext(
                 trace_id=0x000000000000000000000000DEADBEEF,

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -149,7 +149,7 @@ class TestOTLPSpanExporter(TestCase):
                     "trace_id": 67545097771067222548457157018666467027,
                 }
             ),
-            resource=SDKResource(OrderedDict([("a", 1), ("b", False)])),
+            resource=SDKResource(OrderedDict([("a", 1), ("b", False)]), ""),
             parent=Mock(**{"span_id": 12345}),
             attributes=OrderedDict([("a", 1), ("b", True)]),
             events=[event_mock],

--- a/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/common_tests.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/common_tests.py
@@ -180,7 +180,7 @@ class CommonEncoderTestCases:
                     is_remote=False,
                     trace_flags=TraceFlags(TraceFlags.SAMPLED),
                 ),
-                resource=trace.Resource({}),
+                resource=trace.Resource({}, ""),
             )
             span.start(start_time=start_time)
             span.set_attribute("string1", "v" * 500)
@@ -379,7 +379,7 @@ class CommonEncoderTestCases:
                         context=other_context, attributes={"key_bool": True}
                     ),
                 ),
-                resource=trace.Resource({}),
+                resource=trace.Resource({}, ""),
             )
             span1.start(start_time=start_times[0])
             span1.set_attribute("key_bool", False)
@@ -393,7 +393,7 @@ class CommonEncoderTestCases:
                 context=parent_span_context,
                 parent=None,
                 resource=trace.Resource(
-                    attributes={"key_resource": "some_resource"}
+                    attributes={"key_resource": "some_resource"}, schema_url=""
                 ),
             )
             span2.start(start_time=start_times[1])
@@ -405,7 +405,7 @@ class CommonEncoderTestCases:
                 context=other_context,
                 parent=None,
                 resource=trace.Resource(
-                    attributes={"key_resource": "some_resource"}
+                    attributes={"key_resource": "some_resource"}, schema_url=""
                 ),
             )
             span3.start(start_time=start_times[2])
@@ -416,7 +416,7 @@ class CommonEncoderTestCases:
                 name="test-span-3",
                 context=other_context,
                 parent=None,
-                resource=trace.Resource({}),
+                resource=trace.Resource({}, ""),
                 instrumentation_info=InstrumentationInfo(
                     name="name", version="version"
                 ),

--- a/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/test_v1_json.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/test_v1_json.py
@@ -187,7 +187,7 @@ class TestV1JsonEncoder(CommonEncoderTestCases.CommonJsonEncoderTest):
                 trace_flags=TraceFlags(TraceFlags.SAMPLED),
             ),
             parent=trace_api.SpanContext(trace_id, parent_id, is_remote=False),
-            resource=trace.Resource({}),
+            resource=trace.Resource({}, ""),
         )
         otel_span.start(start_time=start_time)
         otel_span.end(end_time=end_time)

--- a/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/test_v2_json.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/tests/encoder/test_v2_json.py
@@ -147,7 +147,7 @@ class TestV2JsonEncoder(CommonEncoderTestCases.CommonJsonEncoderTest):
                 trace_flags=TraceFlags(TraceFlags.SAMPLED),
             ),
             parent=trace_api.SpanContext(trace_id, parent_id, is_remote=False),
-            resource=trace.Resource({}),
+            resource=trace.Resource({}, ""),
         )
         otel_span.start(start_time=start_time)
         otel_span.end(end_time=end_time)

--- a/exporter/opentelemetry-exporter-zipkin-json/tests/test_zipkin_exporter.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/tests/test_zipkin_exporter.py
@@ -44,7 +44,9 @@ class TestZipkinExporter(unittest.TestCase):
     def setUpClass(cls):
         trace.set_tracer_provider(
             TracerProvider(
-                resource=Resource({SERVICE_NAME: TEST_SERVICE_NAME})
+                resource=Resource(
+                    {SERVICE_NAME: TEST_SERVICE_NAME}, schema_url=""
+                )
             )
         )
 

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/tests/encoder/common_tests.py
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/tests/encoder/common_tests.py
@@ -180,7 +180,7 @@ class CommonEncoderTestCases:
                     is_remote=False,
                     trace_flags=TraceFlags(TraceFlags.SAMPLED),
                 ),
-                resource=trace.Resource({}),
+                resource=trace.Resource({}, ""),
             )
             span.start(start_time=start_time)
             span.set_attribute("string1", "v" * 500)
@@ -379,7 +379,7 @@ class CommonEncoderTestCases:
                         context=other_context, attributes={"key_bool": True}
                     ),
                 ),
-                resource=trace.Resource({}),
+                resource=trace.Resource({}, ""),
             )
             span1.start(start_time=start_times[0])
             span1.set_attribute("key_bool", False)
@@ -393,7 +393,7 @@ class CommonEncoderTestCases:
                 context=parent_span_context,
                 parent=None,
                 resource=trace.Resource(
-                    attributes={"key_resource": "some_resource"}
+                    attributes={"key_resource": "some_resource"}, schema_url=""
                 ),
             )
             span2.start(start_time=start_times[1])
@@ -405,7 +405,7 @@ class CommonEncoderTestCases:
                 context=other_context,
                 parent=None,
                 resource=trace.Resource(
-                    attributes={"key_resource": "some_resource"}
+                    attributes={"key_resource": "some_resource"}, schema_url=""
                 ),
             )
             span3.start(start_time=start_times[2])
@@ -416,7 +416,7 @@ class CommonEncoderTestCases:
                 name="test-span-3",
                 context=other_context,
                 parent=None,
-                resource=trace.Resource({}),
+                resource=trace.Resource({}, ""),
                 instrumentation_info=InstrumentationInfo(
                     name="name", version="version"
                 ),

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/tests/test_zipkin_exporter.py
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/tests/test_zipkin_exporter.py
@@ -46,7 +46,7 @@ class TestZipkinExporter(unittest.TestCase):
     def setUpClass(cls):
         trace.set_tracer_provider(
             TracerProvider(
-                resource=Resource({SERVICE_NAME: TEST_SERVICE_NAME})
+                resource=Resource({SERVICE_NAME: TEST_SERVICE_NAME}, "")
             )
         )
 

--- a/opentelemetry-sdk/tests/performance/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/tests/performance/benchmarks/trace/test_benchmark_trace.py
@@ -23,7 +23,8 @@ tracer = trace.TracerProvider(
             "service.name": "A123456789",
             "service.version": "1.34567890",
             "service.instance.id": "123ab456-a123-12ab-12ab-12340a1abc12",
-        }
+        },
+        "",
     ),
 ).get_tracer("sdk_tracer_provider")
 

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -73,7 +73,9 @@ class TestResources(unittest.TestCase):
         self.assertEqual(
             resource,
             resources._DEFAULT_RESOURCE.merge(
-                resources.Resource({resources.SERVICE_NAME: "unknown_service"})
+                resources.Resource(
+                    {resources.SERVICE_NAME: "unknown_service"}, ""
+                )
             ),
         )
         self.assertEqual(resource.schema_url, "")
@@ -82,7 +84,9 @@ class TestResources(unittest.TestCase):
         self.assertEqual(
             resource,
             resources._DEFAULT_RESOURCE.merge(
-                resources.Resource({resources.SERVICE_NAME: "unknown_service"})
+                resources.Resource(
+                    {resources.SERVICE_NAME: "unknown_service"}, ""
+                )
             ),
         )
         self.assertEqual(resource.schema_url, "")
@@ -91,7 +95,9 @@ class TestResources(unittest.TestCase):
         self.assertEqual(
             resource,
             resources._DEFAULT_RESOURCE.merge(
-                resources.Resource({resources.SERVICE_NAME: "unknown_service"})
+                resources.Resource(
+                    {resources.SERVICE_NAME: "unknown_service"}, ""
+                )
             ),
         )
         self.assertEqual(resource.schema_url, "")
@@ -100,17 +106,19 @@ class TestResources(unittest.TestCase):
         self.assertEqual(
             resource,
             resources._DEFAULT_RESOURCE.merge(
-                resources.Resource({resources.SERVICE_NAME: "unknown_service"})
+                resources.Resource(
+                    {resources.SERVICE_NAME: "unknown_service"}, ""
+                )
             ),
         )
         self.assertEqual(resource.schema_url, "")
 
     def test_resource_merge(self):
-        left = resources.Resource({"service": "ui"})
-        right = resources.Resource({"host": "service-host"})
+        left = resources.Resource({"service": "ui"}, "")
+        right = resources.Resource({"host": "service-host"}, "")
         self.assertEqual(
             left.merge(right),
-            resources.Resource({"service": "ui", "host": "service-host"}),
+            resources.Resource({"service": "ui", "host": "service-host"}, ""),
         )
         schema_urls = (
             "https://opentelemetry.io/schemas/1.2.0",
@@ -145,13 +153,15 @@ class TestResources(unittest.TestCase):
         the exception of the empty string.
 
         """
-        left = resources.Resource({"service": "ui", "host": ""})
+        left = resources.Resource({"service": "ui", "host": ""}, "")
         right = resources.Resource(
-            {"host": "service-host", "service": "not-ui"}
+            {"host": "service-host", "service": "not-ui"}, ""
         )
         self.assertEqual(
             left.merge(right),
-            resources.Resource({"service": "not-ui", "host": "service-host"}),
+            resources.Resource(
+                {"service": "not-ui", "host": "service-host"}, ""
+            ),
         )
 
     def test_immutability(self):
@@ -195,7 +205,9 @@ class TestResources(unittest.TestCase):
         self.assertEqual(aggregated_resources, resources.Resource.get_empty())
 
     def test_aggregated_resources_with_static_resource(self):
-        static_resource = resources.Resource({"static_key": "static_value"})
+        static_resource = resources.Resource(
+            {"static_key": "static_value"}, ""
+        )
 
         self.assertEqual(
             resources.get_aggregated_resources(
@@ -206,7 +218,8 @@ class TestResources(unittest.TestCase):
 
         resource_detector = mock.Mock(spec=resources.ResourceDetector)
         resource_detector.detect.return_value = resources.Resource(
-            {"static_key": "try_to_overwrite_existing_value", "key": "value"}
+            {"static_key": "try_to_overwrite_existing_value", "key": "value"},
+            "",
         )
         self.assertEqual(
             resources.get_aggregated_resources(
@@ -216,18 +229,19 @@ class TestResources(unittest.TestCase):
                 {
                     "static_key": "try_to_overwrite_existing_value",
                     "key": "value",
-                }
+                },
+                "",
             ),
         )
 
     def test_aggregated_resources_multiple_detectors(self):
         resource_detector1 = mock.Mock(spec=resources.ResourceDetector)
         resource_detector1.detect.return_value = resources.Resource(
-            {"key1": "value1"}
+            {"key1": "value1"}, ""
         )
         resource_detector2 = mock.Mock(spec=resources.ResourceDetector)
         resource_detector2.detect.return_value = resources.Resource(
-            {"key2": "value2", "key3": "value3"}
+            {"key2": "value2", "key3": "value3"}, ""
         )
         resource_detector3 = mock.Mock(spec=resources.ResourceDetector)
         resource_detector3.detect.return_value = resources.Resource(
@@ -235,7 +249,8 @@ class TestResources(unittest.TestCase):
                 "key2": "try_to_overwrite_existing_value",
                 "key3": "try_to_overwrite_existing_value",
                 "key4": "value4",
-            }
+            },
+            "",
         )
 
         self.assertEqual(
@@ -248,7 +263,8 @@ class TestResources(unittest.TestCase):
                     "key2": "try_to_overwrite_existing_value",
                     "key3": "try_to_overwrite_existing_value",
                     "key4": "value4",
-                }
+                },
+                "",
             ),
         )
 
@@ -314,18 +330,18 @@ class TestOTELResourceDetector(unittest.TestCase):
     def test_one(self):
         detector = resources.OTELResourceDetector()
         os.environ[resources.OTEL_RESOURCE_ATTRIBUTES] = "k=v"
-        self.assertEqual(detector.detect(), resources.Resource({"k": "v"}))
+        self.assertEqual(detector.detect(), resources.Resource({"k": "v"}, ""))
 
     def test_one_with_whitespace(self):
         detector = resources.OTELResourceDetector()
         os.environ[resources.OTEL_RESOURCE_ATTRIBUTES] = "    k  = v   "
-        self.assertEqual(detector.detect(), resources.Resource({"k": "v"}))
+        self.assertEqual(detector.detect(), resources.Resource({"k": "v"}, ""))
 
     def test_multiple(self):
         detector = resources.OTELResourceDetector()
         os.environ[resources.OTEL_RESOURCE_ATTRIBUTES] = "k=v,k2=v2"
         self.assertEqual(
-            detector.detect(), resources.Resource({"k": "v", "k2": "v2"})
+            detector.detect(), resources.Resource({"k": "v", "k2": "v2"}, "")
         )
 
     def test_multiple_with_whitespace(self):
@@ -334,7 +350,7 @@ class TestOTELResourceDetector(unittest.TestCase):
             resources.OTEL_RESOURCE_ATTRIBUTES
         ] = "    k  = v  , k2   = v2 "
         self.assertEqual(
-            detector.detect(), resources.Resource({"k": "v", "k2": "v2"})
+            detector.detect(), resources.Resource({"k": "v", "k2": "v2"}, "")
         )
 
     @mock.patch.dict(
@@ -345,7 +361,7 @@ class TestOTELResourceDetector(unittest.TestCase):
         detector = resources.OTELResourceDetector()
         self.assertEqual(
             detector.detect(),
-            resources.Resource({"service.name": "test-srv-name"}),
+            resources.Resource({"service.name": "test-srv-name"}, ""),
         )
 
     @mock.patch.dict(
@@ -359,5 +375,5 @@ class TestOTELResourceDetector(unittest.TestCase):
         detector = resources.OTELResourceDetector()
         self.assertEqual(
             detector.detect(),
-            resources.Resource({"service.name": "from-service-name"}),
+            resources.Resource({"service.name": "from-service-name"}, ""),
         )

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -51,6 +51,13 @@ class TestResources(unittest.TestCase):
         self.assertIsInstance(resource, resources.Resource)
         self.assertEqual(resource.attributes, expected_attributes)
 
+        schema_url = "https://opentelemetry.io/schemas/1.3.0"
+
+        resource = resources.Resource.create(attributes, schema_url)
+        self.assertIsInstance(resource, resources.Resource)
+        self.assertEqual(resource.attributes, expected_attributes)
+        self.assertEqual(resource.schema_url, schema_url)
+
         os.environ[resources.OTEL_RESOURCE_ATTRIBUTES] = "key=value"
         resource = resources.Resource.create(attributes)
         self.assertIsInstance(resource, resources.Resource)
@@ -69,6 +76,16 @@ class TestResources(unittest.TestCase):
                 resources.Resource({resources.SERVICE_NAME: "unknown_service"})
             ),
         )
+        self.assertEqual(resource.schema_url, "")
+
+        resource = resources.Resource.create(None, None)
+        self.assertEqual(
+            resource,
+            resources._DEFAULT_RESOURCE.merge(
+                resources.Resource({resources.SERVICE_NAME: "unknown_service"})
+            ),
+        )
+        self.assertEqual(resource.schema_url, "")
 
         resource = resources.Resource.create({})
         self.assertEqual(
@@ -77,6 +94,16 @@ class TestResources(unittest.TestCase):
                 resources.Resource({resources.SERVICE_NAME: "unknown_service"})
             ),
         )
+        self.assertEqual(resource.schema_url, "")
+
+        resource = resources.Resource.create({}, None)
+        self.assertEqual(
+            resource,
+            resources._DEFAULT_RESOURCE.merge(
+                resources.Resource({resources.SERVICE_NAME: "unknown_service"})
+            ),
+        )
+        self.assertEqual(resource.schema_url, "")
 
     def test_resource_merge(self):
         left = resources.Resource({"service": "ui"})

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -112,6 +112,31 @@ class TestResources(unittest.TestCase):
             left.merge(right),
             resources.Resource({"service": "ui", "host": "service-host"}),
         )
+        schema_urls = (
+            "https://opentelemetry.io/schemas/1.2.0",
+            "https://opentelemetry.io/schemas/1.3.0",
+        )
+
+        left = resources.Resource.create({}, None)
+        right = resources.Resource.create({}, None)
+        self.assertEqual(left.merge(right).schema_url, "")
+
+        left = resources.Resource.create({}, None)
+        right = resources.Resource.create({}, schema_urls[0])
+        self.assertEqual(left.merge(right).schema_url, schema_urls[0])
+
+        left = resources.Resource.create({}, schema_urls[0])
+        right = resources.Resource.create({}, None)
+        self.assertEqual(left.merge(right).schema_url, schema_urls[0])
+
+        left = resources.Resource.create({}, schema_urls[0])
+        right = resources.Resource.create({}, schema_urls[0])
+        self.assertEqual(left.merge(right).schema_url, schema_urls[0])
+
+        left = resources.Resource.create({}, schema_urls[0])
+        right = resources.Resource.create({}, schema_urls[1])
+        with self.assertRaises(ValueError):
+            left.merge(right)
 
     def test_resource_merge_empty_string(self):
         """Verify Resource.merge behavior with the empty string.

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -878,7 +878,7 @@ class TestSpan(unittest.TestCase):
         self.assertEqual(end_time, span.end_time)
 
     def test_ended_span(self):
-        """"Events, attributes are not allowed after span is ended"""
+        """ "Events, attributes are not allowed after span is ended"""
 
         root = self.tracer.start_span("root")
 
@@ -1229,9 +1229,9 @@ class TestSpanProcessor(unittest.TestCase):
             is_remote=False,
             trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         )
-        parent = trace._Span("parent-name", context, resource=Resource({}))
+        parent = trace._Span("parent-name", context, resource=Resource({}, ""))
         span = trace._Span(
-            "span-name", context, resource=Resource({}), parent=parent
+            "span-name", context, resource=Resource({}, ""), parent=parent
         )
 
         self.assertEqual(
@@ -1268,7 +1268,7 @@ class TestSpanProcessor(unittest.TestCase):
             is_remote=False,
             trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         )
-        span = trace._Span("span-name", context, resource=Resource({}))
+        span = trace._Span("span-name", context, resource=Resource({}, ""))
         span.set_attribute("key", "value")
         span.add_event("event", {"key2": "value2"}, 123)
         date_str = ns_to_iso_str(123)


### PR DESCRIPTION
[#](url) Description

A [change in the OTel specification](https://github.com/open-telemetry/opentelemetry-specification/pull/1692/files) requires a new `schema_url` field in the `Resource` class. This change implements the field, updates the Resource factory method and merge method, and modifies tests which used the old constructor signature. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All `tox` tests were ran on Python 3.9. Two tests were substantively modified, with a number of others modified for failing to conform to the new constructor signature. 

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`

- [x] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
