### PR TITLE
[opentelemetry-api] rename Default instruments to NoOp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.11.0-0.30b0...HEAD)
 
-- Rename Default (DefaultCounter, DefaultHistogram, DefaultObservableCounter,
-  DefaultObservableGauge, DefaultObservableUpDownCounter, DefaultUpDownCounter)
-  instruments to NoOp (NoOpCounter, NoOpHistogram, NoOpObservableCounter,
-  NoOpObservableGauge, NoOpObservableUpDownCounter, NoOpUpDownCounter)
+- Rename `DefaultCounter`, `DefaultHistogram`, `DefaultObservableCounter`,
+  `DefaultObservableGauge`, `DefaultObservableUpDownCounter`, `DefaultUpDownCounter`
+  instruments to `NoOpCounter`, `NoOpHistogram`, `NoOpObservableCounter`,
+  `NoOpObservableGauge`, `NoOpObservableUpDownCounter`, `NoOpUpDownCounter`
   ([#2616](https://github.com/open-telemetry/opentelemetry-python/pull/2616))
 
 ## [1.11.0-0.30b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.11.0-0.30b0) - 2022-04-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.11.0-0.30b0...HEAD)
 
+- Rename Default (DefaultCounter, DefaultHistogram, DefaultObservableCounter,
+  DefaultObservableGauge, DefaultObservableUpDownCounter, DefaultUpDownCounter)
+  instruments to NoOp (NoOpCounter, NoOpHistogram, NoOpObservableCounter,
+  NoOpObservableGauge, NoOpObservableUpDownCounter, NoOpUpDownCounter)
+  ([#2616](https://github.com/open-telemetry/opentelemetry-python/pull/2616))
+
 ## [1.11.0-0.30b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.11.0-0.30b0) - 2022-04-18
 
 - Add support for zero or more callbacks

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -30,12 +30,12 @@ from typing import List, Optional, Set, cast
 
 from opentelemetry._metrics.instrument import (
     Counter,
-    DefaultCounter,
-    DefaultHistogram,
-    DefaultObservableCounter,
-    DefaultObservableGauge,
-    DefaultObservableUpDownCounter,
-    DefaultUpDownCounter,
+    NoOpCounter,
+    NoOpHistogram,
+    NoOpObservableCounter,
+    NoOpObservableGauge,
+    NoOpObservableUpDownCounter,
+    NoOpUpDownCounter,
     Histogram,
     ObservableCounter,
     ObservableGauge,
@@ -423,7 +423,7 @@ class NoOpMeter(Meter):
     def create_counter(self, name, unit="", description="") -> Counter:
         """Returns a no-op Counter."""
         super().create_counter(name, unit=unit, description=description)
-        if self._check_instrument_id(name, DefaultCounter, unit, description):
+        if self._check_instrument_id(name, NoOpCounter, unit, description):
             _logger.warning(
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
@@ -432,7 +432,7 @@ class NoOpMeter(Meter):
                 unit,
                 description,
             )
-        return DefaultCounter(name, unit=unit, description=description)
+        return NoOpCounter(name, unit=unit, description=description)
 
     def create_up_down_counter(
         self, name, unit="", description=""
@@ -442,7 +442,7 @@ class NoOpMeter(Meter):
             name, unit=unit, description=description
         )
         if self._check_instrument_id(
-            name, DefaultUpDownCounter, unit, description
+            name, NoOpUpDownCounter, unit, description
         ):
             _logger.warning(
                 "An instrument with name %s, type %s, unit %s and "
@@ -452,7 +452,7 @@ class NoOpMeter(Meter):
                 unit,
                 description,
             )
-        return DefaultUpDownCounter(name, unit=unit, description=description)
+        return NoOpUpDownCounter(name, unit=unit, description=description)
 
     def create_observable_counter(
         self, name, callbacks=None, unit="", description=""
@@ -462,7 +462,7 @@ class NoOpMeter(Meter):
             name, callbacks, unit=unit, description=description
         )
         if self._check_instrument_id(
-            name, DefaultObservableCounter, unit, description
+            name, NoOpObservableCounter, unit, description
         ):
             _logger.warning(
                 "An instrument with name %s, type %s, unit %s and "
@@ -472,7 +472,7 @@ class NoOpMeter(Meter):
                 unit,
                 description,
             )
-        return DefaultObservableCounter(
+        return NoOpObservableCounter(
             name,
             callbacks,
             unit=unit,
@@ -482,9 +482,7 @@ class NoOpMeter(Meter):
     def create_histogram(self, name, unit="", description="") -> Histogram:
         """Returns a no-op Histogram."""
         super().create_histogram(name, unit=unit, description=description)
-        if self._check_instrument_id(
-            name, DefaultHistogram, unit, description
-        ):
+        if self._check_instrument_id(name, NoOpHistogram, unit, description):
             _logger.warning(
                 "An instrument with name %s, type %s, unit %s and "
                 "description %s has been created already.",
@@ -493,7 +491,7 @@ class NoOpMeter(Meter):
                 unit,
                 description,
             )
-        return DefaultHistogram(name, unit=unit, description=description)
+        return NoOpHistogram(name, unit=unit, description=description)
 
     def create_observable_gauge(
         self, name, callbacks=None, unit="", description=""
@@ -503,7 +501,7 @@ class NoOpMeter(Meter):
             name, callbacks, unit=unit, description=description
         )
         if self._check_instrument_id(
-            name, DefaultObservableGauge, unit, description
+            name, NoOpObservableGauge, unit, description
         ):
             _logger.warning(
                 "An instrument with name %s, type %s, unit %s and "
@@ -513,7 +511,7 @@ class NoOpMeter(Meter):
                 unit,
                 description,
             )
-        return DefaultObservableGauge(
+        return NoOpObservableGauge(
             name,
             callbacks,
             unit=unit,
@@ -528,7 +526,7 @@ class NoOpMeter(Meter):
             name, callbacks, unit=unit, description=description
         )
         if self._check_instrument_id(
-            name, DefaultObservableUpDownCounter, unit, description
+            name, NoOpObservableUpDownCounter, unit, description
         ):
             _logger.warning(
                 "An instrument with name %s, type %s, unit %s and "
@@ -538,7 +536,7 @@ class NoOpMeter(Meter):
                 unit,
                 description,
             )
-        return DefaultObservableUpDownCounter(
+        return NoOpObservableUpDownCounter(
             name,
             callbacks,
             unit=unit,

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -30,13 +30,13 @@ from typing import List, Optional, Set, cast
 
 from opentelemetry._metrics.instrument import (
     Counter,
+    Histogram,
     NoOpCounter,
     NoOpHistogram,
     NoOpObservableCounter,
     NoOpObservableGauge,
     NoOpObservableUpDownCounter,
     NoOpUpDownCounter,
-    Histogram,
     ObservableCounter,
     ObservableGauge,
     ObservableUpDownCounter,

--- a/opentelemetry-api/src/opentelemetry/_metrics/instrument.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/instrument.py
@@ -119,7 +119,7 @@ class Counter(_Monotonic, Synchronous):
         pass
 
 
-class DefaultCounter(Counter):
+class NoOpCounter(Counter):
     def __init__(self, name, unit="", description=""):
         super().__init__(name, unit=unit, description=description)
 
@@ -144,7 +144,7 @@ class UpDownCounter(_NonMonotonic, Synchronous):
         pass
 
 
-class DefaultUpDownCounter(UpDownCounter):
+class NoOpUpDownCounter(UpDownCounter):
     def __init__(self, name, unit="", description=""):
         super().__init__(name, unit=unit, description=description)
 
@@ -169,7 +169,7 @@ class ObservableCounter(_Monotonic, Asynchronous):
     """
 
 
-class DefaultObservableCounter(ObservableCounter):
+class NoOpObservableCounter(ObservableCounter):
     def __init__(self, name, callbacks=None, unit="", description=""):
         super().__init__(name, callbacks, unit=unit, description=description)
 
@@ -192,7 +192,7 @@ class ObservableUpDownCounter(_NonMonotonic, Asynchronous):
     """
 
 
-class DefaultObservableUpDownCounter(ObservableUpDownCounter):
+class NoOpObservableUpDownCounter(ObservableUpDownCounter):
     def __init__(self, name, callbacks=None, unit="", description=""):
         super().__init__(name, callbacks, unit=unit, description=description)
 
@@ -220,7 +220,7 @@ class Histogram(_Grouping, Synchronous):
         pass
 
 
-class DefaultHistogram(Histogram):
+class NoOpHistogram(Histogram):
     def __init__(self, name, unit="", description=""):
         super().__init__(name, unit=unit, description=description)
 
@@ -246,7 +246,7 @@ class ObservableGauge(_Grouping, Asynchronous):
     """
 
 
-class DefaultObservableGauge(ObservableGauge):
+class NoOpObservableGauge(ObservableGauge):
     def __init__(self, name, callbacks=None, unit="", description=""):
         super().__init__(name, callbacks, unit=unit, description=description)
 

--- a/opentelemetry-api/tests/metrics/test_instruments.py
+++ b/opentelemetry-api/tests/metrics/test_instruments.py
@@ -19,11 +19,11 @@ from unittest import TestCase
 from opentelemetry._metrics import Meter, NoOpMeter
 from opentelemetry._metrics.instrument import (
     Counter,
+    Histogram,
+    Instrument,
     NoOpCounter,
     NoOpHistogram,
     NoOpUpDownCounter,
-    Histogram,
-    Instrument,
     ObservableCounter,
     ObservableGauge,
     ObservableUpDownCounter,

--- a/opentelemetry-api/tests/metrics/test_instruments.py
+++ b/opentelemetry-api/tests/metrics/test_instruments.py
@@ -19,9 +19,9 @@ from unittest import TestCase
 from opentelemetry._metrics import Meter, NoOpMeter
 from opentelemetry._metrics.instrument import (
     Counter,
-    DefaultCounter,
-    DefaultHistogram,
-    DefaultUpDownCounter,
+    NoOpCounter,
+    NoOpHistogram,
+    NoOpUpDownCounter,
     Histogram,
     Instrument,
     ObservableCounter,
@@ -94,7 +94,7 @@ class TestCounter(TestCase):
 
         self.assertTrue(hasattr(Counter, "add"))
 
-        self.assertIsNone(DefaultCounter("name").add(1))
+        self.assertIsNone(NoOpCounter("name").add(1))
 
         add_signature = signature(Counter.add)
         self.assertIn("attributes", add_signature.parameters.keys())
@@ -262,7 +262,7 @@ class TestHistogram(TestCase):
 
         self.assertTrue(hasattr(Histogram, "record"))
 
-        self.assertIsNone(DefaultHistogram("name").record(1))
+        self.assertIsNone(NoOpHistogram("name").record(1))
 
         record_signature = signature(Histogram.record)
         self.assertIn("attributes", record_signature.parameters.keys())
@@ -273,7 +273,7 @@ class TestHistogram(TestCase):
             record_signature.parameters["amount"].default, Signature.empty
         )
 
-        self.assertIsNone(DefaultHistogram("name").record(1))
+        self.assertIsNone(NoOpHistogram("name").record(1))
 
 
 class TestObservableGauge(TestCase):
@@ -441,7 +441,7 @@ class TestUpDownCounter(TestCase):
 
         self.assertTrue(hasattr(UpDownCounter, "add"))
 
-        self.assertIsNone(DefaultUpDownCounter("name").add(1))
+        self.assertIsNone(NoOpUpDownCounter("name").add(1))
 
         add_signature = signature(UpDownCounter.add)
         self.assertIn("attributes", add_signature.parameters.keys())


### PR DESCRIPTION
To remain consistent with NoOpMeterProvider and NoOpMeter, the instruments they produce have been renamed as well.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Documentation has been updated
