### PR TITLE
Add support for additional Span Limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Trace ID validation to meet [TraceID spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#spancontext) ([#1992](https://github.com/open-telemetry/opentelemetry-python/pull/1992))
 - Fixed Python 3.10 incompatibility in `opentelemetry-opentracing-shim` tests
   ([#2018](https://github.com/open-telemetry/opentelemetry-python/pull/2018))
+- `opentelemetry-sdk` added support for `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`
+  ([#2044](https://github.com/open-telemetry/opentelemetry-python/pull/2044))
+- `opentelemetry-sdk` Fixed bugs (#2041, #2042 & #2045) in Span Limits
+  ([#2044](https://github.com/open-telemetry/opentelemetry-python/pull/2044))
 
 ## [0.23.1](https://github.com/open-telemetry/opentelemetry-python/pull/1987) - 2021-07-26
 

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -17,36 +17,59 @@ import logging
 import threading
 from collections import OrderedDict
 from collections.abc import MutableMapping
-from typing import MutableSequence, Optional, Sequence
+from typing import Optional, Sequence, Union
 
 from opentelemetry.util import types
 
-_VALID_ATTR_VALUE_TYPES = (bool, str, int, float)
+# bytes are accepted as a user supplied value for attributes but
+# decoded to strings internally.
+_VALID_ATTR_VALUE_TYPES = (bool, str, bytes, int, float)
 
 
 _logger = logging.getLogger(__name__)
 
 
-def _is_valid_attribute_value(value: types.AttributeValue) -> bool:
-    """Checks if attribute value is valid.
+def _clean_attribute(
+    key: str, value: types.AttributeValue, max_len: Optional[int]
+) -> Optional[types.AttributeValue]:
+    """Checks if attribute value is valid and cleans it if required.
+
+    The function returns the cleaned value or None if the value is not valid.
 
     An attribute value is valid if it is either:
         - A primitive type: string, boolean, double precision floating
             point (IEEE 754-1985) or integer.
         - An array of primitive type values. The array MUST be homogeneous,
             i.e. it MUST NOT contain values of different types.
+
+    An attribute needs cleansing if:
+        - Its length is greater than the maximum allowed length.
+        - It needs to be encoded/decoded e.g, bytes to strings.
     """
 
+    if key is None or key == "":
+        _logger.warning("invalid key `%s` (empty or null)", key)
+        return None
+
     if isinstance(value, _VALID_ATTR_VALUE_TYPES):
-        return True
+        return _clean_attribute_value(value, max_len)
 
     if isinstance(value, Sequence):
-
         sequence_first_valid_type = None
+        cleaned_seq = []
+
         for element in value:
+            # None is considered valid in any sequence
+            if element is None:
+                cleaned_seq.append(element)
+
+            element = _clean_attribute_value(element, max_len)
+            # reject invalid elements
             if element is None:
                 continue
+
             element_type = type(element)
+            # Reject attribute value if sequence contains a value with an incompatible type.
             if element_type not in _VALID_ATTR_VALUE_TYPES:
                 _logger.warning(
                     "Invalid type %s in attribute value sequence. Expected one of "
@@ -57,19 +80,25 @@ def _is_valid_attribute_value(value: types.AttributeValue) -> bool:
                         for valid_type in _VALID_ATTR_VALUE_TYPES
                     ],
                 )
-                return False
+                return None
+
             # The type of the sequence must be homogeneous. The first non-None
             # element determines the type of the sequence
             if sequence_first_valid_type is None:
                 sequence_first_valid_type = element_type
-            elif not isinstance(element, sequence_first_valid_type):
+            # use equality instead of isinstance as isinstance(True, int) evaluates to True
+            elif element_type != sequence_first_valid_type:
                 _logger.warning(
                     "Mixed types %s and %s in attribute value sequence",
                     sequence_first_valid_type.__name__,
                     type(element).__name__,
                 )
-                return False
-        return True
+                return None
+
+            cleaned_seq.append(element)
+
+        # Freeze mutable sequences defensively
+        return tuple(cleaned_seq)
 
     _logger.warning(
         "Invalid type %s for attribute value. Expected one of %s or a "
@@ -77,36 +106,25 @@ def _is_valid_attribute_value(value: types.AttributeValue) -> bool:
         type(value).__name__,
         [valid_type.__name__ for valid_type in _VALID_ATTR_VALUE_TYPES],
     )
-    return False
+    return None
 
 
-def _filter_attributes(attributes: types.Attributes) -> None:
-    """Applies attribute validation rules and drops (key, value) pairs
-    that doesn't adhere to attributes specification.
+def _clean_attribute_value(
+    value: types.AttributeValue, limit: Optional[int]
+) -> Union[types.AttributeValue, None]:
+    if value is None:
+        return None
 
-    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes.
-    """
-    if attributes:
-        for attr_key, attr_value in list(attributes.items()):
-            if not attr_key:
-                _logger.warning("invalid key `%s` (empty or null)", attr_key)
-                attributes.pop(attr_key)
-                continue
+    if isinstance(value, bytes):
+        try:
+            value = value.decode()
+        except ValueError:
+            _logger.warning("Byte attribute could not be decoded.")
+            return None
 
-            if _is_valid_attribute_value(attr_value):
-                if isinstance(attr_value, MutableSequence):
-                    attributes[attr_key] = tuple(attr_value)
-                if isinstance(attr_value, bytes):
-                    try:
-                        attributes[attr_key] = attr_value.decode()
-                    except ValueError:
-                        attributes.pop(attr_key)
-                        _logger.warning("Byte attribute could not be decoded.")
-            else:
-                attributes.pop(attr_key)
-
-
-_DEFAULT_LIMIT = 128
+    if limit is not None and isinstance(value, str):
+        value = value[:limit]
+    return value
 
 
 class BoundedAttributes(MutableMapping):
@@ -118,9 +136,10 @@ class BoundedAttributes(MutableMapping):
 
     def __init__(
         self,
-        maxlen: Optional[int] = _DEFAULT_LIMIT,
+        maxlen: Optional[int] = None,
         attributes: types.Attributes = None,
         immutable: bool = True,
+        max_value_len: Optional[int] = None,
     ):
         if maxlen is not None:
             if not isinstance(maxlen, int) or maxlen < 0:
@@ -129,10 +148,10 @@ class BoundedAttributes(MutableMapping):
                 )
         self.maxlen = maxlen
         self.dropped = 0
+        self.max_value_len = max_value_len
         self._dict = OrderedDict()  # type: OrderedDict
         self._lock = threading.Lock()  # type: threading.Lock
         if attributes:
-            _filter_attributes(attributes)
             for key, value in attributes.items():
                 self[key] = value
         self._immutable = immutable
@@ -158,7 +177,10 @@ class BoundedAttributes(MutableMapping):
             elif self.maxlen is not None and len(self._dict) == self.maxlen:
                 del self._dict[next(iter(self._dict.keys()))]
                 self.dropped += 1
-            self._dict[key] = value
+
+            value = _clean_attribute(key, value, self.max_value_len)
+            if value is not None:
+                self._dict[key] = value
 
     def __delitem__(self, key):
         if getattr(self, "_immutable", False):

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -16,69 +16,48 @@
 
 import collections
 import unittest
+from typing import MutableSequence
 
-from opentelemetry.attributes import (
-    BoundedAttributes,
-    _filter_attributes,
-    _is_valid_attribute_value,
-)
+from opentelemetry.attributes import BoundedAttributes, _clean_attribute
 
 
 class TestAttributes(unittest.TestCase):
-    def test_is_valid_attribute_value(self):
-        self.assertFalse(_is_valid_attribute_value([1, 2, 3.4, "ss", 4]))
-        self.assertFalse(_is_valid_attribute_value([dict(), 1, 2, 3.4, 4]))
-        self.assertFalse(_is_valid_attribute_value(["sw", "lf", 3.4, "ss"]))
-        self.assertFalse(_is_valid_attribute_value([1, 2, 3.4, 5]))
-        self.assertFalse(_is_valid_attribute_value(dict()))
-        self.assertTrue(_is_valid_attribute_value(True))
-        self.assertTrue(_is_valid_attribute_value("hi"))
-        self.assertTrue(_is_valid_attribute_value(3.4))
-        self.assertTrue(_is_valid_attribute_value(15))
-        self.assertTrue(_is_valid_attribute_value([1, 2, 3, 5]))
-        self.assertTrue(_is_valid_attribute_value([1.2, 2.3, 3.4, 4.5]))
-        self.assertTrue(_is_valid_attribute_value([True, False]))
-        self.assertTrue(_is_valid_attribute_value(["ss", "dw", "fw"]))
-        self.assertTrue(_is_valid_attribute_value([]))
+    def assertValid(self, value, key="k"):
+        expected = value
+        if isinstance(value, MutableSequence):
+            expected = tuple(value)
+        self.assertEqual(_clean_attribute(key, value, None), expected)
+
+    def assertInvalid(self, value, key="k"):
+        self.assertIsNone(_clean_attribute(key, value, None))
+
+    def test_clean_attribute(self):
+        self.assertInvalid([1, 2, 3.4, "ss", 4])
+        self.assertInvalid([dict(), 1, 2, 3.4, 4])
+        self.assertInvalid(["sw", "lf", 3.4, "ss"])
+        self.assertInvalid([1, 2, 3.4, 5])
+        self.assertInvalid(dict())
+        self.assertInvalid([1, True])
+        self.assertValid(True)
+        self.assertValid("hi")
+        self.assertValid(3.4)
+        self.assertValid(15)
+        self.assertValid([1, 2, 3, 5])
+        self.assertValid([1.2, 2.3, 3.4, 4.5])
+        self.assertValid([True, False])
+        self.assertValid(["ss", "dw", "fw"])
+        self.assertValid([])
         # None in sequences are valid
-        self.assertTrue(_is_valid_attribute_value(["A", None, None]))
-        self.assertTrue(_is_valid_attribute_value(["A", None, None, "B"]))
-        self.assertTrue(_is_valid_attribute_value([None, None]))
-        self.assertFalse(_is_valid_attribute_value(["A", None, 1]))
-        self.assertFalse(_is_valid_attribute_value([None, "A", None, 1]))
+        self.assertValid(["A", None, None])
+        self.assertValid(["A", None, None, "B"])
+        self.assertValid([None, None])
+        self.assertInvalid(["A", None, 1])
+        self.assertInvalid([None, "A", None, 1])
 
-    def test_filter_attributes(self):
-        attrs_with_invalid_keys = {
-            "": "empty-key",
-            None: "None-value",
-            "attr-key": "attr-value",
-        }
-        _filter_attributes(attrs_with_invalid_keys)
-        self.assertTrue(len(attrs_with_invalid_keys), 1)
-        self.assertEqual(attrs_with_invalid_keys, {"attr-key": "attr-value"})
-
-        attrs_with_invalid_values = {
-            "nonhomogeneous": [1, 2, 3.4, "ss", 4],
-            "nonprimitive": dict(),
-            "mixed": [1, 2.4, "st", dict()],
-            "validkey1": "validvalue1",
-            "intkey": 5,
-            "floatkey": 3.14,
-            "boolkey": True,
-            "valid-byte-string": b"hello-otel",
-        }
-        _filter_attributes(attrs_with_invalid_values)
-        self.assertEqual(len(attrs_with_invalid_values), 5)
-        self.assertEqual(
-            attrs_with_invalid_values,
-            {
-                "validkey1": "validvalue1",
-                "intkey": 5,
-                "floatkey": 3.14,
-                "boolkey": True,
-                "valid-byte-string": "hello-otel",
-            },
-        )
+        # test keys
+        self.assertValid("value", "key")
+        self.assertInvalid("value", "")
+        self.assertInvalid("value", None)
 
 
 class TestBoundedAttributes(unittest.TestCase):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
@@ -98,12 +98,37 @@ The :envvar:`OTEL_BSP_MAX_EXPORT_BATCH_SIZE` represents the maximum batch size f
 Default: 512
 """
 
+OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT = "OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT"
+"""
+.. envvar:: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+
+The :envvar:`OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT` represents the maximum allowed event attribute count.
+Default: 128
+"""
+
+OTEL_LINK_ATTRIBUTE_COUNT_LIMIT = "OTEL_LINK_ATTRIBUTE_COUNT_LIMIT"
+"""
+.. envvar:: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+
+The :envvar:`OTEL_LINK_ATTRIBUTE_COUNT_LIMIT` represents the maximum allowed link attribute count.
+Default: 128
+"""
+
 OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT = "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT"
 """
 .. envvar:: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
 
 The :envvar:`OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` represents the maximum allowed span attribute count.
 Default: 128
+"""
+
+OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT = (
+    "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT"
+)
+"""
+.. envvar:: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+
+The :envvar:`OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` represents the maximum allowed length attribute values can have.
 """
 
 OTEL_SPAN_EVENT_COUNT_LIMIT = "OTEL_SPAN_EVENT_COUNT_LIMIT"

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -27,6 +27,7 @@ from opentelemetry.context import Context
 from opentelemetry.sdk import resources, trace
 from opentelemetry.sdk.environment_variables import (
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
+    OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
     OTEL_SPAN_EVENT_COUNT_LIMIT,
     OTEL_SPAN_LINK_COUNT_LIMIT,
     OTEL_TRACES_SAMPLER,
@@ -38,13 +39,10 @@ from opentelemetry.sdk.util import ns_to_iso_str
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
 from opentelemetry.test.spantestutil import (
     get_span_with_dropped_attributes_events_links,
+    new_tracer,
 )
 from opentelemetry.trace import StatusCode
 from opentelemetry.util._time import _time_ns
-
-
-def new_tracer(span_limits=None) -> trace_api.Tracer:
-    return trace.TracerProvider(span_limits=span_limits).get_tracer(__name__)
 
 
 class TestTracer(unittest.TestCase):
@@ -653,6 +651,7 @@ class TestSpan(unittest.TestCase):
             root.set_attribute(
                 "list-with-non-primitive-data-type", [dict(), 123]
             )
+            root.set_attribute("list-with-numeric-and-bool", [1, True])
 
             root.set_attribute("", 123)
             root.set_attribute(None, 123)
@@ -1314,6 +1313,15 @@ class TestSpanProcessor(unittest.TestCase):
 class TestSpanLimits(unittest.TestCase):
     # pylint: disable=protected-access
 
+    long_val = "v" * 1000
+
+    def _assert_attr_length(self, attr_val, max_len):
+        if isinstance(attr_val, str):
+            expected = self.long_val
+            if max_len is not None:
+                expected = expected[:max_len]
+            self.assertEqual(attr_val, expected)
+
     def test_limits_defaults(self):
         limits = trace.SpanLimits()
         self.assertEqual(
@@ -1326,9 +1334,11 @@ class TestSpanLimits(unittest.TestCase):
         self.assertEqual(
             limits.max_links, trace._DEFAULT_OTEL_SPAN_LINK_COUNT_LIMIT
         )
+        self.assertIsNone(limits.max_attribute_length)
 
     def test_limits_values_code(self):
-        max_attributes, max_events, max_links = (
+        max_attributes, max_events, max_links, max_attr_length = (
+            randint(0, 10000),
             randint(0, 10000),
             randint(0, 10000),
             randint(0, 10000),
@@ -1337,13 +1347,16 @@ class TestSpanLimits(unittest.TestCase):
             max_attributes=max_attributes,
             max_events=max_events,
             max_links=max_links,
+            max_attribute_length=max_attr_length,
         )
         self.assertEqual(limits.max_attributes, max_attributes)
         self.assertEqual(limits.max_events, max_events)
         self.assertEqual(limits.max_links, max_links)
+        self.assertEqual(limits.max_attribute_length, max_attr_length)
 
     def test_limits_values_env(self):
-        max_attributes, max_events, max_links = (
+        max_attributes, max_events, max_links, max_attr_length = (
+            randint(0, 10000),
             randint(0, 10000),
             randint(0, 10000),
             randint(0, 10000),
@@ -1354,6 +1367,7 @@ class TestSpanLimits(unittest.TestCase):
                 OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: str(max_attributes),
                 OTEL_SPAN_EVENT_COUNT_LIMIT: str(max_events),
                 OTEL_SPAN_LINK_COUNT_LIMIT: str(max_links),
+                OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT: str(max_attr_length),
             },
         ):
             limits = trace.SpanLimits()
@@ -1361,7 +1375,9 @@ class TestSpanLimits(unittest.TestCase):
             self.assertEqual(limits.max_events, max_events)
             self.assertEqual(limits.max_links, max_links)
 
-    def _test_span_limits(self, tracer):
+    def _test_span_limits(
+        self, tracer, max_attrs, max_events, max_links, max_attr_len
+    ):
         id_generator = RandomIdGenerator()
         some_links = [
             trace_api.Link(
@@ -1369,25 +1385,48 @@ class TestSpanLimits(unittest.TestCase):
                     trace_id=id_generator.generate_trace_id(),
                     span_id=id_generator.generate_span_id(),
                     is_remote=False,
-                )
+                ),
+                attributes={"k": self.long_val},
             )
             for _ in range(100)
         ]
 
         some_attrs = {
-            "init_attribute_{}".format(idx): idx for idx in range(100)
+            "init_attribute_{}".format(idx): self.long_val
+            for idx in range(100)
         }
         with tracer.start_as_current_span(
             "root", links=some_links, attributes=some_attrs
         ) as root:
-            self.assertEqual(len(root.links), 30)
-            self.assertEqual(len(root.attributes), 10)
+            self.assertEqual(len(root.links), max_links)
+            self.assertEqual(len(root.attributes), max_attrs)
             for idx in range(100):
-                root.set_attribute("my_attribute_{}".format(idx), 0)
-                root.add_event("my_event_{}".format(idx))
+                root.set_attribute(
+                    "my_str_attribute_{}".format(idx), self.long_val
+                )
+                root.set_attribute(
+                    "my_byte_attribute_{}".format(idx), self.long_val.encode()
+                )
+                root.set_attribute(
+                    "my_int_attribute_{}".format(idx), self.long_val.encode()
+                )
+                root.add_event(
+                    "my_event_{}".format(idx), attributes={"k": self.long_val}
+                )
 
-            self.assertEqual(len(root.attributes), 10)
-            self.assertEqual(len(root.events), 20)
+            self.assertEqual(len(root.attributes), max_attrs)
+            self.assertEqual(len(root.events), max_events)
+
+            for link in root.links:
+                for attr_val in link.attributes.values():
+                    self._assert_attr_length(attr_val, max_attr_len)
+
+            for event in root.events:
+                for attr_val in event.attributes.values():
+                    self._assert_attr_length(attr_val, max_attr_len)
+
+            for attr_val in root.attributes.values():
+                self._assert_attr_length(attr_val, max_attr_len)
 
     def _test_span_no_limits(self, tracer):
         num_links = int(trace._DEFAULT_OTEL_SPAN_LINK_COUNT_LIMIT) + randint(
@@ -1413,7 +1452,9 @@ class TestSpanLimits(unittest.TestCase):
         )
         with tracer.start_as_current_span("root") as root:
             for idx in range(num_events):
-                root.add_event("my_event_{}".format(idx))
+                root.add_event(
+                    "my_event_{}".format(idx), attributes={"k": self.long_val}
+                )
 
             self.assertEqual(len(root.events), num_events)
 
@@ -1422,20 +1463,31 @@ class TestSpanLimits(unittest.TestCase):
         ) + randint(1, 100)
         with tracer.start_as_current_span("root") as root:
             for idx in range(num_attributes):
-                root.set_attribute("my_attribute_{}".format(idx), 0)
+                root.set_attribute(
+                    "my_attribute_{}".format(idx), self.long_val
+                )
 
             self.assertEqual(len(root.attributes), num_attributes)
+            for attr_val in root.attributes.values():
+                self.assertEqual(attr_val, self.long_val)
 
     @mock.patch.dict(
         "os.environ",
         {
-            OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "10",
-            OTEL_SPAN_EVENT_COUNT_LIMIT: "20",
-            OTEL_SPAN_LINK_COUNT_LIMIT: "30",
+            OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "13",
+            OTEL_SPAN_EVENT_COUNT_LIMIT: "7",
+            OTEL_SPAN_LINK_COUNT_LIMIT: "4",
+            OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT: "11",
         },
     )
     def test_span_limits_env(self):
-        self._test_span_limits(new_tracer())
+        self._test_span_limits(
+            new_tracer(),
+            max_attrs=13,
+            max_events=7,
+            max_links=4,
+            max_attr_len=11,
+        )
 
     @mock.patch.dict(
         "os.environ",
@@ -1443,24 +1495,39 @@ class TestSpanLimits(unittest.TestCase):
             OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "10",
             OTEL_SPAN_EVENT_COUNT_LIMIT: "20",
             OTEL_SPAN_LINK_COUNT_LIMIT: "30",
+            OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT: "40",
         },
     )
     def test_span_limits_default_to_env(self):
         self._test_span_limits(
             new_tracer(
                 span_limits=trace.SpanLimits(
-                    max_attributes=None, max_events=None, max_links=None
+                    max_attributes=None,
+                    max_events=None,
+                    max_links=None,
+                    max_attribute_length=None,
                 )
-            )
+            ),
+            max_attrs=10,
+            max_events=20,
+            max_links=30,
+            max_attr_len=40,
         )
 
     def test_span_limits_code(self):
         self._test_span_limits(
             new_tracer(
                 span_limits=trace.SpanLimits(
-                    max_attributes=10, max_events=20, max_links=30
+                    max_attributes=11,
+                    max_events=15,
+                    max_links=13,
+                    max_attribute_length=9,
                 )
-            )
+            ),
+            max_attrs=11,
+            max_events=15,
+            max_links=13,
+            max_attr_len=9,
         )
 
     @mock.patch.dict(
@@ -1469,6 +1536,7 @@ class TestSpanLimits(unittest.TestCase):
             OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "unset",
             OTEL_SPAN_EVENT_COUNT_LIMIT: "unset",
             OTEL_SPAN_LINK_COUNT_LIMIT: "unset",
+            OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT: "unset",
         },
     )
     def test_span_no_limits_env(self):
@@ -1481,6 +1549,7 @@ class TestSpanLimits(unittest.TestCase):
                     max_attributes=trace.SpanLimits.UNSET,
                     max_links=trace.SpanLimits.UNSET,
                     max_events=trace.SpanLimits.UNSET,
+                    max_attribute_length=trace.SpanLimits.UNSET,
                 )
             )
         )


### PR DESCRIPTION
# Description
Added support for `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT` & `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT`, and fixes a number of bugs.

Fixes #2045
Fixes #2043
Fixes #2042
Fixes #2041


Otel Specification: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#span-limits-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added/updated tests
- [x]  Manual testing

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
