### PR TITLE
Update Jaeger Thrift Exporter documentation example

### DIFF
--- a/exporter/opentelemetry-exporter-jaeger-thrift/src/opentelemetry/exporter/jaeger/thrift/__init__.py
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/src/opentelemetry/exporter/jaeger/thrift/__init__.py
@@ -32,10 +32,15 @@ Usage
 
     from opentelemetry import trace
     from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-    trace.set_tracer_provider(TracerProvider())
+    trace.set_tracer_provider(
+    TracerProvider(
+            resource=Resource.create({SERVICE_NAME: "my-helloworld-service"})
+        )
+    )
     tracer = trace.get_tracer(__name__)
 
     # create a JaegerExporter


### PR DESCRIPTION
if you copy the example of the documentation, the name of the service will be "unkown_service"

![image](https://user-images.githubusercontent.com/14133711/128786741-06ffe4b5-1649-4638-91b6-26e113d886d7.png)

