### PR TITLE
Capture exception information in log attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   “site-packages/src”
   ([#2525](https://github.com/open-telemetry/opentelemetry-python/pull/2525))
 - Capture exception information as part of log attributes
-  ([#2525](https://github.com/open-telemetry/opentelemetry-python/pull/2525))
+  ([#2531](https://github.com/open-telemetry/opentelemetry-python/pull/2531))
 
 ## [1.10.0-0.29b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.10.0-0.29b0) - 2022-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix incorrect installation of some exporter “convenience” packages into
   “site-packages/src”
   ([#2525](https://github.com/open-telemetry/opentelemetry-python/pull/2525))
+- Capture exception information as part of log attributes
+  ([#2525](https://github.com/open-telemetry/opentelemetry-python/pull/2525))
 
 ## [1.10.0-0.29b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.10.0-0.29b0) - 2022-03-10
-
-
 
 - Docs rework: [non-API docs are
   moving](https://github.com/open-telemetry/opentelemetry-python/issues/2172) to

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -324,11 +324,14 @@ class LoggingHandler(logging.Handler):
         attributes = {
             k: v for k, v in vars(record).items() if k not in _RESERVED_ATTRS
         }
-        if record.exc_info:
+        if record.exc_info is not None:
+            exc_type = ""
+            message = ""
+            stack_trace = ""
             exctype, value, tb = record.exc_info
             if exctype is not None:
                 exc_type = exctype.__name__
-            if value is not None:
+            if value is not None and value.args:
                 message = value.args[0]
             if tb is not None:
                 # https://github.com/open-telemetry/opentelemetry-specification/blob/9fa7c656b26647b27e485a6af7e38dc716eba98a/specification/trace/semantic_conventions/exceptions.md#stacktrace-representation

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -331,6 +331,7 @@ class LoggingHandler(logging.Handler):
             if value is not None:
                 message = value.args[0]
             if tb is not None:
+                # https://github.com/open-telemetry/opentelemetry-specification/blob/9fa7c656b26647b27e485a6af7e38dc716eba98a/specification/trace/semantic_conventions/exceptions.md#stacktrace-representation
                 stack_trace = "".join(
                     traceback.format_exception(*record.exc_info)
                 )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -332,11 +332,11 @@ class LoggingHandler(logging.Handler):
                 message = value.args[0]
             callstack = []
             if tb is not None:
-                for fileName, line, method, text in traceback.extract_tb(tb):
+                for file_name, line, method, text in traceback.extract_tb(tb):
                     callstack.append(
                         {
                             "method": method,
-                            "fileName": fileName,
+                            "fileName": file_name,
                             "line": line,
                             "text": text,
                         }

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -333,16 +333,20 @@ class LoggingHandler(logging.Handler):
             callstack = []
             if tb is not None:
                 for fileName, line, method, text in traceback.extract_tb(tb):
-                    callstack.append({
-                        'method': method,
-                        'fileName': fileName,
-                        'line': line,
-                        'text': text,
-                    })
+                    callstack.append(
+                        {
+                            "method": method,
+                            "fileName": fileName,
+                            "line": line,
+                            "text": text,
+                        }
+                    )
                 callstack.reverse()
             attributes[SpanAttributes.EXCEPTION_TYPE] = exc_type
             attributes[SpanAttributes.EXCEPTION_MESSAGE] = message
-            attributes[SpanAttributes.EXCEPTION_STACKTRACE] = json.dumps(callstack)
+            attributes[SpanAttributes.EXCEPTION_STACKTRACE] = json.dumps(
+                callstack
+            )
         return attributes
 
     def _translate(self, record: logging.LogRecord) -> LogRecord:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -29,12 +29,12 @@ from opentelemetry.sdk.environment_variables import (
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.util import ns_to_iso_str
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
+from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import (
     format_span_id,
     format_trace_id,
     get_current_span,
 )
-from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.span import TraceFlags
 from opentelemetry.util._providers import _load_provider
 from opentelemetry.util._time import _time_ns

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -330,23 +330,11 @@ class LoggingHandler(logging.Handler):
                 exc_type = exctype.__name__
             if value is not None:
                 message = value.args[0]
-            callstack = []
             if tb is not None:
-                for file_name, line, method, text in traceback.extract_tb(tb):
-                    callstack.append(
-                        {
-                            "method": method,
-                            "fileName": file_name,
-                            "line": line,
-                            "text": text,
-                        }
-                    )
-                callstack.reverse()
+                stack_trace = "".join(traceback.format_exception(*record.exc_info))
             attributes[SpanAttributes.EXCEPTION_TYPE] = exc_type
             attributes[SpanAttributes.EXCEPTION_MESSAGE] = message
-            attributes[SpanAttributes.EXCEPTION_STACKTRACE] = json.dumps(
-                callstack
-            )
+            attributes[SpanAttributes.EXCEPTION_STACKTRACE] = stack_trace
         return attributes
 
     def _translate(self, record: logging.LogRecord) -> LogRecord:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -331,7 +331,9 @@ class LoggingHandler(logging.Handler):
             if value is not None:
                 message = value.args[0]
             if tb is not None:
-                stack_trace = "".join(traceback.format_exception(*record.exc_info))
+                stack_trace = "".join(
+                    traceback.format_exception(*record.exc_info)
+                )
             attributes[SpanAttributes.EXCEPTION_TYPE] = exc_type
             attributes[SpanAttributes.EXCEPTION_MESSAGE] = message
             attributes[SpanAttributes.EXCEPTION_STACKTRACE] = stack_trace

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -84,7 +84,7 @@ class TestLoggingHandler(unittest.TestCase):
         emitter_mock = Mock(spec=LogEmitter)
         logger = get_logger(log_emitter=emitter_mock)
         try:
-            div = 1 / 0 
+            div = 1 / 0
         except:
             logger.exception("Zero Division Error")
         args, _ = emitter_mock.emit.call_args_list[0]
@@ -107,7 +107,7 @@ class TestLoggingHandler(unittest.TestCase):
         self.assertEqual(stack_trace[0]["method"], "test_log_record_exception")
         self.assertEqual(stack_trace[0]["fileName"], __file__)
         # self.assertEqual(stack_trace[0]["line"], 87)
-        self.assertEqual(stack_trace[0]["text"], "div = 1/0")
+        self.assertEqual(stack_trace[0]["text"], "div = 1 / 0")
 
     def test_log_record_trace_correlation(self):
         emitter_mock = Mock(spec=LogEmitter)

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -98,7 +98,9 @@ class TestLoggingHandler(unittest.TestCase):
             log_record.attributes[SpanAttributes.EXCEPTION_MESSAGE],
             "division by zero",
         )
-        stack_trace = log_record.attributes[SpanAttributes.EXCEPTION_STACKTRACE]
+        stack_trace = log_record.attributes[
+            SpanAttributes.EXCEPTION_STACKTRACE
+        ]
         self.assertIsInstance(stack_trace, str)
         self.assertTrue("Traceback" in stack_trace)
         self.assertTrue("div = 1 / 0" in stack_trace)

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -84,7 +84,7 @@ class TestOTLPHandler(unittest.TestCase):
         emitter_mock = Mock(spec=LogEmitter)
         logger = get_logger(log_emitter=emitter_mock)
         try:
-            div = 1/0
+            div = 1 / 0
         except:
             logger.exception("Zero Division Error")
         args, _ = emitter_mock.emit.call_args_list[0]
@@ -92,10 +92,18 @@ class TestOTLPHandler(unittest.TestCase):
 
         self.assertIsNotNone(log_record)
         self.assertEqual(log_record.body, "Zero Division Error")
-        self.assertEqual(log_record.attributes[SpanAttributes.EXCEPTION_TYPE], ZeroDivisionError.__name__)
-        self.assertEqual(log_record.attributes[SpanAttributes.EXCEPTION_MESSAGE], "division by zero")
+        self.assertEqual(
+            log_record.attributes[SpanAttributes.EXCEPTION_TYPE],
+            ZeroDivisionError.__name__,
+        )
+        self.assertEqual(
+            log_record.attributes[SpanAttributes.EXCEPTION_MESSAGE],
+            "division by zero",
+        )
         print(log_record.attributes[SpanAttributes.EXCEPTION_STACKTRACE])
-        stack_trace = json.loads(log_record.attributes[SpanAttributes.EXCEPTION_STACKTRACE])
+        stack_trace = json.loads(
+            log_record.attributes[SpanAttributes.EXCEPTION_STACKTRACE]
+        )
         self.assertEqual(len(stack_trace), 1)
         self.assertEqual(stack_trace[0]["method"], "test_log_record_exception")
         self.assertEqual(stack_trace[0]["fileName"], __file__)

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import json
 import logging
 import unittest
 from unittest.mock import Mock
@@ -100,13 +98,13 @@ class TestLoggingHandler(unittest.TestCase):
             log_record.attributes[SpanAttributes.EXCEPTION_MESSAGE],
             "division by zero",
         )
-        stack_trace = json.loads(
-            log_record.attributes[SpanAttributes.EXCEPTION_STACKTRACE]
-        )
-        self.assertEqual(len(stack_trace), 1)
-        self.assertEqual(stack_trace[0]["method"], "test_log_record_exception")
-        self.assertEqual(stack_trace[0]["fileName"], __file__)
-        self.assertEqual(stack_trace[0]["text"], "div = 1 / 0")
+        stack_trace = log_record.attributes[SpanAttributes.EXCEPTION_STACKTRACE]
+        self.assertIsInstance(stack_trace, str)
+        self.assertTrue("Traceback" in stack_trace)
+        self.assertTrue("div = 1 / 0" in stack_trace)
+        self.assertTrue("ZeroDivisionError" in stack_trace)
+        self.assertTrue("division by zero" in stack_trace)
+        self.assertTrue(__file__ in stack_trace)
 
     def test_log_record_trace_correlation(self):
         emitter_mock = Mock(spec=LogEmitter)

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -82,8 +82,7 @@ class TestLoggingHandler(unittest.TestCase):
         emitter_mock = Mock(spec=LogEmitter)
         logger = get_logger(log_emitter=emitter_mock)
         try:
-            # pylint:disable=unused-variable
-            div = 1 / 0  # noqa: F841
+            raise ZeroDivisionError("division by zero")
         except ZeroDivisionError:
             logger.exception("Zero Division Error")
         args, _ = emitter_mock.emit.call_args_list[0]
@@ -104,7 +103,6 @@ class TestLoggingHandler(unittest.TestCase):
         ]
         self.assertIsInstance(stack_trace, str)
         self.assertTrue("Traceback" in stack_trace)
-        self.assertTrue("div = 1 / 0" in stack_trace)
         self.assertTrue("ZeroDivisionError" in stack_trace)
         self.assertTrue("division by zero" in stack_trace)
         self.assertTrue(__file__ in stack_trace)

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -84,8 +84,7 @@ class TestLoggingHandler(unittest.TestCase):
         emitter_mock = Mock(spec=LogEmitter)
         logger = get_logger(log_emitter=emitter_mock)
         try:
-            div = 1 / 0
-            print(div)
+            div = 1 / 0  # noqa: F841
         except ZeroDivisionError:
             logger.exception("Zero Division Error")
         args, _ = emitter_mock.emit.call_args_list[0]
@@ -107,7 +106,6 @@ class TestLoggingHandler(unittest.TestCase):
         self.assertEqual(len(stack_trace), 1)
         self.assertEqual(stack_trace[0]["method"], "test_log_record_exception")
         self.assertEqual(stack_trace[0]["fileName"], __file__)
-        # self.assertEqual(stack_trace[0]["line"], 87)
         self.assertEqual(stack_trace[0]["text"], "div = 1 / 0")
 
     def test_log_record_trace_correlation(self):

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -82,6 +82,7 @@ class TestLoggingHandler(unittest.TestCase):
         emitter_mock = Mock(spec=LogEmitter)
         logger = get_logger(log_emitter=emitter_mock)
         try:
+            # pylint:disable=unused-variable
             div = 1 / 0  # noqa: F841
         except ZeroDivisionError:
             logger.exception("Zero Division Error")

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -84,7 +84,7 @@ class TestLoggingHandler(unittest.TestCase):
         emitter_mock = Mock(spec=LogEmitter)
         logger = get_logger(log_emitter=emitter_mock)
         try:
-            div = 1/0
+            div = 1 / 0 
         except:
             logger.exception("Zero Division Error")
         args, _ = emitter_mock.emit.call_args_list[0]

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -85,7 +85,8 @@ class TestLoggingHandler(unittest.TestCase):
         logger = get_logger(log_emitter=emitter_mock)
         try:
             div = 1 / 0
-        except:
+            print(div)
+        except ZeroDivisionError:
             logger.exception("Zero Division Error")
         args, _ = emitter_mock.emit.call_args_list[0]
         log_record = args[0]

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -84,7 +84,7 @@ class TestLoggingHandler(unittest.TestCase):
         emitter_mock = Mock(spec=LogEmitter)
         logger = get_logger(log_emitter=emitter_mock)
         try:
-            div = 1 / 0
+            div = 1/0
         except:
             logger.exception("Zero Division Error")
         args, _ = emitter_mock.emit.call_args_list[0]
@@ -100,7 +100,6 @@ class TestLoggingHandler(unittest.TestCase):
             log_record.attributes[SpanAttributes.EXCEPTION_MESSAGE],
             "division by zero",
         )
-        print(log_record.attributes[SpanAttributes.EXCEPTION_STACKTRACE])
         stack_trace = json.loads(
             log_record.attributes[SpanAttributes.EXCEPTION_STACKTRACE]
         )


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-python/issues/2529

From specs:
Capture as attributes - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#errors-and-exceptions
Semantic conventions - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md#attributes