### PR TITLE
Exempt resource attributes from span limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2101](https://github.com/open-telemetry/opentelemetry-python/pull/2101))
 - Fix incorrect headers parsing via environment variables
   ([#2103](https://github.com/open-telemetry/opentelemetry-python/pull/2103))
+- Attribute limits no longer apply to Resource attributes
+  ([#2138](https://github.com/open-telemetry/opentelemetry-python/pull/2138))
 
 ## [1.5.0-0.24b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.5.0-0.24b0) - 2021-08-26
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -1069,11 +1069,6 @@ class TracerProvider(trace_api.TracerProvider):
         self._span_limits = span_limits or SpanLimits()
         self._atexit_handler = None
 
-        self._resource._attributes = BoundedAttributes(
-            self._span_limits.max_attributes,
-            self._resource._attributes,
-            max_value_len=self._span_limits.max_attribute_length,
-        )
         if shutdown_on_exit:
             self._atexit_handler = atexit.register(self.shutdown)
 

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1490,7 +1490,6 @@ class TestSpanLimits(unittest.TestCase):
         self.assertEqual(3, span.dropped_events)
         self.assertEqual(2, span.events[0].attributes.dropped)
         self.assertEqual(2, span.links[0].attributes.dropped)
-        self.assertEqual(2, span.resource.attributes.dropped)
 
     def _test_span_limits(
         self,


### PR DESCRIPTION
# Description

Exempts resources from attribute limits as is now recommended by the spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#exempt-entities

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated existing test

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
