### PR TITLE
Improve log message in OTLP exporters

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -302,11 +302,18 @@ class OTLPExporterMixin(
                             + retry_info.retry_delay.nanos / 1.0e9
                         )
 
-                    logger.debug(
-                        "Waiting %ss before retrying export of span", delay
+                    logger.warning(
+                        "Transient error %s encountered while exporting span batch, retrying in %ss.",
+                        error.code(),
+                        delay,
                     )
                     sleep(delay)
                     continue
+                else:
+                    logger.error(
+                        "Failed to export span batch, error code: %s",
+                        error.code(),
+                    )
 
                 if error.code() == StatusCode.OK:
                     return self._result.SUCCESS

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -138,13 +138,15 @@ class OTLPSpanExporter(SpanExporter):
             if resp.status_code in (200, 202):
                 return SpanExportResult.SUCCESS
             elif self._retryable(resp):
-                _logger.debug(
-                    "Waiting %ss before retrying export of span", delay
+                _logger.warning(
+                    "Transient error %s encountered while exporting span batch, retrying in %ss.",
+                    resp.reason,
+                    delay,
                 )
                 sleep(delay)
                 continue
             else:
-                _logger.warning(
+                _logger.error(
                     "Failed to export batch code: %s, reason: %s",
                     resp.status_code,
                     resp.text,


### PR DESCRIPTION
# Description

Helps with #2284. Let us warn when there is a chance of recovering and error when we drop the batch.