### PR TITLE
add OTEL_LOGS_EXPORTER env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2253](https://github.com/open-telemetry/opentelemetry-python/pull/2253))
 - Rename ConsoleExporter to ConsoleLogExporter
   ([#2307](https://github.com/open-telemetry/opentelemetry-python/pull/2307))
+- Adding OTEL_LOGS_EXPORTER environment variable
+  ([#2320](https://github.com/open-telemetry/opentelemetry-python/pull/2320))
 
 ## [1.7.1-0.26b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.7.0-0.26b0) - 2021-11-11
 

--- a/opentelemetry-api/src/opentelemetry/environment_variables.py
+++ b/opentelemetry-api/src/opentelemetry/environment_variables.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+OTEL_LOGS_EXPORTER = "OTEL_LOGS_EXPORTER"
+"""
+.. envvar:: OTEL_LOGS_EXPORTER
+
+"""
+
 OTEL_METRICS_EXPORTER = "OTEL_METRICS_EXPORTER"
 """
 .. envvar:: OTEL_METRICS_EXPORTER

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -25,6 +25,7 @@ from pkg_resources import iter_entry_points
 
 from opentelemetry import trace
 from opentelemetry.environment_variables import (
+    OTEL_LOGS_EXPORTER,
     OTEL_PYTHON_ID_GENERATOR,
     OTEL_TRACES_EXPORTER,
 )
@@ -44,9 +45,6 @@ _EXPORTER_OTLP_PROTO_GRPC = "otlp_proto_grpc"
 
 _RANDOM_ID_GENERATOR = "random"
 _DEFAULT_ID_GENERATOR = _RANDOM_ID_GENERATOR
-
-# TODO: add log exporter env variable
-_OTEL_LOGS_EXPORTER = "OTEL_LOGS_EXPORTER"
 
 
 def _get_id_generator() -> str:
@@ -175,7 +173,7 @@ def _import_id_generator(id_generator_name: str) -> IdGenerator:
 def _initialize_components(auto_instrumentation_version):
     trace_exporters, log_exporters = _import_exporters(
         _get_exporter_names(environ.get(OTEL_TRACES_EXPORTER)),
-        _get_exporter_names(environ.get(_OTEL_LOGS_EXPORTER)),
+        _get_exporter_names(environ.get(OTEL_LOGS_EXPORTER)),
     )
     id_generator_name = _get_id_generator()
     id_generator = _import_id_generator(id_generator_name)


### PR DESCRIPTION
As per the change in the specification (https://github.com/open-telemetry/opentelemetry-specification/commit/9fc9757df59c10acd92f0910484f4309d722fc18) making the OTEL_LOGS_EXPORTER variable official.

Fixes #2315

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Documentation has been updated
