### PR TITLE
add note about proto version to README.rst

### DIFF
--- a/opentelemetry-proto/README.rst
+++ b/opentelemetry-proto/README.rst
@@ -6,6 +6,11 @@ OpenTelemetry Python Proto
 .. |pypi| image:: https://badge.fury.io/py/opentelemetry-proto.svg
    :target: https://pypi.org/project/opentelemetry-proto/
 
+This library contains the generated code for OpenTelemetry protobuf data model. The code in the current
+package was generated using the v0.9.0 release_ of opentelemetry-proto.
+
+.. _release: https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.9.0
+
 Installation
 ------------
 

--- a/scripts/proto_codegen.sh
+++ b/scripts/proto_codegen.sh
@@ -70,3 +70,5 @@ python -m grpc_tools.protoc \
     --mypy_out=. \
     --grpc_python_out=. \
     $service_protos
+
+echo "Please update ./opentelemetry-proto/README.rst to include the updated version."


### PR DESCRIPTION
# Description
Adds a note to the `opentelemetry-proto` readme file about the proto version used in the package. also added a note to the proto generation script to remind its caller to update this document.

Fixes #2222 
