### PR TITLE
fix: documentation on "Well known exporters" and OTEL_TRACES_EXPORTER variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.4.0-0.23b0...HEAD)
+- Fix documentation on well known exporters and variable OTEL_TRACES_EXPORTER which were misnamed [#2023](https://github.com/open-telemetry/opentelemetry-python/pull/2023)
 - `opentelemetry-distro` & `opentelemetry-sdk` Moved Auto Instrumentation Configurator code to SDK
   to let distros use its default implementation
   ([#1937](https://github.com/open-telemetry/opentelemetry-python/pull/1937))

--- a/opentelemetry-instrumentation/README.rst
+++ b/opentelemetry-instrumentation/README.rst
@@ -56,7 +56,7 @@ this can be overriden when needed.
 The command supports the following configuration options as CLI arguments and environment vars:
 
 
-* ``--trace-exporter`` or ``OTEL_TRACE_EXPORTER``
+* ``--trace-exporter`` or ``OTEL_TRACES_EXPORTER``
 
 Used to specify which trace exporter to use. Can be set to one or more of the well-known exporter
 names (see below).
@@ -68,11 +68,14 @@ You can pass multiple values to configure multiple exporters e.g, ``zipkin,prome
 
 Well known trace exporter names:
 
-    - jaeger
+    - jaeger_proto
+    - jaeger_thrift
     - opencensus
     - otlp
     - otlp_proto_grpc_span
-    - zipkin
+    - otlp_proto_http_span
+    - zipkin_json
+    - zipkin_proto
 
 ``otlp`` is an alias for ``otlp_proto_grpc_span``.
 
@@ -102,7 +105,7 @@ The above command will pass ``--trace-exporter otlp`` to the instrument command 
 
 ::
 
-    opentelemetry-instrument --trace-exporter zipkin,otlp celery -A tasks worker --loglevel=info
+    opentelemetry-instrument --trace-exporter zipkin_json,otlp celery -A tasks worker --loglevel=info
 
 The above command will configure global trace provider, attach zipkin and otlp exporters to it and then
 start celery with the rest of the arguments. 


### PR DESCRIPTION
Following the auto-instrumentation README and examples, I encountered 2 inconsistencies between doc and code, so I fixed the documentation:

fix: documentation on "Well known exporters" -> zipkin doesn't exist but zipkin_json and zipkin_proto exist, etc. Thanks @ocelotl 
fix: documentation env var is not OTEL_TRACE_EXPORTER but OTEL_TRACE**S**_EXPORTER