### PR TITLE
rename test-core env to opentelemetry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
       matrix:
         python-version: [ py36, py37, py38, py39, pypy3 ]
-        package: ["api,sdk,instrumentation,semantic,getting,distro,shim", "exporter,proto", "propagator"]
+        package: ["api", "sdk", "instrumentation", "semantic", "getting", "distro" , "shim", "exporter", "proto", "propagator"]
         os: [ ubuntu-20.04, windows-2019 ]
     steps:
       - name: Checkout Core Repo @ SHA - ${{ github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
       matrix:
         python-version: [ py36, py37, py38, py39, pypy3 ]
-        package: ["instrumentation", "core", "exporter", "propagator"]
+        package: ["api,sdk,instrumentation,semantic,getting,distro,shim", "exporter,proto", "propagator"]
         os: [ ubuntu-20.04, windows-2019 ]
     steps:
       - name: Checkout Core Repo @ SHA - ${{ github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
       matrix:
         python-version: [ py36, py37, py38, py39, pypy3 ]
-        package: ["api", "sdk", "instrumentation", "semantic", "getting", "distro" , "shim", "exporter", "proto", "propagator"]
+        package: ["api", "sdk", "instrumentation", "semantic", "getting", "distro" , "shim", "exporter", "protobuf", "propagator"]
         os: [ ubuntu-20.04, windows-2019 ]
     steps:
       - name: Checkout Core Repo @ SHA - ${{ github.sha }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,8 @@ You can run:
 - `tox` to run all existing tox commands, including unit tests for all packages
   under multiple Python versions
 - `tox -e docs` to regenerate the API docs
-- `tox -e test-core-api` and `tox -e test-core-sdk` to run the API and SDK unit tests
-- `tox -e py37-test-core-api` to e.g. run the API unit tests under a specific
+- `tox -e opentelemetry-api` and `tox -e opentelemetry-sdk` to run the API and SDK unit tests
+- `tox -e py37-opentelemetry-api` to e.g. run the API unit tests under a specific
   Python version
 - `tox -e lint` to run lint checks on all code
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,82 +4,65 @@ skip_missing_interpreters = True
 envlist =
     ; Environments are organized by individual package, allowing
     ; for specifying supported Python versions per package.
-    ; opentelemetry-api
-    py3{6,7,8,9}-test-core-api
-    pypy3-test-core-api
+    py3{6,7,8,9}-opentelemetry-api
+    pypy3-opentelemetry-api
 
-    ; opentelemetry-proto
-    py3{6,7,8,9}-test-core-proto
-    pypy3-test-core-proto
+    py3{6,7,8,9}-opentelemetry-proto
+    pypy3-opentelemetry-proto
 
-    ; opentelemetry-sdk
-    py3{6,7,8,9}-test-core-sdk
-    pypy3-test-core-sdk
+    py3{6,7,8,9}-opentelemetry-sdk
+    pypy3-opentelemetry-sdk
 
-    ; opentelemetry-instrumentation
-    py3{6,7,8,9}-test-core-instrumentation
-    pypy3-test-core-instrumentation
+    py3{6,7,8,9}-opentelemetry-instrumentation
+    pypy3-opentelemetry-instrumentation
 
-    ; opentelemetry-semantic-conventions
-    py3{6,7,8,9}-test-semantic-conventions
-    pypy3-test-semantic-conventions
+    py3{6,7,8,9}-opentelemetry-semantic-conventions
+    pypy3-opentelemetry-semantic-conventions
 
     ; docs/getting-started
-    py3{6,7,8,9}-test-core-getting-started
-    pypy3-test-core-getting-started
+    py3{6,7,8,9}-opentelemetry-getting-started
+    pypy3-opentelemetry-getting-started
 
-    ; opentelemetry-distro
-    py3{6,7,8,9}-test-core-distro
-    pypy3-test-core-distro
+    py3{6,7,8,9}-opentelemetry-distro
+    pypy3-opentelemetry-distro
 
-    ; opentelemetry-exporter-jaeger
-    py3{6,7,8,9}-test-exporter-jaeger-combined
+    py3{6,7,8,9}-opentelemetry-opentracing-shim
+    pypy3-opentelemetry-opentracing-shim
 
-    ; opentelemetry-exporter-jaeger-proto-grpc
-    py3{6,7,8,9}-test-exporter-jaeger-proto-grpc
+    py3{6,7,8,9}-opentelemetry-exporter-jaeger-combined
 
-    ; opentelemetry-exporter-jaeger-thrift
-    py3{6,7,8,9}-test-exporter-jaeger-thrift
+    py3{6,7,8,9}-opentelemetry-exporter-jaeger-proto-grpc
 
-    ; opentelemetry-exporter-opencensus
-    py3{6,7,8,9}-test-exporter-opencensus
+    py3{6,7,8,9}-opentelemetry-exporter-jaeger-thrift
+
+    py3{6,7,8,9}-opentelemetry-exporter-opencensus
     ; exporter-opencensus intentionally excluded from pypy3
 
-    ; opentelemetry-exporter-otlp-combined
-    py3{6,7,8,9}-test-exporter-otlp-combined
+    ; opentelemetry-exporter-otlp
+    py3{6,7,8,9}-opentelemetry-exporter-otlp-combined
     ; intentionally excluded from pypy3
 
-    ; opentelemetry-exporter-otlp-proto-grpc
-    py3{6,7,8,9}-test-exporter-otlp-proto-grpc
+    py3{6,7,8,9}-opentelemetry-exporter-otlp-proto-grpc
     ; intentionally excluded from pypy3
 
-    ; opentelemetry-exporter-otlp-proto-http
-    py3{6,7,8,9}-test-exporter-otlp-proto-http
-    pypy3-test-exporter-otlp-proto-http
+    py3{6,7,8,9}-opentelemetry-exporter-otlp-proto-http
+    pypy3-opentelemetry-exporter-otlp-proto-http
 
     ; opentelemetry-exporter-zipkin
-    py3{6,7,8,9}-test-exporter-zipkin-combined
-    pypy3-test-exporter-zipkin-combined
+    py3{6,7,8,9}-opentelemetry-exporter-zipkin-combined
+    pypy3-opentelemetry-exporter-zipkin-combined
 
-    ; opentelemetry-exporter-zipkin-proto-http
-    py3{6,7,8,9}-test-exporter-zipkin-proto-http
-    pypy3-test-exporter-zipkin-proto-http
+    py3{6,7,8,9}-opentelemetry-exporter-zipkin-proto-http
+    pypy3-opentelemetry-exporter-zipkin-proto-http
 
-    ; opentelemetry-exporter-zipkin-json
-    py3{6,7,8,9}-test-exporter-zipkin-json
-    pypy3-test-exporter-zipkin-json
+    py3{6,7,8,9}-opentelemetry-exporter-zipkin-json
+    pypy3-opentelemetry-exporter-zipkin-json
 
-    ; opentelemetry-opentracing-shim
-    py3{6,7,8,9}-test-core-opentracing-shim
-    pypy3-test-core-opentracing-shim
+    py3{6,7,8,9}-opentelemetry-propagator-b3
+    pypy3-opentelemetry-propagator-b3
 
-    ; opentelemetry-propagator-b3
-    py3{6,7,8,9}-test-propagator-b3
-    pypy3-test-propagator-b3
-
-    ; opentelemetry-propagator-jaeger
-    py3{6,7,8,9}-test-propagator-jaeger
-    pypy3-test-propagator-jaeger
+    py3{6,7,8,9}-opentelemetry-propagator-jaeger
+    pypy3-opentelemetry-propagator-jaeger
 
     lint
     tracecontext
@@ -91,49 +74,50 @@ envlist =
 [testenv]
 deps =
   -c dev-requirements.txt
-  test: pytest
-  test: pytest-benchmark
+  opentelemetry: pytest
+  opentelemetry: pytest-benchmark
   coverage: pytest
   coverage: pytest-cov
   mypy,mypyinstalled: mypy
 
-setenv = mypy: MYPYPATH={toxinidir}/opentelemetry-api/src/
+setenv =
+  mypy: MYPYPATH={toxinidir}/opentelemetry-api/src/
 
 changedir =
-  test-core-api: opentelemetry-api/tests
-  test-core-sdk: opentelemetry-sdk/tests
-  test-core-proto: opentelemetry-proto/tests
-  test-semantic-conventions: opentelemetry-semantic-conventions/tests
-  test-core-instrumentation: opentelemetry-instrumentation/tests
-  test-core-getting-started: docs/getting_started/tests
-  test-core-opentracing-shim: shim/opentelemetry-opentracing-shim/tests
-  test-core-distro: opentelemetry-distro/tests
+  api: opentelemetry-api/tests
+  sdk: opentelemetry-sdk/tests
+  proto: opentelemetry-proto/tests
+  semantic-conventions: opentelemetry-semantic-conventions/tests
+  instrumentation: opentelemetry-instrumentation/tests
+  getting-started: docs/getting_started/tests
+  opentracing-shim: shim/opentelemetry-opentracing-shim/tests
+  distro: opentelemetry-distro/tests
 
-  test-exporter-jaeger-combined: exporter/opentelemetry-exporter-jaeger/tests
-  test-exporter-jaeger-proto-grpc: exporter/opentelemetry-exporter-jaeger-proto-grpc/tests
-  test-exporter-jaeger-thrift: exporter/opentelemetry-exporter-jaeger-thrift/tests
-  test-exporter-opencensus: exporter/opentelemetry-exporter-opencensus/tests
-  test-exporter-otlp-combined: exporter/opentelemetry-exporter-otlp/tests
-  test-exporter-otlp-proto-grpc: exporter/opentelemetry-exporter-otlp-proto-grpc/tests
-  test-exporter-otlp-proto-http: exporter/opentelemetry-exporter-otlp-proto-http/tests
-  test-exporter-zipkin-combined: exporter/opentelemetry-exporter-zipkin/tests
-  test-exporter-zipkin-proto-http: exporter/opentelemetry-exporter-zipkin-proto-http/tests
-  test-exporter-zipkin-json: exporter/opentelemetry-exporter-zipkin-json/tests
+  exporter-jaeger-combined: exporter/opentelemetry-exporter-jaeger/tests
+  exporter-jaeger-proto-grpc: exporter/opentelemetry-exporter-jaeger-proto-grpc/tests
+  exporter-jaeger-thrift: exporter/opentelemetry-exporter-jaeger-thrift/tests
+  exporter-opencensus: exporter/opentelemetry-exporter-opencensus/tests
+  exporter-otlp-combined: exporter/opentelemetry-exporter-otlp/tests
+  exporter-otlp-proto-grpc: exporter/opentelemetry-exporter-otlp-proto-grpc/tests
+  exporter-otlp-proto-http: exporter/opentelemetry-exporter-otlp-proto-http/tests
+  exporter-zipkin-combined: exporter/opentelemetry-exporter-zipkin/tests
+  exporter-zipkin-proto-http: exporter/opentelemetry-exporter-zipkin-proto-http/tests
+  exporter-zipkin-json: exporter/opentelemetry-exporter-zipkin-json/tests
   
-  test-propagator-b3: propagator/opentelemetry-propagator-b3/tests
-  test-propagator-jaeger: propagator/opentelemetry-propagator-jaeger/tests
+  propagator-b3: propagator/opentelemetry-propagator-b3/tests
+  propagator-jaeger: propagator/opentelemetry-propagator-jaeger/tests
 
 commands_pre =
 ; Install without -e to test the actual installation
   py3{6,7,8,9}: python -m pip install -U pip setuptools wheel
 ; Install common packages for all the tests. These are not needed in all the
 ; cases but it saves a lot of boilerplate in this file.
-  test: pip install {toxinidir}/opentelemetry-api {toxinidir}/opentelemetry-semantic-conventions {toxinidir}/opentelemetry-instrumentation {toxinidir}/opentelemetry-sdk {toxinidir}/tests/util
+  opentelemetry: pip install {toxinidir}/opentelemetry-api {toxinidir}/opentelemetry-semantic-conventions {toxinidir}/opentelemetry-instrumentation {toxinidir}/opentelemetry-sdk {toxinidir}/tests/util
 
-  test-core-sdk: pip install {toxinidir}/opentelemetry-instrumentation
-  test-core-opentracing-shim: pip install {toxinidir}/opentelemetry-instrumentation
+  sdk: pip install {toxinidir}/opentelemetry-instrumentation
+  opentracing-shim: pip install {toxinidir}/opentelemetry-instrumentation
 
-  test-core-proto: pip install {toxinidir}/opentelemetry-proto
+  proto: pip install {toxinidir}/opentelemetry-proto
   distro: pip install {toxinidir}/opentelemetry-distro
   instrumentation: pip install {toxinidir}/opentelemetry-instrumentation
 
@@ -183,7 +167,7 @@ commands_pre =
   mypyinstalled: pip install file://{toxinidir}/opentelemetry-api/
 
 commands =
-  test: pytest {posargs}
+  opentelemetry: pytest {posargs}
   coverage: {toxinidir}/scripts/coverage.sh
 
   mypy: mypy --namespace-packages --explicit-package-bases opentelemetry-api/src/opentelemetry/

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ envlist =
     py3{6,7,8,9}-opentelemetry-api
     pypy3-opentelemetry-api
 
-    py3{6,7,8,9}-opentelemetry-proto
-    pypy3-opentelemetry-proto
+    py3{6,7,8,9}-opentelemetry-protobuf
+    pypy3-opentelemetry-protobuf
 
     py3{6,7,8,9}-opentelemetry-sdk
     pypy3-opentelemetry-sdk
@@ -86,7 +86,7 @@ setenv =
 changedir =
   api: opentelemetry-api/tests
   sdk: opentelemetry-sdk/tests
-  proto: opentelemetry-proto/tests
+  protobuf: opentelemetry-proto/tests
   semantic-conventions: opentelemetry-semantic-conventions/tests
   instrumentation: opentelemetry-instrumentation/tests
   getting-started: docs/getting_started/tests
@@ -117,7 +117,7 @@ commands_pre =
   sdk: pip install {toxinidir}/opentelemetry-instrumentation
   opentracing-shim: pip install {toxinidir}/opentelemetry-instrumentation
 
-  proto: pip install {toxinidir}/opentelemetry-proto
+  protobuf: pip install {toxinidir}/opentelemetry-proto
   distro: pip install {toxinidir}/opentelemetry-distro
   instrumentation: pip install {toxinidir}/opentelemetry-instrumentation
 


### PR DESCRIPTION
# Description

First step towards making developer experience more intuitive, renamed the tox environments to `opentelemetry-` since `test-core-` isn't really clear. This allows users to run

`tox -e opentelemetry-api` or `tox -e opentelemetry-sdk` to run tests which is to me makes more sense. Would love others' input of course. `opentelemetry-protobuf` is the only package that doesn't match its directory name, because `opentelemetry-proto` caused all envs for exporters with the words proto in their names to also run due to tox factor being used.


## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Documentation has been updated
