### PR TITLE
fixing documentation and return value

### DIFF
--- a/docs/examples/metrics/example.py
+++ b/docs/examples/metrics/example.py
@@ -3,9 +3,7 @@ from opentelemetry.exporter.otlp.proto.grpc._metric_exporter import (
     OTLPMetricExporter,
 )
 from opentelemetry.sdk._metrics import MeterProvider
-from opentelemetry.sdk._metrics.export import (
-    PeriodicExportingMetricReader,
-)
+from opentelemetry.sdk._metrics.export import PeriodicExportingMetricReader
 
 exporter = OTLPMetricExporter(insecure=True)
 reader = PeriodicExportingMetricReader(exporter)

--- a/docs/examples/metrics/example.py
+++ b/docs/examples/metrics/example.py
@@ -3,12 +3,16 @@ from opentelemetry.exporter.otlp.proto.grpc._metric_exporter import (
     OTLPMetricExporter,
 )
 from opentelemetry.sdk._metrics import MeterProvider
+from opentelemetry.sdk._metrics.export import (
+    PeriodicExportingMetricReader,
+)
 
-provider = MeterProvider()
 exporter = OTLPMetricExporter(insecure=True)
-# TODO: fill in details for metric reader
+reader = PeriodicExportingMetricReader(exporter)
+provider = MeterProvider(metric_readers=[reader])
 set_meter_provider(provider)
 
 meter = get_meter_provider().get_meter("getting-started")
 counter = meter.create_counter("first_counter")
+counter.add(1)
 # TODO: fill in details for additional metrics

--- a/docs/getting_started/metrics_example.py
+++ b/docs/getting_started/metrics_example.py
@@ -17,13 +17,17 @@
 
 from opentelemetry._metrics import get_meter_provider, set_meter_provider
 from opentelemetry.sdk._metrics import MeterProvider
-from opentelemetry.sdk._metrics.export import ConsoleMetricExporter
+from opentelemetry.sdk._metrics.export import (
+    ConsoleMetricExporter,
+    PeriodicExportingMetricReader,
+)
 
-provider = MeterProvider()
 exporter = ConsoleMetricExporter()
-# TODO: fill in details for metric reader
+reader = PeriodicExportingMetricReader(exporter)
+provider = MeterProvider(metric_readers=[reader])
 set_meter_provider(provider)
 
 meter = get_meter_provider().get_meter("getting-started")
 counter = meter.create_counter("first_counter")
+counter.add(1)
 # TODO: fill in details for additional metrics

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/export/__init__.py
@@ -154,6 +154,8 @@ class PeriodicExportingMetricReader(MetricReader):
         self.collect()
 
     def _receive_metrics(self, metrics: Iterable[Metric]) -> None:
+        if metrics is None:
+            return
         token = attach(set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
         try:
             self._exporter.export(metrics)
@@ -172,4 +174,5 @@ class PeriodicExportingMetricReader(MetricReader):
 
         self._shutdown_event.set()
         self._daemon_thread.join()
-        return self._exporter.shutdown()
+        self._exporter.shutdown()
+        return True


### PR DESCRIPTION
The metrics examples have been updated to include the MetricReader and the return value shutdown has been updated, as the exporter doesn't return a bool.
