### PR TITLE
Propagation: only warn about oversized baggage headers when headers exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade GRPC/protobuf related dependency and regenerate otlp protobufs
   ([#2201](https://github.com/open-telemetry/opentelemetry-python/pull/2201))
+- Propagation: only warn about oversized baggage headers when headers exist
+  ([#2212](https://github.com/open-telemetry/opentelemetry-python/pull/2212))
 
 ## [1.6.0-0.25b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.0-0.25b0) - 2021-10-13
 

--- a/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
@@ -53,7 +53,10 @@ class W3CBaggagePropagator(textmap.TextMapPropagator):
             getter.get(carrier, self._BAGGAGE_HEADER_NAME)
         )
 
-        if not header or len(header) > self._MAX_HEADER_LENGTH:
+        if not header:
+            return context
+
+        if len(header) > self._MAX_HEADER_LENGTH:
             _logger.warning(
                 "Baggage header `%s` exceeded the maximum number of bytes per baggage-string",
                 header,


### PR DESCRIPTION
# Description

Warnings were being logged about the baggage header being too long when the header was not present. This PR just adds a check to make sure the warning is only emitted when the header exists.

The main issue is that this was creating a lot of noise in logs, because the project where opentelemetry is used is the first one to receive requests (and thus will never have the baggage header set).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tox has been run. I'm not sure much else is necessary, given that no behavior has been changed, only logging.

- [x] Run tox

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
