### PR TITLE
use BoundedAttributes for attributes in link, event, resource, spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Attributes for `Link` and `Resource` are immutable as they are for `Event`, which means
   any attempt to modify attributes directly will result in a `TypeError` exception.
   ([#1909](https://github.com/open-telemetry/opentelemetry-python/pull/1909))
+- Added `BoundedDict` to the API to make it available for `Link` which is defined in the
+  API. Marked `BoundedDict` in the SDK as deprecated as a result.
+  ([#1915](https://github.com/open-telemetry/opentelemetry-python/pull/1915))
 
 ## [1.3.0-0.22b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.3.0-0.22b0) - 2021-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Attributes for `Link` and `Resource` are immutable as they are for `Event`, which means
   any attempt to modify attributes directly will result in a `TypeError` exception.
   ([#1909](https://github.com/open-telemetry/opentelemetry-python/pull/1909))
-- Added `BoundedDict` to the API to make it available for `Link` which is defined in the
+- Added `BoundedAttributes` to the API to make it available for `Link` which is defined in the
   API. Marked `BoundedDict` in the SDK as deprecated as a result.
   ([#1915](https://github.com/open-telemetry/opentelemetry-python/pull/1915))
 

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -164,7 +164,8 @@ class BoundedDict(MutableMapping):
     def __delitem__(self, key):
         if getattr(self, "_immutable", False):
             raise TypeError
-        del self._dict[key]
+        with self._lock:
+            del self._dict[key]
 
     def __iter__(self):
         with self._lock:

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -110,7 +110,7 @@ def _filter_attributes(attributes: types.Attributes) -> None:
 _DEFAULT_LIMIT = 128
 
 
-class BoundedDict(MutableMapping):
+class BoundedAttributes(MutableMapping):
     """An ordered dict with a fixed max capacity.
 
     Oldest elements are dropped when the dict is full and a new element is

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -107,12 +107,6 @@ def _filter_attributes(attributes: types.Attributes) -> None:
                 attributes.pop(attr_key)
 
 
-def _create_immutable_attributes(
-    attributes: types.Attributes,
-) -> types.Attributes:
-    return MappingProxyType(attributes.copy() if attributes else {})
-
-
 _DEFAULT_LIMIT = 128
 
 

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -14,8 +14,11 @@
 # type: ignore
 
 import logging
+import threading
+from collections import OrderedDict
+from collections.abc import MutableMapping
 from types import MappingProxyType
-from typing import MutableSequence, Sequence
+from typing import MutableSequence, Optional, Sequence
 
 from opentelemetry.util import types
 
@@ -108,3 +111,73 @@ def _create_immutable_attributes(
     attributes: types.Attributes,
 ) -> types.Attributes:
     return MappingProxyType(attributes.copy() if attributes else {})
+
+
+_DEFAULT_LIMIT = 128
+
+
+class BoundedDict(MutableMapping):
+    """An ordered dict with a fixed max capacity.
+
+    Oldest elements are dropped when the dict is full and a new element is
+    added.
+    """
+
+    def __init__(
+        self,
+        maxlen: Optional[int] = _DEFAULT_LIMIT,
+        attributes: types.Attributes = None,
+        immutable: bool = True,
+    ):
+        if maxlen is not None:
+            if not isinstance(maxlen, int):
+                raise ValueError
+            if maxlen < 0:
+                raise ValueError
+        self.maxlen = maxlen
+        self.dropped = 0
+        self._dict = OrderedDict()  # type: OrderedDict
+        self._lock = threading.Lock()  # type: threading.Lock
+        if attributes:
+            _filter_attributes(attributes)
+            for key, value in attributes.items():
+                self[key] = value
+        self._immutable = immutable
+
+    def __repr__(self):
+        return "{}({}, maxlen={})".format(
+            type(self).__name__, dict(self._dict), self.maxlen
+        )
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __setitem__(self, key, value):
+        if getattr(self, "_immutable", False):
+            raise TypeError
+        with self._lock:
+            if self.maxlen is not None and self.maxlen == 0:
+                self.dropped += 1
+                return
+
+            if key in self._dict:
+                del self._dict[key]
+            elif self.maxlen is not None and len(self._dict) == self.maxlen:
+                del self._dict[next(iter(self._dict.keys()))]
+                self.dropped += 1
+            self._dict[key] = value
+
+    def __delitem__(self, key):
+        if getattr(self, "_immutable", False):
+            raise TypeError
+        del self._dict[key]
+
+    def __iter__(self):
+        with self._lock:
+            return iter(self._dict.copy())
+
+    def __len__(self):
+        return len(self._dict)
+
+    def copy(self):
+        return self._dict.copy()

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -124,10 +124,10 @@ class BoundedDict(MutableMapping):
         immutable: bool = True,
     ):
         if maxlen is not None:
-            if not isinstance(maxlen, int):
-                raise ValueError
-            if maxlen < 0:
-                raise ValueError
+            if not isinstance(maxlen, int) or maxlen < 0:
+                raise ValueError(
+                    "maxlen must be valid int greater or equal to 0"
+                )
         self.maxlen = maxlen
         self.dropped = 0
         self._dict = OrderedDict()  # type: OrderedDict

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -82,7 +82,7 @@ from logging import getLogger
 from typing import Iterator, Optional, Sequence, cast
 
 from opentelemetry import context as context_api
-from opentelemetry.attributes import BoundedDict # type: ignore
+from opentelemetry.attributes import BoundedDict  # type: ignore
 from opentelemetry.context.context import Context
 from opentelemetry.environment_variables import OTEL_PYTHON_TRACER_PROVIDER
 from opentelemetry.trace.propagation import (

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -82,7 +82,7 @@ from logging import getLogger
 from typing import Iterator, Optional, Sequence, cast
 
 from opentelemetry import context as context_api
-from opentelemetry.attributes import BoundedDict  # type: ignore
+from opentelemetry.attributes import BoundedAttributes  # type: ignore
 from opentelemetry.context.context import Context
 from opentelemetry.environment_variables import OTEL_PYTHON_TRACER_PROVIDER
 from opentelemetry.trace.propagation import (
@@ -140,7 +140,7 @@ class Link(_LinkBase):
         attributes: types.Attributes = None,
     ) -> None:
         super().__init__(context)
-        self._attributes = BoundedDict(
+        self._attributes = BoundedAttributes(
             attributes=attributes
         )  # type: types.Attributes
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -82,7 +82,7 @@ from logging import getLogger
 from typing import Iterator, Optional, Sequence, cast
 
 from opentelemetry import context as context_api
-from opentelemetry.attributes import BoundedDict
+from opentelemetry.attributes import BoundedDict # type: ignore
 from opentelemetry.context.context import Context
 from opentelemetry.environment_variables import OTEL_PYTHON_TRACER_PROVIDER
 from opentelemetry.trace.propagation import (

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -82,9 +82,7 @@ from logging import getLogger
 from typing import Iterator, Optional, Sequence, cast
 
 from opentelemetry import context as context_api
-from opentelemetry.attributes import (  # type: ignore
-    _create_immutable_attributes,
-)
+from opentelemetry.attributes import BoundedDict
 from opentelemetry.context.context import Context
 from opentelemetry.environment_variables import OTEL_PYTHON_TRACER_PROVIDER
 from opentelemetry.trace.propagation import (
@@ -142,8 +140,8 @@ class Link(_LinkBase):
         attributes: types.Attributes = None,
     ) -> None:
         super().__init__(context)
-        self._attributes = _create_immutable_attributes(
-            attributes
+        self._attributes = BoundedDict(
+            attributes=attributes
         )  # type: types.Attributes
 
     @property

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -18,7 +18,7 @@ import collections
 import unittest
 
 from opentelemetry.attributes import (
-    BoundedDict,
+    BoundedAttributes,
     _filter_attributes,
     _is_valid_attribute_value,
 )
@@ -81,7 +81,7 @@ class TestAttributes(unittest.TestCase):
         )
 
 
-class TestBoundedDict(unittest.TestCase):
+class TestBoundedAttributes(unittest.TestCase):
     base = collections.OrderedDict(
         [
             ("name", "Firulais"),
@@ -93,12 +93,12 @@ class TestBoundedDict(unittest.TestCase):
 
     def test_negative_maxlen(self):
         with self.assertRaises(ValueError):
-            BoundedDict(-1)
+            BoundedAttributes(-1)
 
     def test_from_map(self):
         dic_len = len(self.base)
         base_copy = collections.OrderedDict(self.base)
-        bdict = BoundedDict(dic_len, base_copy)
+        bdict = BoundedAttributes(dic_len, base_copy)
 
         self.assertEqual(len(bdict), dic_len)
 
@@ -114,14 +114,14 @@ class TestBoundedDict(unittest.TestCase):
 
         # map too big
         half_len = dic_len // 2
-        bdict = BoundedDict(half_len, self.base)
+        bdict = BoundedAttributes(half_len, self.base)
         self.assertEqual(len(tuple(bdict)), half_len)
         self.assertEqual(bdict.dropped, dic_len - half_len)
 
     def test_bounded_dict(self):
         # create empty dict
         dic_len = len(self.base)
-        bdict = BoundedDict(dic_len, immutable=False)
+        bdict = BoundedAttributes(dic_len, immutable=False)
         self.assertEqual(len(bdict), 0)
 
         # fill dict
@@ -134,7 +134,7 @@ class TestBoundedDict(unittest.TestCase):
         for key in self.base:
             self.assertEqual(bdict[key], self.base[key])
 
-        # test __iter__ in BoundedDict
+        # test __iter__ in BoundedAttributes
         for key in bdict:
             self.assertEqual(bdict[key], self.base[key])
 
@@ -161,7 +161,7 @@ class TestBoundedDict(unittest.TestCase):
             _ = bdict["new-name"]
 
     def test_no_limit_code(self):
-        bdict = BoundedDict(maxlen=None, immutable=False)
+        bdict = BoundedAttributes(maxlen=None, immutable=False)
         for num in range(100):
             bdict[num] = num
 
@@ -169,6 +169,6 @@ class TestBoundedDict(unittest.TestCase):
             self.assertEqual(bdict[num], num)
 
     def test_immutable(self):
-        bdict = BoundedDict()
+        bdict = BoundedAttributes()
         with self.assertRaises(TypeError):
             bdict["should-not-work"] = "dict immutable"

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -19,7 +19,6 @@ import unittest
 
 from opentelemetry.attributes import (
     BoundedDict,
-    _create_immutable_attributes,
     _filter_attributes,
     _is_valid_attribute_value,
 )
@@ -80,13 +79,6 @@ class TestAttributes(unittest.TestCase):
                 "valid-byte-string": "hello-otel",
             },
         )
-
-    def test_create_immutable_attributes(self):
-        attrs = {"key": "value", "pi": 3.14}
-        immutable = _create_immutable_attributes(attrs)
-        # TypeError: 'mappingproxy' object does not support item assignment
-        with self.assertRaises(TypeError):
-            immutable["pi"] = 1.34
 
 
 class TestBoundedDict(unittest.TestCase):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -64,7 +64,7 @@ from json import dumps
 
 import pkg_resources
 
-from opentelemetry.attributes import BoundedDict
+from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk.environment_variables import (
     OTEL_RESOURCE_ATTRIBUTES,
     OTEL_SERVICE_NAME,
@@ -144,7 +144,7 @@ class Resource:
     def __init__(
         self, attributes: Attributes, schema_url: typing.Optional[str] = None
     ):
-        self._attributes = BoundedDict(attributes=attributes)
+        self._attributes = BoundedAttributes(attributes=attributes)
         if schema_url is None:
             schema_url = ""
         self._schema_url = schema_url

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -64,10 +64,7 @@ from json import dumps
 
 import pkg_resources
 
-from opentelemetry.attributes import (
-    _create_immutable_attributes,
-    _filter_attributes,
-)
+from opentelemetry.attributes import BoundedDict
 from opentelemetry.sdk.environment_variables import (
     OTEL_RESOURCE_ATTRIBUTES,
     OTEL_SERVICE_NAME,
@@ -147,8 +144,7 @@ class Resource:
     def __init__(
         self, attributes: Attributes, schema_url: typing.Optional[str] = None
     ):
-        _filter_attributes(attributes)
-        self._attributes = _create_immutable_attributes(attributes)
+        self._attributes = BoundedDict(attributes=attributes)
         if schema_url is None:
             schema_url = ""
         self._schema_url = schema_url

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -567,8 +567,13 @@ class SpanLimits:
         )
 
     def __repr__(self):
-        return "max_attributes={}, max_events={}, max_links={}".format(
-            self.max_attributes, self.max_events, self.max_links
+        return "{}(max_attributes={}, max_events={}, max_links={}, max_event_attributes={}, max_link_attributes={})".format(
+            type(self).__name__,
+            self.max_attributes,
+            self.max_events,
+            self.max_links,
+            self.max_event_attributes,
+            self.max_link_attributes,
         )
 
     @classmethod

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -532,12 +532,6 @@ class SpanLimits:
 
     UNSET = -1
 
-    max_attributes: int
-    max_events: int
-    max_links: int
-    max_event_attributes: int
-    max_link_attributes: int
-
     def __init__(
         self,
         max_attributes: Optional[int] = None,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -39,7 +39,10 @@ from typing import (
 
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
-from opentelemetry.attributes import BoundedAttributes, _is_valid_attribute_value
+from opentelemetry.attributes import (
+    BoundedAttributes,
+    _is_valid_attribute_value,
+)
 from opentelemetry.sdk import util
 from opentelemetry.sdk.environment_variables import (
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
@@ -751,7 +754,9 @@ class Span(trace_api.Span, ReadableSpan):
         attributes: types.Attributes = None,
         timestamp: Optional[int] = None,
     ) -> None:
-        attributes = BoundedAttributes(self._limits.max_event_attributes, attributes)
+        attributes = BoundedAttributes(
+            self._limits.max_event_attributes, attributes
+        )
         self._add_event(
             Event(
                 name=name,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -39,11 +39,7 @@ from typing import (
 
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
-from opentelemetry.attributes import (
-    _create_immutable_attributes,
-    _filter_attributes,
-    _is_valid_attribute_value,
-)
+from opentelemetry.attributes import BoundedDict, _is_valid_attribute_value
 from opentelemetry.sdk import util
 from opentelemetry.sdk.environment_variables import (
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
@@ -53,7 +49,7 @@ from opentelemetry.sdk.environment_variables import (
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import sampling
 from opentelemetry.sdk.trace.id_generator import IdGenerator, RandomIdGenerator
-from opentelemetry.sdk.util import BoundedDict, BoundedList
+from opentelemetry.sdk.util import BoundedList
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
 from opentelemetry.trace import SpanContext
 from opentelemetry.trace.status import Status, StatusCode
@@ -65,6 +61,8 @@ logger = logging.getLogger(__name__)
 _DEFAULT_OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT = 128
 _DEFAULT_OTEL_SPAN_EVENT_COUNT_LIMIT = 128
 _DEFAULT_OTEL_SPAN_LINK_COUNT_LIMIT = 128
+_DEFAULT_OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT = 128
+_DEFAULT_OTEL_LINK_ATTRIBUTE_COUNT_LIMIT = 128
 
 
 _ENV_VALUE_UNSET = "unset"
@@ -526,6 +524,10 @@ class SpanLimits:
         max_links: Maximum number of links that can be added to a Span.
             Environment variable: OTEL_SPAN_LINK_COUNT_LIMIT
             Default: {_DEFAULT_SPAN_LINK_COUNT_LIMIT}
+        max_event_attributes: Maximum number of attributes that can be added to an Event.
+            Default: {_DEFAULT_OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT}
+        max_link_attributes: Maximum number of attributes that can be added to a Link.
+            Default: {_DEFAULT_OTEL_LINK_ATTRIBUTE_COUNT_LIMIT}
     """
 
     UNSET = -1
@@ -533,12 +535,16 @@ class SpanLimits:
     max_attributes: int
     max_events: int
     max_links: int
+    max_event_attributes: int
+    max_link_attributes: int
 
     def __init__(
         self,
         max_attributes: Optional[int] = None,
         max_events: Optional[int] = None,
         max_links: Optional[int] = None,
+        max_event_attributes: Optional[int] = None,
+        max_link_attributes: Optional[int] = None,
     ):
         self.max_attributes = self._from_env_if_absent(
             max_attributes,
@@ -554,6 +560,16 @@ class SpanLimits:
             max_links,
             OTEL_SPAN_LINK_COUNT_LIMIT,
             _DEFAULT_OTEL_SPAN_LINK_COUNT_LIMIT,
+        )
+        self.max_event_attributes = self._from_env_if_absent(
+            max_event_attributes,
+            OTEL_SPAN_LINK_COUNT_LIMIT,
+            _DEFAULT_OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT,
+        )
+        self.max_link_attributes = self._from_env_if_absent(
+            max_link_attributes,
+            OTEL_SPAN_LINK_COUNT_LIMIT,
+            _DEFAULT_OTEL_LINK_ATTRIBUTE_COUNT_LIMIT,
         )
 
     def __repr__(self):
@@ -591,6 +607,8 @@ _UnsetLimits = SpanLimits(
     max_attributes=SpanLimits.UNSET,
     max_events=SpanLimits.UNSET,
     max_links=SpanLimits.UNSET,
+    max_event_attributes=SpanLimits.UNSET,
+    max_link_attributes=SpanLimits.UNSET,
 )
 
 SPAN_ATTRIBUTE_COUNT_LIMIT = SpanLimits._from_env_if_absent(
@@ -661,22 +679,14 @@ class Span(trace_api.Span, ReadableSpan):
         self._span_processor = span_processor
         self._limits = limits
         self._lock = threading.Lock()
-
-        _filter_attributes(attributes)
-        if not attributes:
-            self._attributes = self._new_attributes()
-        else:
-            self._attributes = BoundedDict.from_map(
-                self._limits.max_attributes, attributes
-            )
-
+        self._attributes = BoundedDict(
+            self._limits.max_attributes, attributes, immutable=False
+        )
         self._events = self._new_events()
         if events:
             for event in events:
-                _filter_attributes(event.attributes)
-                # pylint: disable=protected-access
-                event._attributes = _create_immutable_attributes(
-                    event.attributes
+                event._attributes = BoundedDict(
+                    self._limits.max_event_attributes, event.attributes
                 )
                 self._events.append(event)
 
@@ -689,9 +699,6 @@ class Span(trace_api.Span, ReadableSpan):
         return '{}(name="{}", context={})'.format(
             type(self).__name__, self._name, self._context
         )
-
-    def _new_attributes(self):
-        return BoundedDict(self._limits.max_attributes)
 
     def _new_events(self):
         return BoundedList(self._limits.max_events)
@@ -745,13 +752,12 @@ class Span(trace_api.Span, ReadableSpan):
         attributes: types.Attributes = None,
         timestamp: Optional[int] = None,
     ) -> None:
-        _filter_attributes(attributes)
-        attributes = _create_immutable_attributes(attributes)
+        attributes = BoundedDict(self._limits.max_event_attributes, attributes)
         self._add_event(
             Event(
                 name=name,
                 attributes=attributes,
-                timestamp=_time_ns() if timestamp is None else timestamp,
+                timestamp=timestamp,
             )
         )
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -39,7 +39,7 @@ from typing import (
 
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
-from opentelemetry.attributes import BoundedDict, _is_valid_attribute_value
+from opentelemetry.attributes import BoundedAttributes, _is_valid_attribute_value
 from opentelemetry.sdk import util
 from opentelemetry.sdk.environment_variables import (
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
@@ -473,7 +473,7 @@ class ReadableSpan:
 
     @staticmethod
     def _format_attributes(attributes):
-        if isinstance(attributes, BoundedDict):
+        if isinstance(attributes, BoundedAttributes):
             return attributes._dict  # pylint: disable=protected-access
         if isinstance(attributes, MappingProxyType):
             return attributes.copy()
@@ -678,13 +678,13 @@ class Span(trace_api.Span, ReadableSpan):
         self._span_processor = span_processor
         self._limits = limits
         self._lock = threading.Lock()
-        self._attributes = BoundedDict(
+        self._attributes = BoundedAttributes(
             self._limits.max_attributes, attributes, immutable=False
         )
         self._events = self._new_events()
         if events:
             for event in events:
-                event._attributes = BoundedDict(
+                event._attributes = BoundedAttributes(
                     self._limits.max_event_attributes, event.attributes
                 )
                 self._events.append(event)
@@ -751,7 +751,7 @@ class Span(trace_api.Span, ReadableSpan):
         attributes: types.Attributes = None,
         timestamp: Optional[int] = None,
     ) -> None:
-        attributes = BoundedDict(self._limits.max_event_attributes, attributes)
+        attributes = BoundedAttributes(self._limits.max_event_attributes, attributes)
         self._add_event(
             Event(
                 name=name,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -18,6 +18,8 @@ from collections import OrderedDict, deque
 from collections.abc import MutableMapping, Sequence
 from typing import Optional
 
+from deprecated import deprecated
+
 
 def ns_to_iso_str(nanoseconds):
     """Get an ISO 8601 string from time_ns value."""
@@ -91,6 +93,7 @@ class BoundedList(Sequence):
         return bounded_list
 
 
+@deprecated(version="1.4.0")  # type: ignore
 class BoundedDict(MutableMapping):
     """An ordered dict with a fixed max capacity.
 


### PR DESCRIPTION
# Description

Continuing towards making attributes consistent across Span, Link, Event and Resource by utilizing BoundedDict everywhere. Added `BoundedDict` to the API to make it available for `Link` which is defined in the API. Marked `BoundedDict` in the SDK as deprecated as a result. This is getting us one step closer to supporting dropped attribute counts in the exporters. One question I have for reviewers is whether the BoundedDict should be in `opentelemetry.attributes` or not, it could live in utils or something like that instead.

Fixes #1906 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
