### PR TITLE
Remove links to metrics/logs feature branches from docs

### DIFF
--- a/docs/examples/logs/README.rst
+++ b/docs/examples/logs/README.rst
@@ -1,6 +1,11 @@
 OpenTelemetry Logs SDK
 ======================
 
+.. warning::
+   OpenTelemetry Python logs are in an experimental state. The APIs within
+   :mod:`opentelemetry.sdk._logs` are subject to change in minor/patch releases and make no
+   backward compatability guarantees at this time.
+
 Start the Collector locally to see data being exported. Write the following file:
 
 .. code-block:: yaml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,9 +11,8 @@ The Python `OpenTelemetry <https://opentelemetry.io/>`_ client.
 This documentation describes the :doc:`opentelemetry-api <api/api>`,
 :doc:`opentelemetry-sdk <sdk/sdk>`, and several `integration packages <#integrations>`_.
 
-The library is currently stable for tracing. Support for `metrics <https://github.com/open-telemetry/opentelemetry-python/tree/metrics>`_
-and `logging <https://github.com/open-telemetry/opentelemetry-python/tree/logs>`_ is currently under development and is considered
-experimental.
+The library is currently stable for tracing. Support for :doc:`metrics <api/metrics>` and
+:doc:`logging <sdk/logs>` are currently under development and are considered experimental.
 
 Requirement
 -----------


### PR DESCRIPTION
- Update links in the main index.rst file to not link to feature branches
- Added warning to logs example 