### PR TITLE
Attribute parent is not part of the Span Interface

### DIFF
--- a/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
+++ b/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
@@ -81,7 +81,9 @@ class JaegerPropagator(TextMapPropagator):
         if span_context == trace.INVALID_SPAN_CONTEXT:
             return
 
-        span_parent_id = span.parent.span_id if span.parent else 0
+        span_parent_id = (
+            span.parent.span_id if hasattr(span, parent) and span.parent else 0
+        )
         trace_flags = span_context.trace_flags
         if trace_flags.sampled:
             trace_flags |= self.DEBUG_FLAG

--- a/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
+++ b/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
@@ -82,7 +82,7 @@ class JaegerPropagator(TextMapPropagator):
             return
 
         span_parent_id = (
-            span.parent.span_id if hasattr(span, parent) and span.parent else 0
+            span.parent.span_id if hasattr(span, "parent") and span.parent else 0
         )
         trace_flags = span_context.trace_flags
         if trace_flags.sampled:


### PR DESCRIPTION
# Description

Not all span implementation have the parent attribute . For example, [NonRecordingSpan](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-api/src/opentelemetry/trace/span.py#L484-L534) don't have parent

When using ShimTracer , we can have NonRecordingSpan that is retrieved at propagator level 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test with ShimTracer + JaegerPropagator and then try to inject some

# Does This PR Require a Contrib Repo Change?

- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
