### PR TITLE
update base version of python to 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install tox
         run: pip install -U tox
       - name: Cache tox environment

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pylint==2.6.0
+pylint==2.7.1
 flake8~=3.7
 isort~=5.8
 black~=20.8b1

--- a/tox.ini
+++ b/tox.ini
@@ -175,7 +175,7 @@ commands =
   mypyinstalled: mypy --namespace-packages opentelemetry-api/tests/mypysmoke.py --strict
 
 [testenv:lint]
-basepython: python3.8
+basepython: python3.9
 recreate = True
 deps =
   -c dev-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -238,6 +238,7 @@ deps =
 
 commands_pre =
   pip install -e {toxinidir}/opentelemetry-api \
+              -e {toxinidir}/opentelemetry-semantic-conventions \
               -e {toxinidir}/opentelemetry-sdk \
               -e {toxinidir}/opentelemetry-python-contrib/opentelemetry-instrumentation \
               -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests \

--- a/tox.ini
+++ b/tox.ini
@@ -272,7 +272,7 @@ commands_post =
   docker-compose down -v
 
 [testenv:public-symbols-check]
-basepython: python3.8
+basepython: python3.9
 recreate = True
 deps =
   GitPython


### PR DESCRIPTION
Noticed that lint and some of the other targets were still using python 3.8, updating them to 3.9