### PR TITLE
Fix opentracing shim references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2145](https://github.com/open-telemetry/opentelemetry-python/pull/2145))
 - Add `schema_url` to `TracerProvider.get_tracer`
   ([#2154](https://github.com/open-telemetry/opentelemetry-python/pull/2154))
+- Fix parental trace relationship for opentracing `follows_from` reference
+  ()
 
 ## [1.5.0-0.24b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.5.0-0.24b0) - 2021-08-26
 

--- a/shim/opentelemetry-opentracing-shim/tests/test_shim.py
+++ b/shim/opentelemetry-opentracing-shim/tests/test_shim.py
@@ -389,6 +389,24 @@ class TestShim(TestCase):
                     parent.context.unwrap(),
                 )
 
+    def test_follows_from_references(self):
+        """Test span creation using the `references` argument with a follows from relationship."""
+
+        with self.shim.start_span("ParentSpan") as parent:
+            ref = opentracing.follows_from(parent.context)
+
+        with self.shim.start_active_span(
+            "FollowingSpan", references=[ref]
+        ) as child:
+            self.assertEqual(
+                child.span.unwrap().links[0].context,
+                parent.context.unwrap(),
+            )
+            self.assertEqual(
+                child.span.unwrap().parent,
+                parent.context.unwrap(),
+            )
+
     def test_set_operation_name(self):
         """Test `set_operation_name()` method."""
 


### PR DESCRIPTION
# Description

This addresses the issue described in https://github.com/open-telemetry/opentelemetry-python/issues/2179

Fixes #2179 

## Type of change

Please delete options that are not relevant.

- [/] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [/] This was tested in a minimal working example [here](https://github.com/robertsben/otel-example/tree/follows-from-ref)

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `opentelemetry-instrumentation/` have changed
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [/] No.

# Checklist:

- [/] Followed the style guidelines of this project
- [/] Changelogs have been updated
- [/] Unit tests have been added
- [/] Documentation has been updated
