### PR TITLE
[logs] prevent None from causing problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2383](https://github.com/open-telemetry/opentelemetry-python/pull/2383))
 - [exporter/opentelemetry-exporter-otlp-proto-grpc] Add Gauge to OTLPMetricExporter
   ([#2408](https://github.com/open-telemetry/opentelemetry-python/pull/2408))
+- [logs] prevent None from causing problems
+  ([#2410](https://github.com/open-telemetry/opentelemetry-python/pull/2410))
 
 ## [1.8.0-0.27b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.8.0-0.27b0) - 2021-12-17
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -88,10 +88,10 @@ class LogRecord:
                 "attributes": self.attributes,
                 "timestamp": ns_to_iso_str(self.timestamp),
                 "trace_id": f"0x{format_trace_id(self.trace_id)}"
-                if self.trace_id
+                if self.trace_id is not None
                 else "",
                 "span_id": f"0x{format_span_id(self.span_id)}"
-                is self.span_id
+                if self.span_id
                 else "",
                 "trace_flags": self.trace_flags,
                 "resource": repr(self.resource.attributes)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -91,7 +91,7 @@ class LogRecord:
                 if self.trace_id is not None
                 else "",
                 "span_id": f"0x{format_span_id(self.span_id)}"
-                if self.span_id
+                if self.span_id is not None
                 else "",
                 "trace_flags": self.trace_flags,
                 "resource": repr(self.resource.attributes)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -87,8 +87,12 @@ class LogRecord:
                 "severity_text": self.severity_text,
                 "attributes": self.attributes,
                 "timestamp": ns_to_iso_str(self.timestamp),
-                "trace_id": f"0x{format_trace_id(self.trace_id)}",
-                "span_id": f"0x{format_span_id(self.span_id)}",
+                "trace_id": f"0x{format_trace_id(self.trace_id)}"
+                if self.trace_id
+                else "",
+                "span_id": f"0x{format_span_id(self.span_id)}"
+                is self.span_id
+                else "",
                 "trace_flags": self.trace_flags,
                 "resource": repr(self.resource.attributes)
                 if self.resource

--- a/opentelemetry-sdk/tests/logs/test_log_record.py
+++ b/opentelemetry-sdk/tests/logs/test_log_record.py
@@ -1,0 +1,42 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+
+from opentelemetry.sdk._logs import LogRecord
+
+
+class TestLogRecord(unittest.TestCase):
+    def test_log_record_to_json(self):
+        expected = json.dumps(
+            {
+                "body": "a log line",
+                "name": None,
+                "severity_number": "None",
+                "severity_text": None,
+                "attributes": None,
+                "timestamp": "1970-01-01T00:00:00.000000Z",
+                "trace_id": "",
+                "span_id": "",
+                "trace_flags": None,
+                "resource": "",
+            },
+            indent=4,
+        )
+        actual = LogRecord(
+            timestamp=0,
+            body="a log line",
+        ).to_json()
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
If the trace or span ID is None for a log entry, the result would raise an error, this change prevents that.
