### PR TITLE
use timeout in force_flush

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/logs/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/logs/export/__init__.py
@@ -266,9 +266,7 @@ class BatchLogProcessor(LogProcessor):
             flush_request = self._get_or_create_flush_request()
             self._condition.notify_all()
 
-        ret = flush_request.event.wait(
-           timeout_millis / 1e3
-        )
+        ret = flush_request.event.wait(timeout_millis / 1e3)
         if not ret:
             _logger.warning("Timeout was exceeded in force_flush().")
         return ret

--- a/opentelemetry-sdk/src/opentelemetry/sdk/logs/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/logs/export/__init__.py
@@ -266,7 +266,9 @@ class BatchLogProcessor(LogProcessor):
             flush_request = self._get_or_create_flush_request()
             self._condition.notify_all()
 
-        ret = flush_request.event.wait(flush_request.event.wait(timeout_millis/1e3))
+        ret = flush_request.event.wait(
+            flush_request.event.wait(timeout_millis / 1e3)
+        )
         if not ret:
             _logger.warning("Timeout was exceeded in force_flush().")
         return ret

--- a/opentelemetry-sdk/src/opentelemetry/sdk/logs/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/logs/export/__init__.py
@@ -266,7 +266,7 @@ class BatchLogProcessor(LogProcessor):
             flush_request = self._get_or_create_flush_request()
             self._condition.notify_all()
 
-        ret = flush_request.event.wait()
+        ret = flush_request.event.wait(flush_request.event.wait(timeout_millis/1e3))
         if not ret:
             _logger.warning("Timeout was exceeded in force_flush().")
         return ret

--- a/opentelemetry-sdk/src/opentelemetry/sdk/logs/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/logs/export/__init__.py
@@ -267,7 +267,7 @@ class BatchLogProcessor(LogProcessor):
             self._condition.notify_all()
 
         ret = flush_request.event.wait(
-            flush_request.event.wait(timeout_millis / 1e3)
+           timeout_millis / 1e3
         )
         if not ret:
             _logger.warning("Timeout was exceeded in force_flush().")


### PR DESCRIPTION
# Description

The tests for the logs branch were hanging every so often, especially with pypy3, I tracked the issue down to a missing timeout on force_flush in the `BatchLogProcessor`.

Fixes #2117

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
