### PR TITLE
Fix typos of “it's” where “its” is meant

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -320,7 +320,7 @@ class Tracer(ABC):
         as the current span in this tracer's context.
 
         Exiting the context manager will call the span's end method,
-        as well as return the current span to it's previous value by
+        as well as return the current span to its previous value by
         returning to the previous context.
 
         Example::

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py
@@ -32,7 +32,7 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="""
         opentelemetry-instrument automatically instruments a Python
-        program and it's dependencies and then runs the program.
+        program and its dependencies and then runs the program.
         """
     )
 

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/propagators.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/propagators.py
@@ -16,7 +16,7 @@
 This module implements experimental propagators to inject trace context
 into response carriers. This is useful for server side frameworks that start traces
 when server requests and want to share the trace context with the client so the
-client can add it's spans to the same trace.
+client can add its spans to the same trace.
 
 This is part of an upcoming W3C spec and will eventually make it to the Otel spec.
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -532,7 +532,7 @@ class SpanLimits:
     All limit arguments must be either a non-negative integer, ``None`` or ``SpanLimits.UNSET``.
 
     - All limit arguments are optional.
-    - If a limit argument is not set, the class will try to read it's value from the corresponding
+    - If a limit argument is not set, the class will try to read its value from the corresponding
       environment variable.
     - If the environment variable is not set, the default value for the limit is used.
 

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/__init__.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/__init__.py
@@ -608,7 +608,7 @@ clear whether the exception will escape.
     MESSAGING_KAFKA_MESSAGE_KEY = "messaging.kafka.message_key"
     """
     Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message_id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set.
-    Note: If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
+    Note: If the key type is not string, its string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
     """
 
     MESSAGING_KAFKA_CONSUMER_GROUP = "messaging.kafka.consumer_group"


### PR DESCRIPTION
# Description

This PR fixes typos where `it's` (“it is”) is written, but context indicates `its` (possessive) is intended.

There is no open issue for these typos. I have marked it as a bug fix since some typos are user-visible.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I did not test it at all, since it contains only trivial string changes.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `opentelemetry-instrumentation/` have changed
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated **Do you update changelogs for trivial fixes like this?**
- [ ] Unit tests have been added **not applicable**
- [ ] Documentation has been updated **not applicable**
