### PR TITLE
Update opentelemetry-sdk min compatible version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.9.1-0.28b1...HEAD)
 
+- `opentelemetry-exporter-otlp-grpc` update SDK dependency to ~1.9.
+  ([#2440](https://github.com/open-telemetry/opentelemetry-python/pull/2440))
+
 ## [1.9.1-0.28b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.1-0.28b1) - 2022-01-29
 
 - Update opentelemetry-proto to v0.12.0. Note that this update removes deprecated status codes.

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52
     opentelemetry-api ~= 1.3
-    opentelemetry-sdk ~= 1.3
+    opentelemetry-sdk ~= 1.9
     opentelemetry-proto == 1.9.1
     backoff ~= 1.10.0
 


### PR DESCRIPTION
# Description

OTLP gRPC exporter depends on a new feature (env var constant) from opentelemetry-sdk added in 1.9. This PR updates the minimum compatible version of SDK for the OTLP gRPC exporter.

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/2438
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Exisring tests

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
