### PR TITLE
Add check for duplicate instrument names

### DIFF
--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -165,7 +165,6 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_id(name, Counter, unit, description)
 
     @abstractmethod
     def create_up_down_counter(
@@ -179,7 +178,6 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_id(name, UpDownCounter, unit, description)
 
     @abstractmethod
     def create_observable_counter(
@@ -263,7 +261,6 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_id(name, ObservableCounter, unit, description)
 
     @abstractmethod
     def create_histogram(self, name, unit="", description="") -> Histogram:
@@ -275,7 +272,6 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_id(name, Histogram, unit, description)
 
     @abstractmethod
     def create_observable_gauge(
@@ -293,7 +289,6 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_id(name, ObservableGauge, unit, description)
 
     @abstractmethod
     def create_observable_up_down_counter(
@@ -310,9 +305,6 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_id(
-            name, ObservableUpDownCounter, unit, description
-        )
 
 
 class _ProxyMeter(Meter):

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -132,7 +132,11 @@ class Meter(ABC):
     def schema_url(self):
         return self._schema_url
 
-    # FIXME check that the instrument name has not been used already
+    def _check_instrument_name(self, name):
+        if name in self._instrument_names:
+            raise Exception(f"Instrument name {name} has been used already")
+
+        self._instrument_names.add(name)
 
     @abstractmethod
     def create_counter(self, name, unit="", description="") -> Counter:
@@ -144,6 +148,7 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
+        self._check_instrument_name(name)
 
     @abstractmethod
     def create_up_down_counter(
@@ -157,6 +162,7 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
+        self._check_instrument_name(name)
 
     @abstractmethod
     def create_observable_counter(
@@ -240,6 +246,7 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
+        self._check_instrument_name(name)
 
     @abstractmethod
     def create_histogram(self, name, unit="", description="") -> Histogram:
@@ -251,6 +258,7 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
+        self._check_instrument_name(name)
 
     @abstractmethod
     def create_observable_gauge(
@@ -268,13 +276,13 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
+        self._check_instrument_name(name)
 
     @abstractmethod
     def create_observable_up_down_counter(
         self, name, callback, unit="", description=""
     ) -> ObservableUpDownCounter:
-        """Creates an `ObservableUpDownCounter` instrument
-
+        """
         Args:
             name: The name of the instrument to be created
             callback: A callback that returns an iterable of
@@ -285,6 +293,7 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
+        self._check_instrument_name(name)
 
 
 class _ProxyMeter(Meter):

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -426,7 +426,7 @@ class NoOpMeter(Meter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                DefaultCounter.__name__,
+                Counter.__name__,
                 unit,
                 description,
             )
@@ -446,7 +446,7 @@ class NoOpMeter(Meter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                DefaultUpDownCounter.__name__,
+                UpDownCounter.__name__,
                 unit,
                 description,
             )
@@ -466,7 +466,7 @@ class NoOpMeter(Meter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                DefaultObservableCounter.__name__,
+                ObservableCounter.__name__,
                 unit,
                 description,
             )
@@ -487,7 +487,7 @@ class NoOpMeter(Meter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                DefaultHistogram.__name__,
+                Histogram.__name__,
                 unit,
                 description,
             )
@@ -507,7 +507,7 @@ class NoOpMeter(Meter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                DefaultObservableGauge.__name__,
+                ObservableGauge.__name__,
                 unit,
                 description,
             )
@@ -532,7 +532,7 @@ class NoOpMeter(Meter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                DefaultObservableUpDownCounter.__name__,
+                ObservableUpDownCounter.__name__,
                 unit,
                 description,
             )

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -294,7 +294,8 @@ class Meter(ABC):
     def create_observable_up_down_counter(
         self, name, callback, unit="", description=""
     ) -> ObservableUpDownCounter:
-        """
+        """Creates an `ObservableUpDownCounter` instrument
+
         Args:
             name: The name of the instrument to be created
             callback: A callback that returns an iterable of

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -146,7 +146,12 @@ class Meter(ABC):
         else:
 
             with self._instrument_ids_lock:
-                self._instrument_ids.add(instrument_id)
+                if instrument_id in self._instrument_ids:
+                    _logger.warning(
+                        "Instrument id %s has been used already", instrument_id
+                    )
+                else:
+                    self._instrument_ids.add(instrument_id)
 
     @abstractmethod
     def create_counter(self, name, unit="", description="") -> Counter:

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -133,7 +133,9 @@ class Meter(ABC):
     def schema_url(self):
         return self._schema_url
 
-    def _check_instrument_id(self, name, type_, unit, description):
+    def _check_instrument_id(
+        self, name: str, type_: type, unit: str, description: str
+    ) -> None:
 
         instrument_id = "".join(
             [name.strip().lower(), str(type_), unit, description]

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -135,25 +135,25 @@ class Meter(ABC):
 
     def _check_instrument_id(
         self, name: str, type_: type, unit: str, description: str
-    ) -> None:
+    ) -> bool:
+        """
+        Check if an instrument with the same name, type, unit and description
+        has been registered already.
+        """
+
+        result = False
 
         instrument_id = ",".join(
             [name.strip().lower(), type_.__name__, unit, description]
         )
 
-        if instrument_id in self._instrument_ids:
-            _logger.warning(
-                "Instrument id %s has been used already", instrument_id
-            )
-        else:
+        with self._instrument_ids_lock:
+            if instrument_id in self._instrument_ids:
+                result = True
+            else:
+                self._instrument_ids.add(instrument_id)
 
-            with self._instrument_ids_lock:
-                if instrument_id in self._instrument_ids:
-                    _logger.warning(
-                        "Instrument id %s has been used already", instrument_id
-                    )
-                else:
-                    self._instrument_ids.add(instrument_id)
+        return result
 
     @abstractmethod
     def create_counter(self, name, unit="", description="") -> Counter:
@@ -421,6 +421,15 @@ class NoOpMeter(Meter):
     def create_counter(self, name, unit="", description="") -> Counter:
         """Returns a no-op Counter."""
         super().create_counter(name, unit=unit, description=description)
+        if self._check_instrument_id(name, DefaultCounter, unit, description):
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                DefaultCounter.__name__,
+                unit,
+                description,
+            )
         return DefaultCounter(name, unit=unit, description=description)
 
     def create_up_down_counter(
@@ -430,6 +439,17 @@ class NoOpMeter(Meter):
         super().create_up_down_counter(
             name, unit=unit, description=description
         )
+        if self._check_instrument_id(
+            name, DefaultUpDownCounter, unit, description
+        ):
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                DefaultUpDownCounter.__name__,
+                unit,
+                description,
+            )
         return DefaultUpDownCounter(name, unit=unit, description=description)
 
     def create_observable_counter(
@@ -439,6 +459,17 @@ class NoOpMeter(Meter):
         super().create_observable_counter(
             name, callback, unit=unit, description=description
         )
+        if self._check_instrument_id(
+            name, DefaultObservableCounter, unit, description
+        ):
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                DefaultObservableCounter.__name__,
+                unit,
+                description,
+            )
         return DefaultObservableCounter(
             name,
             callback,
@@ -449,6 +480,17 @@ class NoOpMeter(Meter):
     def create_histogram(self, name, unit="", description="") -> Histogram:
         """Returns a no-op Histogram."""
         super().create_histogram(name, unit=unit, description=description)
+        if self._check_instrument_id(
+            name, DefaultHistogram, unit, description
+        ):
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                DefaultHistogram.__name__,
+                unit,
+                description,
+            )
         return DefaultHistogram(name, unit=unit, description=description)
 
     def create_observable_gauge(
@@ -458,6 +500,17 @@ class NoOpMeter(Meter):
         super().create_observable_gauge(
             name, callback, unit=unit, description=description
         )
+        if self._check_instrument_id(
+            name, DefaultObservableGauge, unit, description
+        ):
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                DefaultObservableGauge.__name__,
+                unit,
+                description,
+            )
         return DefaultObservableGauge(
             name,
             callback,
@@ -472,6 +525,17 @@ class NoOpMeter(Meter):
         super().create_observable_up_down_counter(
             name, callback, unit=unit, description=description
         )
+        if self._check_instrument_id(
+            name, DefaultObservableUpDownCounter, unit, description
+        ):
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                DefaultObservableUpDownCounter.__name__,
+                unit,
+                description,
+            )
         return DefaultObservableUpDownCounter(
             name,
             callback,

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -119,6 +119,7 @@ class Meter(ABC):
         self._version = version
         self._schema_url = schema_url
         self._instrument_names = set()
+        self._instrument_names_lock = Lock()
 
     @property
     def name(self):
@@ -136,7 +137,8 @@ class Meter(ABC):
         if name.strip().lower() in self._instrument_names:
             raise Exception(f"Instrument name {name} has been used already")
 
-        self._instrument_names.add(name)
+        with self._instrument_names_lock:
+            self._instrument_names.add(name)
 
     @abstractmethod
     def create_counter(self, name, unit="", description="") -> Counter:

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -137,8 +137,8 @@ class Meter(ABC):
         self, name: str, type_: type, unit: str, description: str
     ) -> None:
 
-        instrument_id = "".join(
-            [name.strip().lower(), str(type_), unit, description]
+        instrument_id = ",".join(
+            [name.strip().lower(), type_.__name__, unit, description]
         )
 
         if instrument_id in self._instrument_ids:

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -119,7 +119,7 @@ class Meter(ABC):
         self._version = version
         self._schema_url = schema_url
         self._instrument_ids: Set[str] = set()
-        self._instrument_names_lock = Lock()
+        self._instrument_ids_lock = Lock()
 
     @property
     def name(self):
@@ -133,17 +133,20 @@ class Meter(ABC):
     def schema_url(self):
         return self._schema_url
 
-    def _check_instrument_name(self, name, type_, unit, description):
+    def _check_instrument_id(self, name, type_, unit, description):
 
         instrument_id = "".join(
             [name.strip().lower(), str(type_), unit, description]
         )
 
         if instrument_id in self._instrument_ids:
-            _logger.warning("Instrument name %s has been used already", name)
+            _logger.warning(
+                "Instrument id %s has been used already", instrument_id
+            )
         else:
 
-            self._instrument_ids.add(instrument_id)
+            with self._instrument_ids_lock:
+                self._instrument_ids.add(instrument_id)
 
     @abstractmethod
     def create_counter(self, name, unit="", description="") -> Counter:
@@ -155,7 +158,7 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_name(name, Counter, unit, description)
+        self._check_instrument_id(name, Counter, unit, description)
 
     @abstractmethod
     def create_up_down_counter(
@@ -169,7 +172,7 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_name(name, UpDownCounter, unit, description)
+        self._check_instrument_id(name, UpDownCounter, unit, description)
 
     @abstractmethod
     def create_observable_counter(
@@ -253,7 +256,7 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_name(name, ObservableCounter, unit, description)
+        self._check_instrument_id(name, ObservableCounter, unit, description)
 
     @abstractmethod
     def create_histogram(self, name, unit="", description="") -> Histogram:
@@ -265,7 +268,7 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_name(name, Histogram, unit, description)
+        self._check_instrument_id(name, Histogram, unit, description)
 
     @abstractmethod
     def create_observable_gauge(
@@ -283,7 +286,7 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_name(name, ObservableGauge, unit, description)
+        self._check_instrument_id(name, ObservableGauge, unit, description)
 
     @abstractmethod
     def create_observable_up_down_counter(
@@ -300,7 +303,7 @@ class Meter(ABC):
                 example, ``By`` for bytes. UCUM units are recommended.
             description: A description for this instrument and what it measures.
         """
-        self._check_instrument_name(
+        self._check_instrument_id(
             name, ObservableUpDownCounter, unit, description
         )
 

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -133,7 +133,7 @@ class Meter(ABC):
         return self._schema_url
 
     def _check_instrument_name(self, name):
-        if name in self._instrument_names:
+        if name.strip().lower() in self._instrument_names:
             raise Exception(f"Instrument name {name} has been used already")
 
         self._instrument_names.add(name)

--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -34,10 +34,10 @@ Example::
 
     import flask
     import requests
-    from opentelemetry import propagators
+    from opentelemetry import propagate
 
 
-    PROPAGATOR = propagators.get_global_textmap()
+    PROPAGATOR = propagate.get_global_textmap()
 
 
     def get_header_from_flask_request(request, key):

--- a/opentelemetry-api/tests/metrics/test_meter.py
+++ b/opentelemetry-api/tests/metrics/test_meter.py
@@ -17,15 +17,7 @@ from logging import WARNING
 from unittest import TestCase
 from unittest.mock import Mock
 
-from opentelemetry._metrics import Meter
-from opentelemetry._metrics.instrument import (
-    Counter,
-    Histogram,
-    ObservableCounter,
-    ObservableGauge,
-    ObservableUpDownCounter,
-    UpDownCounter,
-)
+from opentelemetry._metrics import Meter, NoOpMeter
 
 # FIXME Test that the meter methods can be called concurrently safely.
 
@@ -64,63 +56,9 @@ class ChildMeter(Meter):
 
 class TestMeter(TestCase):
     def test_repeated_instrument_names(self):
-        class TestMeter(Meter):
-            def create_counter(self, name, unit="", description="") -> Counter:
-                self._check_instrument_id(name, Counter, unit, description)
-                super().create_counter(
-                    name, unit=unit, description=description
-                )
-
-            def create_up_down_counter(
-                self, name, unit="", description=""
-            ) -> UpDownCounter:
-                self._check_instrument_id(
-                    name, UpDownCounter, unit, description
-                )
-                super().create_up_down_counter(
-                    name, unit=unit, description=description
-                )
-
-            def create_observable_counter(
-                self, name, callback, unit="", description=""
-            ) -> ObservableCounter:
-                self._check_instrument_id(
-                    name, ObservableCounter, unit, description
-                )
-                super().create_observable_up_down_counter(
-                    name, callback, unit=unit, description=description
-                )
-
-            def create_histogram(
-                self, name, unit="", description=""
-            ) -> Histogram:
-                self._check_instrument_id(name, Histogram, unit, description)
-                super().create_histogram(
-                    name, unit=unit, description=description
-                )
-
-            def create_observable_gauge(
-                self, name, callback, unit="", description=""
-            ) -> ObservableGauge:
-                self._check_instrument_id(
-                    name, ObservableGauge, unit, description
-                )
-                super().create_observable_gauge(
-                    name, callback, unit=unit, description=description
-                )
-
-            def create_observable_up_down_counter(
-                self, name, callback, unit="", description=""
-            ) -> ObservableUpDownCounter:
-                self._check_instrument_id(
-                    name, ObservableUpDownCounter, unit, description
-                )
-                super().create_observable_up_down_counter(
-                    name, callback, unit=unit, description=description
-                )
 
         try:
-            test_meter = TestMeter("name")
+            test_meter = NoOpMeter("name")
 
             test_meter.create_counter("counter")
             test_meter.create_up_down_counter("up_down_counter")

--- a/opentelemetry-api/tests/metrics/test_meter.py
+++ b/opentelemetry-api/tests/metrics/test_meter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # type: ignore
 
+from logging import WARNING
 from unittest import TestCase
 from unittest.mock import Mock
 
@@ -121,14 +122,21 @@ class TestMeter(TestCase):
         for instrument_name in [
             "counter",
             "up_down_counter",
-            "observable_counter",
             "histogram",
+        ]:
+            with self.assertLogs(level=WARNING):
+                getattr(test_meter, f"create_{instrument_name}")(
+                    instrument_name
+                )
+
+        for instrument_name in [
+            "observable_counter",
             "observable_gauge",
             "observable_up_down_counter",
         ]:
-            with self.assertRaises(Exception):
+            with self.assertLogs(level=WARNING):
                 getattr(test_meter, f"create_{instrument_name}")(
-                    instrument_name
+                    instrument_name, Mock()
                 )
 
     def test_create_counter(self):

--- a/opentelemetry-api/tests/metrics/test_meter.py
+++ b/opentelemetry-api/tests/metrics/test_meter.py
@@ -66,6 +66,7 @@ class TestMeter(TestCase):
     def test_repeated_instrument_names(self):
         class TestMeter(Meter):
             def create_counter(self, name, unit="", description="") -> Counter:
+                self._check_instrument_id(name, Counter, unit, description)
                 super().create_counter(
                     name, unit=unit, description=description
                 )
@@ -73,6 +74,9 @@ class TestMeter(TestCase):
             def create_up_down_counter(
                 self, name, unit="", description=""
             ) -> UpDownCounter:
+                self._check_instrument_id(
+                    name, UpDownCounter, unit, description
+                )
                 super().create_up_down_counter(
                     name, unit=unit, description=description
                 )
@@ -80,6 +84,9 @@ class TestMeter(TestCase):
             def create_observable_counter(
                 self, name, callback, unit="", description=""
             ) -> ObservableCounter:
+                self._check_instrument_id(
+                    name, ObservableCounter, unit, description
+                )
                 super().create_observable_up_down_counter(
                     name, callback, unit=unit, description=description
                 )
@@ -87,6 +94,7 @@ class TestMeter(TestCase):
             def create_histogram(
                 self, name, unit="", description=""
             ) -> Histogram:
+                self._check_instrument_id(name, Histogram, unit, description)
                 super().create_histogram(
                     name, unit=unit, description=description
                 )
@@ -94,6 +102,9 @@ class TestMeter(TestCase):
             def create_observable_gauge(
                 self, name, callback, unit="", description=""
             ) -> ObservableGauge:
+                self._check_instrument_id(
+                    name, ObservableGauge, unit, description
+                )
                 super().create_observable_gauge(
                     name, callback, unit=unit, description=description
                 )
@@ -101,6 +112,9 @@ class TestMeter(TestCase):
             def create_observable_up_down_counter(
                 self, name, callback, unit="", description=""
             ) -> ObservableUpDownCounter:
+                self._check_instrument_id(
+                    name, ObservableUpDownCounter, unit, description
+                )
                 super().create_observable_up_down_counter(
                     name, callback, unit=unit, description=description
                 )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/__init__.py
@@ -65,7 +65,19 @@ class Meter(APIMeter):
         self._measurement_consumer = measurement_consumer
 
     def create_counter(self, name, unit="", description="") -> APICounter:
-        self._check_instrument_id(name, Counter, unit, description)
+        if self._check_instrument_id(name, Counter, unit, description):
+            # FIXME #2558 go through all views here and check if this
+            # instrument registration conflict can be fixed. If it can be, do
+            # not log the following warning.
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                Counter.__name__,
+                unit,
+                description,
+            )
+
         return Counter(
             name,
             self._instrumentation_info,
@@ -77,7 +89,19 @@ class Meter(APIMeter):
     def create_up_down_counter(
         self, name, unit="", description=""
     ) -> APIUpDownCounter:
-        self._check_instrument_id(name, UpDownCounter, unit, description)
+        if self._check_instrument_id(name, UpDownCounter, unit, description):
+            # FIXME #2558 go through all views here and check if this
+            # instrument registration conflict can be fixed. If it can be, do
+            # not log the following warning.
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                UpDownCounter.__name__,
+                unit,
+                description,
+            )
+
         return UpDownCounter(
             name,
             self._instrumentation_info,
@@ -89,7 +113,20 @@ class Meter(APIMeter):
     def create_observable_counter(
         self, name, callback, unit="", description=""
     ) -> APIObservableCounter:
-        self._check_instrument_id(name, ObservableCounter, unit, description)
+        if self._check_instrument_id(
+            name, ObservableCounter, unit, description
+        ):
+            # FIXME #2558 go through all views here and check if this
+            # instrument registration conflict can be fixed. If it can be, do
+            # not log the following warning.
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                ObservableCounter.__name__,
+                unit,
+                description,
+            )
         instrument = ObservableCounter(
             name,
             self._instrumentation_info,
@@ -104,7 +141,18 @@ class Meter(APIMeter):
         return instrument
 
     def create_histogram(self, name, unit="", description="") -> APIHistogram:
-        self._check_instrument_id(name, Histogram, unit, description)
+        if self._check_instrument_id(name, Histogram, unit, description):
+            # FIXME #2558 go through all views here and check if this
+            # instrument registration conflict can be fixed. If it can be, do
+            # not log the following warning.
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                Histogram.__name__,
+                unit,
+                description,
+            )
         return Histogram(
             name,
             self._instrumentation_info,
@@ -116,7 +164,18 @@ class Meter(APIMeter):
     def create_observable_gauge(
         self, name, callback, unit="", description=""
     ) -> APIObservableGauge:
-        self._check_instrument_id(name, ObservableGauge, unit, description)
+        if self._check_instrument_id(name, ObservableGauge, unit, description):
+            # FIXME #2558 go through all views here and check if this
+            # instrument registration conflict can be fixed. If it can be, do
+            # not log the following warning.
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                ObservableGauge.__name__,
+                unit,
+                description,
+            )
 
         instrument = ObservableGauge(
             name,
@@ -134,9 +193,20 @@ class Meter(APIMeter):
     def create_observable_up_down_counter(
         self, name, callback, unit="", description=""
     ) -> APIObservableUpDownCounter:
-        self._check_instrument_id(
+        if self._check_instrument_id(
             name, ObservableUpDownCounter, unit, description
-        )
+        ):
+            # FIXME #2558 go through all views here and check if this
+            # instrument registration conflict can be fixed. If it can be, do
+            # not log the following warning.
+            _logger.warning(
+                "An instrument with name %s, type %s, unit %s and "
+                "description %s has been created already.",
+                name,
+                ObservableUpDownCounter.__name__,
+                unit,
+                description,
+            )
 
         instrument = ObservableUpDownCounter(
             name,
@@ -285,6 +355,8 @@ class MeterProvider(APIMeterProvider):
         info = InstrumentationInfo(name, version, schema_url)
         with self._meter_lock:
             if not self._meters.get(info):
+                # FIXME #2558 pass SDKConfig object to meter so that the meter
+                # has access to views.
                 self._meters[info] = Meter(
                     info,
                     self._measurement_consumer,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/__init__.py
@@ -65,6 +65,7 @@ class Meter(APIMeter):
         self._measurement_consumer = measurement_consumer
 
     def create_counter(self, name, unit=None, description=None) -> APICounter:
+        super().create_counter(name, unit=unit, description=description)
         return Counter(
             name,
             self._instrumentation_info,
@@ -76,6 +77,9 @@ class Meter(APIMeter):
     def create_up_down_counter(
         self, name, unit=None, description=None
     ) -> APIUpDownCounter:
+        super().create_up_down_counter(
+            name, unit=unit, description=description
+        )
         return UpDownCounter(
             name,
             self._instrumentation_info,
@@ -87,6 +91,9 @@ class Meter(APIMeter):
     def create_observable_counter(
         self, name, callback, unit=None, description=None
     ) -> APIObservableCounter:
+        super().create_observable_counter(
+            name, callback, unit=unit, description=description
+        )
 
         instrument = ObservableCounter(
             name,
@@ -104,6 +111,7 @@ class Meter(APIMeter):
     def create_histogram(
         self, name, unit=None, description=None
     ) -> APIHistogram:
+        super().create_histogram(name, unit=unit, description=description)
         return Histogram(
             name,
             self._instrumentation_info,
@@ -115,6 +123,9 @@ class Meter(APIMeter):
     def create_observable_gauge(
         self, name, callback, unit=None, description=None
     ) -> APIObservableGauge:
+        super().create_observable_gauge(
+            name, callback, unit=unit, description=description
+        )
 
         instrument = ObservableGauge(
             name,
@@ -132,6 +143,9 @@ class Meter(APIMeter):
     def create_observable_up_down_counter(
         self, name, callback, unit=None, description=None
     ) -> APIObservableUpDownCounter:
+        super().create_observable_up_down_counter(
+            name, callback, unit=unit, description=description
+        )
 
         instrument = ObservableUpDownCounter(
             name,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/__init__.py
@@ -65,7 +65,7 @@ class Meter(APIMeter):
         self._measurement_consumer = measurement_consumer
 
     def create_counter(self, name, unit="", description="") -> APICounter:
-        super().create_counter(name, unit=unit, description=description)
+        self._check_instrument_id(name, Counter, unit, description)
         return Counter(
             name,
             self._instrumentation_info,
@@ -77,9 +77,7 @@ class Meter(APIMeter):
     def create_up_down_counter(
         self, name, unit="", description=""
     ) -> APIUpDownCounter:
-        super().create_up_down_counter(
-            name, unit=unit, description=description
-        )
+        self._check_instrument_id(name, UpDownCounter, unit, description)
         return UpDownCounter(
             name,
             self._instrumentation_info,
@@ -91,10 +89,7 @@ class Meter(APIMeter):
     def create_observable_counter(
         self, name, callback, unit="", description=""
     ) -> APIObservableCounter:
-        super().create_observable_counter(
-            name, callback, unit=unit, description=description
-        )
-
+        self._check_instrument_id(name, ObservableCounter, unit, description)
         instrument = ObservableCounter(
             name,
             self._instrumentation_info,
@@ -109,7 +104,7 @@ class Meter(APIMeter):
         return instrument
 
     def create_histogram(self, name, unit="", description="") -> APIHistogram:
-        super().create_histogram(name, unit=unit, description=description)
+        self._check_instrument_id(name, Histogram, unit, description)
         return Histogram(
             name,
             self._instrumentation_info,
@@ -121,9 +116,7 @@ class Meter(APIMeter):
     def create_observable_gauge(
         self, name, callback, unit="", description=""
     ) -> APIObservableGauge:
-        super().create_observable_gauge(
-            name, callback, unit=unit, description=description
-        )
+        self._check_instrument_id(name, ObservableGauge, unit, description)
 
         instrument = ObservableGauge(
             name,
@@ -141,8 +134,8 @@ class Meter(APIMeter):
     def create_observable_up_down_counter(
         self, name, callback, unit="", description=""
     ) -> APIObservableUpDownCounter:
-        super().create_observable_up_down_counter(
-            name, callback, unit=unit, description=description
+        self._check_instrument_id(
+            name, ObservableUpDownCounter, unit, description
         )
 
         instrument = ObservableUpDownCounter(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/__init__.py
@@ -73,7 +73,7 @@ class Meter(APIMeter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                Counter.__name__,
+                APICounter.__name__,
                 unit,
                 description,
             )
@@ -97,7 +97,7 @@ class Meter(APIMeter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                UpDownCounter.__name__,
+                APIUpDownCounter.__name__,
                 unit,
                 description,
             )
@@ -123,7 +123,7 @@ class Meter(APIMeter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                ObservableCounter.__name__,
+                APIObservableCounter.__name__,
                 unit,
                 description,
             )
@@ -149,7 +149,7 @@ class Meter(APIMeter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                Histogram.__name__,
+                APIHistogram.__name__,
                 unit,
                 description,
             )
@@ -172,7 +172,7 @@ class Meter(APIMeter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                ObservableGauge.__name__,
+                APIObservableGauge.__name__,
                 unit,
                 description,
             )
@@ -203,7 +203,7 @@ class Meter(APIMeter):
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
                 name,
-                ObservableUpDownCounter.__name__,
+                APIObservableUpDownCounter.__name__,
                 unit,
                 description,
             )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/__init__.py
@@ -64,7 +64,7 @@ class Meter(APIMeter):
         self._instrumentation_info = instrumentation_info
         self._measurement_consumer = measurement_consumer
 
-    def create_counter(self, name, unit=None, description=None) -> APICounter:
+    def create_counter(self, name, unit="", description="") -> APICounter:
         super().create_counter(name, unit=unit, description=description)
         return Counter(
             name,
@@ -75,7 +75,7 @@ class Meter(APIMeter):
         )
 
     def create_up_down_counter(
-        self, name, unit=None, description=None
+        self, name, unit="", description=""
     ) -> APIUpDownCounter:
         super().create_up_down_counter(
             name, unit=unit, description=description
@@ -89,7 +89,7 @@ class Meter(APIMeter):
         )
 
     def create_observable_counter(
-        self, name, callback, unit=None, description=None
+        self, name, callback, unit="", description=""
     ) -> APIObservableCounter:
         super().create_observable_counter(
             name, callback, unit=unit, description=description
@@ -108,9 +108,7 @@ class Meter(APIMeter):
 
         return instrument
 
-    def create_histogram(
-        self, name, unit=None, description=None
-    ) -> APIHistogram:
+    def create_histogram(self, name, unit="", description="") -> APIHistogram:
         super().create_histogram(name, unit=unit, description=description)
         return Histogram(
             name,
@@ -121,7 +119,7 @@ class Meter(APIMeter):
         )
 
     def create_observable_gauge(
-        self, name, callback, unit=None, description=None
+        self, name, callback, unit="", description=""
     ) -> APIObservableGauge:
         super().create_observable_gauge(
             name, callback, unit=unit, description=description
@@ -141,7 +139,7 @@ class Meter(APIMeter):
         return instrument
 
     def create_observable_up_down_counter(
-        self, name, callback, unit=None, description=None
+        self, name, callback, unit="", description=""
     ) -> APIObservableUpDownCounter:
         super().create_observable_up_down_counter(
             name, callback, unit=unit, description=description

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -298,6 +298,32 @@ class TestMeter(TestCase):
     def setUp(self):
         self.meter = Meter(Mock(), Mock())
 
+    def test_repeated_instrument_names(self):
+        try:
+            self.meter.create_counter("counter")
+            self.meter.create_up_down_counter("up_down_counter")
+            self.meter.create_observable_counter("observable_counter", Mock())
+            self.meter.create_histogram("histogram")
+            self.meter.create_observable_gauge("observable_gauge", Mock())
+            self.meter.create_observable_up_down_counter(
+                "observable_up_down_counter", Mock()
+            )
+        except Exception as error:
+            self.fail(f"Unexpected exception raised {error}")
+
+        for instrument_name in [
+            "counter",
+            "up_down_counter",
+            "observable_counter",
+            "histogram",
+            "observable_gauge",
+            "observable_up_down_counter",
+        ]:
+            with self.assertRaises(Exception):
+                getattr(self.meter, f"create_{instrument_name}")(
+                    instrument_name
+                )
+
     def test_create_counter(self):
         counter = self.meter.create_counter(
             "name", unit="unit", description="description"

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -243,17 +243,17 @@ class TestMeterProvider(ConcurrencyTestBase):
 
         meter_provider._measurement_consumer.register_asynchronous_instrument.assert_called_with(
             meter_provider.get_meter("name").create_observable_counter(
-                "name", Mock()
+                "name0", Mock()
             )
         )
         meter_provider._measurement_consumer.register_asynchronous_instrument.assert_called_with(
             meter_provider.get_meter("name").create_observable_up_down_counter(
-                "name", Mock()
+                "name1", Mock()
             )
         )
         meter_provider._measurement_consumer.register_asynchronous_instrument.assert_called_with(
             meter_provider.get_meter("name").create_observable_gauge(
-                "name", Mock()
+                "name2", Mock()
             )
         )
 

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -314,14 +314,21 @@ class TestMeter(TestCase):
         for instrument_name in [
             "counter",
             "up_down_counter",
-            "observable_counter",
             "histogram",
+        ]:
+            with self.assertLogs(level=WARNING):
+                getattr(self.meter, f"create_{instrument_name}")(
+                    instrument_name
+                )
+
+        for instrument_name in [
+            "observable_counter",
             "observable_gauge",
             "observable_up_down_counter",
         ]:
-            with self.assertRaises(Exception):
+            with self.assertLogs(level=WARNING):
                 getattr(self.meter, f"create_{instrument_name}")(
-                    instrument_name
+                    instrument_name, Mock()
                 )
 
     def test_create_counter(self):


### PR DESCRIPTION
Fixes #2142

This PR adds the checking for duplicate instrument names in the API. Others may disagree and would consider this belongs in the SDK, please leave your comments :v:


The issue includes this question:

> [Which instrument fields are considered non-identifying (description?)](https://github.com/open-telemetry/opentelemetry-python/issues/2142#issue-1005792307)

I think that since the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument) only requires that the instrument names are not repeated, we should be concerned with the `name` attribute of instruments only.