### PR TITLE
Add OTLP HTTP exporter as dependency to OTLP exporter package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2101](https://github.com/open-telemetry/opentelemetry-python/pull/2101))
 - Fix incorrect headers parsing via environment variables
   ([#2103](https://github.com/open-telemetry/opentelemetry-python/pull/2103))
+- `opentelemetry-exporter-otlp`: Add `opentelemetry-otlp-proto-http` as dependency
+- ([#2147](https://github.com/open-telemetry/opentelemetry-python/pull/2147))
 
 ## [1.5.0-0.24b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.5.0-0.24b0) - 2021-08-26
 

--- a/exporter/opentelemetry-exporter-otlp/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp/setup.cfg
@@ -39,6 +39,7 @@ python_requires = >=3.6
 packages=find_namespace:
 install_requires =
     opentelemetry-exporter-otlp-proto-grpc == 1.5.0
+    opentelemetry-exporter-otlp-proto-http == 1.5.0
 
 [options.entry_points]
 opentelemetry_traces_exporter =


### PR DESCRIPTION
# Description

Adds OTLP HTTP exporter as a dependency to `opentelemetry-exporter-otlp` convenience package to make it install together when the convenience package gets installed. 


# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Changelogs have been updated
