### PR TITLE
Bump semantic conventions from 1.6.1 to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2442](https://github.com/open-telemetry/opentelemetry-python/pull/2442))
 - bugfix(auto-instrumentation): attach OTLPHandler to root logger
   ([#2450](https://github.com/open-telemetry/opentelemetry-python/pull/2450))
+- Bump semantic conventions from 1.6.1 to 1.8.0
+  ([#2461](https://github.com/open-telemetry/opentelemetry-python/pull/2461))
 
 ## [1.9.1-0.28b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.1-0.28b1) - 2022-01-29
 

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/resource/__init__.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/resource/__init__.py
@@ -28,7 +28,8 @@ class ResourceAttributes:
 
     CLOUD_REGION = "cloud.region"
     """
-    The geographical region the resource is running. Refer to your provider's docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), or [Google Cloud regions](https://cloud.google.com/about/locations).
+    The geographical region the resource is running.
+    Note: Refer to your provider's docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), [Google Cloud regions](https://cloud.google.com/about/locations), or [Tencent Cloud regions](https://intl.cloud.tencent.com/document/product/213/6091).
     """
 
     CLOUD_AVAILABILITY_ZONE = "cloud.availability_zone"
@@ -103,7 +104,7 @@ class ResourceAttributes:
 
     CONTAINER_NAME = "container.name"
     """
-    Container name.
+    Container name used by container runtime.
     """
 
     CONTAINER_ID = "container.id"
@@ -267,7 +268,12 @@ As an alternative, consider setting `faas.id` as a span attribute instead.
 
     K8S_CONTAINER_NAME = "k8s.container.name"
     """
-    The name of the Container in a Pod template.
+    The name of the Container from Pod specification, must be unique within a Pod. Container runtime usually uses different globally unique name (`container.name`).
+    """
+
+    K8S_CONTAINER_RESTART_COUNT = "k8s.container.restart_count"
+    """
+    Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec.
     """
 
     K8S_REPLICASET_UID = "k8s.replicaset.uid"
@@ -472,6 +478,9 @@ class CloudProviderValues(Enum):
     GCP = "gcp"
     """Google Cloud Platform."""
 
+    TENCENT_CLOUD = "tencent_cloud"
+    """Tencent Cloud."""
+
 
 class CloudPlatformValues(Enum):
     ALIBABA_CLOUD_ECS = "alibaba_cloud_ecs"
@@ -494,6 +503,9 @@ class CloudPlatformValues(Enum):
 
     AWS_ELASTIC_BEANSTALK = "aws_elastic_beanstalk"
     """AWS Elastic Beanstalk."""
+
+    AWS_APP_RUNNER = "aws_app_runner"
+    """AWS App Runner."""
 
     AZURE_VM = "azure_vm"
     """Azure Virtual Machines."""
@@ -525,6 +537,15 @@ class CloudPlatformValues(Enum):
     GCP_APP_ENGINE = "gcp_app_engine"
     """Google Cloud App Engine (GAE)."""
 
+    TENCENT_CLOUD_CVM = "tencent_cloud_cvm"
+    """Tencent Cloud Cloud Virtual Machine (CVM)."""
+
+    TENCENT_CLOUD_EKS = "tencent_cloud_eks"
+    """Tencent Cloud Elastic Kubernetes Service (EKS)."""
+
+    TENCENT_CLOUD_SCF = "tencent_cloud_scf"
+    """Tencent Cloud Serverless Cloud Function (SCF)."""
+
 
 class AwsEcsLaunchtypeValues(Enum):
     EC2 = "ec2"
@@ -552,6 +573,9 @@ class HostArchValues(Enum):
 
     PPC64 = "ppc64"
     """64-bit PowerPC."""
+
+    S390X = "s390x"
+    """IBM z/Architecture."""
 
     X86 = "x86"
     """32-bit x86."""
@@ -622,3 +646,6 @@ class TelemetrySdkLanguageValues(Enum):
 
     WEBJS = "webjs"
     """webjs."""
+
+    SWIFT = "swift"
+    """swift."""

--- a/scripts/semconv/generate.sh
+++ b/scripts/semconv/generate.sh
@@ -4,8 +4,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec version to make SemanticAttributes generation reproducible
-SPEC_VERSION=v1.6.1
-OTEL_SEMCONV_GEN_IMG_VERSION=0.5.0
+SPEC_VERSION=v1.8.0
+OTEL_SEMCONV_GEN_IMG_VERSION=0.9.0
 
 cd ${SCRIPT_DIR}
 


### PR DESCRIPTION
# Description

Some hbase/cassandra semantic conventions were removed but I don't think we are using them in out instrumentations. 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `tox -e opentelemetry-semantic-conventions`

# Does This PR Require a Contrib Repo Change?

- [x] No.

