### PR TITLE
Update Zoom meeting link to match calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ For information about contributing to OpenTelemetry Python, see [CONTRIBUTING.md
 
 We meet weekly on Thursdays at 9AM PST. The meeting is subject to change depending on contributors' availability. Check the [OpenTelemetry community calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com) for specific dates.
 
-Meetings take place via [Zoom video conference](https://zoom.us/j/6729396170). The passcode is _77777_.
+Meetings take place via [Zoom video conference](https://zoom.us/j/8287234601?pwd=YjN2MURycXc4cEZlYTRtYjJaM0grZz09). The passcode is _77777_.
 
 Meeting notes are available as a public [Google doc](https://docs.google.com/document/d/1CIMGoIOZ-c3-igzbd6_Pnxx1SjAkjwqoYSUWxPY8XIs/edit). For edit access, get in touch on [GitHub Discussions](https://github.com/open-telemetry/opentelemetry-python/discussions).
 


### PR DESCRIPTION
# Description

A quick PR to update the Zoom meeting link to the one on the OTel Public Calendar