### PR TITLE
Reset async instrumentation aggregations each collection interval

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/aggregation.py
@@ -101,15 +101,18 @@ class _SumAggregation(_Aggregation[Sum]):
                 value=value,
             )
 
-        if self._value is None:
-            return None
+        with self._lock:
+            if self._value is None:
+                return None
+            value = self._value
+            self._value = None
 
         return Sum(
             aggregation_temporality=AggregationTemporality.CUMULATIVE,
             is_monotonic=self._instrument_is_monotonic,
             start_time_unix_nano=self._start_time_unix_nano,
             time_unix_nano=now,
-            value=self._value,
+            value=value,
         )
 
 
@@ -126,12 +129,15 @@ class _LastValueAggregation(_Aggregation[Gauge]):
         """
         Atomically return a point for the current value of the metric.
         """
-        if self._value is None:
-            return None
+        with self._lock:
+            if self._value is None:
+                return None
+            value = self._value
+            self._value = None
 
         return Gauge(
             time_unix_nano=_time_ns(),
-            value=self._value,
+            value=value,
         )
 
 

--- a/opentelemetry-sdk/tests/metrics/test_aggregation.py
+++ b/opentelemetry-sdk/tests/metrics/test_aggregation.py
@@ -133,19 +133,20 @@ class TestSynchronousSumAggregation(TestCase):
         self.assertEqual(first_sum.value, 1)
         self.assertTrue(first_sum.is_monotonic)
 
+        # should have been reset after first collect
         sum_aggregation.aggregate(measurement(1))
         second_sum = sum_aggregation.collect()
 
-        self.assertEqual(second_sum.value, 2)
+        self.assertEqual(second_sum.value, 1)
         self.assertTrue(second_sum.is_monotonic)
 
         self.assertEqual(
             second_sum.start_time_unix_nano, first_sum.start_time_unix_nano
         )
 
-        self.assertIsNone(
-            _SumAggregation(True, AggregationTemporality.CUMULATIVE).collect()
-        )
+        # if no point seen for a whole interval, should return None
+        third_sum = sum_aggregation.collect()
+        self.assertIsNone(third_sum)
 
 
 class TestLastValueAggregation(TestCase):
@@ -193,6 +194,10 @@ class TestLastValueAggregation(TestCase):
         self.assertGreater(
             second_gauge.time_unix_nano, first_gauge.time_unix_nano
         )
+
+        # if no observation seen for the interval, it should return None
+        third_gauge = last_value_aggregation.collect()
+        self.assertIsNone(third_gauge)
 
 
 class TestExplicitBucketHistogramAggregation(TestCase):


### PR DESCRIPTION
# Description

Fixes the bug where async instruments' aggregations were not being reset after each collection interval. Since they observe a total value, they should be reset each collection. For example

```py
def total_number_of_processes_callback() -> Iterable[Measurement]:
    yield Measurement(get_current_cpu_time())

meter.create_observable_counter(
  "system_processes_count",
  cpu_time_callback,
  description="The total number of processes that have run on this machine",
)
```
The SDK would report the wrong values like so:

| expected total num proceses  | actual reported by SDK |
| ----------- | ----------- |
| 20      | 20       |
| 24   | 44        |
| 30   | 74        |

This PR fixes it so we correctly report the total num processes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated tests to capture behavior. Also manually tested with prometheus and scraping `/proc/stat`

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
