### PR TITLE
Handle traceback.format_exception() API change in Python 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to let distros use its default implementation
   ([#1937](https://github.com/open-telemetry/opentelemetry-python/pull/1937))
 - Add Trace ID validation to meet [TraceID spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#spancontext) ([#1992](https://github.com/open-telemetry/opentelemetry-python/pull/1992))
+- Fixed Python 3.10 incompatibility in `opentelemetry-opentracing-shim` tests
+  ([#2018](https://github.com/open-telemetry/opentelemetry-python/pull/2018))
 
 ## [0.23.1](https://github.com/open-telemetry/opentelemetry-python/pull/1987) - 2021-07-26
 

--- a/shim/opentelemetry-opentracing-shim/tests/test_shim.py
+++ b/shim/opentelemetry-opentracing-shim/tests/test_shim.py
@@ -482,9 +482,7 @@ class TestShim(TestCase):
 
         ex = exc_ctx.exception
         expected_stack = "".join(
-            traceback.format_exception(
-                etype=type(ex), value=ex, tb=ex.__traceback__
-            )
+            traceback.format_exception(type(ex), value=ex, tb=ex.__traceback__)
         )
         # Verify exception details have been added to span.
         exc_event = scope.span.unwrap().events[0]


### PR DESCRIPTION
The first argument of `traceback.format_exception()` has been renamed from “`etype`” to “`exc`” and is now positional-only. Passing it as a positional argument rather than a keyword argument fixes a `TypeError` on Python 3.10 while remaining compatible with previous Python releases:
  - On Python 3.10, the parameter *should* be the exception object; it is now possible to call `format_exception()` with only the exception object, omitting “`value`” and “`tb`”. Here the type of the exception object is given instead; however, this is OK because “`value`” and “`tb`” are also given, and therefore the positional “`exc`” parameter is ignored and may have any value or type whatsoever.
  - From Python 3.5 to 3.9, the first argument is “`etype`” and is correctly the type of the exception object; however, its actual value is still ignored in favor of the type of “`value`”.
  - Prior to Python 3.5, the “`etype`” would actually be used, if this project supported those Python versions.

The changes in the `traceback` module in Python 3.10 are documented at:
https://docs.python.org/3.10/library/traceback.html#traceback.print_exception
https://docs.python.org/3.10/library/traceback.html#traceback.format_exception
https://docs.python.org/3.10/library/traceback.html#traceback.format_exception_only
https://docs.python.org/3.10/library/traceback.html#traceback.TracebackException.format_exception_only

# Description

See the formatted commit message text above.

Fixes # (issue)

No issue has been filed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I’m working on updating the `python-opentelemetry` package on Fedora Linux, which I just started maintaining. I can confirm this fixes failing `opentelemetry-opentracing-shim` tests on Fedora Rawhide (the development version) with a pre-release version of Python 3.10. The updated package isn’t yet ready, but fortunately you don’t need to use the same environment as I am to replicate this.

Suffice it to say that if you try to run the tests on Python 3.10 in *any* environment, you should see a `TypeError` in the `opentelemetry-opentracing-shim` tests, and you should find that this PR fixes it. Furthermore, you can confirm compatibility with Python 3.9 and older by running the tests however you normally run them. Nothing about this PR is sensitive to the particulars of your environment other than the Python version.

- [x] Run the tests on Python 3.10 and on existing supported Python versions—with no special requirements for the test environment.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `opentelemetry-instrumentation/` have changed
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added *N/A—this PR only fixes existing test code*
- [ ] Documentation has been updated *N/A—this PR is only an internal change to test code*
