### PR TITLE
Fix OTLP exporter not grouping exported spans properly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: 82c4f600872a72fedaebad758f0d5588dfb53a00
+  CONTRIB_REPO_SHA: c100b21fa40727709bb31cf4e2b67b737a09ea2c
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BoundedAttributes` to the API to make it available for `Link` which is defined in the
   API. Marked `BoundedDict` in the SDK as deprecated as a result.
   ([#1915](https://github.com/open-telemetry/opentelemetry-python/pull/1915))
+- Fix OTLP SpanExporter to distinguish spans based off Resource and InstrumentationInfo
+  ([#1915](https://github.com/open-telemetry/opentelemetry-python/pull/1915))
 
 ## [1.3.0-0.22b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.3.0-0.22b0) - 2021-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   API. Marked `BoundedDict` in the SDK as deprecated as a result.
   ([#1915](https://github.com/open-telemetry/opentelemetry-python/pull/1915))
 - Fix OTLP SpanExporter to distinguish spans based off Resource and InstrumentationInfo
-  ([#1915](https://github.com/open-telemetry/opentelemetry-python/pull/1915))
+  ([#1927](https://github.com/open-telemetry/opentelemetry-python/pull/1927))
 
 ## [1.3.0-0.22b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.3.0-0.22b0) - 2021-06-01
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -157,7 +157,9 @@ def get_resource_data(
             resource_class(
                 **{
                     "resource": collector_resource,
-                    "instrumentation_library_{}".format(name): instrumentation_library_data.values(),
+                    "instrumentation_library_{}".format(
+                        name
+                    ): instrumentation_library_data.values(),
                 }
             )
         )

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -157,9 +157,7 @@ def get_resource_data(
             resource_class(
                 **{
                     "resource": collector_resource,
-                    "instrumentation_library_{}".format(name): [
-                        instrumentation_library_data
-                    ],
+                    "instrumentation_library_{}".format(name): instrumentation_library_data.values(),
                 }
             )
         )

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
@@ -236,30 +236,42 @@ class OTLPSpanExporter(
         sdk_resource_instrumentation_library_spans = {}
 
         for sdk_span in data:
-            instrumentation_library_spans_map = sdk_resource_instrumentation_library_spans.get(sdk_span.resource, {})
+            instrumentation_library_spans_map = (
+                sdk_resource_instrumentation_library_spans.get(
+                    sdk_span.resource, {}
+                )
+            )
             # If we haven't seen the Resource yet, add it to the map
             if not instrumentation_library_spans_map:
                 sdk_resource_instrumentation_library_spans[
                     sdk_span.resource
                 ] = instrumentation_library_spans_map
-            instrumentation_library_spans = instrumentation_library_spans_map.get(sdk_span.instrumentation_info)
+            instrumentation_library_spans = (
+                instrumentation_library_spans_map.get(
+                    sdk_span.instrumentation_info
+                )
+            )
             # If we haven't seen the InstrumentationInfo for this Resource yet, add it to the map
             if not instrumentation_library_spans:
                 if sdk_span.instrumentation_info is not None:
-                    instrumentation_library_spans_map[sdk_span.instrumentation_info] = (
-                        InstrumentationLibrarySpans(
-                            instrumentation_library=InstrumentationLibrary(
-                                name=sdk_span.instrumentation_info.name,
-                                version=sdk_span.instrumentation_info.version,
-                            )
+                    instrumentation_library_spans_map[
+                        sdk_span.instrumentation_info
+                    ] = InstrumentationLibrarySpans(
+                        instrumentation_library=InstrumentationLibrary(
+                            name=sdk_span.instrumentation_info.name,
+                            version=sdk_span.instrumentation_info.version,
                         )
                     )
                 else:
                     # If no InstrumentationInfo, store in None key
-                    instrumentation_library_spans_map[sdk_span.instrumentation_info] = (
-                        InstrumentationLibrarySpans()
-                    )
-            instrumentation_library_spans = instrumentation_library_spans_map.get(sdk_span.instrumentation_info)
+                    instrumentation_library_spans_map[
+                        sdk_span.instrumentation_info
+                    ] = InstrumentationLibrarySpans()
+            instrumentation_library_spans = (
+                instrumentation_library_spans_map.get(
+                    sdk_span.instrumentation_info
+                )
+            )
             self._collector_span_kwargs = {}
 
             self._translate_name(sdk_span)
@@ -279,7 +291,9 @@ class OTLPSpanExporter(
                 "SPAN_KIND_{}".format(sdk_span.kind.name),
             )
 
-            instrumentation_library_spans.spans.append(CollectorSpan(**self._collector_span_kwargs))
+            instrumentation_library_spans.spans.append(
+                CollectorSpan(**self._collector_span_kwargs)
+            )
 
         return ExportTraceServiceRequest(
             resource_spans=get_resource_data(

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
@@ -236,12 +236,17 @@ class OTLPSpanExporter(
         sdk_resource_instrumentation_library_spans = {}
 
         for sdk_span in data:
-
-            if sdk_span.resource not in (
-                sdk_resource_instrumentation_library_spans.keys()
-            ):
+            instrumentation_library_spans_map = sdk_resource_instrumentation_library_spans.get(sdk_span.resource, {})
+            # If we haven't seen the Resource yet, add it to the map
+            if not instrumentation_library_spans_map:
+                sdk_resource_instrumentation_library_spans[
+                    sdk_span.resource
+                ] = instrumentation_library_spans_map
+            instrumentation_library_spans = instrumentation_library_spans_map.get(sdk_span.instrumentation_info)
+            # If we haven't seen the InstrumentationInfo for this Resource yet, add it to the map
+            if not instrumentation_library_spans:
                 if sdk_span.instrumentation_info is not None:
-                    instrumentation_library_spans = (
+                    instrumentation_library_spans_map[sdk_span.instrumentation_info] = (
                         InstrumentationLibrarySpans(
                             instrumentation_library=InstrumentationLibrary(
                                 name=sdk_span.instrumentation_info.name,
@@ -249,16 +254,12 @@ class OTLPSpanExporter(
                             )
                         )
                     )
-
                 else:
-                    instrumentation_library_spans = (
+                    # If no InstrumentationInfo, store in None key
+                    instrumentation_library_spans_map[sdk_span.instrumentation_info] = (
                         InstrumentationLibrarySpans()
                     )
-
-                sdk_resource_instrumentation_library_spans[
-                    sdk_span.resource
-                ] = instrumentation_library_spans
-
+            instrumentation_library_spans = instrumentation_library_spans_map.get(sdk_span.instrumentation_info)
             self._collector_span_kwargs = {}
 
             self._translate_name(sdk_span)
@@ -278,9 +279,7 @@ class OTLPSpanExporter(
                 "SPAN_KIND_{}".format(sdk_span.kind.name),
             )
 
-            sdk_resource_instrumentation_library_spans[
-                sdk_span.resource
-            ].spans.append(CollectorSpan(**self._collector_span_kwargs))
+            instrumentation_library_spans.spans.append(CollectorSpan(**self._collector_span_kwargs))
 
         return ExportTraceServiceRequest(
             resource_spans=get_resource_data(

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -534,7 +534,6 @@ class TestOTLPSpanExporter(TestCase):
         self.assertEqual(expected, self.exporter._translate_data([self.span]))
 
     def test_translate_spans_multi(self):
-
         expected = ExportTraceServiceRequest(
             resource_spans=[
                 ResourceSpans(
@@ -636,8 +635,8 @@ class TestOTLPSpanExporter(TestCase):
                                 OTLPSpan(
                                     # pylint: disable=no-member
                                     name="c",
-                                    start_time_unix_nano=self.span.start_time,
-                                    end_time_unix_nano=self.span.end_time,
+                                    start_time_unix_nano=self.span3.start_time,
+                                    end_time_unix_nano=self.span3.end_time,
                                     trace_state="a=b,c=d",
                                     span_id=int.to_bytes(
                                         10217189687419569865, 8, "big"
@@ -656,7 +655,7 @@ class TestOTLPSpanExporter(TestCase):
                                     status=Status(code=0, message=""),
                                 )
                             ],
-                        )
+                        ),
                     ],
                 ),
                 ResourceSpans(
@@ -677,8 +676,8 @@ class TestOTLPSpanExporter(TestCase):
                                 OTLPSpan(
                                     # pylint: disable=no-member
                                     name="b",
-                                    start_time_unix_nano=self.span.start_time,
-                                    end_time_unix_nano=self.span.end_time,
+                                    start_time_unix_nano=self.span2.start_time,
+                                    end_time_unix_nano=self.span2.end_time,
                                     trace_state="a=b,c=d",
                                     span_id=int.to_bytes(
                                         10217189687419569865, 8, "big"
@@ -704,7 +703,10 @@ class TestOTLPSpanExporter(TestCase):
         )
 
         # pylint: disable=protected-access
-        self.assertEqual(expected, self.exporter._translate_data([self.span, self.span2, self.span3]))
+        self.assertEqual(
+            expected,
+            self.exporter._translate_data([self.span, self.span2, self.span3]),
+        )
 
     def _check_translated_status(
         self,


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-python/issues/1814

Split exported spans based of Resource and InstrumentationInfo.