### PR TITLE
Fix delta histogram sum not being reset on collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2525](https://github.com/open-telemetry/opentelemetry-python/pull/2525))
 - Change OTLPHandler to LoggingHandler
   ([#2528](https://github.com/open-telemetry/opentelemetry-python/pull/2528))
+- Fix delta histogram sum not being reset on collection
+  ([#2533](https://github.com/open-telemetry/opentelemetry-python/pull/2533)) 
 
 ## [1.10.0-0.29b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.10.0-0.29b0) - 2022-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change OTLPHandler to LoggingHandler
   ([#2528](https://github.com/open-telemetry/opentelemetry-python/pull/2528))
 - Fix delta histogram sum not being reset on collection
-  ([#2533](https://github.com/open-telemetry/opentelemetry-python/pull/2533)) 
+  ([#2533](https://github.com/open-telemetry/opentelemetry-python/pull/2533))
 
 ## [1.10.0-0.29b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.10.0-0.29b0) - 2022-03-10
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/aggregation.py
@@ -191,9 +191,11 @@ class _ExplicitBucketHistogramAggregation(_Aggregation[Histogram]):
         with self._lock:
             value = self._bucket_counts
             start_time_unix_nano = self._start_time_unix_nano
+            histogram_sum = self._sum
 
             self._bucket_counts = self._get_empty_bucket_counts()
             self._start_time_unix_nano = now + 1
+            self._sum = 0
 
         return Histogram(
             start_time_unix_nano=start_time_unix_nano,
@@ -201,7 +203,7 @@ class _ExplicitBucketHistogramAggregation(_Aggregation[Histogram]):
             bucket_counts=tuple(value),
             explicit_bounds=self._boundaries,
             aggregation_temporality=AggregationTemporality.DELTA,
-            sum=self._sum,
+            sum=histogram_sum,
         )
 
 

--- a/opentelemetry-sdk/tests/metrics/test_aggregation.py
+++ b/opentelemetry-sdk/tests/metrics/test_aggregation.py
@@ -286,6 +286,7 @@ class TestExplicitBucketHistogramAggregation(TestCase):
         first_histogram = explicit_bucket_histogram_aggregation.collect()
 
         self.assertEqual(first_histogram.bucket_counts, (0, 1, 0, 0))
+        self.assertEqual(first_histogram.sum, 1)
 
         # CI fails the last assertion without this
         sleep(0.1)
@@ -294,6 +295,7 @@ class TestExplicitBucketHistogramAggregation(TestCase):
         second_histogram = explicit_bucket_histogram_aggregation.collect()
 
         self.assertEqual(second_histogram.bucket_counts, (0, 1, 0, 0))
+        self.assertEqual(second_histogram.sum, 1)
 
         self.assertGreater(
             second_histogram.time_unix_nano, first_histogram.time_unix_nano


### PR DESCRIPTION
# Description

This PR fixes an issue where `_ExplicitBucketHistogramAggregation` does not reset the `_sum` field on collection, even though it always creates an `AggregationTemporality.DELTA` histogram and resets `_bucket_counts` to an all-zero array. This caused `sum` values to be wrong on export for both `AggregationTemporality.DELTA` and `AggregationTemporality.CUMULATIVE`

Fixes #2532

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added missing assertions to unit test.

# Checklist:

- [ ] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
