### PR TITLE
Only check for public symbols in public packages/modules

### DIFF
--- a/scripts/public_symbols_checker.py
+++ b/scripts/public_symbols_checker.py
@@ -34,10 +34,18 @@ def get_symbols(change_type, diff_lines_getter, prefix):
     ):
 
         b_file_path = diff_lines.b_blob.path
+        b_file_path_obj = Path(b_file_path)
 
         if (
-            Path(b_file_path).suffix != ".py"
+            b_file_path_obj.suffix != ".py"
             or "opentelemetry" not in b_file_path
+            or any(
+                # single leading underscore
+                part[0] == "_" and part[1] != "_"
+                # tests directories
+                or part == "tests"
+                for part in b_file_path_obj.parts
+            )
         ):
             continue
 


### PR DESCRIPTION
# Description

Update public symbols checker to skip files which:
- Have a path part starting with a single leading underscore, for example `opentelemetry-sdk/src/opentelemetry/sdk/_metrics/__init__.py` would not be checked but `opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py` would be
- Have the full string `tests` as one of the path parts, for example `opentelemetry-sdk/tests/metrics/test_metrics.py` would not be checked but `opentelemetry-sdk/src/opentelemetry/foo/equalitytests/foo.py` would be.'
  
  Note this could skip a file like `opentelemetry-sdk/src/opentelemetry/foo/tests/foo.py`, but since some of our packages are within another directory e.g. `exporter/opentelemetry-exporter-otlp-grpc` I can't simply check the second path part.


## Type of change

Tooling

# How Has This Been Tested?

Tested by creating new commits on top that pass/fail the check, see #2459 [CI run](https://github.com/open-telemetry/opentelemetry-python/runs/5147192191?check_suite_focus=true):

```
The code in this branch adds the following public symbols:

- opentelemetry-sdk/src/opentelemetry/sdk/trace/testsfoo.py
	Foo

- opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
	Foo

Please make sure that all of them are strictly necessary, if not, please consider prefixing them with an underscore to make them private. After that, please label this PR with "Skip Public API check".
```

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

N/A
