### PR TITLE
Fix prometheus histogram "+Inf" bucket

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
@@ -65,6 +65,7 @@ API
 import collections
 import logging
 import re
+from itertools import chain
 from typing import Iterable, Optional, Sequence, Tuple
 
 from prometheus_client import core
@@ -78,14 +79,13 @@ _logger = logging.getLogger(__name__)
 def _convert_buckets(metric: Metric) -> Sequence[Tuple[str, int]]:
     buckets = []
     total_count = 0
-    for index, value in enumerate(metric.point.bucket_counts):
-        total_count += value
-        buckets.append(
-            (
-                f"{metric.point.explicit_bounds[index]}",
-                total_count,
-            )
-        )
+    for upper_bound, count in zip(
+        chain(metric.point.explicit_bounds, ["+Inf"]),
+        metric.point.bucket_counts,
+    ):
+        total_count += count
+        buckets.append((f"{upper_bound}", total_count))
+
     return buckets
 
 


### PR DESCRIPTION
# Description

Fixes the prometheus exporter to report the `+Inf` overflow bucket which should be equivalent to the count. The previous code assumed there was no overflow bucket, but there will always be an overflow bucket generated by the SDK. The test was using a faulty `Histogram` without one.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated unit tests, tested exporter with the real SDK.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
