### PR TITLE
Refactor metric format

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
@@ -134,9 +134,8 @@ class OTLPMetricExporter(
                         unit=metric.unit,
                     )
 
-                    for data_point in metric.data.data_points:
-
-                        if isinstance(metric.data, Gauge):
+                    if isinstance(metric.data, Gauge):
+                        for data_point in metric.data.data_points:
                             pt = pb2.NumberDataPoint(
                                 attributes=self._translate_attributes(
                                     data_point.attributes
@@ -149,7 +148,8 @@ class OTLPMetricExporter(
                                 pt.as_double = data_point.value
                             pb2_metric.gauge.data_points.append(pt)
 
-                        elif isinstance(metric.data, Histogram):
+                    elif isinstance(metric.data, Histogram):
+                        for data_point in metric.data.data_points:
                             pt = pb2.HistogramDataPoint(
                                 attributes=self._translate_attributes(
                                     data_point.attributes
@@ -167,7 +167,9 @@ class OTLPMetricExporter(
                                 metric.data.aggregation_temporality
                             )
                             pb2_metric.histogram.data_points.append(pt)
-                        elif isinstance(metric.data, Sum):
+
+                    elif isinstance(metric.data, Sum):
+                        for data_point in metric.data.data_points:
                             pt = pb2.NumberDataPoint(
                                 attributes=self._translate_attributes(
                                     data_point.attributes
@@ -191,11 +193,11 @@ class OTLPMetricExporter(
                                 metric.data.is_monotonic
                             )
                             pb2_metric.sum.data_points.append(pt)
-                        else:
-                            _logger.warn(
-                                "unsupported datapoint type %s", metric.point
-                            )
-                            continue
+                    else:
+                        _logger.warn(
+                            "unsupported datapoint type %s", metric.point
+                        )
+                        continue
 
                     pb2_scope_metrics.metrics.append(pb2_metric)
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
@@ -105,20 +105,16 @@ class OTLPMetricExporter(
                     instrumentation_scope_pb2_scope_metrics
                 ):
 
-                    if instrumentation_scope is None:
-                        instrumentation_scope_pb2_scope_metrics[
-                            None
-                        ] = pb2.ScopeMetrics()
-
-                    else:
-                        instrumentation_scope_pb2_scope_metrics[
-                            instrumentation_scope
-                        ] = pb2.ScopeMetrics(
-                            scope=InstrumentationScope(
-                                name=instrumentation_scope.name,
-                                version=instrumentation_scope.version,
-                            )
+                    # instrumentation_scope comes from the meter, it is never
+                    # None.
+                    instrumentation_scope_pb2_scope_metrics[
+                        instrumentation_scope
+                    ] = pb2.ScopeMetrics(
+                        scope=InstrumentationScope(
+                            name=instrumentation_scope.name,
+                            version=instrumentation_scope.version,
                         )
+                    )
 
                 pb2_scope_metrics = instrumentation_scope_pb2_scope_metrics[
                     instrumentation_scope

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
@@ -104,20 +104,24 @@ class OTLPMetricExporter(
 
                 instrumentation_scope = scope_metrics.scope
 
-                if instrumentation_scope is None:
-                    instrumentation_scope_pb2_scope_metrics[
-                        None
-                    ] = pb2.ScopeMetrics()
+                if instrumentation_scope not in (
+                    instrumentation_scope_pb2_scope_metrics
+                ):
 
-                else:
-                    instrumentation_scope_pb2_scope_metrics[
-                        instrumentation_scope
-                    ] = pb2.ScopeMetrics(
-                        scope=InstrumentationScope(
-                            name=instrumentation_scope.name,
-                            version=instrumentation_scope.version,
+                    if instrumentation_scope is None:
+                        instrumentation_scope_pb2_scope_metrics[
+                            None
+                        ] = pb2.ScopeMetrics()
+
+                    else:
+                        instrumentation_scope_pb2_scope_metrics[
+                            instrumentation_scope
+                        ] = pb2.ScopeMetrics(
+                            scope=InstrumentationScope(
+                                name=instrumentation_scope.name,
+                                version=instrumentation_scope.version,
+                            )
                         )
-                    )
 
                 pb2_scope_metrics = instrumentation_scope_pb2_scope_metrics[
                     instrumentation_scope

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
@@ -101,24 +101,19 @@ class OTLPMetricExporter(
 
                 instrumentation_scope = scope_metrics.scope
 
-                if instrumentation_scope not in (
-                    instrumentation_scope_pb2_scope_metrics
-                ):
-
-                    # instrumentation_scope comes from the meter, it is never
-                    # None.
-                    instrumentation_scope_pb2_scope_metrics[
-                        instrumentation_scope
-                    ] = pb2.ScopeMetrics(
-                        scope=InstrumentationScope(
-                            name=instrumentation_scope.name,
-                            version=instrumentation_scope.version,
-                        )
+                # The SDK groups metrics in instrumentation scopes already so
+                # there is no need to check for existing instrumentation scopes
+                # here.
+                pb2_scope_metrics = pb2.ScopeMetrics(
+                    scope=InstrumentationScope(
+                        name=instrumentation_scope.name,
+                        version=instrumentation_scope.version,
                     )
+                )
 
-                pb2_scope_metrics = instrumentation_scope_pb2_scope_metrics[
+                instrumentation_scope_pb2_scope_metrics[
                     instrumentation_scope
-                ]
+                ] = pb2_scope_metrics
 
                 for metric in scope_metrics.metrics:
                     pb2_metric = pb2.Metric(

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
@@ -83,7 +83,7 @@ class OTLPMetricExporter(
         self, data: MetricsData
     ) -> ExportMetricsServiceRequest:
 
-        resource_instrumentation_scope_pb2_scope_metrics = {}
+        resource_metrics_dict = {}
 
         for resource_metrics in data.resource_metrics:
 
@@ -91,11 +91,9 @@ class OTLPMetricExporter(
 
             # It is safe to assume that each entry in data.resource_metrics is
             # associated with an unique resource.
-            instrumentation_scope_pb2_scope_metrics = {}
+            scope_metrics_dict = {}
 
-            resource_instrumentation_scope_pb2_scope_metrics[
-                resource
-            ] = instrumentation_scope_pb2_scope_metrics
+            resource_metrics_dict[resource] = scope_metrics_dict
 
             for scope_metrics in resource_metrics.scope_metrics:
 
@@ -111,9 +109,7 @@ class OTLPMetricExporter(
                     )
                 )
 
-                instrumentation_scope_pb2_scope_metrics[
-                    instrumentation_scope
-                ] = pb2_scope_metrics
+                scope_metrics_dict[instrumentation_scope] = pb2_scope_metrics
 
                 for metric in scope_metrics.metrics:
                     pb2_metric = pb2.Metric(
@@ -191,7 +187,7 @@ class OTLPMetricExporter(
 
         return ExportMetricsServiceRequest(
             resource_metrics=get_resource_data(
-                resource_instrumentation_scope_pb2_scope_metrics,
+                resource_metrics_dict,
                 pb2.ResourceMetrics,
                 "metrics",
             )

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
@@ -211,12 +211,12 @@ class OTLPMetricExporter(
 
     def export(
         self,
-        metrics: Sequence[Metric],
+        metrics_data: MetricsData,
         timeout_millis: float = 10_000,
         **kwargs,
     ) -> MetricExportResult:
         # TODO(#2663): OTLPExporterMixin should pass timeout to gRPC
-        return self._export(metrics)
+        return self._export(metrics_data)
 
     def shutdown(self, timeout_millis: float = 30_000, **kwargs) -> None:
         pass

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_metric_exporter/__init__.py
@@ -89,16 +89,13 @@ class OTLPMetricExporter(
 
             resource = resource_metrics.resource
 
-            instrumentation_scope_pb2_scope_metrics = (
-                resource_instrumentation_scope_pb2_scope_metrics.get(
-                    resource, {}
-                )
-            )
+            # It is safe to assume that each entry in data.resource_metrics is
+            # associated with an unique resource.
+            instrumentation_scope_pb2_scope_metrics = {}
 
-            if not instrumentation_scope_pb2_scope_metrics:
-                resource_instrumentation_scope_pb2_scope_metrics[
-                    resource
-                ] = instrumentation_scope_pb2_scope_metrics
+            resource_instrumentation_scope_pb2_scope_metrics[
+                resource
+            ] = instrumentation_scope_pb2_scope_metrics
 
             for scope_metrics in resource_metrics.scope_metrics:
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/metrics/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/metrics/test_otlp_metrics_exporter.py
@@ -268,22 +268,13 @@ class TestOTLPMetricExporter(TestCase):
                                 version="first_version",
                                 schema_url="insrumentation_scope_schema_url",
                             ),
-                            metrics=[histogram],
+                            metrics=[histogram, histogram],
                             schema_url="instrumentation_scope_schema_url",
                         ),
                         ScopeMetrics(
                             scope=SDKInstrumentationScope(
                                 name="second_name",
                                 version="second_version",
-                                schema_url="insrumentation_scope_schema_url",
-                            ),
-                            metrics=[histogram],
-                            schema_url="instrumentation_scope_schema_url",
-                        ),
-                        ScopeMetrics(
-                            scope=SDKInstrumentationScope(
-                                name="first_name",
-                                version="first_version",
                                 schema_url="insrumentation_scope_schema_url",
                             ),
                             metrics=[histogram],

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/metrics/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/metrics/test_otlp_metrics_exporter.py
@@ -254,6 +254,56 @@ class TestOTLPMetricExporter(TestCase):
             ),
         }
 
+        self.multiple_scope_histogram = MetricsData(
+            resource_metrics=[
+                ResourceMetrics(
+                    resource=Resource(
+                        attributes={"a": 1, "b": False},
+                        schema_url="resource_schema_url",
+                    ),
+                    scope_metrics=[
+                        ScopeMetrics(
+                            scope=SDKInstrumentationScope(
+                                name="first_name",
+                                version="first_version",
+                                schema_url="insrumentation_scope_schema_url",
+                            ),
+                            metrics=[histogram],
+                            schema_url="instrumentation_scope_schema_url",
+                        ),
+                        ScopeMetrics(
+                            scope=SDKInstrumentationScope(
+                                name="second_name",
+                                version="second_version",
+                                schema_url="insrumentation_scope_schema_url",
+                            ),
+                            metrics=[histogram],
+                            schema_url="instrumentation_scope_schema_url",
+                        ),
+                        ScopeMetrics(
+                            scope=SDKInstrumentationScope(
+                                name="first_name",
+                                version="first_version",
+                                schema_url="insrumentation_scope_schema_url",
+                            ),
+                            metrics=[histogram],
+                            schema_url="instrumentation_scope_schema_url",
+                        ),
+                        ScopeMetrics(
+                            scope=SDKInstrumentationScope(
+                                name="third_name",
+                                version="third_version",
+                                schema_url="insrumentation_scope_schema_url",
+                            ),
+                            metrics=[histogram],
+                            schema_url="instrumentation_scope_schema_url",
+                        ),
+                    ],
+                    schema_url="resource_schema_url",
+                )
+            ]
+        )
+
     def tearDown(self):
         self.server.stop(None)
 
@@ -692,4 +742,182 @@ class TestOTLPMetricExporter(TestCase):
         )
         # pylint: disable=protected-access
         actual = self.exporter._translate_data(self.metrics["histogram"])
+        self.assertEqual(expected, actual)
+
+    def test_translate_multiple_scope_histogram(self):
+        expected = ExportMetricsServiceRequest(
+            resource_metrics=[
+                pb2.ResourceMetrics(
+                    resource=OTLPResource(
+                        attributes=[
+                            KeyValue(key="a", value=AnyValue(int_value=1)),
+                            KeyValue(
+                                key="b", value=AnyValue(bool_value=False)
+                            ),
+                        ]
+                    ),
+                    scope_metrics=[
+                        pb2.ScopeMetrics(
+                            scope=InstrumentationScope(
+                                name="first_name", version="first_version"
+                            ),
+                            metrics=[
+                                pb2.Metric(
+                                    name="histogram",
+                                    unit="s",
+                                    description="foo",
+                                    histogram=pb2.Histogram(
+                                        data_points=[
+                                            pb2.HistogramDataPoint(
+                                                attributes=[
+                                                    KeyValue(
+                                                        key="a",
+                                                        value=AnyValue(
+                                                            int_value=1
+                                                        ),
+                                                    ),
+                                                    KeyValue(
+                                                        key="b",
+                                                        value=AnyValue(
+                                                            bool_value=True
+                                                        ),
+                                                    ),
+                                                ],
+                                                start_time_unix_nano=1641946016139533244,
+                                                time_unix_nano=1641946016139533244,
+                                                count=5,
+                                                sum=67,
+                                                bucket_counts=[1, 4],
+                                                explicit_bounds=[10.0, 20.0],
+                                                exemplars=[],
+                                                flags=pb2.DataPointFlags.FLAG_NONE,
+                                            )
+                                        ],
+                                        aggregation_temporality=AggregationTemporality.DELTA,
+                                    ),
+                                ),
+                                pb2.Metric(
+                                    name="histogram",
+                                    unit="s",
+                                    description="foo",
+                                    histogram=pb2.Histogram(
+                                        data_points=[
+                                            pb2.HistogramDataPoint(
+                                                attributes=[
+                                                    KeyValue(
+                                                        key="a",
+                                                        value=AnyValue(
+                                                            int_value=1
+                                                        ),
+                                                    ),
+                                                    KeyValue(
+                                                        key="b",
+                                                        value=AnyValue(
+                                                            bool_value=True
+                                                        ),
+                                                    ),
+                                                ],
+                                                start_time_unix_nano=1641946016139533244,
+                                                time_unix_nano=1641946016139533244,
+                                                count=5,
+                                                sum=67,
+                                                bucket_counts=[1, 4],
+                                                explicit_bounds=[10.0, 20.0],
+                                                exemplars=[],
+                                                flags=pb2.DataPointFlags.FLAG_NONE,
+                                            )
+                                        ],
+                                        aggregation_temporality=AggregationTemporality.DELTA,
+                                    ),
+                                ),
+                            ],
+                        ),
+                        pb2.ScopeMetrics(
+                            scope=InstrumentationScope(
+                                name="second_name", version="second_version"
+                            ),
+                            metrics=[
+                                pb2.Metric(
+                                    name="histogram",
+                                    unit="s",
+                                    description="foo",
+                                    histogram=pb2.Histogram(
+                                        data_points=[
+                                            pb2.HistogramDataPoint(
+                                                attributes=[
+                                                    KeyValue(
+                                                        key="a",
+                                                        value=AnyValue(
+                                                            int_value=1
+                                                        ),
+                                                    ),
+                                                    KeyValue(
+                                                        key="b",
+                                                        value=AnyValue(
+                                                            bool_value=True
+                                                        ),
+                                                    ),
+                                                ],
+                                                start_time_unix_nano=1641946016139533244,
+                                                time_unix_nano=1641946016139533244,
+                                                count=5,
+                                                sum=67,
+                                                bucket_counts=[1, 4],
+                                                explicit_bounds=[10.0, 20.0],
+                                                exemplars=[],
+                                                flags=pb2.DataPointFlags.FLAG_NONE,
+                                            )
+                                        ],
+                                        aggregation_temporality=AggregationTemporality.DELTA,
+                                    ),
+                                )
+                            ],
+                        ),
+                        pb2.ScopeMetrics(
+                            scope=InstrumentationScope(
+                                name="third_name", version="third_version"
+                            ),
+                            metrics=[
+                                pb2.Metric(
+                                    name="histogram",
+                                    unit="s",
+                                    description="foo",
+                                    histogram=pb2.Histogram(
+                                        data_points=[
+                                            pb2.HistogramDataPoint(
+                                                attributes=[
+                                                    KeyValue(
+                                                        key="a",
+                                                        value=AnyValue(
+                                                            int_value=1
+                                                        ),
+                                                    ),
+                                                    KeyValue(
+                                                        key="b",
+                                                        value=AnyValue(
+                                                            bool_value=True
+                                                        ),
+                                                    ),
+                                                ],
+                                                start_time_unix_nano=1641946016139533244,
+                                                time_unix_nano=1641946016139533244,
+                                                count=5,
+                                                sum=67,
+                                                bucket_counts=[1, 4],
+                                                explicit_bounds=[10.0, 20.0],
+                                                exemplars=[],
+                                                flags=pb2.DataPointFlags.FLAG_NONE,
+                                            )
+                                        ],
+                                        aggregation_temporality=AggregationTemporality.DELTA,
+                                    ),
+                                )
+                            ],
+                        ),
+                    ],
+                )
+            ]
+        )
+        # pylint: disable=protected-access
+        actual = self.exporter._translate_data(self.multiple_scope_histogram)
         self.assertEqual(expected, actual)

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
@@ -242,10 +242,7 @@ class _CustomCollector:
                         [pre_metric_family_id, CounterMetricFamily.__name__]
                     )
 
-                    if (
-                        metric_family_id
-                        not in metric_family_id_metric_family
-                    ):
+                    if metric_family_id not in metric_family_id_metric_family:
                         metric_family_id_metric_family[
                             metric_family_id
                         ] = CounterMetricFamily(

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
@@ -244,7 +244,7 @@ class _CustomCollector:
 
                     if (
                         metric_family_id
-                        not in metric_family_id_metric_family.keys()
+                        not in metric_family_id_metric_family
                     ):
                         metric_family_id_metric_family[
                             metric_family_id

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -91,10 +91,12 @@ class TestPrometheusMetricReader(TestCase):
                     resource=Mock(),
                     scope_metrics=[
                         ScopeMetrics(
-                            scope=Mock(), metrics=[metric], schema_url=Mock()
+                            scope=Mock(),
+                            metrics=[metric],
+                            schema_url="schema_url"
                         )
                     ],
-                    schema_url=Mock(),
+                    schema_url="schema_url",
                 )
             ]
         )
@@ -134,10 +136,12 @@ class TestPrometheusMetricReader(TestCase):
                     resource=Mock(),
                     scope_metrics=[
                         ScopeMetrics(
-                            scope=Mock(), metrics=[metric], schema_url=Mock()
+                            scope=Mock(),
+                            metrics=[metric],
+                            schema_url="schema_url"
                         )
                     ],
-                    schema_url=Mock(),
+                    schema_url="schema_url",
                 )
             ]
         )
@@ -177,10 +181,12 @@ class TestPrometheusMetricReader(TestCase):
                     resource=Mock(),
                     scope_metrics=[
                         ScopeMetrics(
-                            scope=Mock(), metrics=[metric], schema_url=Mock()
+                            scope=Mock(),
+                            metrics=[metric],
+                            schema_url="schema_url"
                         )
                     ],
-                    schema_url=Mock(),
+                    schema_url="schema_url",
                 )
             ]
         )
@@ -240,10 +246,12 @@ class TestPrometheusMetricReader(TestCase):
                     resource=Mock(),
                     scope_metrics=[
                         ScopeMetrics(
-                            scope=Mock(), metrics=[metric], schema_url=Mock()
+                            scope=Mock(),
+                            metrics=[metric],
+                            schema_url="schema_url"
                         )
                     ],
-                    schema_url=Mock(),
+                    schema_url="schema_url",
                 )
             ]
         )

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -93,7 +93,7 @@ class TestPrometheusMetricReader(TestCase):
                         ScopeMetrics(
                             scope=Mock(),
                             metrics=[metric],
-                            schema_url="schema_url"
+                            schema_url="schema_url",
                         )
                     ],
                     schema_url="schema_url",
@@ -138,7 +138,7 @@ class TestPrometheusMetricReader(TestCase):
                         ScopeMetrics(
                             scope=Mock(),
                             metrics=[metric],
-                            schema_url="schema_url"
+                            schema_url="schema_url",
                         )
                     ],
                     schema_url="schema_url",
@@ -183,7 +183,7 @@ class TestPrometheusMetricReader(TestCase):
                         ScopeMetrics(
                             scope=Mock(),
                             metrics=[metric],
-                            schema_url="schema_url"
+                            schema_url="schema_url",
                         )
                     ],
                     schema_url="schema_url",
@@ -248,7 +248,7 @@ class TestPrometheusMetricReader(TestCase):
                         ScopeMetrics(
                             scope=Mock(),
                             metrics=[metric],
-                            schema_url="schema_url"
+                            schema_url="schema_url",
                         )
                     ],
                     schema_url="schema_url",

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 from textwrap import dedent
-from unittest import mock
+from unittest import TestCase
+from unittest.mock import Mock, patch
 
 from prometheus_client import generate_latest
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
@@ -23,19 +23,26 @@ from opentelemetry.exporter.prometheus import (
     PrometheusMetricReader,
     _CustomCollector,
 )
-from opentelemetry.sdk._metrics.export import AggregationTemporality, Histogram
+from opentelemetry.sdk._metrics.export import (
+    AggregationTemporality,
+    Histogram,
+    HistogramDataPoint,
+    Metric,
+    MetricsData,
+    ResourceMetrics,
+    ScopeMetrics,
+)
 from opentelemetry.test.metrictestutil import (
     _generate_gauge,
-    _generate_metric,
     _generate_sum,
     _generate_unsupported_metric,
 )
 
 
-class TestPrometheusMetricReader(unittest.TestCase):
+class TestPrometheusMetricReader(TestCase):
     def setUp(self):
-        self._mock_registry_register = mock.Mock()
-        self._registry_register_patch = mock.patch(
+        self._mock_registry_register = Mock()
+        self._registry_register_patch = patch(
             "prometheus_client.core.REGISTRY.register",
             side_effect=self._mock_registry_register,
         )
@@ -49,7 +56,7 @@ class TestPrometheusMetricReader(unittest.TestCase):
             self.assertTrue(self._mock_registry_register.called)
 
     def test_shutdown(self):
-        with mock.patch(
+        with patch(
             "prometheus_client.core.REGISTRY.unregister"
         ) as registry_unregister_patch:
             exporter = PrometheusMetricReader()
@@ -57,23 +64,43 @@ class TestPrometheusMetricReader(unittest.TestCase):
             self.assertTrue(registry_unregister_patch.called)
 
     def test_histogram_to_prometheus(self):
-        record = _generate_metric(
-            "test@name",
-            Histogram(
-                aggregation_temporality=AggregationTemporality.CUMULATIVE,
-                bucket_counts=[1, 3, 2],
-                explicit_bounds=[123.0, 456.0],
-                start_time_unix_nano=1641946016139533244,
-                max=457,
-                min=1,
-                sum=579.0,
-                time_unix_nano=1641946016139533244,
+        metric = Metric(
+            name="test@name",
+            description="foo",
+            unit="s",
+            data=Histogram(
+                data_points=[
+                    HistogramDataPoint(
+                        attributes={"histo": 1},
+                        start_time_unix_nano=1641946016139533244,
+                        time_unix_nano=1641946016139533244,
+                        count=6,
+                        sum=579.0,
+                        bucket_counts=[1, 3, 2],
+                        explicit_bounds=[123.0, 456.0],
+                        min=1,
+                        max=457,
+                    )
+                ],
+                aggregation_temporality=AggregationTemporality.DELTA,
             ),
-            attributes={"histo": 1},
+        )
+        metrics_data = MetricsData(
+            resource_metrics=[
+                ResourceMetrics(
+                    resource=Mock(),
+                    scope_metrics=[
+                        ScopeMetrics(
+                            scope=Mock(), metrics=[metric], schema_url=Mock()
+                        )
+                    ],
+                    schema_url=Mock(),
+                )
+            ]
         )
 
         collector = _CustomCollector("testprefix")
-        collector.add_metrics_data([record])
+        collector.add_metrics_data(metrics_data)
         result_bytes = generate_latest(collector)
         result = result_bytes.decode("utf-8")
         self.assertEqual(
@@ -93,15 +120,30 @@ class TestPrometheusMetricReader(unittest.TestCase):
 
     def test_sum_to_prometheus(self):
         labels = {"environment@": "staging", "os": "Windows"}
-        record = _generate_sum(
+        metric = _generate_sum(
             "test@sum",
             123,
             attributes=labels,
             description="testdesc",
             unit="testunit",
         )
+
+        metrics_data = MetricsData(
+            resource_metrics=[
+                ResourceMetrics(
+                    resource=Mock(),
+                    scope_metrics=[
+                        ScopeMetrics(
+                            scope=Mock(), metrics=[metric], schema_url=Mock()
+                        )
+                    ],
+                    schema_url=Mock(),
+                )
+            ]
+        )
+
         collector = _CustomCollector("testprefix")
-        collector.add_metrics_data([record])
+        collector.add_metrics_data(metrics_data)
 
         for prometheus_metric in collector.collect():
             self.assertEqual(type(prometheus_metric), CounterMetricFamily)
@@ -121,15 +163,30 @@ class TestPrometheusMetricReader(unittest.TestCase):
 
     def test_gauge_to_prometheus(self):
         labels = {"environment@": "dev", "os": "Unix"}
-        record = _generate_gauge(
+        metric = _generate_gauge(
             "test@gauge",
             123,
             attributes=labels,
             description="testdesc",
             unit="testunit",
         )
+
+        metrics_data = MetricsData(
+            resource_metrics=[
+                ResourceMetrics(
+                    resource=Mock(),
+                    scope_metrics=[
+                        ScopeMetrics(
+                            scope=Mock(), metrics=[metric], schema_url=Mock()
+                        )
+                    ],
+                    schema_url=Mock(),
+                )
+            ]
+        )
+
         collector = _CustomCollector("testprefix")
-        collector.add_metrics_data([record])
+        collector.add_metrics_data(metrics_data)
 
         for prometheus_metric in collector.collect():
             self.assertEqual(type(prometheus_metric), GaugeMetricFamily)
@@ -170,15 +227,28 @@ class TestPrometheusMetricReader(unittest.TestCase):
 
     def test_list_labels(self):
         labels = {"environment@": ["1", "2", "3"], "os": "Unix"}
-        record = _generate_gauge(
+        metric = _generate_gauge(
             "test@gauge",
             123,
             attributes=labels,
             description="testdesc",
             unit="testunit",
         )
+        metrics_data = MetricsData(
+            resource_metrics=[
+                ResourceMetrics(
+                    resource=Mock(),
+                    scope_metrics=[
+                        ScopeMetrics(
+                            scope=Mock(), metrics=[metric], schema_url=Mock()
+                        )
+                    ],
+                    schema_url=Mock(),
+                )
+            ]
+        )
         collector = _CustomCollector("testprefix")
-        collector.add_metrics_data([record])
+        collector.add_metrics_data(metrics_data)
 
         for prometheus_metric in collector.collect():
             self.assertEqual(type(prometheus_metric), GaugeMetricFamily)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/_view_instrument_match.py
@@ -22,16 +22,11 @@ from opentelemetry.sdk._metrics._internal.aggregation import (
     Aggregation,
     DefaultAggregation,
     _Aggregation,
-    _convert_aggregation_temporality,
-    _PointVarT,
     _SumAggregation,
 )
 from opentelemetry.sdk._metrics._internal.export import AggregationTemporality
 from opentelemetry.sdk._metrics._internal.measurement import Measurement
-from opentelemetry.sdk._metrics._internal.point import Metric
-from opentelemetry.sdk._metrics._internal.sdk_configuration import (
-    SdkConfiguration,
-)
+from opentelemetry.sdk._metrics._internal.point import DataPointT
 from opentelemetry.sdk._metrics._internal.view import View
 
 _logger = getLogger(__name__)
@@ -42,17 +37,12 @@ class _ViewInstrumentMatch:
         self,
         view: View,
         instrument: Instrument,
-        sdk_config: SdkConfiguration,
-        instrument_class_temporality: Dict[type, AggregationTemporality],
         instrument_class_aggregation: Dict[type, Aggregation],
     ):
         self._view = view
         self._instrument = instrument
-        self._sdk_config = sdk_config
         self._attributes_aggregation: Dict[frozenset, _Aggregation] = {}
-        self._attributes_previous_point: Dict[frozenset, _PointVarT] = {}
         self._lock = Lock()
-        self._instrument_class_temporality = instrument_class_temporality
         self._instrument_class_aggregation = instrument_class_aggregation
         self._name = self._view._name or self._instrument.name
         self._description = (
@@ -124,46 +114,15 @@ class _ViewInstrumentMatch:
 
         self._attributes_aggregation[attributes].aggregate(measurement)
 
-    def collect(self) -> Iterable[Metric]:
+    def collect(
+        self, aggregation_temporality: AggregationTemporality
+    ) -> Iterable[DataPointT]:
 
+        data_points = []
         with self._lock:
-            for (
-                attributes,
-                aggregation,
-            ) in self._attributes_aggregation.items():
-
-                previous_point = self._attributes_previous_point.get(
-                    attributes
+            for aggregation in self._attributes_aggregation.values():
+                data_points.append(
+                    aggregation.collect(aggregation_temporality)
                 )
 
-                current_point = aggregation.collect()
-
-                # pylint: disable=assignment-from-none
-
-                self._attributes_previous_point[
-                    attributes
-                ] = _convert_aggregation_temporality(
-                    previous_point,
-                    current_point,
-                    AggregationTemporality.CUMULATIVE,
-                )
-
-                if current_point is not None:
-
-                    yield Metric(
-                        attributes=dict(attributes),
-                        description=self._description,
-                        instrumentation_scope=(
-                            self._instrument.instrumentation_scope
-                        ),
-                        name=self._name,
-                        resource=self._sdk_config.resource,
-                        unit=self._instrument.unit,
-                        point=_convert_aggregation_temporality(
-                            previous_point,
-                            current_point,
-                            self._instrument_class_temporality[
-                                self._instrument.__class__
-                            ],
-                        ),
-                    )
+        return data_points

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/_view_instrument_match.py
@@ -118,11 +118,6 @@ class _ViewInstrumentMatch:
         self, aggregation_temporality: AggregationTemporality
     ) -> Iterable[DataPointT]:
 
-        data_points = []
         with self._lock:
             for aggregation in self._attributes_aggregation.values():
-                data_points.append(
-                    aggregation.collect(aggregation_temporality)
-                )
-
-        return data_points
+                yield aggregation.collect(aggregation_temporality)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/export/__init__.py
@@ -19,7 +19,7 @@ from logging import getLogger
 from os import environ, linesep
 from sys import stdout
 from threading import Event, RLock, Thread
-from typing import IO, Callable, Dict, Iterable, Optional, Sequence
+from typing import IO, Callable, Dict, Iterable, Optional
 
 from typing_extensions import final
 
@@ -43,6 +43,7 @@ from opentelemetry.sdk._metrics._internal.instrument import (
     ObservableUpDownCounter,
     UpDownCounter,
 )
+from opentelemetry.sdk._metrics._internal.point import MetricsData
 from opentelemetry.sdk.environment_variables import (
     _OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
 )
@@ -71,7 +72,7 @@ class MetricExporter(ABC):
     @abstractmethod
     def export(
         self,
-        metrics: Sequence["opentelemetry.sdk._metrics.export.Metric"],
+        metrics_data: MetricsData,
         timeout_millis: float = 10_000,
         **kwargs,
     ) -> MetricExportResult:
@@ -113,12 +114,11 @@ class ConsoleMetricExporter(MetricExporter):
 
     def export(
         self,
-        metrics: Sequence["opentelemetry.sdk._metrics.export.Metric"],
+        metrics_data: MetricsData,
         timeout_millis: float = 10_000,
         **kwargs,
     ) -> MetricExportResult:
-        for metric in metrics:
-            self.out.write(self.formatter(metric))
+        self.out.write(self.formatter(metrics_data))
         self.out.flush()
         return MetricExportResult.SUCCESS
 
@@ -393,7 +393,7 @@ class PeriodicExportingMetricReader(MetricReader):
 
     def _receive_metrics(
         self,
-        metrics_data: "opentelemetry.sdk._metrics.export.MetricsData",
+        metrics_data: MetricsData,
         timeout_millis: float = 10_000,
         **kwargs,
     ) -> None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/export/__init__.py
@@ -19,7 +19,7 @@ from logging import getLogger
 from os import environ, linesep
 from sys import stdout
 from threading import Event, RLock, Thread
-from typing import IO, Callable, Dict, Iterable, List, Optional, Sequence
+from typing import IO, Callable, Dict, Iterable, Optional, Sequence
 
 from typing_extensions import final
 
@@ -262,7 +262,7 @@ class MetricReader(ABC):
     @abstractmethod
     def _receive_metrics(
         self,
-        metrics: Iterable["opentelemetry.sdk._metrics.export.Metric"],
+        metrics_data: "opentelemetry.sdk._metrics.export.MetricsData",
         timeout_millis: float = 10_000,
         **kwargs,
     ) -> None:
@@ -283,7 +283,7 @@ class MetricReader(ABC):
 
 
 class InMemoryMetricReader(MetricReader):
-    """Implementation of `MetricReader` that returns its metrics from :func:`get_metrics`.
+    """Implementation of `MetricReader` that returns its metrics from :func:`get_metrics_data`.
 
     This is useful for e.g. unit tests.
     """
@@ -300,24 +300,28 @@ class InMemoryMetricReader(MetricReader):
             preferred_aggregation=preferred_aggregation,
         )
         self._lock = RLock()
-        self._metrics: List["opentelemetry.sdk._metrics.export.Metric"] = []
+        self._metrics_data: (
+            "opentelemetry.sdk._metrics.export.MetricsData"
+        ) = None
 
-    def get_metrics(self) -> List["opentelemetry.sdk._metrics.export.Metric"]:
+    def get_metrics_data(
+        self,
+    ) -> ("opentelemetry.sdk._metrics.export.MetricsData"):
         """Reads and returns current metrics from the SDK"""
         with self._lock:
             self.collect()
-            metrics = self._metrics
-            self._metrics = []
-        return metrics
+            metrics_data = self._metrics_data
+            self._metrics_data = None
+        return metrics_data
 
     def _receive_metrics(
         self,
-        metrics: Iterable["opentelemetry.sdk._metrics.export.Metric"],
+        metrics_data: "opentelemetry.sdk._metrics.export.MetricsData",
         timeout_millis: float = 10_000,
         **kwargs,
     ) -> None:
         with self._lock:
-            self._metrics = list(metrics)
+            self._metrics_data = metrics_data
 
     def shutdown(self, timeout_millis: float = 30_000, **kwargs) -> None:
         pass
@@ -389,15 +393,15 @@ class PeriodicExportingMetricReader(MetricReader):
 
     def _receive_metrics(
         self,
-        metrics: Iterable["opentelemetry.sdk._metrics.export.Metric"],
+        metrics_data: "opentelemetry.sdk._metrics.export.MetricsData",
         timeout_millis: float = 10_000,
         **kwargs,
     ) -> None:
-        if metrics is None:
+        if metrics_data is None:
             return
         token = attach(set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
         try:
-            self._exporter.export(metrics, timeout_millis=timeout_millis)
+            self._exporter.export(metrics_data, timeout_millis=timeout_millis)
         except Exception as e:  # pylint: disable=broad-except,invalid-name
             _logger.exception("Exception while exporting metrics %s", str(e))
         detach(token)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/metric_reader_storage.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/metric_reader_storage.py
@@ -217,12 +217,9 @@ class MetricReaderStorage:
             resource_metrics=[
                 ResourceMetrics(
                     resource=self._sdk_config.resource,
-                    scope_metrics=[
-                        scope_metrics
-                        for scope_metrics in (
-                            instrumentation_scope_scope_metrics.values()
-                        )
-                    ],
+                    scope_metrics=list(
+                        instrumentation_scope_scope_metrics.values()
+                    ),
                     schema_url=self._sdk_config.resource.schema_url,
                 )
             ]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/point.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/point.py
@@ -26,17 +26,38 @@ from opentelemetry.util.types import Attributes
 
 
 @dataclass(frozen=True)
+class NumberDataPoint:
+    """Single data point in a timeseries that describes the time-varying scalar
+    value of a metric.
+    """
+
+    attributes: Attributes
+    start_time_unix_nano: int
+    time_unix_nano: int
+    value: Union[int, float]
+
+
+@dataclass(frozen=True)
 class Sum:
     """Represents the type of a scalar metric that is calculated as a sum of
     all reported measurements over a time interval."""
 
+    data_points: Sequence[NumberDataPoint]
     aggregation_temporality: (
         "opentelemetry.sdk._metrics.export.AggregationTemporality"
     )
     is_monotonic: bool
-    start_time_unix_nano: int
-    time_unix_nano: int
-    value: Union[int, float]
+
+    def to_json(self) -> str:
+        return dumps(
+            {
+                "data_points": dumps(
+                    [asdict(data_point) for data_point in self.data_points]
+                ),
+                "aggregation_temporality": self.aggregation_temporality,
+                "is_monotonic": self.is_monotonic,
+            }
+        )
 
 
 @dataclass(frozen=True)
@@ -45,8 +66,33 @@ class Gauge:
     value for every data point. It should be used for an unknown
     aggregation."""
 
+    data_points: Sequence[NumberDataPoint]
+
+    def to_json(self) -> str:
+        return dumps(
+            {
+                "data_points": dumps(
+                    [asdict(data_point) for data_point in self.data_points]
+                )
+            }
+        )
+
+
+@dataclass(frozen=True)
+class HistogramDataPoint:
+    """Single data point in a timeseries that describes the time-varying scalar
+    value of a metric.
+    """
+
+    attributes: Attributes
+    start_time_unix_nano: int
     time_unix_nano: int
-    value: Union[int, float]
+    count: int
+    sum: Union[int, float]
+    bucket_counts: Sequence[int]
+    explicit_bounds: Sequence[float]
+    min: float
+    max: float
 
 
 @dataclass(frozen=True)
@@ -54,52 +100,67 @@ class Histogram:
     """Represents the type of a metric that is calculated by aggregating as a
     histogram of all reported measurements over a time interval."""
 
+    data_points: Sequence[HistogramDataPoint]
     aggregation_temporality: (
         "opentelemetry.sdk._metrics.export.AggregationTemporality"
     )
-    bucket_counts: Sequence[int]
-    explicit_bounds: Sequence[float]
-    max: int
-    min: int
-    start_time_unix_nano: int
-    sum: Union[int, float]
-    time_unix_nano: int
-
-
-PointT = Union[Sum, Gauge, Histogram]
-
-
-@dataclass(frozen=True)
-class Metric:
-    """Represents a metric point in the OpenTelemetry data model to be exported
-
-    Concrete metric types contain all the information as in the OTLP proto definitions
-    (https://github.com/open-telemetry/opentelemetry-proto/blob/b43e9b18b76abf3ee040164b55b9c355217151f3/opentelemetry/proto/metrics/v1/metrics.proto#L37) but are flattened as much as possible.
-    """
-
-    # common fields to all metric kinds
-    attributes: Attributes
-    description: str
-    instrumentation_scope: InstrumentationScope
-    name: str
-    resource: Resource
-    unit: str
-    point: PointT
-    """Contains non-common fields for the given metric"""
 
     def to_json(self) -> str:
         return dumps(
             {
-                "attributes": self.attributes if self.attributes else "",
-                "description": self.description if self.description else "",
-                "instrumentation_scope": repr(self.instrumentation_scope)
-                if self.instrumentation_scope
-                else "",
-                "name": self.name,
-                "resource": repr(self.resource.attributes)
-                if self.resource
-                else "",
-                "unit": self.unit if self.unit else "",
-                "point": asdict(self.point) if self.point else "",
+                "data_points": dumps(
+                    [asdict(data_point) for data_point in self.data_points]
+                ),
+                "aggregation_temporality": self.aggregation_temporality,
             }
         )
+
+
+DataT = Union[Sum, Gauge, Histogram]
+DataPointT = Union[NumberDataPoint, HistogramDataPoint]
+
+
+@dataclass(frozen=True)
+class Metric:
+    """Represents a metric point in the OpenTelemetry data model to be
+    exported."""
+
+    name: str
+    description: str
+    unit: str
+    data: DataT
+
+    def to_json(self) -> str:
+        return dumps(
+            {
+                "name": self.name,
+                "description": self.description if self.description else "",
+                "unit": self.unit if self.unit else "",
+                "data": self.data.to_json(),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class ScopeMetrics:
+    """A collection of Metrics produced by a scope"""
+
+    scope: InstrumentationScope
+    metrics: Sequence[Metric]
+    schema_url: str
+
+
+@dataclass(frozen=True)
+class ResourceMetrics:
+    """A collection of ScopeMetrics from a Resource"""
+
+    resource: Resource
+    scope_metrics: Sequence[ScopeMetrics]
+    schema_url: str
+
+
+@dataclass(frozen=True)
+class MetricsData:
+    """An array of ResourceMetrics"""
+
+    resource_metrics: Sequence[ResourceMetrics]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/export/__init__.py
@@ -44,9 +44,7 @@ from opentelemetry.sdk._metrics._internal.point import (  # noqa: F401
 __all__ = []
 for key, value in globals().copy().items():
     if not key.startswith("_"):
-        if _version_info.minor == 6:
-            try:
-                value.__module__ = __name__
-            except AttributeError:
-                pass
+        if _version_info.minor == 6 and key in ["DataPointT", "DataT"]:
+            continue
+        value.__module__ = __name__
         __all__.append(key)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/export/__init__.py
@@ -28,17 +28,25 @@ from opentelemetry.sdk._metrics._internal.export import (  # noqa: F401
 
 # The point module is not in the export directory to avoid a circular import.
 from opentelemetry.sdk._metrics._internal.point import (  # noqa: F401
+    DataPointT,
+    DataT,
     Gauge,
     Histogram,
+    HistogramDataPoint,
     Metric,
-    PointT,
+    MetricsData,
+    NumberDataPoint,
+    ResourceMetrics,
+    ScopeMetrics,
     Sum,
 )
 
 __all__ = []
 for key, value in globals().copy().items():
     if not key.startswith("_"):
-        if _version_info.minor == 6 and key == "PointT":
-            continue
-        value.__module__ = __name__
+        if _version_info.minor == 6:
+            try:
+                value.__module__ = __name__
+            except AttributeError:
+                pass
         __all__.append(key)

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_disable_default_views.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_disable_default_views.py
@@ -31,8 +31,15 @@ class TestDisableDefaultViews(TestCase):
         counter.add(10, {"label": "value1"})
         counter.add(10, {"label": "value2"})
         counter.add(10, {"label": "value3"})
-
-        self.assertEqual(reader.get_metrics(), [])
+        self.assertEqual(
+            (
+                reader.get_metrics_data()
+                .resource_metrics[0]
+                .scope_metrics[0]
+                .metrics
+            ),
+            [],
+        )
 
     def test_disable_default_views_add_custom(self):
         reader = InMemoryMetricReader()
@@ -51,6 +58,16 @@ class TestDisableDefaultViews(TestCase):
         counter.add(10, {"label": "value3"})
         histogram.record(12, {"label": "value"})
 
-        metrics = reader.get_metrics()
-        self.assertEqual(len(metrics), 1)
-        self.assertEqual(metrics[0].name, "testhist")
+        metrics = reader.get_metrics_data()
+        self.assertEqual(len(metrics.resource_metrics), 1)
+        self.assertEqual(len(metrics.resource_metrics[0].scope_metrics), 2)
+        self.assertEqual(
+            len(metrics.resource_metrics[0].scope_metrics[0].metrics), 0
+        )
+        self.assertEqual(
+            len(metrics.resource_metrics[0].scope_metrics[1].metrics), 1
+        )
+        self.assertEqual(
+            metrics.resource_metrics[0].scope_metrics[1].metrics[0].name,
+            "testhist",
+        )

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_disable_default_views.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_disable_default_views.py
@@ -60,14 +60,11 @@ class TestDisableDefaultViews(TestCase):
 
         metrics = reader.get_metrics_data()
         self.assertEqual(len(metrics.resource_metrics), 1)
-        self.assertEqual(len(metrics.resource_metrics[0].scope_metrics), 2)
+        self.assertEqual(len(metrics.resource_metrics[0].scope_metrics), 1)
         self.assertEqual(
-            len(metrics.resource_metrics[0].scope_metrics[0].metrics), 0
+            len(metrics.resource_metrics[0].scope_metrics[0].metrics), 1
         )
         self.assertEqual(
-            len(metrics.resource_metrics[0].scope_metrics[1].metrics), 1
-        )
-        self.assertEqual(
-            metrics.resource_metrics[0].scope_metrics[1].metrics[0].name,
+            metrics.resource_metrics[0].scope_metrics[0].metrics[0].name,
             "testhist",
         )

--- a/opentelemetry-sdk/tests/metrics/test_backward_compat.py
+++ b/opentelemetry-sdk/tests/metrics/test_backward_compat.py
@@ -100,8 +100,14 @@ class TestBackwardCompat(TestCase):
         # produce some data
         meter_provider.get_meter("foo").create_counter("mycounter").add(12)
         try:
-            metrics = reader.get_metrics()
+            metrics_data = reader.get_metrics_data()
         except Exception:
             self.fail()
 
-        self.assertEqual(len(metrics), 1)
+        self.assertEqual(len(metrics_data.resource_metrics), 1)
+        self.assertEqual(
+            len(metrics_data.resource_metrics[0].scope_metrics), 1
+        )
+        self.assertEqual(
+            len(metrics_data.resource_metrics[0].scope_metrics[0].metrics), 1
+        )

--- a/opentelemetry-sdk/tests/metrics/test_import.py
+++ b/opentelemetry-sdk/tests/metrics/test_import.py
@@ -46,15 +46,21 @@ class TestImport(TestCase):
             from opentelemetry.sdk._metrics.export import (  # noqa: F401
                 AggregationTemporality,
                 ConsoleMetricExporter,
+                DataPointT,
+                DataT,
                 Gauge,
                 Histogram,
+                HistogramDataPoint,
                 InMemoryMetricReader,
                 Metric,
                 MetricExporter,
                 MetricExportResult,
                 MetricReader,
+                MetricsData,
+                NumberDataPoint,
                 PeriodicExportingMetricReader,
-                PointT,
+                ResourceMetrics,
+                ScopeMetrics,
                 Sum,
             )
         except Exception as error:

--- a/opentelemetry-sdk/tests/metrics/test_in_memory_metric_reader.py
+++ b/opentelemetry-sdk/tests/metrics/test_in_memory_metric_reader.py
@@ -86,19 +86,23 @@ class TestInMemoryMetricReader(TestCase):
         )
         self.assertEqual(
             len(
-                metrics.resource_metrics[0]
-                .scope_metrics[0]
-                .metrics[0]
-                .data.data_points
+                list(
+                    metrics.resource_metrics[0]
+                    .scope_metrics[0]
+                    .metrics[0]
+                    .data.data_points
+                )
             ),
             2,
         )
         self.assertEqual(
             len(
-                metrics.resource_metrics[0]
-                .scope_metrics[0]
-                .metrics[1]
-                .data.data_points
+                list(
+                    metrics.resource_metrics[0]
+                    .scope_metrics[0]
+                    .metrics[1]
+                    .data.data_points
+                )
             ),
             1,
         )

--- a/opentelemetry-sdk/tests/metrics/test_in_memory_metric_reader.py
+++ b/opentelemetry-sdk/tests/metrics/test_in_memory_metric_reader.py
@@ -21,10 +21,9 @@ from opentelemetry.sdk._metrics.export import (
     AggregationTemporality,
     InMemoryMetricReader,
     Metric,
+    NumberDataPoint,
     Sum,
 )
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 
 
 class TestInMemoryMetricReader(TestCase):
@@ -32,21 +31,23 @@ class TestInMemoryMetricReader(TestCase):
         mock_collect_callback = Mock(return_value=[])
         reader = InMemoryMetricReader()
         reader._set_collect_callback(mock_collect_callback)
-        self.assertEqual(reader.get_metrics(), [])
+        self.assertEqual(reader.get_metrics_data(), [])
         mock_collect_callback.assert_called_once()
 
     def test_converts_metrics_to_list(self):
         metric = Metric(
-            attributes={"myattr": "baz"},
-            description="",
-            instrumentation_scope=InstrumentationScope("testmetrics"),
             name="foo",
-            resource=Resource.create(),
+            description="",
             unit="",
-            point=Sum(
-                start_time_unix_nano=1647626444152947792,
-                time_unix_nano=1647626444153163239,
-                value=72.3309814450449,
+            data=Sum(
+                data_points=[
+                    NumberDataPoint(
+                        attributes={"myattr": "baz"},
+                        start_time_unix_nano=1647626444152947792,
+                        time_unix_nano=1647626444153163239,
+                        value=72.3309814450449,
+                    )
+                ],
                 aggregation_temporality=AggregationTemporality.CUMULATIVE,
                 is_monotonic=True,
             ),
@@ -55,9 +56,9 @@ class TestInMemoryMetricReader(TestCase):
         reader = InMemoryMetricReader()
         reader._set_collect_callback(mock_collect_callback)
 
-        returned_metrics = reader.get_metrics()
+        returned_metrics = reader.get_metrics_data()
         mock_collect_callback.assert_called_once()
-        self.assertIsInstance(returned_metrics, list)
+        self.assertIsInstance(returned_metrics, tuple)
         self.assertEqual(len(returned_metrics), 1)
         self.assertIs(returned_metrics[0], metric)
 
@@ -76,6 +77,31 @@ class TestInMemoryMetricReader(TestCase):
         counter1.add(1, {"foo": "1"})
         counter1.add(1, {"foo": "2"})
 
-        metrics = reader.get_metrics()
-        # should be 3 metrics, one from the observable gauge and one for each labelset from the counter
-        self.assertEqual(len(metrics), 3)
+        metrics = reader.get_metrics_data()
+        # should be 3 number data points, one from the observable gauge and one
+        # for each labelset from the counter
+        self.assertEqual(len(metrics.resource_metrics[0].scope_metrics), 2)
+        self.assertEqual(
+            len(metrics.resource_metrics[0].scope_metrics[0].metrics), 1
+        )
+        self.assertEqual(
+            len(metrics.resource_metrics[0].scope_metrics[1].metrics), 1
+        )
+        self.assertEqual(
+            len(
+                metrics.resource_metrics[0]
+                .scope_metrics[1]
+                .metrics[0]
+                .data.data_points
+            ),
+            1,
+        )
+        self.assertEqual(
+            len(
+                metrics.resource_metrics[0]
+                .scope_metrics[0]
+                .metrics[0]
+                .data.data_points
+            ),
+            2,
+        )

--- a/opentelemetry-sdk/tests/metrics/test_in_memory_metric_reader.py
+++ b/opentelemetry-sdk/tests/metrics/test_in_memory_metric_reader.py
@@ -80,21 +80,9 @@ class TestInMemoryMetricReader(TestCase):
         metrics = reader.get_metrics_data()
         # should be 3 number data points, one from the observable gauge and one
         # for each labelset from the counter
-        self.assertEqual(len(metrics.resource_metrics[0].scope_metrics), 2)
+        self.assertEqual(len(metrics.resource_metrics[0].scope_metrics), 1)
         self.assertEqual(
-            len(metrics.resource_metrics[0].scope_metrics[0].metrics), 1
-        )
-        self.assertEqual(
-            len(metrics.resource_metrics[0].scope_metrics[1].metrics), 1
-        )
-        self.assertEqual(
-            len(
-                metrics.resource_metrics[0]
-                .scope_metrics[1]
-                .metrics[0]
-                .data.data_points
-            ),
-            1,
+            len(metrics.resource_metrics[0].scope_metrics[0].metrics), 2
         )
         self.assertEqual(
             len(
@@ -104,4 +92,13 @@ class TestInMemoryMetricReader(TestCase):
                 .data.data_points
             ),
             2,
+        )
+        self.assertEqual(
+            len(
+                metrics.resource_metrics[0]
+                .scope_metrics[0]
+                .metrics[1]
+                .data.data_points
+            ),
+            1,
         )

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -514,11 +514,11 @@ class TestDuplicateInstrumentAggregateData(TestCase):
         self.assertEqual(metric_0.name, "counter")
         self.assertEqual(metric_0.unit, "unit")
         self.assertEqual(metric_0.description, "description")
-        self.assertEqual(metric_0.data.data_points[0].value, 3)
+        self.assertEqual(next(metric_0.data.data_points).value, 3)
 
         metric_1 = scope_metrics[1].metrics[0]
 
         self.assertEqual(metric_1.name, "counter")
         self.assertEqual(metric_1.unit, "unit")
         self.assertEqual(metric_1.description, "description")
-        self.assertEqual(metric_1.data.data_points[0].value, 7)
+        self.assertEqual(next(metric_1.data.data_points).value, 7)

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -506,18 +506,19 @@ class TestDuplicateInstrumentAggregateData(TestCase):
 
         metrics = exporter.metrics[0]
 
-        self.assertEqual(len(metrics), 2)
+        scope_metrics = metrics.resource_metrics[0].scope_metrics
+        self.assertEqual(len(scope_metrics), 2)
 
-        metric_0 = metrics[0]
+        metric_0 = scope_metrics[0].metrics[0]
 
         self.assertEqual(metric_0.name, "counter")
         self.assertEqual(metric_0.unit, "unit")
         self.assertEqual(metric_0.description, "description")
-        self.assertEqual(metric_0.point.value, 3)
+        self.assertEqual(metric_0.data.data_points[0].value, 3)
 
-        metric_1 = metrics[1]
+        metric_1 = scope_metrics[1].metrics[0]
 
         self.assertEqual(metric_1.name, "counter")
         self.assertEqual(metric_1.unit, "unit")
         self.assertEqual(metric_1.description, "description")
-        self.assertEqual(metric_1.point.value, 7)
+        self.assertEqual(metric_1.data.data_points[0].value, 7)

--- a/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
+++ b/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
@@ -23,10 +23,10 @@ from opentelemetry.sdk._metrics.export import (
     Metric,
     MetricExporter,
     MetricExportResult,
+    NumberDataPoint,
     PeriodicExportingMetricReader,
     Sum,
 )
-from opentelemetry.sdk.resources import Resource
 from opentelemetry.test.concurrency_test import ConcurrencyTestBase
 from opentelemetry.util._time import _time_ns
 
@@ -54,29 +54,34 @@ class FakeMetricsExporter(MetricExporter):
 metrics_list = [
     Metric(
         name="sum_name",
-        attributes={},
         description="",
-        instrumentation_scope=None,
-        resource=Resource.create(),
         unit="",
-        point=Sum(
-            start_time_unix_nano=_time_ns(),
-            time_unix_nano=_time_ns(),
-            value=2,
+        data=Sum(
+            data_points=[
+                NumberDataPoint(
+                    attributes={},
+                    start_time_unix_nano=_time_ns(),
+                    time_unix_nano=_time_ns(),
+                    value=2,
+                )
+            ],
             aggregation_temporality=1,
             is_monotonic=True,
         ),
     ),
     Metric(
         name="gauge_name",
-        attributes={},
         description="",
-        instrumentation_scope=None,
-        resource=Resource.create(),
         unit="",
-        point=Gauge(
-            time_unix_nano=_time_ns(),
-            value=2,
+        data=Gauge(
+            data_points=[
+                NumberDataPoint(
+                    attributes={},
+                    start_time_unix_nano=_time_ns(),
+                    time_unix_nano=_time_ns(),
+                    value=2,
+                )
+            ]
         ),
     ),
 ]

--- a/opentelemetry-sdk/tests/metrics/test_point.py
+++ b/opentelemetry-sdk/tests/metrics/test_point.py
@@ -14,22 +14,22 @@
 
 from unittest import TestCase
 
-from opentelemetry.sdk._metrics.export import Gauge, Histogram, Metric, Sum
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+from opentelemetry.sdk._metrics.export import (
+    Gauge,
+    Histogram,
+    HistogramDataPoint,
+    Metric,
+    NumberDataPoint,
+    Sum,
+)
 
 
-def _create_metric(value):
+def _create_metric(data):
     return Metric(
-        attributes={"attr-key": "test-val"},
-        description="test-description",
-        instrumentation_scope=InstrumentationScope(
-            name="name", version="version"
-        ),
         name="test-name",
-        resource=Resource({"resource-key": "resource-val"}),
+        description="test-description",
         unit="test-unit",
-        point=value,
+        data=data,
     )
 
 
@@ -38,40 +38,62 @@ class TestDatapointToJSON(TestCase):
         self.maxDiff = None
         point = _create_metric(
             Sum(
+                data_points=[
+                    NumberDataPoint(
+                        attributes={"attr-key": "test-val"},
+                        start_time_unix_nano=10,
+                        time_unix_nano=20,
+                        value=9,
+                    )
+                ],
                 aggregation_temporality=2,
                 is_monotonic=True,
-                start_time_unix_nano=10,
-                time_unix_nano=20,
-                value=9,
             )
         )
         self.assertEqual(
-            '{"attributes": {"attr-key": "test-val"}, "description": "test-description", "instrumentation_scope": "InstrumentationScope(name, version, None)", "name": "test-name", "resource": "BoundedAttributes({\'resource-key\': \'resource-val\'}, maxlen=None)", "unit": "test-unit", "point": {"aggregation_temporality": 2, "is_monotonic": true, "start_time_unix_nano": 10, "time_unix_nano": 20, "value": 9}}',
+            '{"name": "test-name", "description": "test-description", "unit": "test-unit", "data": "{\\"data_points\\": \\"[{\\\\\\"attributes\\\\\\": {\\\\\\"attr-key\\\\\\": \\\\\\"test-val\\\\\\"}, \\\\\\"start_time_unix_nano\\\\\\": 10, \\\\\\"time_unix_nano\\\\\\": 20, \\\\\\"value\\\\\\": 9}]\\", \\"aggregation_temporality\\": 2, \\"is_monotonic\\": true}"}',
             point.to_json(),
         )
 
     def test_gauge(self):
-        point = _create_metric(Gauge(time_unix_nano=40, value=20))
+        point = _create_metric(
+            Gauge(
+                data_points=[
+                    NumberDataPoint(
+                        attributes={"attr-key": "test-val"},
+                        start_time_unix_nano=10,
+                        time_unix_nano=20,
+                        value=9,
+                    )
+                ]
+            )
+        )
         self.assertEqual(
-            '{"attributes": {"attr-key": "test-val"}, "description": "test-description", "instrumentation_scope": "InstrumentationScope(name, version, None)", "name": "test-name", "resource": "BoundedAttributes({\'resource-key\': \'resource-val\'}, maxlen=None)", "unit": "test-unit", "point": {"time_unix_nano": 40, "value": 20}}',
+            '{"name": "test-name", "description": "test-description", "unit": "test-unit", "data": "{\\"data_points\\": \\"[{\\\\\\"attributes\\\\\\": {\\\\\\"attr-key\\\\\\": \\\\\\"test-val\\\\\\"}, \\\\\\"start_time_unix_nano\\\\\\": 10, \\\\\\"time_unix_nano\\\\\\": 20, \\\\\\"value\\\\\\": 9}]\\"}"}',
             point.to_json(),
         )
 
     def test_histogram(self):
         point = _create_metric(
             Histogram(
+                data_points=[
+                    HistogramDataPoint(
+                        attributes={"attr-key": "test-val"},
+                        start_time_unix_nano=50,
+                        time_unix_nano=60,
+                        count=1,
+                        sum=0.8,
+                        bucket_counts=[0, 0, 1, 0],
+                        explicit_bounds=[0.1, 0.5, 0.9, 1],
+                        min=0.8,
+                        max=0.8,
+                    )
+                ],
                 aggregation_temporality=1,
-                bucket_counts=[0, 0, 1, 0],
-                explicit_bounds=[0.1, 0.5, 0.9, 1],
-                max=0.8,
-                min=0.8,
-                start_time_unix_nano=50,
-                sum=0.8,
-                time_unix_nano=60,
             )
         )
         self.maxDiff = None
         self.assertEqual(
-            '{"attributes": {"attr-key": "test-val"}, "description": "test-description", "instrumentation_scope": "InstrumentationScope(name, version, None)", "name": "test-name", "resource": "BoundedAttributes({\'resource-key\': \'resource-val\'}, maxlen=None)", "unit": "test-unit", "point": {"aggregation_temporality": 1, "bucket_counts": [0, 0, 1, 0], "explicit_bounds": [0.1, 0.5, 0.9, 1], "max": 0.8, "min": 0.8, "start_time_unix_nano": 50, "sum": 0.8, "time_unix_nano": 60}}',
+            '{"name": "test-name", "description": "test-description", "unit": "test-unit", "data": "{\\"data_points\\": \\"[{\\\\\\"attributes\\\\\\": {\\\\\\"attr-key\\\\\\": \\\\\\"test-val\\\\\\"}, \\\\\\"start_time_unix_nano\\\\\\": 50, \\\\\\"time_unix_nano\\\\\\": 60, \\\\\\"count\\\\\\": 1, \\\\\\"sum\\\\\\": 0.8, \\\\\\"bucket_counts\\\\\\": [0, 0, 1, 0], \\\\\\"explicit_bounds\\\\\\": [0.1, 0.5, 0.9, 1], \\\\\\"min\\\\\\": 0.8, \\\\\\"max\\\\\\": 0.8}]\\", \\"aggregation_temporality\\": 1}"}',
             point.to_json(),
         )

--- a/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
+++ b/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
@@ -204,6 +204,7 @@ class Test_ViewInstrumentMatch(TestCase):
         number_data_points = view_instrument_match.collect(
             AggregationTemporality.CUMULATIVE
         )
+        number_data_points = list(number_data_points)
         self.assertEqual(len(number_data_points), 1)
 
         number_data_point = number_data_points[0]

--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/metrictestutil.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/metrictestutil.py
@@ -13,69 +13,72 @@
 # limitations under the License.
 
 
-from collections import OrderedDict
-
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk._metrics.export import (
     AggregationTemporality,
     Gauge,
     Metric,
+    NumberDataPoint,
     Sum,
 )
-from opentelemetry.sdk.resources import Resource as SDKResource
-from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 
 
 def _generate_metric(
-    name, point, attributes=None, description=None, unit=None
+    name, data, attributes=None, description=None, unit=None
 ) -> Metric:
-    if not attributes:
-        attributes = BoundedAttributes(attributes={"a": 1, "b": True})
-    if not description:
+    if description is None:
         description = "foo"
-    if not unit:
+    if unit is None:
         unit = "s"
     return Metric(
-        resource=SDKResource(OrderedDict([("a", 1), ("b", False)])),
-        instrumentation_scope=InstrumentationScope(
-            "first_name", "first_version"
-        ),
-        attributes=attributes,
-        description=description,
         name=name,
+        description=description,
         unit=unit,
-        point=point,
+        data=data,
     )
 
 
 def _generate_sum(
-    name, val, attributes=None, description=None, unit=None
+    name, value, attributes=None, description=None, unit=None
 ) -> Sum:
+    if attributes is None:
+        attributes = BoundedAttributes(attributes={"a": 1, "b": True})
     return _generate_metric(
         name,
         Sum(
+            data_points=[
+                NumberDataPoint(
+                    attributes=attributes,
+                    start_time_unix_nano=1641946015139533244,
+                    time_unix_nano=1641946016139533244,
+                    value=value,
+                )
+            ],
             aggregation_temporality=AggregationTemporality.CUMULATIVE,
             is_monotonic=True,
-            start_time_unix_nano=1641946015139533244,
-            time_unix_nano=1641946016139533244,
-            value=val,
         ),
-        attributes=attributes,
         description=description,
         unit=unit,
     )
 
 
 def _generate_gauge(
-    name, val, attributes=None, description=None, unit=None
+    name, value, attributes=None, description=None, unit=None
 ) -> Gauge:
+    if attributes is None:
+        attributes = BoundedAttributes(attributes={"a": 1, "b": True})
     return _generate_metric(
         name,
         Gauge(
-            time_unix_nano=1641946016139533244,
-            value=val,
+            data_points=[
+                NumberDataPoint(
+                    attributes=attributes,
+                    start_time_unix_nano=1641946015139533244,
+                    time_unix_nano=1641946016139533244,
+                    value=value,
+                )
+            ],
         ),
-        attributes=attributes,
         description=description,
         unit=unit,
     )
@@ -87,7 +90,6 @@ def _generate_unsupported_metric(
     return _generate_metric(
         name,
         None,
-        attributes=attributes,
         description=description,
         unit=unit,
     )


### PR DESCRIPTION
Fixes #2646

This PR has been refactored completely to address [this](https://github.com/open-telemetry/opentelemetry-python/pull/2658#discussion_r866462665) comment.

Since this is a big PR, here is some information to help review:

This PR basically unflattens this [`Metric`](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/_view_instrument_match.py#L153-L169) object to make it match the [OTLP `Metric`](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto#L207) object, and it is implemented [here](https://github.com/open-telemetry/opentelemetry-python/pull/2658/files#diff-b4bee4f0abf754ee12c2b65ce965c7f28d40c46d7765eb513ee62913c42584d5R124).

This means, our `Metric` object now contains a `Sum`, `Histogram` or `Gauge` object and those objects now contain a series of `NumberDataPoint` or `HistogramDataPoint` objects as defined by the proto.

This changes many things but it is pretty much just a rearranging of data. The only "significant" change is that it was necessary to remove `_convert_aggregation_temporality`, this conversion has been split and moved into each aggregation `collect` method. I find it better since we now don't have all the `if`s that did something different depending on the point type but instead that specific code is moved into each aggregation that matches the corresponding point type.

