### PR TITLE
Use exact dep versions in getting started docs tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -137,7 +137,7 @@ commands_pre =
   distro: pip install {toxinidir}/opentelemetry-distro
   instrumentation: pip install {toxinidir}/opentelemetry-instrumentation
 
-  getting-started: pip install requests flask -e {toxinidir}/opentelemetry-instrumentation -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests {toxinidir}/opentelemetry-python-contrib/util/opentelemetry-util-http -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask
+  getting-started: pip install requests==2.26.0 flask==2.0.1 -e {toxinidir}/opentelemetry-instrumentation -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests {toxinidir}/opentelemetry-python-contrib/util/opentelemetry-util-http -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-wsgi -e {toxinidir}/opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-flask
 
   opencensus: pip install {toxinidir}/exporter/opentelemetry-exporter-opencensus
 


### PR DESCRIPTION
# Description

This speeds up tox as pip knows exactly what to install. Otherwise pip
downloads multiple versions of requests slowing things down.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Dev/Tooling enchancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Existing tests pass

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
