### PR TITLE
Update SDK time precision warning to reference correct PEP

### DIFF
--- a/opentelemetry-api/src/opentelemetry/util/_time.py
+++ b/opentelemetry-api/src/opentelemetry/util/_time.py
@@ -19,7 +19,7 @@ if version_info.minor < 7:
     getLogger(__name__).warning(  # pylint: disable=logging-not-lazy
         "You are using Python 3.%s. This version does not support timestamps "
         "with nanosecond precision and the OpenTelemetry SDK will use "
-        "millisecond precision instead. Please refer to PEP 546 for more "
+        "millisecond precision instead. Please refer to PEP 564 for more "
         "information. Please upgrade to Python 3.7 or newer to use nanosecond "
         "precision." % version_info.minor
     )


### PR DESCRIPTION
# Description

When developing on Python older than 3.7 a warning is logged about timing
precision, this fixes that warning to reference PEP 564. This is the PEP
that talks about nanosecond precision in python:

https://www.python.org/dev/peps/pep-0564/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The above link has been read and verified it refers to time precision instead of
backporting SSL memory to Python 2.7 (PEP 546).

# Checklist:

- [x] Documentation has been updated
