### PR TITLE
Update _view_instrument_match.py

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_view_instrument_match.py
@@ -68,7 +68,7 @@ class _ViewInstrumentMatch:
 
         if attributes not in self._attributes_aggregation.keys():
             with self._lock:
-                self._attributes_aggregation[attributes] = self._aggregation()
+                self._attributes_aggregation[attributes] = self._aggregation
 
         self._attributes_aggregation[attributes].aggregate(measurement)
 


### PR DESCRIPTION
The type _aggregation is a function and therefore, should not contain '( )' when being assigned.

# Description

I was running a test on opentelemetry metrics, and found a bug which was trying to call a function '()' to an object (e.g. SumAggregator). By removing the (), the code runs properly.

Fixes # 2478

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- Tested on my local environment (MacOS 12.2.1) using python 3.9.9.
- cloned the repo and installed the opentelemetry-sdk and opentelemetry-api
- used sample script that emits metrics.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration : As for the reproduction, please see https://github.com/open-telemetry/opentelemetry-python/issues/2478

- [x] removed '()' at line 71 of opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_view_instrument_match.py

# Does This PR Require a Contrib Repo Change? - No

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated - Not necessary - this is a simple typo correction
- [ ] Unit tests have been added - Not necessary - this is a simple typo correction
- [ ] Documentation has been updated - Not necessary - this is a simple typo correction
