### PR TITLE
Fix a mixed-up changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.6.2-0.25b2](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.2-0.25b2) - 2021-10-19
 
+- Fix parental trace relationship for opentracing `follows_from` reference
+  ([#2180](https://github.com/open-telemetry/opentelemetry-python/pull/2180))
+
 ## [1.6.1-0.25b1](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.1-0.25b1) - 2021-10-18
 
 - Fix ReadableSpan property types attempting to create a mapping from a list
@@ -109,9 +112,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2201](https://github.com/open-telemetry/opentelemetry-python/pull/2201))
 - Propagation: only warn about oversized baggage headers when headers exist
   ([#2212](https://github.com/open-telemetry/opentelemetry-python/pull/2212))
-
-- Fix parental trace relationship for opentracing `follows_from` reference
-  ([#2180](https://github.com/open-telemetry/opentelemetry-python/pull/2180))
 
 ## [1.6.0-0.25b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.0-0.25b0) - 2021-10-13
 


### PR DESCRIPTION
`1.6.1-0.25b1` had the changelog entry that was supposed to be for `1.6.2-0.25b2`. Compare with release notes at:

https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.1
https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.6.2

# Description

One changelog entry is moved to the correct release. Before this PR, `1.6.2-0.25b2` had no changes listed. I did not file an issue for this trivial fix.

## Type of change

Please delete options that are not relevant.

(none)

# How Has This Been Tested?

Inspect the changelog.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated **I don’t think a changelog correction needs a changelog entry, but I could be wrong.**
- [ ] Unit tests have been added **not applicable**
- [ ] Documentation has been updated **not applicable**
