### PR TITLE
[bugfix] aggregate expects a measurement

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_view_instrument_match.py
@@ -68,7 +68,7 @@ class _ViewInstrumentMatch:
             with self._lock:
                 self._attributes_aggregation[attributes] = self._aggregation()
 
-        self._attributes_aggregation[attributes].aggregate(measurement.value)
+        self._attributes_aggregation[attributes].aggregate(measurement)
 
     def collect(self, temporality: int) -> Iterable[Metric]:
 


### PR DESCRIPTION
The previous code was passing in a value. This will need an end-to-end test, but the functionality can only get tested once #2456 is merged.