### PR TITLE
update open calls to pass encoding

### DIFF
--- a/docs/examples/error_handler/error_handler_0/setup.py
+++ b/docs/examples/error_handler/error_handler_0/setup.py
@@ -20,7 +20,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "error_handler_0", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/docs/examples/error_handler/error_handler_1/setup.py
+++ b/docs/examples/error_handler/error_handler_1/setup.py
@@ -20,7 +20,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "error_handler_1", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.py
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.py
@@ -27,7 +27,7 @@ VERSION_FILENAME = os.path.join(
     "version.py",
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/util.py
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/util.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 def _load_credential_from_file(path) -> ChannelCredentials:
     try:
-        with open(path, "rb", encoding="utf-8") as creds_file:
+        with open(path, "rb") as creds_file:
             credential = creds_file.read()
             return ssl_channel_credentials(credential)
     except FileNotFoundError:

--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/util.py
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/util.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 def _load_credential_from_file(path) -> ChannelCredentials:
     try:
-        with open(path, "rb") as creds_file:
+        with open(path, "rb", encoding="utf-8") as creds_file:
             credential = creds_file.read()
             return ssl_channel_credentials(credential)
     except FileNotFoundError:

--- a/exporter/opentelemetry-exporter-jaeger-thrift/setup.py
+++ b/exporter/opentelemetry-exporter-jaeger-thrift/setup.py
@@ -26,7 +26,7 @@ VERSION_FILENAME = os.path.join(
     "version.py",
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-jaeger/setup.py
+++ b/exporter/opentelemetry-exporter-jaeger/setup.py
@@ -20,7 +20,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "exporter", "jaeger", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-opencensus/setup.py
+++ b/exporter/opentelemetry-exporter-opencensus/setup.py
@@ -20,7 +20,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "exporter", "opencensus", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.py
@@ -27,7 +27,7 @@ VERSION_FILENAME = os.path.join(
     "version.py",
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -168,7 +168,7 @@ def get_resource_data(
 
 def _load_credential_from_file(filepath) -> ChannelCredentials:
     try:
-        with open(filepath, "rb", encoding="utf-8") as creds_file:
+        with open(filepath, "rb") as creds_file:
             credential = creds_file.read()
             return ssl_channel_credentials(credential)
     except FileNotFoundError:

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -168,7 +168,7 @@ def get_resource_data(
 
 def _load_credential_from_file(filepath) -> ChannelCredentials:
     try:
-        with open(filepath, "rb") as creds_file:
+        with open(filepath, "rb", encoding="utf-8") as creds_file:
             credential = creds_file.read()
             return ssl_channel_credentials(credential)
     except FileNotFoundError:

--- a/exporter/opentelemetry-exporter-otlp-proto-http/setup.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/setup.py
@@ -27,7 +27,7 @@ VERSION_FILENAME = os.path.join(
     "version.py",
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-otlp/setup.py
+++ b/exporter/opentelemetry-exporter-otlp/setup.py
@@ -20,7 +20,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "exporter", "otlp", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-zipkin-json/setup.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/setup.py
@@ -26,7 +26,7 @@ VERSION_FILENAME = os.path.join(
     "version.py",
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/setup.py
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/setup.py
@@ -27,7 +27,7 @@ VERSION_FILENAME = os.path.join(
     "version.py",
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/exporter/opentelemetry-exporter-zipkin/setup.py
+++ b/exporter/opentelemetry-exporter-zipkin/setup.py
@@ -20,7 +20,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "exporter", "zipkin", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/opentelemetry-api/setup.py
+++ b/opentelemetry-api/setup.py
@@ -19,7 +19,7 @@ import setuptools
 BASE_DIR = os.path.dirname(__file__)
 VERSION_FILENAME = os.path.join(BASE_DIR, "src", "opentelemetry", "version.py")
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(

--- a/opentelemetry-distro/setup.py
+++ b/opentelemetry-distro/setup.py
@@ -21,7 +21,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "distro", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(

--- a/opentelemetry-instrumentation/setup.py
+++ b/opentelemetry-instrumentation/setup.py
@@ -21,7 +21,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "instrumentation", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(

--- a/opentelemetry-proto/setup.py
+++ b/opentelemetry-proto/setup.py
@@ -21,7 +21,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "proto", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(

--- a/opentelemetry-sdk/setup.py
+++ b/opentelemetry-sdk/setup.py
@@ -21,7 +21,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "sdk", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(

--- a/opentelemetry-semantic-conventions/setup.py
+++ b/opentelemetry-semantic-conventions/setup.py
@@ -21,7 +21,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "semconv", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(

--- a/propagator/opentelemetry-propagator-b3/setup.py
+++ b/propagator/opentelemetry-propagator-b3/setup.py
@@ -20,7 +20,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "propagators", "b3", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/propagator/opentelemetry-propagator-jaeger/setup.py
+++ b/propagator/opentelemetry-propagator-jaeger/setup.py
@@ -20,7 +20,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "propagators", "jaeger", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/scripts/check_for_valid_readme.py
+++ b/scripts/check_for_valid_readme.py
@@ -8,7 +8,7 @@ import readme_renderer.rst
 
 def is_valid_rst(path):
     """Checks if RST can be rendered on PyPI."""
-    with open(path) as readme_file:
+    with open(path, encoding="utf-8") as readme_file:
         markup = readme_file.read()
     return readme_renderer.rst.render(markup, stream=sys.stderr) is not None
 

--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -552,13 +552,13 @@ def lint_args(args):
 def update_changelog(path, version, new_entry):
     unreleased_changes = False
     try:
-        with open(path) as changelog:
+        with open(path, encoding="utf-8") as changelog:
             text = changelog.read()
             if "## [{}]".format(version) in text:
                 raise AttributeError(
                     "{} already contans version {}".format(path, version)
                 )
-        with open(path) as changelog:
+        with open(path, encoding="utf-8") as changelog:
             for line in changelog:
                 if line.startswith("## [Unreleased]"):
                     unreleased_changes = False
@@ -574,7 +574,7 @@ def update_changelog(path, version, new_entry):
     if unreleased_changes:
         print("updating: {}".format(path))
         text = re.sub(r"## \[Unreleased\].*", new_entry, text)
-        with open(path, "w") as changelog:
+        with open(path, "w", encoding="utf-8") as changelog:
             changelog.write(text)
 
 
@@ -645,14 +645,14 @@ def update_files(targets, filename, search, replace):
             print("file missing: {}/{}".format(target, filename))
             continue
 
-        with open(curr_file) as _file:
+        with open(curr_file, encoding="utf-8") as _file:
             text = _file.read()
 
         if replace in text:
             print("{} already contains {}".format(curr_file, replace))
             continue
 
-        with open(curr_file, "w") as _file:
+        with open(curr_file, "w", encoding="utf-8") as _file:
             _file.write(re.sub(search, replace, text))
 
     if errors:

--- a/shim/opentelemetry-opentracing-shim/setup.py
+++ b/shim/opentelemetry-opentracing-shim/setup.py
@@ -25,7 +25,7 @@ VERSION_FILENAME = os.path.join(
     "version.py",
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])

--- a/tests/util/setup.py
+++ b/tests/util/setup.py
@@ -20,7 +20,7 @@ VERSION_FILENAME = os.path.join(
     BASE_DIR, "src", "opentelemetry", "test", "version.py"
 )
 PACKAGE_INFO = {}
-with open(VERSION_FILENAME) as f:
+with open(VERSION_FILENAME, encoding="utf-8") as f:
     exec(f.read(), PACKAGE_INFO)
 
 setuptools.setup(version=PACKAGE_INFO["__version__"])


### PR DESCRIPTION
# Description

Ensure all calls to `open` pass an encoding as suggested by pylint:
`W1514: Using open without explicitly specifying an encoding (unspecified-encoding)`

Fixes #2126 
Part of #2123 

# Checklist:

- [x] Followed the style guidelines of this project
