### PR TITLE
Fix SDK observable instruments to emit SDK Measurement

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/instrument.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/instrument.py
@@ -24,7 +24,6 @@ from opentelemetry._metrics.instrument import Histogram as APIHistogram
 from opentelemetry._metrics.instrument import (
     ObservableCounter as APIObservableCounter,
 )
-from opentelemetry._metrics.measurement import Measurement as APIMeasurement
 from opentelemetry._metrics.instrument import (
     ObservableGauge as APIObservableGauge,
 )
@@ -32,6 +31,7 @@ from opentelemetry._metrics.instrument import (
     ObservableUpDownCounter as APIObservableUpDownCounter,
 )
 from opentelemetry._metrics.instrument import UpDownCounter as APIUpDownCounter
+from opentelemetry._metrics.measurement import Measurement as APIMeasurement
 from opentelemetry.sdk._metrics.aggregation import (
     _Aggregation,
     _ExplicitBucketHistogramAggregation,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/instrument.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/instrument.py
@@ -16,7 +16,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Generator, Iterable, Union
+from typing import Callable, Dict, Generator, Iterable, Union
 
 from opentelemetry._metrics.instrument import CallbackT
 from opentelemetry._metrics.instrument import Counter as APICounter
@@ -24,6 +24,7 @@ from opentelemetry._metrics.instrument import Histogram as APIHistogram
 from opentelemetry._metrics.instrument import (
     ObservableCounter as APIObservableCounter,
 )
+from opentelemetry._metrics.measurement import Measurement as APIMeasurement
 from opentelemetry._metrics.instrument import (
     ObservableGauge as APIObservableGauge,
 )
@@ -86,7 +87,7 @@ class _Asynchronous(_Instrument):
         self._measurement_consumer = measurement_consumer
         super().__init__(name, callback, unit=unit, description=description)
 
-        self._callback = callback
+        self._callback: Callable[[], Iterable[APIMeasurement]]
 
         if isinstance(callback, Generator):
 
@@ -94,10 +95,16 @@ class _Asynchronous(_Instrument):
                 return next(callback)
 
             self._callback = inner
+        else:
+            self._callback = callback
 
-    @property
-    def callback(self) -> CallbackT:
-        return self._callback
+    def callback(self) -> Iterable[Measurement]:
+        for api_measurement in self._callback():
+            yield Measurement(
+                api_measurement.value,
+                instrument=self,
+                attributes=api_measurement.attributes,
+            )
 
 
 class Counter(_Synchronous, APICounter):

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_cpu_time.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_cpu_time.py
@@ -14,10 +14,12 @@
 # type: ignore
 
 import io
-from typing import Generator, Iterable
+from typing import Generator, Iterable, List
 from unittest import TestCase
+from opentelemetry._metrics.instrument import Instrument
 
-from opentelemetry._metrics.measurement import Measurement
+from opentelemetry._metrics.measurement import Measurement as APIMeasurement
+from opentelemetry.sdk._metrics.measurement import Measurement
 from opentelemetry.sdk._metrics import MeterProvider
 
 # FIXME Test that the instrument methods can be called concurrently safely.
@@ -39,61 +41,137 @@ procs_running 2
 procs_blocked 0
 softirq 1644603067 0 166540056 208 309152755 8936439 0 1354908 935642970 13 222975718\n"""
 
-    measurements_expected = [
-        Measurement(6150, {"cpu": "cpu0", "state": "user"}),
-        Measurement(3177, {"cpu": "cpu0", "state": "nice"}),
-        Measurement(5946, {"cpu": "cpu0", "state": "system"}),
-        Measurement(891264, {"cpu": "cpu0", "state": "idle"}),
-        Measurement(1296, {"cpu": "cpu0", "state": "iowait"}),
-        Measurement(0, {"cpu": "cpu0", "state": "irq"}),
-        Measurement(8343, {"cpu": "cpu0", "state": "softirq"}),
-        Measurement(421, {"cpu": "cpu0", "state": "guest"}),
-        Measurement(0, {"cpu": "cpu0", "state": "guest_nice"}),
-        Measurement(5882, {"cpu": "cpu1", "state": "user"}),
-        Measurement(3491, {"cpu": "cpu1", "state": "nice"}),
-        Measurement(6404, {"cpu": "cpu1", "state": "system"}),
-        Measurement(891564, {"cpu": "cpu1", "state": "idle"}),
-        Measurement(1244, {"cpu": "cpu1", "state": "iowait"}),
-        Measurement(0, {"cpu": "cpu1", "state": "irq"}),
-        Measurement(2410, {"cpu": "cpu1", "state": "softirq"}),
-        Measurement(418, {"cpu": "cpu1", "state": "guest"}),
-        Measurement(0, {"cpu": "cpu1", "state": "guest_nice"}),
-    ]
+    @staticmethod
+    def create_measurements_expected(
+        instrument: Instrument,
+    ) -> List[Measurement]:
+        return [
+            Measurement(
+                6150.29,
+                instrument=instrument,
+                attributes={"cpu": "cpu0", "state": "user"},
+            ),
+            Measurement(
+                3177.46,
+                instrument=instrument,
+                attributes={"cpu": "cpu0", "state": "nice"},
+            ),
+            Measurement(
+                5946.01,
+                instrument=instrument,
+                attributes={"cpu": "cpu0", "state": "system"},
+            ),
+            Measurement(
+                891264.59,
+                instrument=instrument,
+                attributes={"cpu": "cpu0", "state": "idle"},
+            ),
+            Measurement(
+                1296.29,
+                instrument=instrument,
+                attributes={"cpu": "cpu0", "state": "iowait"},
+            ),
+            Measurement(
+                0.0,
+                instrument=instrument,
+                attributes={"cpu": "cpu0", "state": "irq"},
+            ),
+            Measurement(
+                8343.46,
+                instrument=instrument,
+                attributes={"cpu": "cpu0", "state": "softirq"},
+            ),
+            Measurement(
+                421.37,
+                instrument=instrument,
+                attributes={"cpu": "cpu0", "state": "guest"},
+            ),
+            Measurement(
+                0,
+                instrument=instrument,
+                attributes={"cpu": "cpu0", "state": "guest_nice"},
+            ),
+            Measurement(
+                5882.32,
+                instrument=instrument,
+                attributes={"cpu": "cpu1", "state": "user"},
+            ),
+            Measurement(
+                3491.85,
+                instrument=instrument,
+                attributes={"cpu": "cpu1", "state": "nice"},
+            ),
+            Measurement(
+                6404.92,
+                instrument=instrument,
+                attributes={"cpu": "cpu1", "state": "system"},
+            ),
+            Measurement(
+                891564.11,
+                instrument=instrument,
+                attributes={"cpu": "cpu1", "state": "idle"},
+            ),
+            Measurement(
+                1244.85,
+                instrument=instrument,
+                attributes={"cpu": "cpu1", "state": "iowait"},
+            ),
+            Measurement(
+                0,
+                instrument=instrument,
+                attributes={"cpu": "cpu1", "state": "irq"},
+            ),
+            Measurement(
+                2410.04,
+                instrument=instrument,
+                attributes={"cpu": "cpu1", "state": "softirq"},
+            ),
+            Measurement(
+                418.62,
+                instrument=instrument,
+                attributes={"cpu": "cpu1", "state": "guest"},
+            ),
+            Measurement(
+                0,
+                instrument=instrument,
+                attributes={"cpu": "cpu1", "state": "guest_nice"},
+            ),
+        ]
 
     def test_cpu_time_callback(self):
-        def cpu_time_callback() -> Iterable[Measurement]:
+        def cpu_time_callback() -> Iterable[APIMeasurement]:
             procstat = io.StringIO(self.procstat_str)
             procstat.readline()  # skip the first line
             for line in procstat:
                 if not line.startswith("cpu"):
                     break
                 cpu, *states = line.split()
-                yield Measurement(
-                    int(states[0]) // 100, {"cpu": cpu, "state": "user"}
+                yield APIMeasurement(
+                    int(states[0]) / 100, {"cpu": cpu, "state": "user"}
                 )
-                yield Measurement(
-                    int(states[1]) // 100, {"cpu": cpu, "state": "nice"}
+                yield APIMeasurement(
+                    int(states[1]) / 100, {"cpu": cpu, "state": "nice"}
                 )
-                yield Measurement(
-                    int(states[2]) // 100, {"cpu": cpu, "state": "system"}
+                yield APIMeasurement(
+                    int(states[2]) / 100, {"cpu": cpu, "state": "system"}
                 )
-                yield Measurement(
-                    int(states[3]) // 100, {"cpu": cpu, "state": "idle"}
+                yield APIMeasurement(
+                    int(states[3]) / 100, {"cpu": cpu, "state": "idle"}
                 )
-                yield Measurement(
-                    int(states[4]) // 100, {"cpu": cpu, "state": "iowait"}
+                yield APIMeasurement(
+                    int(states[4]) / 100, {"cpu": cpu, "state": "iowait"}
                 )
-                yield Measurement(
-                    int(states[5]) // 100, {"cpu": cpu, "state": "irq"}
+                yield APIMeasurement(
+                    int(states[5]) / 100, {"cpu": cpu, "state": "irq"}
                 )
-                yield Measurement(
-                    int(states[6]) // 100, {"cpu": cpu, "state": "softirq"}
+                yield APIMeasurement(
+                    int(states[6]) / 100, {"cpu": cpu, "state": "softirq"}
                 )
-                yield Measurement(
-                    int(states[7]) // 100, {"cpu": cpu, "state": "guest"}
+                yield APIMeasurement(
+                    int(states[7]) / 100, {"cpu": cpu, "state": "guest"}
                 )
-                yield Measurement(
-                    int(states[8]) // 100, {"cpu": cpu, "state": "guest_nice"}
+                yield APIMeasurement(
+                    int(states[8]) / 100, {"cpu": cpu, "state": "guest_nice"}
                 )
 
         meter = MeterProvider().get_meter("name")
@@ -103,12 +181,14 @@ softirq 1644603067 0 166540056 208 309152755 8936439 0 1354908 935642970 13 2229
             unit="s",
             description="CPU time",
         )
-        measurements = list(observable_counter._callback())
-        self.assertEqual(measurements, self.measurements_expected)
+        measurements = list(observable_counter.callback())
+        self.assertEqual(
+            measurements, self.create_measurements_expected(observable_counter)
+        )
 
     def test_cpu_time_generator(self):
         def cpu_time_generator() -> Generator[
-            Iterable[Measurement], None, None
+            Iterable[APIMeasurement], None, None
         ]:
             while True:
                 measurements = []
@@ -119,55 +199,55 @@ softirq 1644603067 0 166540056 208 309152755 8936439 0 1354908 935642970 13 2229
                         break
                     cpu, *states = line.split()
                     measurements.append(
-                        Measurement(
-                            int(states[0]) // 100,
+                        APIMeasurement(
+                            int(states[0]) / 100,
                             {"cpu": cpu, "state": "user"},
                         )
                     )
                     measurements.append(
-                        Measurement(
-                            int(states[1]) // 100,
+                        APIMeasurement(
+                            int(states[1]) / 100,
                             {"cpu": cpu, "state": "nice"},
                         )
                     )
                     measurements.append(
-                        Measurement(
-                            int(states[2]) // 100,
+                        APIMeasurement(
+                            int(states[2]) / 100,
                             {"cpu": cpu, "state": "system"},
                         )
                     )
                     measurements.append(
-                        Measurement(
-                            int(states[3]) // 100,
+                        APIMeasurement(
+                            int(states[3]) / 100,
                             {"cpu": cpu, "state": "idle"},
                         )
                     )
                     measurements.append(
-                        Measurement(
-                            int(states[4]) // 100,
+                        APIMeasurement(
+                            int(states[4]) / 100,
                             {"cpu": cpu, "state": "iowait"},
                         )
                     )
                     measurements.append(
-                        Measurement(
-                            int(states[5]) // 100, {"cpu": cpu, "state": "irq"}
+                        APIMeasurement(
+                            int(states[5]) / 100, {"cpu": cpu, "state": "irq"}
                         )
                     )
                     measurements.append(
-                        Measurement(
-                            int(states[6]) // 100,
+                        APIMeasurement(
+                            int(states[6]) / 100,
                             {"cpu": cpu, "state": "softirq"},
                         )
                     )
                     measurements.append(
-                        Measurement(
-                            int(states[7]) // 100,
+                        APIMeasurement(
+                            int(states[7]) / 100,
                             {"cpu": cpu, "state": "guest"},
                         )
                     )
                     measurements.append(
-                        Measurement(
-                            int(states[8]) // 100,
+                        APIMeasurement(
+                            int(states[8]) / 100,
                             {"cpu": cpu, "state": "guest_nice"},
                         )
                     )
@@ -180,5 +260,9 @@ softirq 1644603067 0 166540056 208 309152755 8936439 0 1354908 935642970 13 2229
             unit="s",
             description="CPU time",
         )
-        measurements = list(observable_counter._callback())
-        self.assertEqual(measurements, self.measurements_expected)
+        measurements = list(observable_counter.callback())
+        self.assertEqual(
+            measurements, self.create_measurements_expected(observable_counter)
+        )
+
+    maxDiff = None

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_cpu_time.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_cpu_time.py
@@ -16,11 +16,11 @@
 import io
 from typing import Generator, Iterable, List
 from unittest import TestCase
-from opentelemetry._metrics.instrument import Instrument
 
+from opentelemetry._metrics.instrument import Instrument
 from opentelemetry._metrics.measurement import Measurement as APIMeasurement
-from opentelemetry.sdk._metrics.measurement import Measurement
 from opentelemetry.sdk._metrics import MeterProvider
+from opentelemetry.sdk._metrics.measurement import Measurement
 
 # FIXME Test that the instrument methods can be called concurrently safely.
 

--- a/opentelemetry-sdk/tests/metrics/test_instrument.py
+++ b/opentelemetry-sdk/tests/metrics/test_instrument.py
@@ -14,6 +14,7 @@
 
 from unittest import TestCase
 from unittest.mock import Mock
+from opentelemetry._metrics.measurement import Measurement as APIMeasurement
 
 from opentelemetry.sdk._metrics.instrument import (
     Counter,
@@ -23,6 +24,9 @@ from opentelemetry.sdk._metrics.instrument import (
     ObservableUpDownCounter,
     UpDownCounter,
 )
+from opentelemetry.sdk._metrics.measurement import Measurement
+
+TEST_ATTRIBUTES = {"foo": "bar"}
 
 
 class TestCounter(TestCase):
@@ -53,66 +57,170 @@ class TestUpDownCounter(TestCase):
         mc.consume_measurement.assert_called_once()
 
 
+def callable_callback():
+    return [
+        APIMeasurement(1, attributes=TEST_ATTRIBUTES),
+        APIMeasurement(2, attributes=TEST_ATTRIBUTES),
+        APIMeasurement(3, attributes=TEST_ATTRIBUTES),
+    ]
+
+
+def generator_callback():
+    yield [
+        APIMeasurement(1, attributes=TEST_ATTRIBUTES),
+        APIMeasurement(2, attributes=TEST_ATTRIBUTES),
+        APIMeasurement(3, attributes=TEST_ATTRIBUTES),
+    ]
+
+
 class TestObservableGauge(TestCase):
     def test_callable_callback(self):
-        def callback():
-            return [1, 2, 3]
+        observable_gauge = ObservableGauge(
+            "name", Mock(), Mock(), callable_callback
+        )
 
-        observable_gauge = ObservableGauge("name", Mock(), Mock(), callback)
-
-        self.assertEqual(observable_gauge.callback(), [1, 2, 3])
+        self.assertEqual(
+            list(observable_gauge.callback()),
+            [
+                Measurement(
+                    1, instrument=observable_gauge, attributes=TEST_ATTRIBUTES
+                ),
+                Measurement(
+                    2, instrument=observable_gauge, attributes=TEST_ATTRIBUTES
+                ),
+                Measurement(
+                    3, instrument=observable_gauge, attributes=TEST_ATTRIBUTES
+                ),
+            ],
+        )
 
     def test_generator_callback(self):
-        def callback():
-            yield [1, 2, 3]
+        observable_gauge = ObservableGauge(
+            "name", Mock(), Mock(), generator_callback()
+        )
 
-        observable_gauge = ObservableGauge("name", Mock(), Mock(), callback())
-
-        self.assertEqual(observable_gauge.callback(), [1, 2, 3])
+        self.assertEqual(
+            list(observable_gauge.callback()),
+            [
+                Measurement(
+                    1, instrument=observable_gauge, attributes=TEST_ATTRIBUTES
+                ),
+                Measurement(
+                    2, instrument=observable_gauge, attributes=TEST_ATTRIBUTES
+                ),
+                Measurement(
+                    3, instrument=observable_gauge, attributes=TEST_ATTRIBUTES
+                ),
+            ],
+        )
 
 
 class TestObservableCounter(TestCase):
     def test_callable_callback(self):
-        def callback():
-            return [1, 2, 3]
-
         observable_counter = ObservableCounter(
-            "name", Mock(), Mock(), callback
+            "name", Mock(), Mock(), callable_callback
         )
 
-        self.assertEqual(observable_counter.callback(), [1, 2, 3])
+        self.assertEqual(
+            list(observable_counter.callback()),
+            [
+                Measurement(
+                    1,
+                    instrument=observable_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+                Measurement(
+                    2,
+                    instrument=observable_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+                Measurement(
+                    3,
+                    instrument=observable_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+            ],
+        )
 
     def test_generator_callback(self):
-        def callback():
-            yield [1, 2, 3]
-
         observable_counter = ObservableCounter(
-            "name", Mock(), Mock(), callback()
+            "name", Mock(), Mock(), generator_callback()
         )
 
-        self.assertEqual(observable_counter.callback(), [1, 2, 3])
+        self.assertEqual(
+            list(observable_counter.callback()),
+            [
+                Measurement(
+                    1,
+                    instrument=observable_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+                Measurement(
+                    2,
+                    instrument=observable_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+                Measurement(
+                    3,
+                    instrument=observable_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+            ],
+        )
 
 
 class TestObservableUpDownCounter(TestCase):
     def test_callable_callback(self):
-        def callback():
-            return [1, 2, 3]
-
         observable_up_down_counter = ObservableUpDownCounter(
-            "name", Mock(), Mock(), callback
+            "name", Mock(), Mock(), callable_callback
         )
 
-        self.assertEqual(observable_up_down_counter.callback(), [1, 2, 3])
+        self.assertEqual(
+            list(observable_up_down_counter.callback()),
+            [
+                Measurement(
+                    1,
+                    instrument=observable_up_down_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+                Measurement(
+                    2,
+                    instrument=observable_up_down_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+                Measurement(
+                    3,
+                    instrument=observable_up_down_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+            ],
+        )
 
     def test_generator_callback(self):
-        def callback():
-            yield [1, 2, 3]
-
         observable_up_down_counter = ObservableUpDownCounter(
-            "name", Mock(), Mock(), callback()
+            "name", Mock(), Mock(), generator_callback()
         )
 
-        self.assertEqual(observable_up_down_counter.callback(), [1, 2, 3])
+        self.assertEqual(
+            list(observable_up_down_counter.callback()),
+            [
+                Measurement(
+                    1,
+                    instrument=observable_up_down_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+                Measurement(
+                    2,
+                    instrument=observable_up_down_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+                Measurement(
+                    3,
+                    instrument=observable_up_down_counter,
+                    attributes=TEST_ATTRIBUTES,
+                ),
+            ],
+        )
 
 
 class TestHistogram(TestCase):

--- a/opentelemetry-sdk/tests/metrics/test_instrument.py
+++ b/opentelemetry-sdk/tests/metrics/test_instrument.py
@@ -14,8 +14,8 @@
 
 from unittest import TestCase
 from unittest.mock import Mock
-from opentelemetry._metrics.measurement import Measurement as APIMeasurement
 
+from opentelemetry._metrics.measurement import Measurement as APIMeasurement
 from opentelemetry.sdk._metrics.instrument import (
     Counter,
     Histogram,
@@ -25,8 +25,6 @@ from opentelemetry.sdk._metrics.instrument import (
     UpDownCounter,
 )
 from opentelemetry.sdk._metrics.measurement import Measurement
-
-TEST_ATTRIBUTES = {"foo": "bar"}
 
 
 class TestCounter(TestCase):
@@ -55,6 +53,9 @@ class TestUpDownCounter(TestCase):
         counter = UpDownCounter("name", Mock(), mc)
         counter.add(-1.0)
         mc.consume_measurement.assert_called_once()
+
+
+TEST_ATTRIBUTES = {"foo": "bar"}
 
 
 def callable_callback():


### PR DESCRIPTION
# Description

The metrics SDK was not previously working for async instruments. The callbacks need to emit Measurements which can be consumed by MeasurementConsumer. This fixes it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated tests and manually tested with this script

```py
import time
from rich.pretty import pprint
from typing import Iterable
from opentelemetry._metrics.measurement import Measurement
from opentelemetry.sdk._metrics import MeterProvider
from opentelemetry.sdk._metrics.metric_reader import MetricReader
from opentelemetry.sdk._metrics.point import AggregationTemporality, Metric


class MyReader(MetricReader):
    def _receive_metrics(self, metrics: Iterable[Metric]) -> None:
        """Called by `MetricReader.collect` when it receives a batch of metrics"""
        pprint(metrics)

    def shutdown(self) -> bool:
        print("shutdown called")
        return True


def cpu_time_callback() -> Iterable[Measurement]:
    with open("/proc/stat") as procstat:
        procstat.readline()  # skip the first line
        for line in procstat:
            if not line.startswith("cpu"):
                break
            cpu, *states = line.split()
            yield Measurement(
                int(states[0]) // 100, {"cpu": cpu, "state": "user"}
            )
            yield Measurement(
                int(states[1]) // 100, {"cpu": cpu, "state": "nice"}
            )
            # ... other states


def main() -> None:
    reader = MyReader(preferred_temporality=AggregationTemporality.CUMULATIVE)
    mp = MeterProvider(metric_readers=[reader])
    meter = mp.get_meter("hellometer")
    mycounter = meter.create_counter("mycounter")
    meter.create_observable_counter(
        "system.cpu.time",
        callback=cpu_time_callback,
        unit="ms",
        description="System's CPU time",
    )
    for _ in range(20):
        mycounter.add(12, {"path": "/hello"})
        mycounter.add(10, {"path": "/world"})

    reader.collect()

    time.sleep(2)
    mp.shutdown()


if __name__ == "__main__":
    main()
```

The output is: https://gist.github.com/aabmass/d61350cdffe6f112401d2616eb41f866

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
