### PR TITLE
don't use deprecated abstractclassmethod

### DIFF
--- a/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
+++ b/propagator/opentelemetry-propagator-b3/tests/test_b3_format.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from abc import abstractclassmethod
+from abc import abstractmethod
 from unittest.mock import Mock
 
 import opentelemetry.sdk.trace as trace
@@ -81,11 +81,13 @@ class AbstractB3FormatTestCase:
     def get_child_parent_new_carrier(cls, old_carrier):
         return get_child_parent_new_carrier(old_carrier, cls.get_propagator())
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def get_propagator(cls):
         pass
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def get_trace_id(cls, carrier):
         pass
 


### PR DESCRIPTION
# Description

Don't use deprecated method.
```
W1513: Using deprecated decorator abc.abstractclassmethod() (deprecated-decorator)
```

Fixes #2134 
Part of #2123 