### PR TITLE
Introduce SpanLimits class to tracing SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
 
+### Added 
+- Allow span limits to be set programatically via TracerProvider.
+  ([#1877](https://github.com/open-telemetry/opentelemetry-python/pull/1877))
+
 ### Changed
 - Updated get_tracer to return an empty string when passed an invalid name
   ([#1854](https://github.com/open-telemetry/opentelemetry-python/pull/1854))


### PR DESCRIPTION
# Description

This renames the internal `_Limits` class to `SpanLimits` and allows an instance of SpanLimits to be passed to TracerProvider.

Implements the following proposal: [discussion](https://github.com/open-telemetry/opentelemetry-python/discussions/1859)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new tests

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
