### PR TITLE
Add _ViewInstrumentMatch

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_view_instrument_match.py
@@ -15,9 +15,11 @@
 
 from logging import getLogger
 from threading import Lock
-from typing import Callable, Dict, Iterable, List, Optional
+from typing import Callable, Dict, Iterable, List, Set
 
-from opentelemetry.sdk._metrics.aggregation import Aggregation, _PointVarT
+from opentelemetry.sdk._metrics.aggregation import (
+    Aggregation, _convert_aggregation_temporality
+)
 from opentelemetry.sdk._metrics.measurement import Measurement
 from opentelemetry.sdk._metrics.point import AggregationTemporality, Metric
 from opentelemetry.sdk.resources import Resource
@@ -31,13 +33,9 @@ class _ViewInstrumentMatch:
         self,
         name: str,
         unit: str,
-        description: str,
-        attribute_keys: Dict[str, str],
-        extra_dimensions: List[str],
+        attribute_keys: Set[str] = None,
         aggregation: Aggregation,
         exemplar_reservoir: Callable,
-        resource: Resource,
-        instrumentation_info: InstrumentationInfo,
     ):
         self._name = name
         self._unit = unit
@@ -58,7 +56,7 @@ class _ViewInstrumentMatch:
         self._lock = Lock()
 
     def consume_measurement(self, measurement: Measurement) -> None:
-        if measurement.attributes is None:
+        if measurement.attributes is not None:
             measurement_attributes = set()
 
         else:
@@ -113,11 +111,3 @@ class _ViewInstrumentMatch:
                             temporality,
                         ),
                     )
-
-
-def _convert_aggregation_temporality(
-    previous_point: Optional[_PointVarT],
-    current_point: _PointVarT,
-    aggregation_temporality: int,
-) -> _PointVarT:
-    return None

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_view_instrument_match.py
@@ -62,12 +62,6 @@ class _ViewInstrumentMatch:
         else:
             attributes = measurement.attributes
 
-        if not attributes:
-
-            _logger.warning("Empty measurement attributes found")
-
-            return
-
         attributes = frozenset(attributes.items())
 
         if attributes not in self._attributes_aggregation.keys():

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_view_instrument_match.py
@@ -1,0 +1,123 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from logging import getLogger
+from threading import Lock
+from typing import Callable, Dict, Iterable, List, Optional
+
+from opentelemetry.sdk._metrics.aggregation import Aggregation, _PointVarT
+from opentelemetry.sdk._metrics.measurement import Measurement
+from opentelemetry.sdk._metrics.point import AggregationTemporality, Metric
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
+
+_logger = getLogger(__name__)
+
+
+class _ViewInstrumentMatch:
+    def __init__(
+        self,
+        name: str,
+        unit: str,
+        description: str,
+        attribute_keys: Dict[str, str],
+        extra_dimensions: List[str],
+        aggregation: Aggregation,
+        exemplar_reservoir: Callable,
+        resource: Resource,
+        instrumentation_info: InstrumentationInfo,
+    ):
+        self._name = name
+        self._unit = unit
+        self._description = description
+        self._resource = resource
+        self._instrumentation_info = instrumentation_info
+
+        if attribute_keys is None:
+            self._attribute_keys = set()
+        else:
+            self._attribute_keys = set(attribute_keys.items())
+
+        self._extra_dimensions = extra_dimensions
+        self._aggregation = aggregation
+        self._exemplar_reservoir = exemplar_reservoir
+        self._attributes_aggregation = {}
+        self._attributes_previous_point = {}
+        self._lock = Lock()
+
+    def consume_measurement(self, measurement: Measurement) -> None:
+        if measurement.attributes is None:
+            measurement_attributes = set()
+
+        else:
+            measurement_attributes = set(measurement.attributes.items())
+
+        attributes = frozenset(
+            measurement_attributes.intersection(self._attribute_keys)
+        )
+
+        # What if attributes == frozenset()?
+
+        if attributes not in self._attributes_aggregation.keys():
+            with self._lock:
+                self._attributes_aggregation[attributes] = self._aggregation
+
+        self._attributes_aggregation[attributes].aggregate(measurement.value)
+
+    def collect(self, temporality: int) -> Iterable[Metric]:
+        with self._lock:
+            for (
+                attributes,
+                aggregation,
+            ) in self._attributes_aggregation.items():
+
+                previous_point = self._attributes_previous_point.get(
+                    attributes
+                )
+
+                current_point = aggregation.collect()
+
+                # pylint: disable=assignment-from-none
+                self._attributes_previous_point[
+                    attributes
+                ] = _convert_aggregation_temporality(
+                    previous_point,
+                    current_point,
+                    AggregationTemporality.CUMULATIVE,
+                )
+
+                if current_point is not None:
+
+                    yield Metric(
+                        attributes=dict(attributes),
+                        description=self._description,
+                        instrumentation_info=self._instrumentation_info,
+                        name=self._name,
+                        resource=self._resource,
+                        unit=self._unit,
+                        point=_convert_aggregation_temporality(
+                            previous_point,
+                            current_point,
+                            temporality,
+                        ),
+                    )
+
+
+def _convert_aggregation_temporality(
+    previous_point: Optional[_PointVarT],
+    current_point: _PointVarT,
+    aggregation_temporality: int,
+) -> _PointVarT:
+    return None

--- a/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
+++ b/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from logging import WARNING
 from unittest import TestCase
 from unittest.mock import Mock
 
@@ -54,14 +53,16 @@ class Test_ViewInstrumentMatch(TestCase):
             {frozenset([("c", "d")]): self.mock_aggregation_instance},
         )
 
-        with self.assertLogs(level=WARNING):
-            view_instrument_match.consume_measurement(
-                Measurement(value=0, attributes={"w": "x", "y": "z"})
-            )
+        view_instrument_match.consume_measurement(
+            Measurement(value=0, attributes={"w": "x", "y": "z"})
+        )
 
         self.assertEqual(
             view_instrument_match._attributes_aggregation,
-            {frozenset([("c", "d")]): self.mock_aggregation_instance},
+            {
+                frozenset(): self.mock_aggregation_instance,
+                frozenset([("c", "d")]): self.mock_aggregation_instance,
+            },
         )
 
         view_instrument_match = _ViewInstrumentMatch(

--- a/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
+++ b/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
@@ -1,0 +1,69 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+from unittest.mock import Mock
+
+from opentelemetry.sdk._metrics._view_instrument_match import (
+    _ViewInstrumentMatch,
+)
+from opentelemetry.sdk._metrics.measurement import Measurement
+from opentelemetry.sdk._metrics.point import Metric
+
+
+class Test_ViewInstrumentMatch(TestCase):
+    @classmethod
+    def setUpClass(cls):
+
+        cls.mock_aggregation = Mock()
+        cls.mock_exemplar_reservoir = Mock()
+        cls.mock_resource = Mock()
+        cls.mock_instrumentation_info = Mock()
+
+        cls.view_instrument_match = _ViewInstrumentMatch(
+            "name",
+            "unit",
+            "description",
+            {"a": "b", "c": "d"},
+            ["a", "b", "c"],
+            cls.mock_aggregation,
+            cls.mock_exemplar_reservoir,
+            cls.mock_resource,
+            cls.mock_instrumentation_info,
+        )
+        cls.view_instrument_match.consume_measurement(
+            Measurement(value=0, attributes={"c": "d", "f": "g"})
+        )
+
+    def test_consume_measurement(self):
+
+        self.assertEqual(
+            self.view_instrument_match._attributes_aggregation,
+            {frozenset([("c", "d")]): self.mock_aggregation},
+        )
+
+    def test_collect(self):
+
+        self.assertEqual(
+            next(self.view_instrument_match.collect(1)),
+            Metric(
+                attributes={"c": "d"},
+                description="description",
+                instrumentation_info=self.mock_instrumentation_info,
+                name="name",
+                resource=self.mock_resource,
+                unit="unit",
+                point=None,
+            ),
+        )


### PR DESCRIPTION
Fixes #2300

This class is intentionally named `ViewInstrumentMatch` because it represents a match between a View and an Instrument. There will be as many instances of `ViewInstrumentMatch` as there will be matches between Views and Instruments. I think this is a more descriptive name than `ViewStorage` considering the fact that instances of this class do no store any Views.