### PR TITLE
fix except handling in get_aggregated_resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2450](https://github.com/open-telemetry/opentelemetry-python/pull/2450))
 - Bump semantic conventions from 1.6.1 to 1.8.0
   ([#2461](https://github.com/open-telemetry/opentelemetry-python/pull/2461))
+- fix exception handling in get_aggregated_resources
+  ([#2464](https://github.com/open-telemetry/opentelemetry-python/pull/2464))
 
 ## [1.9.1-0.28b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.1-0.28b1) - 2022-01-29
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -308,12 +308,12 @@ def get_aggregated_resources(
                 detected_resource = future.result(timeout=timeout)
             # pylint: disable=broad-except
             except Exception as ex:
+                detected_resource = _EMPTY_RESOURCE
                 if detector.raise_on_error:
                     raise ex
                 logger.warning(
                     "Exception %s in detector %s, ignoring", ex, detector
                 )
-                detected_resource = _EMPTY_RESOURCE
             finally:
                 detectors_merged_resource = detectors_merged_resource.merge(
                     detected_resource


### PR DESCRIPTION
Minor Fix with exception handling in get_aggregated_resources

# Description

Fixes 
```
UnboundLocalError: local variable 'detected_resource' referenced before assignment 
```
This happen only if raise_on_error is True with a resource detector.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Run with and without patch.
```python
from opentelemetry.sdk.resources import ResourceDetector
from opentelemetry.sdk.resources import get_aggregated_resources


class ErrorDetector(ResourceDetector):
    def __init__(self, raise_on_error=False):
        super().__init__(raise_on_error)

    def detect(self):
        raise Exception


get_aggregated_resources([ErrorDetector(raise_on_error=True)])
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated

# Does This PR Require a Contrib Repo Change?

- [x] No.