### PR TITLE
Fix slow batch processor test for pypy + windows

### DIFF
--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -366,7 +366,7 @@ class TestBatchSpanProcessor(unittest.TestCase):
         )
         span_processor = export.BatchSpanProcessor(
             my_exporter,
-            schedule_delay_millis=50,
+            schedule_delay_millis=200,
         )
 
         # create single span
@@ -376,7 +376,7 @@ class TestBatchSpanProcessor(unittest.TestCase):
         self.assertTrue(export_event.wait(2))
         export_time = time.time()
         self.assertEqual(len(spans_names_list), 1)
-        self.assertGreaterEqual((export_time - start_time) * 1e3, 50)
+        self.assertGreaterEqual((export_time - start_time) * 1e3, 200)
 
         span_processor.shutdown()
 

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -364,19 +364,19 @@ class TestBatchSpanProcessor(unittest.TestCase):
         my_exporter = MySpanExporter(
             destination=spans_names_list, export_event=export_event
         )
+        start_time = time.time()
         span_processor = export.BatchSpanProcessor(
             my_exporter,
-            schedule_delay_millis=200,
+            schedule_delay_millis=500,
         )
 
         # create single span
-        start_time = time.time()
         _create_start_and_end_span("foo", span_processor)
 
         self.assertTrue(export_event.wait(2))
         export_time = time.time()
         self.assertEqual(len(spans_names_list), 1)
-        self.assertGreaterEqual((export_time - start_time) * 1e3, 200)
+        self.assertGreaterEqual((export_time - start_time) * 1e3, 500)
 
         span_processor.shutdown()
 


### PR DESCRIPTION
# Description

I think the reason this test has been failing is that it is so slow on pypy+windows that the processor completes a partial, one or even multiple 50ms ticks by the time we start measuring. If the worker is well into a 50ms tick (first or nth), our span will take less than 50ms to be exporter. This PR starts measuring time right before creating the processor as it guarantees the elapsed time will include the processor timeout + the time it takes the processor to initialize. We increase the timeout generously to account for slow processor start.


Please delete options that are not relevant.

- [x] Tooling/dev enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated existing test

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
