### PR TITLE
Add global LogEmitterProvider and convenience function get_log_emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.3.0-0.22b0...HEAD)
 
+### Added
+- Add global LogEmitterProvider and convenience function get_log_emitter
+  ([#1901](https://github.com/open-telemetry/opentelemetry-python/pull/1901))
+
 ### Changed
 - Updated `opentelemetry-opencensus-exporter` to use `service_name` of spans instead of resource
   ([#1897](https://github.com/open-telemetry/opentelemetry-python/pull/1897))

--- a/opentelemetry-sdk/setup.cfg
+++ b/opentelemetry-sdk/setup.cfg
@@ -51,6 +51,8 @@ where = src
 [options.entry_points]
 opentelemetry_tracer_provider =
     sdk_tracer_provider = opentelemetry.sdk.trace:TracerProvider
+opentelemetry_log_emitter_provider =
+    sdk_log_emitter_provider = opentelemetry.sdk.logs:LogEmitterProvider
 opentelemetry_exporter =
     console_span = opentelemetry.sdk.trace.export:ConsoleSpanExporter
 opentelemetry_id_generator =

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
@@ -242,3 +242,8 @@ The following two environment variables have the same effect
 
 If both are set, :envvar:`OTEL_SERVICE_NAME` takes precedence.
 """
+
+OTEL_PYTHON_LOG_EMITTER_PROVIDER = "OTEL_PYTHON_LOG_EMITTER_PROVIDER"
+"""
+.. envvar:: OTEL_PYTHON_LOG_EMITTER_PROVIDER
+"""

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
@@ -246,4 +246,8 @@ If both are set, :envvar:`OTEL_SERVICE_NAME` takes precedence.
 OTEL_PYTHON_LOG_EMITTER_PROVIDER = "OTEL_PYTHON_LOG_EMITTER_PROVIDER"
 """
 .. envvar:: OTEL_PYTHON_LOG_EMITTER_PROVIDER
+
+The :envvar:`OTEL_PYTHON_LOG_EMITTER_PROVIDER` environment variable allows users to
+provide the entry point for loading the log emitter provider. If not specified, SDK
+LogEmitterProvider is used.
 """

--- a/opentelemetry-sdk/tests/logs/__init__.py
+++ b/opentelemetry-sdk/tests/logs/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/opentelemetry-sdk/tests/logs/test_global_provider.py
+++ b/opentelemetry-sdk/tests/logs/test_global_provider.py
@@ -1,3 +1,17 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # type:ignore
 import unittest
 from importlib import reload

--- a/opentelemetry-sdk/tests/logs/test_global_provider.py
+++ b/opentelemetry-sdk/tests/logs/test_global_provider.py
@@ -1,0 +1,61 @@
+# type:ignore
+import unittest
+from importlib import reload
+from logging import WARNING
+from unittest.mock import patch
+
+from opentelemetry.sdk import logs
+from opentelemetry.sdk.environment_variables import (
+    OTEL_PYTHON_LOG_EMITTER_PROVIDER,
+)
+from opentelemetry.sdk.logs import (
+    LogEmitterProvider,
+    get_log_emitter_provider,
+    set_log_emitter_provider,
+)
+
+
+class TestGlobals(unittest.TestCase):
+    def tearDown(self):
+        reload(logs)
+
+    def check_override_not_allowed(self):
+        """set_log_emitter_provider should throw a warning when overridden"""
+        provider = get_log_emitter_provider()
+        with self.assertLogs(level=WARNING) as test:
+            set_log_emitter_provider(LogEmitterProvider())
+            self.assertEqual(
+                test.output,
+                [
+                    (
+                        "WARNING:opentelemetry.sdk.logs:Overriding of current "
+                        "LogEmitterProvider is not allowed"
+                    )
+                ],
+            )
+        self.assertIs(provider, get_log_emitter_provider())
+
+    def test_set_tracer_provider(self):
+        reload(logs)
+        provider = LogEmitterProvider()
+        set_log_emitter_provider(provider)
+        retrieved_provider = get_log_emitter_provider()
+        self.assertEqual(provider, retrieved_provider)
+
+    def test_tracer_provider_override_warning(self):
+        reload(logs)
+        self.check_override_not_allowed()
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_PYTHON_LOG_EMITTER_PROVIDER: "sdk_log_emitter_provider"},
+    )
+    def test_sdk_log_emitter_provider(self):
+        reload(logs)
+        self.check_override_not_allowed()
+
+    @patch.dict("os.environ", {OTEL_PYTHON_LOG_EMITTER_PROVIDER: "unknown"})
+    def test_unknown_log_emitter_provider(self):
+        reload(logs)
+        with self.assertRaises(Exception):
+            get_log_emitter_provider()


### PR DESCRIPTION
# Description

Part-2 of #1890. This adds support for set/register and access a global default LogEmitterProvider.