### PR TITLE
Add validation for Trace ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-distro` & `opentelemetry-sdk` Moved Auto Instrumentation Configurator code to SDK
   to let distros use its default implementation
   ([#1937](https://github.com/open-telemetry/opentelemetry-python/pull/1937))
-- Add Trace ID validation to meet [TraceID spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#spancontext) ([#1992]((https://github.com/open-telemetry/opentelemetry-python/pull/1992)))
+- Add Trace ID validation to meet [TraceID spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#spancontext) ([#1992](https://github.com/open-telemetry/opentelemetry-python/pull/1992))
 
 ## [0.23.1](https://github.com/open-telemetry/opentelemetry-python/pull/1987) - 2021-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-distro` & `opentelemetry-sdk` Moved Auto Instrumentation Configurator code to SDK
   to let distros use its default implementation
   ([#1937](https://github.com/open-telemetry/opentelemetry-python/pull/1937))
+- Add Trace ID validation to meet [TraceID spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#spancontext) ([#1992]((https://github.com/open-telemetry/opentelemetry-python/pull/1992)))
 
 ## [0.23.1](https://github.com/open-telemetry/opentelemetry-python/pull/1987) - 2021-07-26
 

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -389,7 +389,7 @@ class TraceState(typing.Mapping[str, str]):
 
 
 DEFAULT_TRACE_STATE = TraceState.get_default()
-
+_TRACE_ID_HEX_LENGTH = 2 ** 128 - 1
 
 class SpanContext(
     typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]
@@ -423,7 +423,7 @@ class SpanContext(
         is_valid = (
             trace_id != INVALID_TRACE_ID
             and span_id != INVALID_SPAN_ID
-            and trace_id < 2 ** 128 - 1
+            and trace_id < _TRACE_ID_HEX_LENGTH
         )
 
         return tuple.__new__(

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -391,6 +391,7 @@ class TraceState(typing.Mapping[str, str]):
 DEFAULT_TRACE_STATE = TraceState.get_default()
 _TRACE_ID_HEX_LENGTH = 2 ** 128 - 1
 
+
 class SpanContext(
     typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]
 ):

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -393,6 +393,7 @@ DEFAULT_TRACE_STATE = TraceState.get_default()
 _TRACE_ID_BYTES = 16
 _TRACE_ID_HEX_LENGTH = 2 * _TRACE_ID_BYTES
 
+
 def _validate_trace_id(trace_id: int) -> bool:
     """Validates a trace_id.
 
@@ -408,6 +409,7 @@ def _validate_trace_id(trace_id: int) -> bool:
         return False
 
     return True
+
 
 class SpanContext(
     typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]
@@ -438,7 +440,11 @@ class SpanContext(
         if trace_state is None:
             trace_state = DEFAULT_TRACE_STATE
 
-        is_valid = trace_id != INVALID_TRACE_ID and span_id != INVALID_SPAN_ID and _validate_trace_id(trace_id)
+        is_valid = (
+            trace_id != INVALID_TRACE_ID
+            and span_id != INVALID_SPAN_ID
+            and _validate_trace_id(trace_id)
+        )
 
         return tuple.__new__(
             cls,

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -390,26 +390,6 @@ class TraceState(typing.Mapping[str, str]):
 
 DEFAULT_TRACE_STATE = TraceState.get_default()
 
-_TRACE_ID_BYTES = 16
-_TRACE_ID_HEX_LENGTH = 2 * _TRACE_ID_BYTES
-
-
-def _validate_trace_id(trace_id: int) -> bool:
-    """Validates a trace_id.
-
-    Args:
-        trace_id: An int that is expected to corresponds to 16-bytes hexdecimal value
-
-    Returns:
-        True if trace_id is valid, False otherwise.
-    """
-    if not trace_id:
-        return False
-    if len(format(trace_id, "032x")) != _TRACE_ID_HEX_LENGTH:
-        return False
-
-    return True
-
 
 class SpanContext(
     typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]
@@ -443,7 +423,7 @@ class SpanContext(
         is_valid = (
             trace_id != INVALID_TRACE_ID
             and span_id != INVALID_SPAN_ID
-            and _validate_trace_id(trace_id)
+            and trace_id < 2 ** 128 - 1
         )
 
         return tuple.__new__(

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -390,6 +390,24 @@ class TraceState(typing.Mapping[str, str]):
 
 DEFAULT_TRACE_STATE = TraceState.get_default()
 
+_TRACE_ID_BYTES = 16
+_TRACE_ID_HEX_LENGTH = 2 * _TRACE_ID_BYTES
+
+def _validate_trace_id(trace_id: int) -> bool:
+    """Validates a trace_id.
+
+    Args:
+        trace_id: An int that is expected to corresponds to 16-bytes hexdecimal value
+
+    Returns:
+        True if trace_id is valid, False otherwise.
+    """
+    if not trace_id:
+        return False
+    if len(format(trace_id, "032x")) != _TRACE_ID_HEX_LENGTH:
+        return False
+
+    return True
 
 class SpanContext(
     typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]
@@ -420,7 +438,7 @@ class SpanContext(
         if trace_state is None:
             trace_state = DEFAULT_TRACE_STATE
 
-        is_valid = trace_id != INVALID_TRACE_ID and span_id != INVALID_SPAN_ID
+        is_valid = trace_id != INVALID_TRACE_ID and span_id != INVALID_SPAN_ID and _validate_trace_id(trace_id)
 
         return tuple.__new__(
             cls,

--- a/opentelemetry-api/tests/trace/test_span_context.py
+++ b/opentelemetry-api/tests/trace/test_span_context.py
@@ -34,3 +34,12 @@ class TestSpanContext(unittest.TestCase):
         pickle_sc = pickle.loads(pickle.dumps(sc))
         self.assertEqual(sc.trace_id, pickle_sc.trace_id)
         self.assertEqual(sc.span_id, pickle_sc.span_id)
+
+        invalid_sc = trace.SpanContext(
+            9999999999999999999999999999999999999999999999999999999999999999999999999999,
+            9,
+            is_remote=False,
+            trace_flags=trace.DEFAULT_TRACE_OPTIONS,
+            trace_state=trace.DEFAULT_TRACE_STATE,
+        )
+        self.assertFalse(invalid_sc.is_valid)


### PR DESCRIPTION
# Description

This adds the validator in the constructor of SpanContext so that we can detect the invalid trace ID as early as possible.

Fixes #1991 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] TestSpanContext

I added the section in TestSpanContext in `opentelemetry-api/tests/trace/test_span_context.py` to validate Trace ID.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
