### PR TITLE
Loosen up the dependency on backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2566](https://github.com/open-telemetry/opentelemetry-python/pull/2566))
 - Remove `enable_default_view` option from sdk MeterProvider
   ([#2547](https://github.com/open-telemetry/opentelemetry-python/pull/2547))
-- Update otlp-proto-grpc exporter to have more lax requirements for `backoff` lib
+- Update otlp-proto-grpc and otlp-proto-http exporters to have more lax requirements for `backoff` lib
   ([#2575](https://github.com/open-telemetry/opentelemetry-python/pull/2575))
 
 ## [1.10.0-0.29b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.10.0-0.29b0) - 2022-03-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2566](https://github.com/open-telemetry/opentelemetry-python/pull/2566))
 - Remove `enable_default_view` option from sdk MeterProvider
   ([#2547](https://github.com/open-telemetry/opentelemetry-python/pull/2547))
+- Update otlp-proto-grpc exporter to have more lax requirements for `backoff` lib
+  ([#2575](https://github.com/open-telemetry/opentelemetry-python/pull/2575))
 
 ## [1.10.0-0.29b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.10.0-0.29b0) - 2022-03-10
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     opentelemetry-api ~= 1.3
     opentelemetry-sdk ~= 1.10.0
     opentelemetry-proto == 1.10.0
-    backoff ~= 1.10.0
+    backoff >= 1.10.0, < 2.0.0
 
 [options.extras_require]
 test =

--- a/exporter/opentelemetry-exporter-otlp-proto-http/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     opentelemetry-api ~= 1.3
     opentelemetry-sdk ~= 1.3
     opentelemetry-proto == 1.10.0
-    backoff ~= 1.10.0
+    backoff >= 1.10.0, < 2.0.0
 
 [options.extras_require]
 test =


### PR DESCRIPTION
# Description

Updating backoff lib dependency for otpl-proto-grpc exporter to be more lax with version constraints. 

Fixes #2384 


