### PR TITLE
Rename base test assertion methods for consistency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: 1a665d692f3f87c7cfee8a96b624b05ed8854d60
+  CONTRIB_REPO_SHA: 2a92e255f7595024242e45c0050c8f3de7140b6b
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: 3ad534cbba41c2b92618f5f03c4c92cee4a72df6
+  CONTRIB_REPO_SHA: 637ef45a531718a026806ce33504af1f0b1e3f78
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: 637ef45a531718a026806ce33504af1f0b1e3f78
+  CONTRIB_REPO_SHA: 1a665d692f3f87c7cfee8a96b624b05ed8854d60
 
 jobs:
   build:

--- a/tests/util/src/opentelemetry/test/test_base.py
+++ b/tests/util/src/opentelemetry/test/test_base.py
@@ -24,6 +24,8 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 
 
 class TestBase(unittest.TestCase):
+    # pylint: disable=C0103
+
     @classmethod
     def setUpClass(cls):
         cls.original_tracer_provider = trace_api.get_tracer_provider()
@@ -44,7 +46,7 @@ class TestBase(unittest.TestCase):
     def setUp(self):
         self.memory_exporter.clear()
 
-    def assertSpanInstrumentationInfo(self, span, module):
+    def assertSpanHasInstrumentationInfo(self, span, module):
         self.assertEqual(span.instrumentation_info.name, module.__name__)
         self.assertEqual(span.instrumentation_info.version, module.__version__)
 

--- a/tests/util/src/opentelemetry/test/test_base.py
+++ b/tests/util/src/opentelemetry/test/test_base.py
@@ -46,7 +46,7 @@ class TestBase(unittest.TestCase):
     def setUp(self):
         self.memory_exporter.clear()
 
-    def assertSpanHasInstrumentationInfo(self, span, module):
+    def assertEqualSpanInstrumentationInfo(self, span, module):
         self.assertEqual(span.instrumentation_info.name, module.__name__)
         self.assertEqual(span.instrumentation_info.version, module.__version__)
 

--- a/tests/util/src/opentelemetry/test/test_base.py
+++ b/tests/util/src/opentelemetry/test/test_base.py
@@ -44,11 +44,11 @@ class TestBase(unittest.TestCase):
     def setUp(self):
         self.memory_exporter.clear()
 
-    def check_span_instrumentation_info(self, span, module):
+    def assertSpanInstrumentationInfo(self, span, module):
         self.assertEqual(span.instrumentation_info.name, module.__name__)
         self.assertEqual(span.instrumentation_info.version, module.__version__)
 
-    def assert_span_has_attributes(self, span, attributes):
+    def assertSpanHasAttributes(self, span, attributes):
         for key, val in attributes.items():
             self.assertIn(key, span.attributes)
             self.assertEqual(val, span.attributes[key])


### PR DESCRIPTION
# Description

Update base test class to have more consistent assertion methods with rest of Python ecosystem.

- [x] Dev/Tooling enchancement
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Existing Tests

# Does This PR Require a Contrib Repo Change?

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/641
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
