### PR TITLE
Release for V1.3.0 and 0.22b0, update release script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: c46b39e4e94af5ae8f97e684960f1aec0595c33e
+  CONTRIB_REPO_SHA: bfc767f40e50643adf36c07952a07b8f1e380b2f
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.3.0-0.22b0...HEAD)
+
+## [1.3.0-0.22b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.3.0-0.22b0) - 2021-06-01
+
+
 
 ### Added 
 - Allow span limits to be set programatically via TracerProvider.

--- a/docs/examples/error_handler/error_handler_0/setup.cfg
+++ b/docs/examples/error_handler/error_handler_0/setup.cfg
@@ -36,7 +36,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-sdk == 1.3.0.dev0
+    opentelemetry-sdk == 1.3.0
 
 [options.packages.find]
 where = src

--- a/docs/examples/error_handler/error_handler_0/src/error_handler_0/version.py
+++ b/docs/examples/error_handler/error_handler_0/src/error_handler_0/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.21.dev0"
+__version__ = "0.22b0"

--- a/docs/examples/error_handler/error_handler_1/setup.cfg
+++ b/docs/examples/error_handler/error_handler_1/setup.cfg
@@ -36,7 +36,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-sdk == 1.3.0.dev0
+    opentelemetry-sdk == 1.3.0
 
 [options.packages.find]
 where = src

--- a/docs/examples/error_handler/error_handler_1/src/error_handler_1/version.py
+++ b/docs/examples/error_handler/error_handler_1/src/error_handler_1/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.21.dev0"
+__version__ = "0.22b0"

--- a/eachdist.ini
+++ b/eachdist.ini
@@ -19,7 +19,7 @@ packages=
     opentelemetry-sdk
     opentelemetry-proto
     opentelemetry-propagator-jaeger
-    pentelemetry-propagator-b3
+    opentelemetry-propagator-b3
     opentelemetry-exporter-zipkin-proto-http
     opentelemetry-exporter-zipkin-json
     opentelemetry-exporter-zipkin

--- a/eachdist.ini
+++ b/eachdist.ini
@@ -13,29 +13,29 @@ sortfirst=
     exporter/*
 
 [stable]
-version=1.3.0.dev0
+version=1.3.0
 
 packages=
     opentelemetry-sdk
     opentelemetry-proto
-    propagator/opentelemetry-propagator-jaeger
-    propagator/opentelemetry-propagator-b3
-    exporter/opentelemetry-exporter-zipkin-proto-http
-    exporter/opentelemetry-exporter-zipkin-json
-    exporter/opentelemetry-exporter-zipkin
-    exporter/opentelemetry-exporter-otlp-proto-grpc
-    exporter/opentelemetry-exporter-otlp
-    exporter/opentelemetry-exporter-jaeger-thrift
-    exporter/opentelemetry-exporter-jaeger-proto-grpc
-    exporter/opentelemetry-exporter-jaeger
+    opentelemetry-propagator-jaeger
+    pentelemetry-propagator-b3
+    opentelemetry-exporter-zipkin-proto-http
+    opentelemetry-exporter-zipkin-json
+    opentelemetry-exporter-zipkin
+    opentelemetry-exporter-otlp-proto-grpc
+    opentelemetry-exporter-otlp
+    opentelemetry-exporter-jaeger-thrift
+    opentelemetry-exporter-jaeger-proto-grpc
+    opentelemetry-exporter-jaeger
     opentelemetry-api
 
 [prerelease]
-version=0.22.dev0
+version=0.22b0
 
 packages=
     opentelemetry-opentracing-shim
-    exporter/opentelemetry-exporter-opencensus
+    opentelemetry-exporter-opencensus
     opentelemetry-distro
     opentelemetry-semantic-conventions
     opentelemetry-test
@@ -46,12 +46,12 @@ packages=
 version=1.10a0
 
 packages=
-    exporter/opentelemetry-exporter-prometheus-remote-write
-    exporter/opentelemetry-exporter-prometheus
+    opentelemetry-exporter-prometheus-remote-write
+    opentelemetry-exporter-prometheus
     opentelemetry-api
     opentelemetry-sdk
-    exporter/opentelemetry-exporter-otlp-proto-grpc
-    exporter/opentelemetry-exporter-otlp
+    opentelemetry-exporter-otlp-proto-grpc
+    opentelemetry-exporter-otlp
 
 [lintroots]
 extraroots=examples/*,scripts/

--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.cfg
@@ -42,8 +42,8 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52
-    opentelemetry-api == 1.3.0.dev0
-    opentelemetry-sdk == 1.3.0.dev0
+    opentelemetry-api == 1.3.0
+    opentelemetry-sdk == 1.3.0
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/version.py
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/exporter/opentelemetry-exporter-jaeger-thrift/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/setup.cfg
@@ -41,8 +41,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     thrift >= 0.10.0
-    opentelemetry-api == 1.3.0.dev0
-    opentelemetry-sdk == 1.3.0.dev0
+    opentelemetry-api == 1.3.0
+    opentelemetry-sdk == 1.3.0
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-jaeger-thrift/src/opentelemetry/exporter/jaeger/thrift/version.py
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/src/opentelemetry/exporter/jaeger/thrift/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/exporter/opentelemetry-exporter-jaeger/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger/setup.cfg
@@ -39,8 +39,8 @@ python_requires = >=3.6
 
 packages=find_namespace:
 install_requires =
-    opentelemetry-exporter-jaeger-proto-grpc == 1.3.0.dev0
-    opentelemetry-exporter-jaeger-thrift == 1.3.0.dev0
+    opentelemetry-exporter-jaeger-proto-grpc == 1.3.0
+    opentelemetry-exporter-jaeger-thrift == 1.3.0
 
 [options.extras_require]
 test =

--- a/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/version.py
+++ b/exporter/opentelemetry-exporter-jaeger/src/opentelemetry/exporter/jaeger/version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/exporter/opentelemetry-exporter-opencensus/setup.cfg
+++ b/exporter/opentelemetry-exporter-opencensus/setup.cfg
@@ -42,8 +42,8 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     opencensus-proto >= 0.1.0, < 1.0.0
-    opentelemetry-api == 1.3.0.dev0
-    opentelemetry-sdk == 1.3.0.dev0
+    opentelemetry-api == 1.3.0
+    opentelemetry-sdk == 1.3.0
     protobuf >= 3.13.0
 
 [options.packages.find]

--- a/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
+++ b/exporter/opentelemetry-exporter-opencensus/src/opentelemetry/exporter/opencensus/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.22.dev0"
+__version__ = "0.22b0"

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
@@ -41,9 +41,9 @@ packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52
-    opentelemetry-api == 1.3.0.dev0
-    opentelemetry-sdk == 1.3.0.dev0
-    opentelemetry-proto == 1.3.0.dev0
+    opentelemetry-api == 1.3.0
+    opentelemetry-sdk == 1.3.0
+    opentelemetry-proto == 1.3.0
     backoff ~= 1.10.0
 
 [options.extras_require]

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/version.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/exporter/opentelemetry-exporter-otlp/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp/setup.cfg
@@ -38,4 +38,4 @@ classifiers =
 python_requires = >=3.6
 packages=find_namespace:
 install_requires =
-    opentelemetry-exporter-otlp-proto-grpc == 1.3.0.dev0
+    opentelemetry-exporter-otlp-proto-grpc == 1.3.0

--- a/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/version.py
+++ b/exporter/opentelemetry-exporter-otlp/src/opentelemetry/exporter/otlp/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/exporter/opentelemetry-exporter-zipkin-json/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin-json/setup.cfg
@@ -42,8 +42,8 @@ package_dir=
 packages=find_namespace:
 install_requires =
     requests ~= 2.7
-    opentelemetry-api == 1.3.0.dev0
-    opentelemetry-sdk == 1.3.0.dev0
+    opentelemetry-api == 1.3.0
+    opentelemetry-sdk == 1.3.0
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/json/version.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/json/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/setup.cfg
@@ -43,9 +43,9 @@ packages=find_namespace:
 install_requires =
     protobuf >= 3.12
     requests ~= 2.7
-    opentelemetry-api == 1.3.0.dev0
-    opentelemetry-sdk == 1.3.0.dev0
-    opentelemetry-exporter-zipkin-json == 1.3.0.dev0
+    opentelemetry-api == 1.3.0
+    opentelemetry-sdk == 1.3.0
+    opentelemetry-exporter-zipkin-json == 1.3.0
 
 [options.packages.find]
 where = src

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/src/opentelemetry/exporter/zipkin/proto/http/version.py
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/src/opentelemetry/exporter/zipkin/proto/http/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/exporter/opentelemetry-exporter-zipkin/setup.cfg
+++ b/exporter/opentelemetry-exporter-zipkin/setup.cfg
@@ -38,8 +38,8 @@ classifiers =
 python_requires = >=3.6
 packages=find_namespace:
 install_requires =
-    opentelemetry-exporter-zipkin-json == 1.3.0.dev0
-    opentelemetry-exporter-zipkin-proto-http == 1.3.0.dev0
+    opentelemetry-exporter-zipkin-json == 1.3.0
+    opentelemetry-exporter-zipkin-proto-http == 1.3.0
 
 [options.extras_require]
 test =

--- a/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/version.py
+++ b/exporter/opentelemetry-exporter-zipkin/src/opentelemetry/exporter/zipkin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/opentelemetry-api/src/opentelemetry/version.py
+++ b/opentelemetry-api/src/opentelemetry/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/opentelemetry-distro/setup.cfg
+++ b/opentelemetry-distro/setup.cfg
@@ -41,9 +41,9 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 1.3.0.dev0
-    opentelemetry-instrumentation == 0.22.dev0
-    opentelemetry-sdk == 1.3.0.dev0
+    opentelemetry-api == 1.3.0
+    opentelemetry-instrumentation == 0.22b0
+    opentelemetry-sdk == 1.3.0
 
 [options.packages.find]
 where = src
@@ -57,4 +57,4 @@ opentelemetry_configurator =
 [options.extras_require]
 test =
 otlp =
-    opentelemetry-exporter-otlp == 1.3.0.dev0
+    opentelemetry-exporter-otlp == 1.3.0

--- a/opentelemetry-distro/src/opentelemetry/distro/version.py
+++ b/opentelemetry-distro/src/opentelemetry/distro/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.22.dev0"
+__version__ = "0.22b0"

--- a/opentelemetry-proto/src/opentelemetry/proto/version.py
+++ b/opentelemetry-proto/src/opentelemetry/proto/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/opentelemetry-sdk/setup.cfg
+++ b/opentelemetry-sdk/setup.cfg
@@ -42,8 +42,8 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 1.3.0.dev0
-    opentelemetry-semantic-conventions == 0.22.dev0
+    opentelemetry-api == 1.3.0
+    opentelemetry-semantic-conventions == 0.22b0
 
 [options.packages.find]
 where = src

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/version.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.22.dev0"
+__version__ = "0.22b0"

--- a/propagator/opentelemetry-propagator-b3/setup.cfg
+++ b/propagator/opentelemetry-propagator-b3/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.3.0.dev0
+    opentelemetry-api == 1.3.0
     deprecated >= 1.2.6
 
 [options.extras_require]

--- a/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/version.py
+++ b/propagator/opentelemetry-propagator-b3/src/opentelemetry/propagators/b3/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/propagator/opentelemetry-propagator-jaeger/setup.cfg
+++ b/propagator/opentelemetry-propagator-jaeger/setup.cfg
@@ -40,7 +40,7 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.3.0.dev0
+    opentelemetry-api == 1.3.0
 
 [options.extras_require]
 test =

--- a/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/version.py
+++ b/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0.dev0"
+__version__ = "1.3.0"

--- a/shim/opentelemetry-opentracing-shim/setup.cfg
+++ b/shim/opentelemetry-opentracing-shim/setup.cfg
@@ -42,11 +42,11 @@ packages=find_namespace:
 install_requires =
     Deprecated >= 1.2.6
     opentracing ~= 2.0
-    opentelemetry-api == 1.3.0.dev0
+    opentelemetry-api == 1.3.0
 
 [options.extras_require]
 test =
-    opentelemetry-test == 0.22.dev0
+    opentelemetry-test == 0.22b0
     opentracing ~= 2.2.0
 
 [options.packages.find]

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/version.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.22.dev0"
+__version__ = "0.22b0"

--- a/tests/util/setup.cfg
+++ b/tests/util/setup.cfg
@@ -37,8 +37,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 1.3.0.dev0
-    opentelemetry-sdk == 1.3.0.dev0
+    opentelemetry-api == 1.3.0
+    opentelemetry-sdk == 1.3.0
 
 [options.extras_require]
 test = flask~=1.0

--- a/tests/util/src/opentelemetry/test/version.py
+++ b/tests/util/src/opentelemetry/test/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.dev0"
+__version__ = "0.22b0"


### PR DESCRIPTION
Paths in Windows use backslashes instead of forward slashes. Updated release script to use package name instead of path to find target in release script.