### PR TITLE
Sanitize resource attribute pairs to avoid exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1887](https://github.com/open-telemetry/opentelemetry-python/pull/1887))
 - Make batch processor fork aware and reinit when needed
   ([#2242](https://github.com/open-telemetry/opentelemetry-python/pull/2242))
+- `opentelemetry-sdk` Sanitize env var resource attribute pairs
+  ([#2256](https://github.com/open-telemetry/opentelemetry-python/pull/2256))
 
 ## [1.6.2-0.25b2](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.2-0.25b2) - 2021-10-19
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -266,13 +266,20 @@ class OTELResourceDetector(ResourceDetector):
     def detect(self) -> "Resource":
         env_resources_items = os.environ.get(OTEL_RESOURCE_ATTRIBUTES)
         env_resource_map = {}
+
         if env_resources_items:
-            env_resource_map = {
-                key.strip(): value.strip()
-                for key, value in (
-                    item.split("=") for item in env_resources_items.split(",")
-                )
-            }
+            for item in env_resources_items.split(","):
+                try:
+                    key, value = item.split("=", maxsplit=1)
+                except ValueError as exc:
+                    logger.warning(
+                        "Invalid key value resource attribute pair %s: %s",
+                        item,
+                        exc,
+                    )
+                    continue
+                env_resource_map[key.strip()] = value.strip()
+
         service_name = os.environ.get(OTEL_SERVICE_NAME)
         if service_name:
             env_resource_map[SERVICE_NAME] = service_name

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -482,6 +482,16 @@ class TestOTELResourceDetector(unittest.TestCase):
             detector.detect(), resources.Resource({"k": "v", "k2": "v2"})
         )
 
+    def test_invalid_key_value_pairs(self):
+        detector = resources.OTELResourceDetector()
+        os.environ[
+            resources.OTEL_RESOURCE_ATTRIBUTES
+        ] = "k=v,k2=v2,invalid,,foo=bar=baz,"
+        self.assertEqual(
+            detector.detect(),
+            resources.Resource({"k": "v", "k2": "v2", "foo": "bar=baz"}),
+        )
+
     @mock.patch.dict(
         os.environ,
         {resources.OTEL_SERVICE_NAME: "test-srv-name"},


### PR DESCRIPTION
# Description

Sanitze the `OTEL_RESOURCE_ATTRIBUTES` environment variable for "invalid" key/value pairs so that we do not throw a 

```python
ValueError: not enough values to unpack (expected 2, got 1)
```

exception.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Added a unit test to for the empty string `""` as well as a pair that does not have the `=` symbol.

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
~- [] Documentation has been updated~
