### PR TITLE
Add default and service name to get_aggregated_resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.4.0-0.23b0...HEAD)
-- Fix documentation on well known exporters and variable OTEL_TRACES_EXPORTER which were misnamed [#2023](https://github.com/open-telemetry/opentelemetry-python/pull/2023)
+- Fix documentation on well known exporters and variable OTEL_TRACES_EXPORTER which were misnamed
+  ([#2023](https://github.com/open-telemetry/opentelemetry-python/pull/2023))
+- `opentelemetry-sdk` `get_aggregated_resource()` returns default resource and service name
+  whenever called
+  ([#2013](https://github.com/open-telemetry/opentelemetry-python/pull/2013))
 - `opentelemetry-distro` & `opentelemetry-sdk` Moved Auto Instrumentation Configurator code to SDK
   to let distros use its default implementation
   ([#1937](https://github.com/open-telemetry/opentelemetry-python/pull/1937))

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -291,7 +291,7 @@ def get_aggregated_resources(
     :param timeout: Number of seconds to wait for each detector to return
     :return:
     """
-    detectors_merged_resource = initial_resource or _EMPTY_RESOURCE
+    detectors_merged_resource = initial_resource or Resource.create()
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
         futures = [executor.submit(detector.detect) for detector in detectors]
@@ -312,4 +312,4 @@ def get_aggregated_resources(
                     detected_resource
                 )
 
-    return Resource.create().merge(detectors_merged_resource)
+    return detectors_merged_resource

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -230,7 +230,14 @@ class TestResources(unittest.TestCase):
 
     def test_aggregated_resources_no_detectors(self):
         aggregated_resources = resources.get_aggregated_resources([])
-        self.assertEqual(aggregated_resources, resources.Resource.get_empty())
+        self.assertEqual(
+            aggregated_resources,
+            resources._DEFAULT_RESOURCE.merge(
+                resources.Resource(
+                    {resources.SERVICE_NAME: "unknown_service"}, ""
+                )
+            ),
+        )
 
     def test_aggregated_resources_with_static_resource(self):
         static_resource = resources.Resource({"static_key": "static_value"})
@@ -239,7 +246,11 @@ class TestResources(unittest.TestCase):
             resources.get_aggregated_resources(
                 [], initial_resource=static_resource
             ),
-            static_resource,
+            resources._DEFAULT_RESOURCE.merge(
+                resources.Resource(
+                    {resources.SERVICE_NAME: "unknown_service"}, ""
+                )
+            ).merge(static_resource),
         )
 
         resource_detector = mock.Mock(spec=resources.ResourceDetector)
@@ -250,11 +261,17 @@ class TestResources(unittest.TestCase):
             resources.get_aggregated_resources(
                 [resource_detector], initial_resource=static_resource
             ),
-            resources.Resource(
-                {
-                    "static_key": "try_to_overwrite_existing_value",
-                    "key": "value",
-                }
+            resources._DEFAULT_RESOURCE.merge(
+                resources.Resource(
+                    {resources.SERVICE_NAME: "unknown_service"}, ""
+                )
+            ).merge(
+                resources.Resource(
+                    {
+                        "static_key": "try_to_overwrite_existing_value",
+                        "key": "value",
+                    }
+                )
             ),
         )
 
@@ -280,13 +297,19 @@ class TestResources(unittest.TestCase):
             resources.get_aggregated_resources(
                 [resource_detector1, resource_detector2, resource_detector3]
             ),
-            resources.Resource(
-                {
-                    "key1": "value1",
-                    "key2": "try_to_overwrite_existing_value",
-                    "key3": "try_to_overwrite_existing_value",
-                    "key4": "value4",
-                }
+            resources._DEFAULT_RESOURCE.merge(
+                resources.Resource(
+                    {resources.SERVICE_NAME: "unknown_service"}, ""
+                )
+            ).merge(
+                resources.Resource(
+                    {
+                        "key1": "value1",
+                        "key2": "try_to_overwrite_existing_value",
+                        "key3": "try_to_overwrite_existing_value",
+                        "key4": "value4",
+                    }
+                )
             ),
         )
 
@@ -321,9 +344,15 @@ class TestResources(unittest.TestCase):
             resources.get_aggregated_resources(
                 [resource_detector1, resource_detector2]
             ),
-            resources.Resource(
-                {"key1": "value1", "key2": "value2", "key3": "value3"},
-                "url1",
+            resources._DEFAULT_RESOURCE.merge(
+                resources.Resource(
+                    {resources.SERVICE_NAME: "unknown_service"}, ""
+                )
+            ).merge(
+                resources.Resource(
+                    {"key1": "value1", "key2": "value2", "key3": "value3"},
+                    "url1",
+                )
             ),
         )
         with self.assertLogs(level=ERROR) as log_entry:
@@ -331,8 +360,14 @@ class TestResources(unittest.TestCase):
                 resources.get_aggregated_resources(
                     [resource_detector2, resource_detector3]
                 ),
-                resources.Resource(
-                    {"key2": "value2", "key3": "value3"}, "url1"
+                resources._DEFAULT_RESOURCE.merge(
+                    resources.Resource(
+                        {resources.SERVICE_NAME: "unknown_service"}, ""
+                    )
+                ).merge(
+                    resources.Resource(
+                        {"key2": "value2", "key3": "value3"}, "url1"
+                    )
                 ),
             )
             self.assertIn("url1", log_entry.output[0])
@@ -347,14 +382,20 @@ class TestResources(unittest.TestCase):
                         resource_detector1,
                     ]
                 ),
-                resources.Resource(
-                    {
-                        "key1": "value1",
-                        "key2": "try_to_overwrite_existing_value",
-                        "key3": "try_to_overwrite_existing_value",
-                        "key4": "value4",
-                    },
-                    "url1",
+                resources._DEFAULT_RESOURCE.merge(
+                    resources.Resource(
+                        {resources.SERVICE_NAME: "unknown_service"}, ""
+                    )
+                ).merge(
+                    resources.Resource(
+                        {
+                            "key1": "value1",
+                            "key2": "try_to_overwrite_existing_value",
+                            "key3": "try_to_overwrite_existing_value",
+                            "key4": "value4",
+                        },
+                        "url1",
+                    )
                 ),
             )
             self.assertIn("url1", log_entry.output[0])
@@ -366,7 +407,11 @@ class TestResources(unittest.TestCase):
         resource_detector.raise_on_error = False
         self.assertEqual(
             resources.get_aggregated_resources([resource_detector]),
-            resources.Resource.get_empty(),
+            resources._DEFAULT_RESOURCE.merge(
+                resources.Resource(
+                    {resources.SERVICE_NAME: "unknown_service"}, ""
+                )
+            ),
         )
 
     def test_resource_detector_raise_error(self):

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -239,18 +239,16 @@ class TestResources(unittest.TestCase):
             ),
         )
 
-    def test_aggregated_resources_with_static_resource(self):
+    def test_aggregated_resources_with_default_destroying_static_resource(
+        self,
+    ):
         static_resource = resources.Resource({"static_key": "static_value"})
 
         self.assertEqual(
             resources.get_aggregated_resources(
                 [], initial_resource=static_resource
             ),
-            resources._DEFAULT_RESOURCE.merge(
-                resources.Resource(
-                    {resources.SERVICE_NAME: "unknown_service"}, ""
-                )
-            ).merge(static_resource),
+            static_resource,
         )
 
         resource_detector = mock.Mock(spec=resources.ResourceDetector)
@@ -261,17 +259,11 @@ class TestResources(unittest.TestCase):
             resources.get_aggregated_resources(
                 [resource_detector], initial_resource=static_resource
             ),
-            resources._DEFAULT_RESOURCE.merge(
-                resources.Resource(
-                    {resources.SERVICE_NAME: "unknown_service"}, ""
-                )
-            ).merge(
-                resources.Resource(
-                    {
-                        "static_key": "try_to_overwrite_existing_value",
-                        "key": "value",
-                    }
-                )
+            resources.Resource(
+                {
+                    "static_key": "try_to_overwrite_existing_value",
+                    "key": "value",
+                }
             ),
         )
 


### PR DESCRIPTION
# Description

We want the business metrics `_DEFAULT_RESOURCE` attributes to be set on the resource returned by `get_aggregated_resources()`, and we also want the `service_name` to be set to some default if it is not.

In this PR, we update `get_aggregated_resources()` so that it adds both those things, and the `Resource.create()` will call it instead so that it retains all its attributes as before.

The `get_aggregated_resources()` method had something _added_ to its API, but other than that nothing API related changes.

Fixes #1996

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

N/A

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
~- [ ] Documentation has been updated~
