### PR TITLE
Update metric_reader_storage.py - fixes bug #2487

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/metric_reader_storage.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/metric_reader_storage.py
@@ -75,7 +75,7 @@ class MetricReaderStorage:
             # if no view targeted the instrument, use the default
             if not matches:
                 # TODO: the logic to select aggregation could be moved
-                if isinstance(instrument, Counter):
+                if isinstance(instrument, Counter) or isinstance(instrument, UpDownCounter):
                     agg = _SumAggregation(True, AggregationTemporality.DELTA)
                 elif isinstance(instrument, Histogram):
                     agg = _ExplicitBucketHistogramAggregation()


### PR DESCRIPTION
# Description
When metric reader storage is storing 'Counter' type, it should also process 'UpDownCounter' as well. Failing to check the instance of UpDownCounter would result of the counter value not getting Sum aggregated, but ended up to store only the last value given.

Fixes # (issue)
https://github.com/open-telemetry/opentelemetry-python/issues/2487

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
tests were performed using the script given in https://github.com/open-telemetry/opentelemetry-python/issues/2487

- [x] increment and decrement values using UpDownCounter

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
