### PR TITLE
datadog-apm: deprecate opentelemetry datadog exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2493](https://github.com/open-telemetry/opentelemetry-python/pull/2493))
 - [exporter/opentelemetry-exporter-prometheus] restore package using the new metrics API
   ([#2321](https://github.com/open-telemetry/opentelemetry-python/pull/2321))
+- `opentelemetry-datadog-exporter` deprecate package.
+  ([#2571](https://github.com/open-telemetry/opentelemetry-python/pull/2517))
 
 ## [1.9.1-0.28b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.1-0.28b1) - 2022-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2493](https://github.com/open-telemetry/opentelemetry-python/pull/2493))
 - [exporter/opentelemetry-exporter-prometheus] restore package using the new metrics API
   ([#2321](https://github.com/open-telemetry/opentelemetry-python/pull/2321))
-- `opentelemetry-datadog-exporter` deprecate package.
-  ([#2571](https://github.com/open-telemetry/opentelemetry-python/pull/2517))
 
 ## [1.9.1-0.28b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.9.1-0.28b1) - 2022-01-29
 

--- a/docs/examples/datadog_exporter/README.rst
+++ b/docs/examples/datadog_exporter/README.rst
@@ -1,5 +1,10 @@
-Datadog Exporter
+Datadog Span Exporter
 ================
+
+Deprecated
+------------
+This exporter has been deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, please refer to `OTLP Ingest in Datadog Agent <https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent>`_ .
+
 
 These examples show how to use OpenTelemetry to send tracing data to Datadog.
 

--- a/docs/examples/datadog_exporter/README.rst
+++ b/docs/examples/datadog_exporter/README.rst
@@ -1,5 +1,5 @@
 Datadog Span Exporter
-================
+=====================
 
 Deprecated
 ------------

--- a/docs/examples/datadog_exporter/README.rst
+++ b/docs/examples/datadog_exporter/README.rst
@@ -1,9 +1,7 @@
 Datadog Span Exporter
 =====================
 
-Deprecated
-------------
-This exporter has been deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, please refer to `OTLP Ingest in Datadog Agent <https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent>`_ .
+.. warning:: This exporter has been deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, please refer to `OTLP Ingest in Datadog Agent <https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent>`_ .
 
 
 These examples show how to use OpenTelemetry to send tracing data to Datadog.


### PR DESCRIPTION
# Description

Adds deprecation note to the Datadog Span Exporter example.

## Type of change

Please delete options that are not relevant.

- [x] Documentation change

# How Has This Been Tested?

N/A

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/900
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
