### PR TITLE
implement to_json for Metric

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/point.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/point.py
@@ -14,7 +14,7 @@
 
 import json
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import IntEnum
 from typing import Sequence, Union
 
@@ -37,26 +37,11 @@ class Sum:
     aggregation_temporality: AggregationTemporality
     is_monotonic: bool
 
-    def _dict(self):
-        return {
-            "start_time_unix_nano": self.start_time_unix_nano,
-            "time_unix_nano": self.time_unix_nano,
-            "value": self.value,
-            "aggregation_temporality": self.aggregation_temporality,
-            "is_monotonic": self.is_monotonic,
-        }
-
 
 @dataclass(frozen=True)
 class Gauge:
     time_unix_nano: int
     value: Union[int, float]
-
-    def _dict(self):
-        return {
-            "time_unix_nano": self.time_unix_nano,
-            "value": self.value,
-        }
 
 
 @dataclass(frozen=True)
@@ -67,16 +52,6 @@ class Histogram:
     explicit_bounds: Sequence[float]
     sum: Union[int, float]
     aggregation_temporality: AggregationTemporality
-
-    def _dict(self):
-        return {
-            "start_time_unix_nano": self.start_time_unix_nano,
-            "time_unix_nano": self.time_unix_nano,
-            "bucket_counts": self.bucket_counts,
-            "explicit_bounds": self.explicit_bounds,
-            "sum": self.sum,
-            "aggregation_temporality": self.aggregation_temporality,
-        }
 
 
 PointT = Union[Sum, Gauge, Histogram]
@@ -105,7 +80,7 @@ class Metric:
             {
                 "attributes": self.attributes if self.attributes else "",
                 "description": self.description if self.description else "",
-                "instrumentation_info": self.instrumentation_info
+                "instrumentation_info": repr(self.instrumentation_info)
                 if self.instrumentation_info
                 else "",
                 "name": self.name,
@@ -113,6 +88,6 @@ class Metric:
                 if self.resource
                 else "",
                 "unit": self.unit if self.unit else "",
-                "point": self.point._dict() if self.point else "",
+                "point": asdict(self.point) if self.point else "",
             }
         )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/point.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/point.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-
 from dataclasses import asdict, dataclass
 from enum import IntEnum
 from typing import Sequence, Union

--- a/opentelemetry-sdk/tests/metrics/test_point.py
+++ b/opentelemetry-sdk/tests/metrics/test_point.py
@@ -1,0 +1,73 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+from opentelemetry.sdk._metrics.point import Metric, Sum, Gauge, Histogram
+from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
+from opentelemetry.sdk.resources import Resource
+
+
+def _create_metric(value):
+    return Metric(
+        attributes={"attr-key": "test-val"},
+        description="test-description",
+        instrumentation_info=InstrumentationInfo(
+            name="name", version="version"
+        ),
+        name="test-name",
+        resource=Resource({"resource-key": "resource-val"}),
+        unit="test-unit",
+        point=value,
+    )
+
+
+class TestDatapointToJSON(TestCase):
+    def test_sum(self):
+        point = _create_metric(
+            Sum(
+                start_time_unix_nano=10,
+                time_unix_nano=20,
+                value=9,
+                aggregation_temporality=2,
+                is_monotonic=True,
+            )
+        )
+        self.assertEqual(
+            '{"attributes": {"attr-key": "test-val"}, "description": "test-description", "instrumentation_info": "InstrumentationInfo(name, version, None)", "name": "test-name", "resource": "BoundedAttributes({\'resource-key\': \'resource-val\'}, maxlen=None)", "unit": "test-unit", "point": {"start_time_unix_nano": 10, "time_unix_nano": 20, "value": 9, "aggregation_temporality": 2, "is_monotonic": true}}',
+            point.to_json(),
+        )
+
+    def test_gauge(self):
+        point = _create_metric(Gauge(time_unix_nano=40, value=20))
+        self.assertEqual(
+            '{"attributes": {"attr-key": "test-val"}, "description": "test-description", "instrumentation_info": "InstrumentationInfo(name, version, None)", "name": "test-name", "resource": "BoundedAttributes({\'resource-key\': \'resource-val\'}, maxlen=None)", "unit": "test-unit", "point": {"time_unix_nano": 40, "value": 20}}',
+            point.to_json(),
+        )
+
+    def test_histogram(self):
+        point = _create_metric(
+            Histogram(
+                start_time_unix_nano=50,
+                time_unix_nano=60,
+                bucket_counts=[0, 0, 1, 0],
+                explicit_bounds=[0.1, 0.5, 0.9, 1],
+                aggregation_temporality=1,
+                sum=0.8,
+            )
+        )
+        self.maxDiff = None
+        self.assertEqual(
+            '{"attributes": {"attr-key": "test-val"}, "description": "test-description", "instrumentation_info": "InstrumentationInfo(name, version, None)", "name": "test-name", "resource": "BoundedAttributes({\'resource-key\': \'resource-val\'}, maxlen=None)", "unit": "test-unit", "point": {"start_time_unix_nano": 50, "time_unix_nano": 60, "bucket_counts": [0, 0, 1, 0], "explicit_bounds": [0.1, 0.5, 0.9, 1], "sum": 0.8, "aggregation_temporality": 1}}',
+            point.to_json(),
+        )

--- a/opentelemetry-sdk/tests/metrics/test_point.py
+++ b/opentelemetry-sdk/tests/metrics/test_point.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from unittest import TestCase
-from opentelemetry.sdk._metrics.point import Metric, Sum, Gauge, Histogram
-from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
+
+from opentelemetry.sdk._metrics.point import Gauge, Histogram, Metric, Sum
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
 
 
 def _create_metric(value):


### PR DESCRIPTION
Implementing the to_json method for Metric to be used with the ConsoleMetricExporter.
