### PR TITLE
Update dependency on testutil

### DIFF
--- a/tests/opentelemetry-test-utils/setup.cfg
+++ b/tests/opentelemetry-test-utils/setup.cfg
@@ -38,8 +38,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api ~= 1.3
-    opentelemetry-sdk ~= 1.3
+    opentelemetry-api == 1.10.0
+    opentelemetry-sdk == 1.10.0
     asgiref ~= 3.0
 
 [options.extras_require]


### PR DESCRIPTION
Installing ~1.3 dependency on testutil first causes tests for components to [fail](https://github.com/open-telemetry/opentelemetry-python-contrib/runs/6042307561?check_suite_focus=true) if installed first and the dependency for the component is not pinned. Pinning the version for `opentelemetry-api` and `opentelemetry-sdk` for testutils for now to avoid these complications. We should increase the versions  everytime we release now.