### PR TITLE
Fix dependencies for test utils

### DIFF
--- a/tests/opentelemetry-test-utils/setup.cfg
+++ b/tests/opentelemetry-test-utils/setup.cfg
@@ -40,9 +40,11 @@ packages=find_namespace:
 install_requires =
     opentelemetry-api ~= 1.3
     opentelemetry-sdk ~= 1.3
+    asgiref ~= 3.0
+    wsgiref ~= 0.1
 
 [options.extras_require]
-test = flask~=2.0
+test =
 
 [options.packages.find]
 where = src

--- a/tests/opentelemetry-test-utils/setup.cfg
+++ b/tests/opentelemetry-test-utils/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     opentelemetry-api ~= 1.3
     opentelemetry-sdk ~= 1.3
     asgiref ~= 3.0
-    wsgiref ~= 0.1
 
 [options.extras_require]
 test =

--- a/tox.ini
+++ b/tox.ini
@@ -198,6 +198,8 @@ commands_pre =
   python -m pip install -e {toxinidir}/opentelemetry-api[test]
   python -m pip install -e {toxinidir}/opentelemetry-semantic-conventions[test]
   python -m pip install -e {toxinidir}/opentelemetry-sdk[test]
+  # Pin protobuf version due to lint failing on v3.20.0
+  # https://github.com/protocolbuffers/protobuf/issues/9730
   python -m pip install protobuf==3.19.4
   python -m pip install -e {toxinidir}/opentelemetry-proto[test]
   python -m pip install -e {toxinidir}/tests/opentelemetry-test-utils[test]

--- a/tox.ini
+++ b/tox.ini
@@ -198,6 +198,7 @@ commands_pre =
   python -m pip install -e {toxinidir}/opentelemetry-api[test]
   python -m pip install -e {toxinidir}/opentelemetry-semantic-conventions[test]
   python -m pip install -e {toxinidir}/opentelemetry-sdk[test]
+  python -m pip install protobuf==3.19.4
   python -m pip install -e {toxinidir}/opentelemetry-proto[test]
   python -m pip install -e {toxinidir}/tests/opentelemetry-test-utils[test]
   python -m pip install -e {toxinidir}/shim/opentelemetry-opentracing-shim[test]


### PR DESCRIPTION
Removing `flask` as a dependency for `test-utils`. This was left in from a previous [PR](https://github.com/open-telemetry/opentelemetry-python/pull/206) but is no longer needed since we define dependencies for the flask instrumentation [here](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-flask/setup.py#L57) and `test-utils` itself does not use `flask`.

Adding `asgiref` as a dependency for `test-utils` because it uses that library. Previous builds have passed because the tests that use `asgiref` are only in the asgi instrumentation and it has a dependency on [asgiref](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-asgi/setup.cfg#L47) already defined.

Also pinning `protobuf` version for now since upgrading to protobuf v3.20.0 causes lint to [fail](https://github.com/open-telemetry/opentelemetry-python/runs/5822427748?check_suite_focus=true).

Opened an [issue](https://github.com/protocolbuffers/protobuf/issues/9730) on protobuf.