### PR TITLE
Fix dependency for otlp exporter

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     grpcio >= 1.0.0, < 2.0.0
     googleapis-common-protos ~= 1.52
     opentelemetry-api ~= 1.3
-    opentelemetry-sdk ~= 1.10.0
+    opentelemetry-sdk >= 1.10.0
     opentelemetry-proto == 1.10.0
     backoff >= 1.10.0, < 2.0.0
 


### PR DESCRIPTION
`opentelemetry-sdk ~= 1.10.0` prevents from upgrading to 1.11.0. Changing to greater than.

