### PR TITLE
docs(auto-instrument): add missing pip install in README

### DIFF
--- a/docs/examples/auto-instrumentation/README.rst
+++ b/docs/examples/auto-instrumentation/README.rst
@@ -80,6 +80,7 @@ commands that help automatically instruments a program.
     $ pip install opentelemetry-sdk
     $ pip install opentelemetry-instrumentation
     $ pip install opentelemetry-instrumentation-flask
+    $ pip install flask
     $ pip install requests
 
 Execute


### PR DESCRIPTION
# Description

was following the auto-instrumentation example under docs. it is missing `pip install flask` to work correctly.

Fixes #2060  (issue)
add the pip install command to README

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

Run it locally on my fresh setup and got an error about "No module named 'flask'". After installing it as part of the setup the example wroks

# Does This PR Require a Contrib Repo Change?
No

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
