### PR TITLE
use {} instead of dict()

### DIFF
--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -43,10 +43,10 @@ class TestAttributes(unittest.TestCase):
 
     def test_clean_attribute(self):
         self.assertInvalid([1, 2, 3.4, "ss", 4])
-        self.assertInvalid([dict(), 1, 2, 3.4, 4])
+        self.assertInvalid([{}, 1, 2, 3.4, 4])
         self.assertInvalid(["sw", "lf", 3.4, "ss"])
         self.assertInvalid([1, 2, 3.4, 5])
-        self.assertInvalid(dict())
+        self.assertInvalid({})
         self.assertInvalid([1, True])
         self.assertValid(True)
         self.assertValid("hi")

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -213,7 +213,7 @@ class TestResources(unittest.TestCase):
         resource = resources.Resource(
             {
                 resources.SERVICE_NAME: "test",
-                "non-primitive-data-type": dict(),
+                "non-primitive-data-type": {},
                 "invalid-byte-type-attribute": b"\xd8\xe1\xb7\xeb\xa8\xe5 \xd2\xb7\xe1",
                 "": "empty-key-value",
                 None: "null-key-value",

--- a/opentelemetry-sdk/tests/trace/test_sampling.py
+++ b/opentelemetry-sdk/tests/trace/test_sampling.py
@@ -50,7 +50,7 @@ class TestDecision(unittest.TestCase):
 class TestSamplingResult(unittest.TestCase):
     def test_ctr(self):
         attributes = {"asd": "test"}
-        trace_state = dict()
+        trace_state = {}
         # pylint: disable=E1137
         trace_state["test"] = "123"
         result = sampling.SamplingResult(

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -637,10 +637,10 @@ class TestSpan(unittest.TestCase):
     def test_invalid_attribute_values(self):
         with self.tracer.start_as_current_span("root") as root:
             root.set_attributes(
-                {"correct-value": "foo", "non-primitive-data-type": dict()}
+                {"correct-value": "foo", "non-primitive-data-type": {}}
             )
 
-            root.set_attribute("non-primitive-data-type", dict())
+            root.set_attribute("non-primitive-data-type", {})
             root.set_attribute(
                 "list-of-mixed-data-types-numeric-first",
                 [123, False, "string"],
@@ -650,7 +650,7 @@ class TestSpan(unittest.TestCase):
                 [False, 123, "string"],
             )
             root.set_attribute(
-                "list-with-non-primitive-data-type", [dict(), 123]
+                "list-with-non-primitive-data-type", [{}, 123]
             )
             root.set_attribute("list-with-numeric-and-bool", [1, True])
 
@@ -772,9 +772,9 @@ class TestSpan(unittest.TestCase):
 
         with self.tracer.start_as_current_span("root") as root:
             root.add_event("event0", {"attr1": True, "attr2": ["hi", False]})
-            root.add_event("event0", {"attr1": dict()})
+            root.add_event("event0", {"attr1": {}})
             root.add_event("event0", {"attr1": [[True]]})
-            root.add_event("event0", {"attr1": [dict()], "attr2": [1, 2]})
+            root.add_event("event0", {"attr1": [{}], "attr2": [1, 2]})
 
             self.assertEqual(len(root.events), 4)
             self.assertEqual(root.events[0].attributes, {"attr1": True})

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -649,9 +649,7 @@ class TestSpan(unittest.TestCase):
                 "list-of-mixed-data-types-non-numeric-first",
                 [False, 123, "string"],
             )
-            root.set_attribute(
-                "list-with-non-primitive-data-type", [{}, 123]
-            )
+            root.set_attribute("list-with-non-primitive-data-type", [{}, 123])
             root.set_attribute("list-with-numeric-and-bool", [1, True])
 
             root.set_attribute("", 123)


### PR DESCRIPTION
# Description
Continuing fixes from pylint 2.11.0 warnings:
```
R1735: Consider using {} instead of dict() (use-dict-literal)
```

Fixes #2132 
Part of #2123 
