### PR TITLE
bugfix: delay init worker_thread avoid fork processor will cause thread not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2207](https://github.com/open-telemetry/opentelemetry-python/pull/2207))
 - remove `X-B3-ParentSpanId` for B3 propagator as per OpenTelemetry specification
   ([#2237](https://github.com/open-telemetry/opentelemetry-python/pull/2237))
+- Delay init worker_thread at on_end() in the BatchProcessor, avoid fork process will thread not work ([#2257](https://github.com/open-telemetry/opentelemetry-python/pull/2257))
 
 ## [1.6.2-0.25b2](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.2-0.25b2) - 2021-10-19
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -372,7 +372,9 @@ class BatchSpanProcessor(SpanProcessor):
             return True
 
         if self.worker_thread is None:
-            logger.warning("worker thread not init, ignoring call to force_flush().")
+            logger.warning(
+                "worker thread not init, ignoring call to force_flush()."
+            )
             return True
 
         with self.condition:

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -217,12 +217,17 @@ class TestBatchSpanProcessor(unittest.TestCase):
         spans_names_list = []
         my_exporter = MySpanExporter(destination=spans_names_list)
         span_processor = export.BatchSpanProcessor(my_exporter)
-        self.assertIsNone(span_processor.worker_thread, "worker thread at __init__() not init")
+        self.assertIsNone(
+            span_processor.worker_thread,
+            "worker thread at __init__() not init",
+        )
         span_names = ["xxx", "bar", "foo"]
 
         for name in span_names:
             _create_start_and_end_span(name, span_processor)
-        self.assertIsNotNone(span_processor.worker_thread, "worker thread at on_end() init")
+        self.assertIsNotNone(
+            span_processor.worker_thread, "worker thread at on_end() init"
+        )
 
         span_processor.shutdown()
         self.assertTrue(my_exporter.is_shutdown)

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -213,6 +213,21 @@ class TestBatchSpanProcessor(unittest.TestCase):
         # force_flush()
         self.assertListEqual(span_names, spans_names_list)
 
+    def test_work_thread_delay_init(self):
+        spans_names_list = []
+        my_exporter = MySpanExporter(destination=spans_names_list)
+        span_processor = export.BatchSpanProcessor(my_exporter)
+        self.assertIsNone(span_processor.worker_thread, "worker thread at __init__() not init")
+        span_names = ["xxx", "bar", "foo"]
+
+        for name in span_names:
+            _create_start_and_end_span(name, span_processor)
+        self.assertIsNotNone(span_processor.worker_thread, "worker thread at on_end() init")
+
+        span_processor.shutdown()
+        self.assertTrue(my_exporter.is_shutdown)
+        self.assertListEqual(span_names, spans_names_list)
+
     def test_flush(self):
         spans_names_list = []
 


### PR DESCRIPTION
bugfix: delay init worker_thread avoid fork processor will cause thread not work

# Description

at uwsgi fork processor, The Fork process is not performed until BatchProcessor is initialized, and the thread will not work because the Fork will not copy the thread. so at on_end() init work_thread will aovid the case

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test BatchProcessor work_thead delay init

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
