### PR TITLE
fix(otlp): align with upstream pb definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instruments to `NoOpCounter`, `NoOpHistogram`, `NoOpObservableCounter`,
   `NoOpObservableGauge`, `NoOpObservableUpDownCounter`, `NoOpUpDownCounter`
   ([#2616](https://github.com/open-telemetry/opentelemetry-python/pull/2616))
+- Fix `InstrumentationLibrary` naming change
+  ([#2632](https://github.com/open-telemetry/opentelemetry-python/pull/2632))
 
 ## [1.11.0-0.30b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.11.0-0.30b0) - 2022-04-18
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
@@ -32,9 +32,9 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2_grpc import (
     TraceServiceStub,
 )
-from opentelemetry.proto.common.v1.common_pb2 import InstrumentationLibrary
+from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope
 from opentelemetry.proto.trace.v1.trace_pb2 import (
-    InstrumentationLibrarySpans,
+    ScopeSpans,
     ResourceSpans,
 )
 from opentelemetry.proto.trace.v1.trace_pb2 import Span as CollectorSpan
@@ -217,42 +217,42 @@ class OTLPSpanExporter(
     ) -> ExportTraceServiceRequest:
         # pylint: disable=attribute-defined-outside-init
 
-        sdk_resource_instrumentation_library_spans = {}
+        sdk_resource_scope_spans = {}
 
         for sdk_span in data:
-            instrumentation_library_spans_map = (
-                sdk_resource_instrumentation_library_spans.get(
+            scope_spans_map = (
+                sdk_resource_scope_spans.get(
                     sdk_span.resource, {}
                 )
             )
             # If we haven't seen the Resource yet, add it to the map
-            if not instrumentation_library_spans_map:
-                sdk_resource_instrumentation_library_spans[
+            if not scope_spans_map:
+                sdk_resource_scope_spans[
                     sdk_span.resource
-                ] = instrumentation_library_spans_map
-            instrumentation_library_spans = (
-                instrumentation_library_spans_map.get(
+                ] = scope_spans_map
+            scope_spans = (
+                scope_spans_map.get(
                     sdk_span.instrumentation_info
                 )
             )
             # If we haven't seen the InstrumentationInfo for this Resource yet, add it to the map
-            if not instrumentation_library_spans:
+            if not scope_spans:
                 if sdk_span.instrumentation_info is not None:
-                    instrumentation_library_spans_map[
+                    scope_spans_map[
                         sdk_span.instrumentation_info
-                    ] = InstrumentationLibrarySpans(
-                        instrumentation_library=InstrumentationLibrary(
+                    ] = ScopeSpans(
+                        scope=InstrumentationScope(
                             name=sdk_span.instrumentation_info.name,
                             version=sdk_span.instrumentation_info.version,
                         )
                     )
                 else:
                     # If no InstrumentationInfo, store in None key
-                    instrumentation_library_spans_map[
+                    scope_spans_map[
                         sdk_span.instrumentation_info
-                    ] = InstrumentationLibrarySpans()
-            instrumentation_library_spans = (
-                instrumentation_library_spans_map.get(
+                    ] = ScopeSpans()
+            scope_spans = (
+                scope_spans_map.get(
                     sdk_span.instrumentation_info
                 )
             )
@@ -289,13 +289,13 @@ class OTLPSpanExporter(
                 f"SPAN_KIND_{sdk_span.kind.name}",
             )
 
-            instrumentation_library_spans.spans.append(
+            scope_spans.spans.append(
                 CollectorSpan(**self._collector_kwargs)
             )
 
         return ExportTraceServiceRequest(
             resource_spans=get_resource_data(
-                sdk_resource_instrumentation_library_spans,
+                sdk_resource_scope_spans,
                 ResourceSpans,
                 "spans",
             )

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -40,14 +40,14 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2_grpc import (
 from opentelemetry.proto.common.v1.common_pb2 import (
     AnyValue,
     ArrayValue,
-    InstrumentationLibrary,
+    InstrumentationScope,
     KeyValue,
 )
 from opentelemetry.proto.resource.v1.resource_pb2 import (
     Resource as OTLPResource,
 )
 from opentelemetry.proto.trace.v1.trace_pb2 import (
-    InstrumentationLibrarySpans,
+    ScopeSpans,
     ResourceSpans,
 )
 from opentelemetry.proto.trace.v1.trace_pb2 import Span as OTLPSpan
@@ -493,9 +493,9 @@ class TestOTLPSpanExporter(TestCase):
                             ),
                         ]
                     ),
-                    instrumentation_library_spans=[
-                        InstrumentationLibrarySpans(
-                            instrumentation_library=InstrumentationLibrary(
+                    scope_spans=[
+                        ScopeSpans(
+                            scope=InstrumentationScope(
                                 name="name", version="version"
                             ),
                             spans=[
@@ -595,9 +595,9 @@ class TestOTLPSpanExporter(TestCase):
                             ),
                         ]
                     ),
-                    instrumentation_library_spans=[
-                        InstrumentationLibrarySpans(
-                            instrumentation_library=InstrumentationLibrary(
+                    scope_spans=[
+                        ScopeSpans(
+                            scope=InstrumentationScope(
                                 name="name", version="version"
                             ),
                             spans=[
@@ -677,8 +677,8 @@ class TestOTLPSpanExporter(TestCase):
                                 )
                             ],
                         ),
-                        InstrumentationLibrarySpans(
-                            instrumentation_library=InstrumentationLibrary(
+                        ScopeSpans(
+                            scope=InstrumentationScope(
                                 name="name2", version="version2"
                             ),
                             spans=[
@@ -717,9 +717,9 @@ class TestOTLPSpanExporter(TestCase):
                             ),
                         ]
                     ),
-                    instrumentation_library_spans=[
-                        InstrumentationLibrarySpans(
-                            instrumentation_library=InstrumentationLibrary(
+                    scope_spans=[
+                        ScopeSpans(
+                            scope=InstrumentationScope(
                                 name="name", version="version"
                             ),
                             spans=[
@@ -765,7 +765,7 @@ class TestOTLPSpanExporter(TestCase):
     ):
         status = (
             translated.resource_spans[0]
-            .instrumentation_library_spans[0]
+            .scope_spans[0]
             .spans[0]
             .status
         )
@@ -861,28 +861,28 @@ class TestOTLPSpanExporter(TestCase):
         self.assertEqual(
             1,
             translated.resource_spans[0]
-            .instrumentation_library_spans[0]
+            .scope_spans[0]
             .spans[0]
             .dropped_links_count,
         )
         self.assertEqual(
             2,
             translated.resource_spans[0]
-            .instrumentation_library_spans[0]
+            .scope_spans[0]
             .spans[0]
             .dropped_attributes_count,
         )
         self.assertEqual(
             3,
             translated.resource_spans[0]
-            .instrumentation_library_spans[0]
+            .scope_spans[0]
             .spans[0]
             .dropped_events_count,
         )
         self.assertEqual(
             2,
             translated.resource_spans[0]
-            .instrumentation_library_spans[0]
+            .scope_spans[0]
             .spans[0]
             .links[0]
             .dropped_attributes_count,
@@ -890,7 +890,7 @@ class TestOTLPSpanExporter(TestCase):
         self.assertEqual(
             2,
             translated.resource_spans[0]
-            .instrumentation_library_spans[0]
+            .scope_spans[0]
             .spans[0]
             .events[0]
             .dropped_attributes_count,

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/encoder/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/encoder/__init__.py
@@ -24,14 +24,14 @@ from opentelemetry.proto.common.v1.common_pb2 import (
     ArrayValue as PB2ArrayValue,
 )
 from opentelemetry.proto.common.v1.common_pb2 import (
-    InstrumentationLibrary as PB2InstrumentationLibrary,
+    InstrumentationScope as PB2InstrumentationScope,
 )
 from opentelemetry.proto.common.v1.common_pb2 import KeyValue as PB2KeyValue
 from opentelemetry.proto.resource.v1.resource_pb2 import (
     Resource as PB2Resource,
 )
 from opentelemetry.proto.trace.v1.trace_pb2 import (
-    InstrumentationLibrarySpans as PB2InstrumentationLibrarySpans,
+    ScopeSpans as PB2ScopeSpans,
 )
 from opentelemetry.proto.trace.v1.trace_pb2 import (
     ResourceSpans as PB2ResourceSpans,
@@ -79,7 +79,7 @@ def _encode_resource_spans(
     # We need to inspect the spans and group + structure them as:
     #
     #   Resource
-    #     Instrumentation Library
+    #     Scope Spans
     #       Spans
     #
     # First loop organizes the SDK spans in this structure. Protobuf messages
@@ -110,12 +110,12 @@ def _encode_resource_spans(
     pb2_resource_spans = []
 
     for sdk_resource, sdk_instrumentations in sdk_resource_spans.items():
-        instrumentation_library_spans = []
+        scope_spans = []
         for sdk_instrumentation, pb2_spans in sdk_instrumentations.items():
-            instrumentation_library_spans.append(
-                PB2InstrumentationLibrarySpans(
-                    instrumentation_library=(
-                        _encode_instrumentation_library(sdk_instrumentation)
+            scope_spans.append(
+                PB2ScopeSpans(
+                    scope=(
+                        _encode_instrumentation_scope(sdk_instrumentation)
                     ),
                     spans=pb2_spans,
                 )
@@ -123,7 +123,7 @@ def _encode_resource_spans(
         pb2_resource_spans.append(
             PB2ResourceSpans(
                 resource=_encode_resource(sdk_resource),
-                instrumentation_library_spans=instrumentation_library_spans,
+                scope_spans=scope_spans,
             )
         )
 
@@ -245,17 +245,17 @@ def _encode_resource(resource: Resource) -> PB2Resource:
     return pb2_resource
 
 
-def _encode_instrumentation_library(
+def _encode_instrumentation_scope(
     instrumentation_info: InstrumentationInfo,
-) -> PB2InstrumentationLibrary:
+) -> PB2InstrumentationScope:
     if instrumentation_info is None:
-        pb2_instrumentation_library = PB2InstrumentationLibrary()
+        pb2_instrumentation_scope = PB2InstrumentationScope()
     else:
-        pb2_instrumentation_library = PB2InstrumentationLibrary(
+        pb2_instrumentation_scope = PB2InstrumentationScope(
             name=instrumentation_info.name,
             version=instrumentation_info.version,
         )
-    return pb2_instrumentation_library
+    return pb2_instrumentation_scope
 
 
 def _encode_value(value: Any) -> PB2AnyValue:

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_protobuf_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_protobuf_encoder.py
@@ -29,14 +29,14 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
 )
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue as PB2AnyValue
 from opentelemetry.proto.common.v1.common_pb2 import (
-    InstrumentationLibrary as PB2InstrumentationLibrary,
+    InstrumentationScope as PB2InstrumentationScope,
 )
 from opentelemetry.proto.common.v1.common_pb2 import KeyValue as PB2KeyValue
 from opentelemetry.proto.resource.v1.resource_pb2 import (
     Resource as PB2Resource,
 )
 from opentelemetry.proto.trace.v1.trace_pb2 import (
-    InstrumentationLibrarySpans as PB2InstrumentationLibrarySpans,
+    ScopeSpans as PB2ScopeSpans,
 )
 from opentelemetry.proto.trace.v1.trace_pb2 import (
     ResourceSpans as PB2ResourceSpans,
@@ -178,9 +178,9 @@ class TestProtobufEncoder(unittest.TestCase):
             resource_spans=[
                 PB2ResourceSpans(
                     resource=PB2Resource(),
-                    instrumentation_library_spans=[
-                        PB2InstrumentationLibrarySpans(
-                            instrumentation_library=PB2InstrumentationLibrary(),
+                    scope_spans=[
+                        PB2ScopeSpans(
+                            scope=PB2InstrumentationScope(),
                             spans=[
                                 PB2SPan(
                                     trace_id=trace_id,
@@ -274,8 +274,8 @@ class TestProtobufEncoder(unittest.TestCase):
                                 )
                             ],
                         ),
-                        PB2InstrumentationLibrarySpans(
-                            instrumentation_library=PB2InstrumentationLibrary(
+                        PB2ScopeSpans(
+                            scope=PB2InstrumentationScope(
                                 name="name",
                                 version="version",
                             ),
@@ -313,9 +313,9 @@ class TestProtobufEncoder(unittest.TestCase):
                             )
                         ]
                     ),
-                    instrumentation_library_spans=[
-                        PB2InstrumentationLibrarySpans(
-                            instrumentation_library=PB2InstrumentationLibrary(),
+                    scope_spans=[
+                        PB2ScopeSpans(
+                            scope=PB2InstrumentationScope(),
                             spans=[
                                 PB2SPan(
                                     trace_id=trace_id,


### PR DESCRIPTION
# Description

fix opentelemetry-proto changing to resource span definition.

Ref: https://github.com/open-telemetry/opentelemetry-proto/pull/362

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
