### PR TITLE
Implement SynchronousMeasurementConsumer

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/measurement_consumer.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/measurement_consumer.py
@@ -50,15 +50,15 @@ class SynchronousMeasurementConsumer(MeasurementConsumer):
         self._lock = Lock()
         self._sdk_config = sdk_config
         # should never be mutated
-        self._reader_to_state: Mapping[MetricReader, MetricReaderStorage] = {
+        self._reader_storages: Mapping[MetricReader, MetricReaderStorage] = {
             reader: MetricReaderStorage(sdk_config)
             for reader in sdk_config.metric_readers
         }
         self._async_instruments: List["_Asynchronous"] = []
 
     def consume_measurement(self, measurement: Measurement) -> None:
-        for reader_state in self._reader_to_state.values():
-            reader_state.consume_measurement(measurement)
+        for reader_storage in self._reader_storages.values():
+            reader_storage.consume_measurement(measurement)
 
     def register_asynchronous_instrument(
         self, instrument: "_Asynchronous"
@@ -73,4 +73,4 @@ class SynchronousMeasurementConsumer(MeasurementConsumer):
             for async_instrument in self._async_instruments:
                 for measurement in async_instrument.callback():
                     self.consume_measurement(measurement)
-        return self._reader_to_state[metric_reader].collect(temporality)
+        return self._reader_storages[metric_reader].collect(temporality)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/measurement_consumer.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/measurement_consumer.py
@@ -13,12 +13,17 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterable
+from threading import Lock
+from typing import TYPE_CHECKING, Iterable, List, Mapping
 
 from opentelemetry.sdk._metrics.aggregation import AggregationTemporality
 from opentelemetry.sdk._metrics.measurement import Measurement
 from opentelemetry.sdk._metrics.metric_reader import MetricReader
+from opentelemetry.sdk._metrics.metric_reader_storage import (
+    MetricReaderStorage,
+)
 from opentelemetry.sdk._metrics.point import Metric
+from opentelemetry.sdk._metrics.sdk_configuration import SdkConfiguration
 
 if TYPE_CHECKING:
     from opentelemetry.sdk._metrics.instrument import _Asynchronous
@@ -41,15 +46,31 @@ class MeasurementConsumer(ABC):
 
 
 class SynchronousMeasurementConsumer(MeasurementConsumer):
+    def __init__(self, sdk_config: SdkConfiguration) -> None:
+        self._lock = Lock()
+        self._sdk_config = sdk_config
+        # should never be mutated
+        self._reader_to_state: Mapping[MetricReader, MetricReaderStorage] = {
+            reader: MetricReaderStorage(sdk_config)
+            for reader in sdk_config.metric_readers
+        }
+        self._async_instruments: List["_Asynchronous"] = []
+
     def consume_measurement(self, measurement: Measurement) -> None:
-        pass
+        for reader_state in self._reader_to_state.values():
+            reader_state.consume_measurement(measurement)
 
     def register_asynchronous_instrument(
         self, instrument: "_Asynchronous"
     ) -> None:
-        pass
+        with self._lock:
+            self._async_instruments.append(instrument)
 
     def collect(
         self, metric_reader: MetricReader, temporality: AggregationTemporality
     ) -> Iterable[Metric]:
-        pass
+        with self._lock:
+            for async_instrument in self._async_instruments:
+                for measurement in async_instrument.callback():
+                    self.consume_measurement(measurement)
+        return self._reader_to_state[metric_reader].collect(temporality)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/metric_reader_storage.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/metric_reader_storage.py
@@ -1,0 +1,34 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Iterable
+
+from opentelemetry.sdk._metrics.aggregation import AggregationTemporality
+from opentelemetry.sdk._metrics.measurement import Measurement
+from opentelemetry.sdk._metrics.point import Metric
+from opentelemetry.sdk._metrics.sdk_configuration import SdkConfiguration
+
+
+# TODO: #2378
+class MetricReaderStorage:
+    """The SDK's state for a given reader"""
+
+    def __init__(self, sdk_config: SdkConfiguration) -> None:
+        pass
+
+    def consume_measurement(self, measurement: Measurement) -> None:
+        pass
+
+    def collect(self, temporality: AggregationTemporality) -> Iterable[Metric]:
+        pass

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/metric_reader_storage.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/metric_reader_storage.py
@@ -22,7 +22,7 @@ from opentelemetry.sdk._metrics.sdk_configuration import SdkConfiguration
 
 # TODO: #2378
 class MetricReaderStorage:
-    """The SDK's state for a given reader"""
+    """The SDK's storage for a given reader"""
 
     def __init__(self, sdk_config: SdkConfiguration) -> None:
         pass

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/sdk_configuration.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/sdk_configuration.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import Sequence
+
+from opentelemetry.sdk._metrics.metric_reader import MetricReader
+from opentelemetry.sdk.resources import Resource
+
+
+@dataclass
+class SdkConfiguration:
+    resource: Resource
+    # TODO: once views are added
+    # views: Sequence[View]
+    metric_readers: Sequence[MetricReader]

--- a/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
+++ b/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
@@ -39,7 +39,7 @@ class TestSynchronousMeasurementConsumer(TestCase):
         )
         self.assertEqual(len(MockMetricReaderStorage.mock_calls), 5)
 
-    def test_measurements_passed_to_each_reader_state(
+    def test_measurements_passed_to_each_reader_storage(
         self, MockMetricReaderStorage
     ):
         reader_mocks = [Mock() for _ in range(5)]


### PR DESCRIPTION
# Description

- Implemented the `SynchronousMeasurementConsumer` from the design.
- Added a stub implementation and TODO for implementing the MetricReaderStorage (#2378)
- Added a small (internal) `SdkConfiguration` dataclass for passing through SDK configuration from MeterProvider. This avoids having to access private methods/variables on the MeterProvider class.

Fixes #2328

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added test case mocking out dependencies.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
