### PR TITLE
Generate semconv constants update for OTel Spec 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.3.0-0.22b0...HEAD)
+- `opentelemetry-semantic-conventions` Generate semconv constants update for OTel Spec 1.5.0
+  ([#1946](https://github.com/open-telemetry/opentelemetry-python/pull/1946))
 
 ### Added
 - Dropped attributes/events/links count available exposed on ReadableSpans.

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/resource/__init__.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/resource/__init__.py
@@ -14,6 +14,7 @@
 
 from enum import Enum
 
+
 class ResourceAttributes:
     CLOUD_PROVIDER = "cloud.provider"
     """
@@ -457,6 +458,7 @@ As an alternative, consider setting `faas.id` as a span attribute instead.
     Additional description of the web engine (e.g. detailed version and edition information).
     """
 
+
 class CloudProviderValues(Enum):
     AWS = "aws"
     """Amazon Web Services."""
@@ -611,4 +613,3 @@ class TelemetrySdkLanguageValues(Enum):
 
     WEBJS = "webjs"
     """webjs."""
-

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/__init__.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/__init__.py
@@ -14,6 +14,7 @@
 
 from enum import Enum
 
+
 class SpanAttributes:
     AWS_LAMBDA_INVOKED_ARN = "aws.lambda.invoked_arn"
     """
@@ -111,7 +112,9 @@ class SpanAttributes:
     Whether or not the query is idempotent.
     """
 
-    DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = "db.cassandra.speculative_execution_count"
+    DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = (
+        "db.cassandra.speculative_execution_count"
+    )
     """
     The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
     """
@@ -260,7 +263,9 @@ clear whether the exception will escape.
     The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size.
     """
 
-    HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED = "http.request_content_length_uncompressed"
+    HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED = (
+        "http.request_content_length_uncompressed"
+    )
     """
     The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used.
     """
@@ -270,7 +275,9 @@ clear whether the exception will escape.
     The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size.
     """
 
-    HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED = "http.response_content_length_uncompressed"
+    HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED = (
+        "http.response_content_length_uncompressed"
+    )
     """
     The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used.
     """
@@ -352,12 +359,16 @@ clear whether the exception will escape.
     The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID".
     """
 
-    MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES = "messaging.message_payload_size_bytes"
+    MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES = (
+        "messaging.message_payload_size_bytes"
+    )
     """
     The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
     """
 
-    MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES = "messaging.message_payload_compressed_size_bytes"
+    MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES = (
+        "messaging.message_payload_compressed_size_bytes"
+    )
     """
     The compressed size of the message payload in bytes.
     """
@@ -472,17 +483,23 @@ clear whether the exception will escape.
     The JSON-serialized value of each item in the `ConsumedCapacity` response field.
     """
 
-    AWS_DYNAMODB_ITEM_COLLECTION_METRICS = "aws.dynamodb.item_collection_metrics"
+    AWS_DYNAMODB_ITEM_COLLECTION_METRICS = (
+        "aws.dynamodb.item_collection_metrics"
+    )
     """
     The JSON-serialized value of the `ItemCollectionMetrics` response field.
     """
 
-    AWS_DYNAMODB_PROVISIONED_READ_CAPACITY = "aws.dynamodb.provisioned_read_capacity"
+    AWS_DYNAMODB_PROVISIONED_READ_CAPACITY = (
+        "aws.dynamodb.provisioned_read_capacity"
+    )
     """
     The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
     """
 
-    AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY = "aws.dynamodb.provisioned_write_capacity"
+    AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY = (
+        "aws.dynamodb.provisioned_write_capacity"
+    )
     """
     The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.
     """
@@ -517,12 +534,16 @@ clear whether the exception will escape.
     The value of the `Select` request parameter.
     """
 
-    AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES = "aws.dynamodb.global_secondary_indexes"
+    AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES = (
+        "aws.dynamodb.global_secondary_indexes"
+    )
     """
     The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.
     """
 
-    AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES = "aws.dynamodb.local_secondary_indexes"
+    AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES = (
+        "aws.dynamodb.local_secondary_indexes"
+    )
     """
     The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.
     """
@@ -567,7 +588,9 @@ clear whether the exception will escape.
     The JSON-serialized value of each item in the `AttributeDefinitions` request field.
     """
 
-    AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES = "aws.dynamodb.global_secondary_index_updates"
+    AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES = (
+        "aws.dynamodb.global_secondary_index_updates"
+    )
     """
     The JSON-serialized value of each item in the the `GlobalSecondaryIndexUpdates` request field.
     """
@@ -632,6 +655,7 @@ clear whether the exception will escape.
     """
     `error.message` property of response if it is an error response.
     """
+
 
 class DbSystemValues(Enum):
     OTHER_SQL = "other_sql"
@@ -957,4 +981,3 @@ class RpcGrpcStatusCodeValues(Enum):
 
     UNAUTHENTICATED = 16
     """UNAUTHENTICATED."""
-

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/__init__.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/__init__.py
@@ -14,8 +14,13 @@
 
 from enum import Enum
 
-
 class SpanAttributes:
+    AWS_LAMBDA_INVOKED_ARN = "aws.lambda.invoked_arn"
+    """
+    The full invoked ARN as provided on the `Context` passed to the function (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable).
+    Note: This may be different from `faas.id` if an alias is involved.
+    """
+
     DB_SYSTEM = "db.system"
     """
     An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers.
@@ -106,9 +111,7 @@ class SpanAttributes:
     Whether or not the query is idempotent.
     """
 
-    DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = (
-        "db.cassandra.speculative_execution_count"
-    )
+    DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = "db.cassandra.speculative_execution_count"
     """
     The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
     """
@@ -257,9 +260,7 @@ clear whether the exception will escape.
     The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size.
     """
 
-    HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED = (
-        "http.request_content_length_uncompressed"
-    )
+    HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED = "http.request_content_length_uncompressed"
     """
     The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used.
     """
@@ -269,9 +270,7 @@ clear whether the exception will escape.
     The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size.
     """
 
-    HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED = (
-        "http.response_content_length_uncompressed"
-    )
+    HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED = "http.response_content_length_uncompressed"
     """
     The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used.
     """
@@ -353,16 +352,12 @@ clear whether the exception will escape.
     The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID".
     """
 
-    MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES = (
-        "messaging.message_payload_size_bytes"
-    )
+    MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES = "messaging.message_payload_size_bytes"
     """
     The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
     """
 
-    MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES = (
-        "messaging.message_payload_compressed_size_bytes"
-    )
+    MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES = "messaging.message_payload_compressed_size_bytes"
     """
     The compressed size of the message payload in bytes.
     """
@@ -450,9 +445,141 @@ clear whether the exception will escape.
     The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
     """
 
+    RPC_SYSTEM = "rpc.system"
+    """
+    The value `aws-api`.
+    """
+
+    RPC_SERVICE = "rpc.service"
+    """
+    The name of the service to which a request is made, as returned by the AWS SDK.
+    Note: This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
+    """
+
+    RPC_METHOD = "rpc.method"
+    """
+    The name of the operation corresponding to the request, as returned by the AWS SDK.
+    Note: This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
+    """
+
+    AWS_DYNAMODB_TABLE_NAMES = "aws.dynamodb.table_names"
+    """
+    The keys in the `RequestItems` object field.
+    """
+
+    AWS_DYNAMODB_CONSUMED_CAPACITY = "aws.dynamodb.consumed_capacity"
+    """
+    The JSON-serialized value of each item in the `ConsumedCapacity` response field.
+    """
+
+    AWS_DYNAMODB_ITEM_COLLECTION_METRICS = "aws.dynamodb.item_collection_metrics"
+    """
+    The JSON-serialized value of the `ItemCollectionMetrics` response field.
+    """
+
+    AWS_DYNAMODB_PROVISIONED_READ_CAPACITY = "aws.dynamodb.provisioned_read_capacity"
+    """
+    The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
+    """
+
+    AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY = "aws.dynamodb.provisioned_write_capacity"
+    """
+    The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.
+    """
+
+    AWS_DYNAMODB_CONSISTENT_READ = "aws.dynamodb.consistent_read"
+    """
+    The value of the `ConsistentRead` request parameter.
+    """
+
+    AWS_DYNAMODB_PROJECTION = "aws.dynamodb.projection"
+    """
+    The value of the `ProjectionExpression` request parameter.
+    """
+
+    AWS_DYNAMODB_LIMIT = "aws.dynamodb.limit"
+    """
+    The value of the `Limit` request parameter.
+    """
+
+    AWS_DYNAMODB_ATTRIBUTES_TO_GET = "aws.dynamodb.attributes_to_get"
+    """
+    The value of the `AttributesToGet` request parameter.
+    """
+
+    AWS_DYNAMODB_INDEX_NAME = "aws.dynamodb.index_name"
+    """
+    The value of the `IndexName` request parameter.
+    """
+
+    AWS_DYNAMODB_SELECT = "aws.dynamodb.select"
+    """
+    The value of the `Select` request parameter.
+    """
+
+    AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES = "aws.dynamodb.global_secondary_indexes"
+    """
+    The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.
+    """
+
+    AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES = "aws.dynamodb.local_secondary_indexes"
+    """
+    The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.
+    """
+
+    AWS_DYNAMODB_EXCLUSIVE_START_TABLE = "aws.dynamodb.exclusive_start_table"
+    """
+    The value of the `ExclusiveStartTableName` request parameter.
+    """
+
+    AWS_DYNAMODB_TABLE_COUNT = "aws.dynamodb.table_count"
+    """
+    The the number of items in the `TableNames` response parameter.
+    """
+
+    AWS_DYNAMODB_SCAN_FORWARD = "aws.dynamodb.scan_forward"
+    """
+    The value of the `ScanIndexForward` request parameter.
+    """
+
+    AWS_DYNAMODB_SEGMENT = "aws.dynamodb.segment"
+    """
+    The value of the `Segment` request parameter.
+    """
+
+    AWS_DYNAMODB_TOTAL_SEGMENTS = "aws.dynamodb.total_segments"
+    """
+    The value of the `TotalSegments` request parameter.
+    """
+
+    AWS_DYNAMODB_COUNT = "aws.dynamodb.count"
+    """
+    The value of the `Count` response parameter.
+    """
+
+    AWS_DYNAMODB_SCANNED_COUNT = "aws.dynamodb.scanned_count"
+    """
+    The value of the `ScannedCount` response parameter.
+    """
+
+    AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS = "aws.dynamodb.attribute_definitions"
+    """
+    The JSON-serialized value of each item in the `AttributeDefinitions` request field.
+    """
+
+    AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES = "aws.dynamodb.global_secondary_index_updates"
+    """
+    The JSON-serialized value of each item in the the `GlobalSecondaryIndexUpdates` request field.
+    """
+
     MESSAGING_OPERATION = "messaging.operation"
     """
     A string identifying the kind of message consumption as defined in the [Operation names](#operation-names) section above. If the operation is "send", this attribute MUST NOT be set, since the operation can be inferred from the span kind in that case.
+    """
+
+    MESSAGING_RABBITMQ_ROUTING_KEY = "messaging.rabbitmq.routing_key"
+    """
+    RabbitMQ message routing key.
     """
 
     MESSAGING_KAFKA_MESSAGE_KEY = "messaging.kafka.message_key"
@@ -481,26 +608,30 @@ clear whether the exception will escape.
     A boolean that is true if the message is a tombstone.
     """
 
-    RPC_SYSTEM = "rpc.system"
-    """
-    A string identifying the remoting system.
-    """
-
-    RPC_SERVICE = "rpc.service"
-    """
-    The full name of the service being called, including its package name, if applicable.
-    """
-
-    RPC_METHOD = "rpc.method"
-    """
-    The name of the method being called, must be equal to the $method part in the span name.
-    """
-
     RPC_GRPC_STATUS_CODE = "rpc.grpc.status_code"
     """
     The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request.
     """
 
+    RPC_JSONRPC_VERSION = "rpc.jsonrpc.version"
+    """
+    Protocol version as in `jsonrpc` property of request/response. Since JSON-RPC 1.0 does not specify this, the value can be omitted.
+    """
+
+    RPC_JSONRPC_REQUEST_ID = "rpc.jsonrpc.request_id"
+    """
+    `id` property of request or response. Since protocol allows id to be int, string, `null` or missing (for notifications), value is expected to be cast to string for simplicity. Use empty string in case of `null` value. Omit entirely if this is a notification.
+    """
+
+    RPC_JSONRPC_ERROR_CODE = "rpc.jsonrpc.error_code"
+    """
+    `error.code` property of response if it is an error response.
+    """
+
+    RPC_JSONRPC_ERROR_MESSAGE = "rpc.jsonrpc.error_message"
+    """
+    `error.message` property of response if it is an error response.
+    """
 
 class DbSystemValues(Enum):
     OTHER_SQL = "other_sql"
@@ -638,18 +769,24 @@ class DbSystemValues(Enum):
     ELASTICSEARCH = "elasticsearch"
     """Elasticsearch."""
 
+    MEMCACHED = "memcached"
+    """Memcached."""
+
+    COCKROACHDB = "cockroachdb"
+    """CockroachDB."""
+
 
 class NetTransportValues(Enum):
-    IP_TCP = "IP.TCP"
-    """IP.TCP."""
+    IP_TCP = "ip_tcp"
+    """ip_tcp."""
 
-    IP_UDP = "IP.UDP"
-    """IP.UDP."""
+    IP_UDP = "ip_udp"
+    """ip_udp."""
 
-    IP = "IP"
+    IP = "ip"
     """Another IP-based protocol."""
 
-    UNIX = "Unix"
+    UNIX = "unix"
     """Unix Domain socket. See below."""
 
     PIPE = "pipe"
@@ -663,38 +800,38 @@ class NetTransportValues(Enum):
 
 
 class DbCassandraConsistencyLevelValues(Enum):
-    ALL = "ALL"
-    """ALL."""
+    ALL = "all"
+    """all."""
 
-    EACH_QUORUM = "EACH_QUORUM"
-    """EACH_QUORUM."""
+    EACH_QUORUM = "each_quorum"
+    """each_quorum."""
 
-    QUORUM = "QUORUM"
-    """QUORUM."""
+    QUORUM = "quorum"
+    """quorum."""
 
-    LOCAL_QUORUM = "LOCAL_QUORUM"
-    """LOCAL_QUORUM."""
+    LOCAL_QUORUM = "local_quorum"
+    """local_quorum."""
 
-    ONE = "ONE"
-    """ONE."""
+    ONE = "one"
+    """one."""
 
-    TWO = "TWO"
-    """TWO."""
+    TWO = "two"
+    """two."""
 
-    THREE = "THREE"
-    """THREE."""
+    THREE = "three"
+    """three."""
 
-    LOCAL_ONE = "LOCAL_ONE"
-    """LOCAL_ONE."""
+    LOCAL_ONE = "local_one"
+    """local_one."""
 
-    ANY = "ANY"
-    """ANY."""
+    ANY = "any"
+    """any."""
 
-    SERIAL = "SERIAL"
-    """SERIAL."""
+    SERIAL = "serial"
+    """serial."""
 
-    LOCAL_SERIAL = "LOCAL_SERIAL"
-    """LOCAL_SERIAL."""
+    LOCAL_SERIAL = "local_serial"
+    """local_serial."""
 
 
 class FaasTriggerValues(Enum):
@@ -755,7 +892,7 @@ class FaasInvokedProviderValues(Enum):
     """Amazon Web Services."""
 
     AZURE = "azure"
-    """Amazon Web Services."""
+    """Microsoft Azure."""
 
     GCP = "gcp"
     """Google Cloud Platform."""
@@ -820,3 +957,4 @@ class RpcGrpcStatusCodeValues(Enum):
 
     UNAUTHENTICATED = 16
     """UNAUTHENTICATED."""
+

--- a/scripts/semconv/generate.sh
+++ b/scripts/semconv/generate.sh
@@ -4,7 +4,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec version to make SemanticAttributes generation reproducible
-SPEC_VERSION=v1.1.0
+SPEC_VERSION=v1.5.0
+OTEL_SEMCONV_GEN_IMG_VERSION=0.4.1
 
 cd ${SCRIPT_DIR}
 
@@ -22,7 +23,7 @@ docker run --rm \
   -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/trace:/source \
   -v ${SCRIPT_DIR}/templates:/templates \
   -v ${ROOT_DIR}/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/:/output \
-  otel/semconvgen:0.2.1 \
+  otel/semconvgen:$OTEL_SEMCONV_GEN_IMG_VERSION \
   -f /source code \
   --template /templates/semantic_attributes.j2 \
   --output /output/__init__.py \
@@ -31,8 +32,8 @@ docker run --rm \
 docker run --rm \
   -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/resource:/source \
   -v ${SCRIPT_DIR}/templates:/templates \
-  -v ${ROOT_DIR}/opentelemetry-semantic-conventions/src/opentelemetry/semconv/resources/:/output \
-  otel/semconvgen:0.2.1 \
+  -v ${ROOT_DIR}/opentelemetry-semantic-conventions/src/opentelemetry/semconv/resource/:/output \
+  otel/semconvgen:$OTEL_SEMCONV_GEN_IMG_VERSION \
   -f /source code \
   --template /templates/semantic_attributes.j2 \
   --output /output/__init__.py \


### PR DESCRIPTION
# Description

Updates the semantic conventions constants to the [v1.5.0 tag](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.5.0/specification/resource/semantic_conventions) using the `./scripts/semconv/generate.sh` script.

Additionally, after learning how to run the script by updating the Docker image tag with @lonewolf3739 's help from [this Slack message](https://cloud-native.slack.com/archives/C01PD4HUVBL/p1625870622183400), I thought it would be helpful to pull that tag version out as a variable in the `generate.sh` script.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I manually checked all the variables which changed and ensured that no one in contrib or core was using them. Other than that no tests are needed.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~ (Not needed?)
