### PR TITLE
[docs] add documentation for no-op components

### DIFF
--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -70,12 +70,15 @@ class MeterProvider(ABC):
 
 
 class NoOpMeterProvider(MeterProvider):
+    """The default MeterProvider used when no MeterProvider implementation is available."""
+
     def get_meter(
         self,
         name,
         version=None,
         schema_url=None,
     ) -> "Meter":
+        """Returns a NoOpMeter."""
         super().get_meter(name, version=version, schema_url=schema_url)
         return NoOpMeter(name, version=version, schema_url=schema_url)
 
@@ -347,13 +350,20 @@ class _ProxyMeter(Meter):
 
 
 class NoOpMeter(Meter):
+    """The default Meter used when no Meter implementation is available.
+
+    All operations are no-op.
+    """
+
     def create_counter(self, name, unit="", description="") -> Counter:
+        """Returns a no-op Counter."""
         super().create_counter(name, unit=unit, description=description)
         return DefaultCounter(name, unit=unit, description=description)
 
     def create_up_down_counter(
         self, name, unit="", description=""
     ) -> UpDownCounter:
+        """Returns a no-op UpDownCounter."""
         super().create_up_down_counter(
             name, unit=unit, description=description
         )
@@ -362,6 +372,7 @@ class NoOpMeter(Meter):
     def create_observable_counter(
         self, name, callback, unit="", description=""
     ) -> ObservableCounter:
+        """Returns a no-op ObservableCounter."""
         super().create_observable_counter(
             name, callback, unit=unit, description=description
         )
@@ -373,12 +384,14 @@ class NoOpMeter(Meter):
         )
 
     def create_histogram(self, name, unit="", description="") -> Histogram:
+        """Returns a no-op Histogram."""
         super().create_histogram(name, unit=unit, description=description)
         return DefaultHistogram(name, unit=unit, description=description)
 
     def create_observable_gauge(
         self, name, callback, unit="", description=""
     ) -> ObservableGauge:
+        """Returns a no-op ObservableGauge."""
         super().create_observable_gauge(
             name, callback, unit=unit, description=description
         )
@@ -392,6 +405,7 @@ class NoOpMeter(Meter):
     def create_observable_up_down_counter(
         self, name, callback, unit="", description=""
     ) -> ObservableUpDownCounter:
+        """Returns a no-op ObservableUpDownCounter."""
         super().create_observable_up_down_counter(
             name, callback, unit=unit, description=description
         )


### PR DESCRIPTION
This change covers NoOpMeterProvider, NoOpMeter.

Part of #2129
