### PR TITLE
Add a more informative error message when parsing ENV headers

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -51,7 +51,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_TIMEOUT,
 )
 from opentelemetry.sdk.resources import Resource as SDKResource
-from opentelemetry.util.re import parse_headers
+from opentelemetry.util.re import parse_env_headers
 
 logger = logging.getLogger(__name__)
 SDKDataT = TypeVar("SDKDataT")
@@ -236,7 +236,7 @@ class OTLPExporterMixin(
 
         self._headers = headers or environ.get(OTEL_EXPORTER_OTLP_HEADERS)
         if isinstance(self._headers, str):
-            temp_headers = parse_headers(self._headers)
+            temp_headers = parse_env_headers(self._headers)
             self._headers = tuple(temp_headers.items())
         elif isinstance(self._headers, dict):
             self._headers = tuple(self._headers.items())

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -40,7 +40,7 @@ from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http.trace_exporter.encoder import (
     _ProtobufEncoder,
 )
-from opentelemetry.util.re import parse_headers
+from opentelemetry.util.re import parse_env_headers
 
 
 _logger = logging.getLogger(__name__)
@@ -75,7 +75,7 @@ class OTLPSpanExporter(SpanExporter):
             OTEL_EXPORTER_OTLP_TRACES_HEADERS,
             environ.get(OTEL_EXPORTER_OTLP_HEADERS, ""),
         )
-        self._headers = headers or parse_headers(headers_string)
+        self._headers = headers or parse_env_headers(headers_string)
         self._timeout = timeout or int(
             environ.get(
                 OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,

--- a/opentelemetry-api/src/opentelemetry/util/re.py
+++ b/opentelemetry-api/src/opentelemetry/util/re.py
@@ -19,16 +19,20 @@ from urllib.parse import unquote
 
 _logger = logging.getLogger(__name__)
 
+# The following regexes reference this spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables
 
-# https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables
+# Optional whitespace
 _OWS = r"[ \t]*"
-# A key contains one or more US-ASCII character except CTLs or separators.
+# A key contains printable US-ASCII characters except: SP and "(),/:;<=>?@[\]{}
 _KEY_FORMAT = (
     r"[\x21\x23-\x27\x2a\x2b\x2d\x2e\x30-\x39\x41-\x5a\x5e-\x7a\x7c\x7e]+"
 )
-# A value contains a URL encoded UTF-8 string.
+# A value contains a URL-encoded UTF-8 string. The encoded form can contain any
+# printable US-ASCII characters (0x20-0x7f) other than SP, DEL, and ",;/
 _VALUE_FORMAT = r"[\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*"
+# A key-value is key=value, with optional whitespace surrounding key and value
 _KEY_VALUE_FORMAT = rf"{_OWS}{_KEY_FORMAT}{_OWS}={_OWS}{_VALUE_FORMAT}{_OWS}"
+
 _HEADER_PATTERN = compile(_KEY_VALUE_FORMAT)
 _DELIMITER_PATTERN = compile(r"[ \t]*,[ \t]*")
 
@@ -36,10 +40,11 @@ _BAGGAGE_PROPERTY_FORMAT = rf"{_KEY_VALUE_FORMAT}|{_OWS}{_KEY_FORMAT}{_OWS}"
 
 
 # pylint: disable=invalid-name
-def parse_headers(s: str) -> Mapping[str, str]:
+def parse_env_headers(s: str) -> Mapping[str, str]:
     """
-    Parse ``s`` (a ``str`` instance containing HTTP headers). Uses W3C Baggage
-    HTTP header format https://www.w3.org/TR/baggage/#baggage-http-header-format, except that
+    Parse ``s``, which is a ``str`` instance containing HTTP headers encoded
+    for use in ENV variables per the W3C Baggage HTTP header format at
+    https://www.w3.org/TR/baggage/#baggage-http-header-format, except that
     additional semi-colon delimited metadata is not supported.
     """
     headers = {}
@@ -48,7 +53,11 @@ def parse_headers(s: str) -> Mapping[str, str]:
             continue
         match = _HEADER_PATTERN.fullmatch(header.strip())
         if not match:
-            _logger.warning("Header doesn't match the format: %s.", header)
+            _logger.warning(
+                "Header format invalid! Header values in environment variables must be "
+                "URL encoded per the OpenTelemetry Protocol Exporter specification: %s",
+                header
+            )
             continue
         # value may contain any number of `=`
         name, value = match.string.split("=", 1)

--- a/opentelemetry-api/tests/util/test_re.py
+++ b/opentelemetry-api/tests/util/test_re.py
@@ -16,11 +16,11 @@
 
 import unittest
 
-from opentelemetry.util.re import parse_headers
+from opentelemetry.util.re import parse_env_headers
 
 
 class TestParseHeaders(unittest.TestCase):
-    def test_parse_headers(self):
+    def test_parse_env_headers(self):
         inp = [
             # invalid header name
             ("=value", [], True),
@@ -63,10 +63,12 @@ class TestParseHeaders(unittest.TestCase):
             s, expected, warn = case
             if warn:
                 with self.assertLogs(level="WARNING") as cm:
-                    self.assertEqual(parse_headers(s), dict(expected))
+                    self.assertEqual(parse_env_headers(s), dict(expected))
                     self.assertTrue(
-                        "Header doesn't match the format:"
+                        "Header format invalid! Header values in environment "
+                        "variables must be URL encoded per the OpenTelemetry "
+                        "Protocol Exporter specification:"
                         in cm.records[0].message,
                     )
             else:
-                self.assertEqual(parse_headers(s), dict(expected))
+                self.assertEqual(parse_env_headers(s), dict(expected))


### PR DESCRIPTION
Also, rename the function to make it clear that this parsing is specific
to headers provided via ENV variables.

# Description
I ran into this issue recently, and the error message was only somewhat helpful. I read up on some history here (#2248, #2103, #2010) and I think this error message should help point folks in the right direction. I think it's particularly useful here since this is a change from 1.5.0, so if folks are upgrading down the road, their ENV variables will stop working, and it'd be nice to help point them to what they need to change.

I also renamed the method and docstring because my understanding is that this method is specifically (in our context) to parse headers as they are encoded in ENV files, and will fail to parse non-encoded headers, so I wanted to make it clearer what it is doing so it doesn't seem like a general-purpose header parser.

## Type of change

Please delete options that are not relevant.

- [x] Documentation fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I ran the tox tests and everything passed. There should be no functional change in this commit.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes.
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ N/A ] Unit tests have been added
- [ N/A ] Documentation has been updated

(I will double-check on these shortly)
