### PR TITLE
Demonstrate how to set the Resource for LogEmitterProvider

### DIFF
--- a/docs/examples/logs/example.py
+++ b/docs/examples/logs/example.py
@@ -3,18 +3,17 @@ import logging
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.log_exporter import OTLPLogExporter
 from opentelemetry.sdk.logs import (
-    OTLPHandler,
     LogEmitterProvider,
-    get_log_emitter_provider,
+    OTLPHandler,
     set_log_emitter_provider,
 )
 from opentelemetry.sdk.logs.export import SimpleLogProcessor
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     ConsoleSpanExporter,
     SimpleSpanProcessor,
 )
-from opentelemetry.sdk.resources import Resource
 
 trace.set_tracer_provider(TracerProvider())
 trace.get_tracer_provider().add_span_processor(


### PR DESCRIPTION
# Description

Added a Resource to the logs example to make it more complete.
Previously it was using the built-in Resource. Now it adds the
service.name and service.instance.id attributes.

The resulting emitted log records look like this:
```
Resource labels:
     -> telemetry.sdk.language: STRING(python)
     -> telemetry.sdk.name: STRING(opentelemetry)
     -> telemetry.sdk.version: STRING(1.5.0)
     -> service.name: STRING(shoppingcart)
     -> service.instance.id: STRING(instance-12)
InstrumentationLibraryLogs #0
InstrumentationLibrary __main__ 0.1
LogRecord #0
Timestamp: 2021-10-14 18:33:43.425820928 +0000 UTC
Severity: ERROR
ShortName:
Body: Hyderabad, we have a major problem.
Trace ID: ce1577e4a703f42d569e72593ad71888
Span ID: f8908ac4258ceff6
Flags: 1
```
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Run the example and watch the Collector's `logging` exporter output.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated `Not needed`
- [ ] Unit tests have been added `Not applicable. Example.`
- [x] Documentation has been updated
