### PR TITLE
Restrict attribute keys to non-empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2044](https://github.com/open-telemetry/opentelemetry-python/pull/2044))
 - `opentelemetry-sdk` Fixed bugs (#2041, #2042 & #2045) in Span Limits
   ([#2044](https://github.com/open-telemetry/opentelemetry-python/pull/2044))
+- `opentelemetry-api` Attribute keys must be non-empty strings.
+  ([#2057](https://github.com/open-telemetry/opentelemetry-python/pull/2057))
 
 ## [0.23.1](https://github.com/open-telemetry/opentelemetry-python/pull/1987) - 2021-07-26
 

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -47,8 +47,8 @@ def _clean_attribute(
         - It needs to be encoded/decoded e.g, bytes to strings.
     """
 
-    if key is None or key == "":
-        _logger.warning("invalid key `%s` (empty or null)", key)
+    if not (key and isinstance(key, str)):
+        _logger.warning("invalid key `%s`. must be non-empty string.", key)
         return None
 
     if isinstance(value, _VALID_ATTR_VALUE_TYPES):
@@ -118,7 +118,7 @@ def _clean_attribute_value(
     if isinstance(value, bytes):
         try:
             value = value.decode()
-        except ValueError:
+        except UnicodeDecodeError:
             _logger.warning("Byte attribute could not be decoded.")
             return None
 

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -31,6 +31,16 @@ class TestAttributes(unittest.TestCase):
     def assertInvalid(self, value, key="k"):
         self.assertIsNone(_clean_attribute(key, value, None))
 
+    def test_attribute_key_validation(self):
+        # only non-empty strings are valid keys
+        self.assertInvalid(1, "")
+        self.assertInvalid(1, 1)
+        self.assertInvalid(1, {})
+        self.assertInvalid(1, [])
+        self.assertInvalid(1, b"1")
+        self.assertValid(1, "k")
+        self.assertValid(1, "1")
+
     def test_clean_attribute(self):
         self.assertInvalid([1, 2, 3.4, "ss", 4])
         self.assertInvalid([dict(), 1, 2, 3.4, 4])
@@ -142,10 +152,10 @@ class TestBoundedAttributes(unittest.TestCase):
     def test_no_limit_code(self):
         bdict = BoundedAttributes(maxlen=None, immutable=False)
         for num in range(100):
-            bdict[num] = num
+            bdict[str(num)] = num
 
         for num in range(100):
-            self.assertEqual(bdict[num], num)
+            self.assertEqual(bdict[str(num)], num)
 
     def test_immutable(self):
         bdict = BoundedAttributes()


### PR DESCRIPTION
# Description

According to the spec:

> The attribute key, which MUST be a non-null and non-empty string.

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


- [x] Unit tests

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
