### PR TITLE
Check instrument names and units

### DIFF
--- a/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
@@ -28,6 +28,7 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
+    Tuple
 )
 
 # pylint: disable=unused-import; needed for typing and sphinx

--- a/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
@@ -26,9 +26,9 @@ from typing import (
     Iterable,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
-    Tuple
 )
 
 # pylint: disable=unused-import; needed for typing and sphinx

--- a/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
@@ -61,8 +61,8 @@ class Instrument(ABC):
     ) -> None:
         pass
 
-    # pylint: disable=no-self-use
-    def _check_name_and_unit(self, name: str, unit: str) -> Tuple[bool, bool]:
+    @staticmethod
+    def _check_name_and_unit(name: str, unit: str) -> Tuple[bool, bool]:
         """
         Checks the following instrument name and unit for compliance with the
         spec.

--- a/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
@@ -17,6 +17,8 @@
 
 from abc import ABC, abstractmethod
 from logging import getLogger
+from re import ASCII
+from re import compile as re_compile
 from typing import (
     Callable,
     Generator,
@@ -42,6 +44,9 @@ CallbackT = Union[
 
 _logger = getLogger(__name__)
 
+_name_regex = re_compile(r"[a-zA-Z][-.\w]{0,62}", ASCII)
+_unit_regex = re_compile(r"\w{0,63}", ASCII)
+
 
 class Instrument(ABC):
     """Abstract class that serves as base for all instruments."""
@@ -55,9 +60,21 @@ class Instrument(ABC):
     ) -> None:
         pass
 
-        # FIXME check that the instrument name is valid
-        # FIXME check that the unit is 63 characters or shorter
-        # FIXME check that the unit contains only ASCII characters
+    # pylint: disable=no-self-use
+    def _check_name_and_unit(self, name: str, unit: str) -> tuple:
+        """
+        Checks the following instrument name and unit for compliance with the
+        spec.
+
+        Returns a tuple of boolean value, the first one will be `True` if the
+        name is valid, `False` otherwise. The second value will be `True` if
+        the unit is valid, `False` otherwise.
+        """
+
+        return (
+            _name_regex.fullmatch(name) is not None,
+            _unit_regex.fullmatch(unit) is not None,
+        )
 
 
 class _ProxyInstrument(ABC, Generic[InstrumentT]):
@@ -124,7 +141,6 @@ class Counter(Synchronous):
         amount: Union[int, float],
         attributes: Optional[Attributes] = None,
     ) -> None:
-        # FIXME check that the amount is non negative
         pass
 
 

--- a/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
@@ -61,7 +61,7 @@ class Instrument(ABC):
         pass
 
     # pylint: disable=no-self-use
-    def _check_name_and_unit(self, name: str, unit: str) -> tuple:
+    def _check_name_and_unit(self, name: str, unit: str) -> Tuple[bool, bool]:
         """
         Checks the following instrument name and unit for compliance with the
         spec.

--- a/opentelemetry-api/tests/metrics/test_instruments.py
+++ b/opentelemetry-api/tests/metrics/test_instruments.py
@@ -562,3 +562,25 @@ class TestObservableUpDownCounter(TestCase):
             ].default,
             Signature.empty,
         )
+
+    def test_name_regex(self):
+
+        instrument = ChildInstrument("name")
+
+        self.assertTrue(instrument._check_name_and_unit("a" * 63, "unit")[0])
+        self.assertTrue(instrument._check_name_and_unit("a.", "unit")[0])
+        self.assertTrue(instrument._check_name_and_unit("a-", "unit")[0])
+        self.assertTrue(instrument._check_name_and_unit("a_", "unit")[0])
+        self.assertFalse(instrument._check_name_and_unit("a" * 64, "unit")[0])
+        self.assertFalse(instrument._check_name_and_unit("Ñ", "unit")[0])
+        self.assertFalse(instrument._check_name_and_unit("_a", "unit")[0])
+        self.assertFalse(instrument._check_name_and_unit("1a", "unit")[0])
+        self.assertFalse(instrument._check_name_and_unit("", "unit")[0])
+
+    def test_unit_regex(self):
+
+        instrument = ChildInstrument("name")
+
+        self.assertTrue(instrument._check_name_and_unit("name", "a" * 63)[1])
+        self.assertFalse(instrument._check_name_and_unit("name", "a" * 64)[1])
+        self.assertFalse(instrument._check_name_and_unit("name", "Ñ")[1])

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/instrument.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/instrument.py
@@ -47,7 +47,15 @@ class _Synchronous:
         unit: str = "",
         description: str = "",
     ):
-        self.name = name
+        # pylint: disable=no-member
+        is_name_valid, is_unit_valid = self._check_name_and_unit(name, unit)
+
+        if not is_name_valid:
+            raise Exception(f"Invalid name received {name}")
+
+        if not is_unit_valid:
+            raise Exception(f"Invalid unit received {unit}")
+        self.name = name.lower()
         self.unit = unit
         self.description = description
         self.instrumentation_scope = instrumentation_scope
@@ -65,7 +73,15 @@ class _Asynchronous:
         unit: str = "",
         description: str = "",
     ):
-        self.name = name
+        # pylint: disable=no-member
+        is_name_valid, is_unit_valid = self._check_name_and_unit(name, unit)
+
+        if not is_name_valid:
+            raise Exception(f"Invalid name received {name}")
+
+        if not is_unit_valid:
+            raise Exception(f"Invalid unit received {unit}")
+        self.name = name.lower()
         self.unit = unit
         self.description = description
         self.instrumentation_scope = instrumentation_scope

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/instrument.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/instrument.py
@@ -38,6 +38,11 @@ if TYPE_CHECKING:
 _logger = getLogger(__name__)
 
 
+_ERROR_MESSAGE = (
+    "Expected ASCII string of maximum length 63 characters but got {}"
+)
+
+
 class _Synchronous:
     def __init__(
         self,
@@ -51,10 +56,10 @@ class _Synchronous:
         is_name_valid, is_unit_valid = self._check_name_and_unit(name, unit)
 
         if not is_name_valid:
-            raise Exception(f"Invalid name received {name}")
+            raise Exception(_ERROR_MESSAGE.format(name))
 
         if not is_unit_valid:
-            raise Exception(f"Invalid unit received {unit}")
+            raise Exception(_ERROR_MESSAGE.format(unit))
         self.name = name.lower()
         self.unit = unit
         self.description = description
@@ -77,10 +82,10 @@ class _Asynchronous:
         is_name_valid, is_unit_valid = self._check_name_and_unit(name, unit)
 
         if not is_name_valid:
-            raise Exception(f"Invalid name received {name}")
+            raise Exception(_ERROR_MESSAGE.format(name))
 
         if not is_unit_valid:
-            raise Exception(f"Invalid unit received {unit}")
+            raise Exception(_ERROR_MESSAGE.format(unit))
         self.name = name.lower()
         self.unit = unit
         self.description = description

--- a/opentelemetry-sdk/tests/metrics/test_aggregation.py
+++ b/opentelemetry-sdk/tests/metrics/test_aggregation.py
@@ -875,7 +875,7 @@ class TestDefaultAggregation(TestCase):
     def test_counter(self):
 
         aggregation = self.default_aggregation._create_aggregation(
-            Counter(Mock(), Mock(), Mock())
+            Counter("name", Mock(), Mock())
         )
         self.assertIsInstance(aggregation, _SumAggregation)
         self.assertTrue(aggregation._instrument_is_monotonic)
@@ -886,7 +886,7 @@ class TestDefaultAggregation(TestCase):
     def test_up_down_counter(self):
 
         aggregation = self.default_aggregation._create_aggregation(
-            UpDownCounter(Mock(), Mock(), Mock())
+            UpDownCounter("name", Mock(), Mock())
         )
         self.assertIsInstance(aggregation, _SumAggregation)
         self.assertFalse(aggregation._instrument_is_monotonic)
@@ -897,7 +897,7 @@ class TestDefaultAggregation(TestCase):
     def test_observable_counter(self):
 
         aggregation = self.default_aggregation._create_aggregation(
-            ObservableCounter(Mock(), Mock(), Mock(), callbacks=[Mock()])
+            ObservableCounter("name", Mock(), Mock(), callbacks=[Mock()])
         )
         self.assertIsInstance(aggregation, _SumAggregation)
         self.assertTrue(aggregation._instrument_is_monotonic)
@@ -909,7 +909,7 @@ class TestDefaultAggregation(TestCase):
     def test_observable_up_down_counter(self):
 
         aggregation = self.default_aggregation._create_aggregation(
-            ObservableUpDownCounter(Mock(), Mock(), Mock(), callbacks=[Mock()])
+            ObservableUpDownCounter("name", Mock(), Mock(), callbacks=[Mock()])
         )
         self.assertIsInstance(aggregation, _SumAggregation)
         self.assertFalse(aggregation._instrument_is_monotonic)
@@ -922,9 +922,7 @@ class TestDefaultAggregation(TestCase):
 
         aggregation = self.default_aggregation._create_aggregation(
             Histogram(
-                Mock(),
-                Mock(),
-                Mock(),
+                "name",
                 Mock(),
                 Mock(),
             )
@@ -935,7 +933,7 @@ class TestDefaultAggregation(TestCase):
 
         aggregation = self.default_aggregation._create_aggregation(
             ObservableGauge(
-                Mock(),
+                "name",
                 Mock(),
                 Mock(),
                 callbacks=[Mock()],

--- a/opentelemetry-sdk/tests/metrics/test_instrument.py
+++ b/opentelemetry-sdk/tests/metrics/test_instrument.py
@@ -28,6 +28,10 @@ from opentelemetry.sdk._metrics.measurement import Measurement
 
 
 class TestCounter(TestCase):
+    def testname(self):
+        self.assertEqual(Counter("name", Mock(), Mock()).name, "name")
+        self.assertEqual(Counter("Name", Mock(), Mock()).name, "name")
+
     def test_add(self):
         mc = Mock()
         counter = Counter("name", Mock(), mc)
@@ -91,6 +95,10 @@ def generator_callback_1():
 
 
 class TestObservableGauge(TestCase):
+    def testname(self):
+        self.assertEqual(ObservableGauge("name", Mock(), Mock()).name, "name")
+        self.assertEqual(ObservableGauge("Name", Mock(), Mock()).name, "name")
+
     def test_callable_callback_0(self):
         observable_gauge = ObservableGauge(
             "name", Mock(), Mock(), [callable_callback_0]


### PR DESCRIPTION
Fixes #2647

@lzchen we are intentionally leaving out `description` from these checks, since regular Python strings naturally support what is reuqired.