### PR TITLE
Add callback options with timeout to observable callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.11.1-0.30b1...HEAD)
 
+- Add CallbackOptions to observable instrument callback params
+  ([#2664](https://github.com/open-telemetry/opentelemetry-python/pull/2664))
 - Add timeouts to metric SDK
   ([#2653](https://github.com/open-telemetry/opentelemetry-python/pull/2653))
 - Add variadic arguments to metric exporter/reader interfaces

--- a/docs/examples/metrics/example.py
+++ b/docs/examples/metrics/example.py
@@ -5,6 +5,7 @@ from opentelemetry._metrics import (
     get_meter_provider,
     set_meter_provider,
 )
+from opentelemetry._metrics._internal.instrument import CallbackOptions
 from opentelemetry.exporter.otlp.proto.grpc._metric_exporter import (
     OTLPMetricExporter,
 )
@@ -17,15 +18,17 @@ provider = MeterProvider(metric_readers=[reader])
 set_meter_provider(provider)
 
 
-def observable_counter_func() -> Iterable[Observation]:
+def observable_counter_func(options: CallbackOptions) -> Iterable[Observation]:
     yield Observation(1, {})
 
 
-def observable_up_down_counter_func() -> Iterable[Observation]:
+def observable_up_down_counter_func(
+    options: CallbackOptions,
+) -> Iterable[Observation]:
     yield Observation(-10, {})
 
 
-def observable_gauge_func() -> Iterable[Observation]:
+def observable_gauge_func(options: CallbackOptions) -> Iterable[Observation]:
     yield Observation(9, {})
 
 
@@ -37,7 +40,8 @@ counter.add(1)
 
 # Async Counter
 observable_counter = meter.create_observable_counter(
-    "observable_counter", observable_counter_func
+    "observable_counter",
+    [observable_counter_func],
 )
 
 # UpDownCounter
@@ -47,7 +51,7 @@ updown_counter.add(-5)
 
 # Async UpDownCounter
 observable_updown_counter = meter.create_observable_up_down_counter(
-    "observable_updown_counter", observable_up_down_counter_func
+    "observable_updown_counter", [observable_up_down_counter_func]
 )
 
 # Histogram
@@ -55,4 +59,4 @@ histogram = meter.create_histogram("histogram")
 histogram.record(99.9)
 
 # Async Gauge
-gauge = meter.create_observable_gauge("gauge", observable_gauge_func)
+gauge = meter.create_observable_gauge("gauge", [observable_gauge_func])

--- a/docs/getting_started/metrics_example.py
+++ b/docs/getting_started/metrics_example.py
@@ -18,6 +18,7 @@
 from typing import Iterable
 
 from opentelemetry._metrics import (
+    CallbackOptions,
     Observation,
     get_meter_provider,
     set_meter_provider,
@@ -34,15 +35,17 @@ provider = MeterProvider(metric_readers=[reader])
 set_meter_provider(provider)
 
 
-def observable_counter_func() -> Iterable[Observation]:
+def observable_counter_func(options: CallbackOptions) -> Iterable[Observation]:
     yield Observation(1, {})
 
 
-def observable_up_down_counter_func() -> Iterable[Observation]:
+def observable_up_down_counter_func(
+    options: CallbackOptions,
+) -> Iterable[Observation]:
     yield Observation(-10, {})
 
 
-def observable_gauge_func() -> Iterable[Observation]:
+def observable_gauge_func(options: CallbackOptions) -> Iterable[Observation]:
     yield Observation(9, {})
 
 
@@ -54,7 +57,7 @@ counter.add(1)
 
 # Async Counter
 observable_counter = meter.create_observable_counter(
-    "observable_counter", observable_counter_func
+    "observable_counter", [observable_counter_func]
 )
 
 # UpDownCounter
@@ -64,7 +67,7 @@ updown_counter.add(-5)
 
 # Async UpDownCounter
 observable_updown_counter = meter.create_observable_up_down_counter(
-    "observable_updown_counter", observable_up_down_counter_func
+    "observable_updown_counter", [observable_up_down_counter_func]
 )
 
 # Histogram
@@ -72,4 +75,4 @@ histogram = meter.create_histogram("histogram")
 histogram.record(99.9)
 
 # Async Gauge
-gauge = meter.create_observable_gauge("gauge", observable_gauge_func)
+gauge = meter.create_observable_gauge("gauge", [observable_gauge_func])

--- a/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/__init__.py
@@ -49,6 +49,7 @@ from opentelemetry._metrics._internal import (
 )
 from opentelemetry._metrics._internal.instrument import (
     Asynchronous,
+    CallbackOptions,
     CallbackT,
     Counter,
     Histogram,
@@ -71,6 +72,7 @@ for obj in [
     Counter,
     Synchronous,
     Asynchronous,
+    CallbackOptions,
     get_meter_provider,
     get_meter,
     Histogram,
@@ -95,6 +97,7 @@ for obj in [
     obj.__module__ = __name__
 
 __all__ = [
+    "CallbackOptions",
     "MeterProvider",
     "NoOpMeterProvider",
     "Meter",

--- a/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
+++ b/opentelemetry-api/src/opentelemetry/_metrics/_internal/instrument.py
@@ -16,6 +16,7 @@
 
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from logging import getLogger
 from re import ASCII
 from re import compile as re_compile
@@ -36,17 +37,29 @@ from opentelemetry import _metrics as metrics
 from opentelemetry._metrics._internal.observation import Observation
 from opentelemetry.util.types import Attributes
 
-InstrumentT = TypeVar("InstrumentT", bound="Instrument")
-CallbackT = Union[
-    Callable[[], Iterable[Observation]],
-    Generator[Iterable[Observation], None, None],
-]
-
-
 _logger = getLogger(__name__)
 
 _name_regex = re_compile(r"[a-zA-Z][-.\w]{0,62}", ASCII)
 _unit_regex = re_compile(r"\w{0,63}", ASCII)
+
+
+@dataclass(frozen=True)
+class CallbackOptions:
+    """Options for the callback
+
+    Args:
+        timeout_millis: Timeout for the callback's execution. If the callback does asynchronous
+            work (e.g. HTTP requests), it should respect this timeout.
+    """
+
+    timeout_millis: float = 10_000
+
+
+InstrumentT = TypeVar("InstrumentT", bound="Instrument")
+CallbackT = Union[
+    Callable[[CallbackOptions], Iterable[Observation]],
+    Generator[Iterable[Observation], CallbackOptions, None],
+]
 
 
 class Instrument(ABC):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/instrument.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/instrument.py
@@ -106,7 +106,7 @@ class _Asynchronous:
 
         if callbacks is not None:
 
-            for i, callback in enumerate(callbacks):
+            for callback in callbacks:
 
                 if isinstance(callback, Generator):
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/instrument.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/instrument.py
@@ -15,7 +15,15 @@
 # pylint: disable=too-many-ancestors
 
 from logging import getLogger
-from typing import TYPE_CHECKING, Dict, Generator, Iterable, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Union,
+)
 
 from opentelemetry._metrics import CallbackT
 from opentelemetry._metrics import Counter as APICounter
@@ -26,6 +34,7 @@ from opentelemetry._metrics import (
     ObservableUpDownCounter as APIObservableUpDownCounter,
 )
 from opentelemetry._metrics import UpDownCounter as APIUpDownCounter
+from opentelemetry._metrics._internal.instrument import CallbackOptions
 from opentelemetry.sdk._metrics.measurement import Measurement
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 
@@ -93,32 +102,41 @@ class _Asynchronous:
         self._measurement_consumer = measurement_consumer
         super().__init__(name, callbacks, unit=unit, description=description)
 
-        self._callbacks = []
+        self._callbacks: List[CallbackT] = []
 
         if callbacks is not None:
 
-            for callback in callbacks:
+            for i, callback in enumerate(callbacks):
 
                 if isinstance(callback, Generator):
 
-                    def inner(callback=callback) -> Iterable[Measurement]:
-                        return next(callback)
+                    # advance generator to it's first yield
+                    next(callback)
+
+                    def inner(
+                        options: CallbackOptions,
+                        callback=callback,
+                    ) -> Iterable[Measurement]:
+                        try:
+                            return callback.send(options)
+                        except StopIteration:
+                            return []
 
                     self._callbacks.append(inner)
                 else:
                     self._callbacks.append(callback)
 
-    def callback(self) -> Iterable[Measurement]:
+    def callback(
+        self, callback_options: CallbackOptions
+    ) -> Iterable[Measurement]:
         for callback in self._callbacks:
             try:
-                for api_measurement in callback():
+                for api_measurement in callback(callback_options):
                     yield Measurement(
                         api_measurement.value,
                         instrument=self,
                         attributes=api_measurement.attributes,
                     )
-            except StopIteration:
-                pass
             except Exception:  # pylint: disable=broad-except
                 _logger.exception(
                     "Callback failed for instrument %s.", self.name

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/measurement_consumer.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_metrics/_internal/measurement_consumer.py
@@ -16,6 +16,7 @@ from abc import ABC, abstractmethod
 from threading import Lock
 from typing import TYPE_CHECKING, Dict, Iterable, List, Mapping
 
+from opentelemetry._metrics._internal.instrument import CallbackOptions
 from opentelemetry.sdk._metrics._internal.metric_reader_storage import (
     MetricReaderStorage,
 )
@@ -27,7 +28,7 @@ from opentelemetry.sdk._metrics.metric_reader import MetricReader
 from opentelemetry.sdk._metrics.point import AggregationTemporality, Metric
 
 if TYPE_CHECKING:
-    from opentelemetry.sdk._metrics.instrument import _Asynchronous
+    from opentelemetry.sdk._metrics._internal.instrument import _Asynchronous
 
 
 class MeasurementConsumer(ABC):
@@ -78,8 +79,10 @@ class SynchronousMeasurementConsumer(MeasurementConsumer):
     ) -> Iterable[Metric]:
         with self._lock:
             metric_reader_storage = self._reader_storages[metric_reader]
+            # for now, just use the defaults
+            callback_options = CallbackOptions()
             for async_instrument in self._async_instruments:
-                for measurement in async_instrument.callback():
+                for measurement in async_instrument.callback(callback_options):
                     metric_reader_storage.consume_measurement(measurement)
         return self._reader_storages[metric_reader].collect(
             instrument_type_temporality

--- a/opentelemetry-sdk/tests/metrics/test_in_memory_metric_reader.py
+++ b/opentelemetry-sdk/tests/metrics/test_in_memory_metric_reader.py
@@ -70,7 +70,8 @@ class TestInMemoryMetricReader(TestCase):
         meter = MeterProvider(metric_readers=[reader]).get_meter("test_meter")
         counter1 = meter.create_counter("counter1")
         meter.create_observable_gauge(
-            "observable_gauge1", callbacks=[lambda: [Observation(value=12)]]
+            "observable_gauge1",
+            callbacks=[lambda options: [Observation(value=12)]],
         )
         counter1.add(1, {"foo": "1"})
         counter1.add(1, {"foo": "2"})

--- a/opentelemetry-sdk/tests/metrics/test_instrument.py
+++ b/opentelemetry-sdk/tests/metrics/test_instrument.py
@@ -16,6 +16,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from opentelemetry._metrics import Observation
+from opentelemetry._metrics._internal.instrument import CallbackOptions
 from opentelemetry.sdk._metrics.instrument import (
     Counter,
     Histogram,
@@ -62,7 +63,7 @@ class TestUpDownCounter(TestCase):
 TEST_ATTRIBUTES = {"foo": "bar"}
 
 
-def callable_callback_0():
+def callable_callback_0(options: CallbackOptions):
     return [
         Observation(1, attributes=TEST_ATTRIBUTES),
         Observation(2, attributes=TEST_ATTRIBUTES),
@@ -70,7 +71,7 @@ def callable_callback_0():
     ]
 
 
-def callable_callback_1():
+def callable_callback_1(options: CallbackOptions):
     return [
         Observation(4, attributes=TEST_ATTRIBUTES),
         Observation(5, attributes=TEST_ATTRIBUTES),
@@ -79,19 +80,25 @@ def callable_callback_1():
 
 
 def generator_callback_0():
-    yield [
+    options = yield
+    assert isinstance(options, CallbackOptions)
+    options = yield [
         Observation(1, attributes=TEST_ATTRIBUTES),
         Observation(2, attributes=TEST_ATTRIBUTES),
         Observation(3, attributes=TEST_ATTRIBUTES),
     ]
+    assert isinstance(options, CallbackOptions)
 
 
 def generator_callback_1():
-    yield [
+    options = yield
+    assert isinstance(options, CallbackOptions)
+    options = yield [
         Observation(4, attributes=TEST_ATTRIBUTES),
         Observation(5, attributes=TEST_ATTRIBUTES),
         Observation(6, attributes=TEST_ATTRIBUTES),
     ]
+    assert isinstance(options, CallbackOptions)
 
 
 class TestObservableGauge(TestCase):
@@ -105,7 +112,7 @@ class TestObservableGauge(TestCase):
         )
 
         self.assertEqual(
-            list(observable_gauge.callback()),
+            list(observable_gauge.callback(CallbackOptions())),
             [
                 Measurement(
                     1, instrument=observable_gauge, attributes=TEST_ATTRIBUTES
@@ -125,7 +132,7 @@ class TestObservableGauge(TestCase):
         )
 
         self.assertEqual(
-            list(observable_gauge.callback()),
+            list(observable_gauge.callback(CallbackOptions())),
             [
                 Measurement(
                     1, instrument=observable_gauge, attributes=TEST_ATTRIBUTES
@@ -154,7 +161,7 @@ class TestObservableGauge(TestCase):
         )
 
         self.assertEqual(
-            list(observable_gauge.callback()),
+            list(observable_gauge.callback(CallbackOptions())),
             [
                 Measurement(
                     1, instrument=observable_gauge, attributes=TEST_ATTRIBUTES
@@ -178,7 +185,7 @@ class TestObservableGauge(TestCase):
         )
 
         self.assertEqual(
-            list(observable_gauge.callback()),
+            list(observable_gauge.callback(CallbackOptions())),
             [
                 Measurement(
                     1, instrument=observable_gauge, attributes=TEST_ATTRIBUTES
@@ -209,7 +216,7 @@ class TestObservableCounter(TestCase):
         )
 
         self.assertEqual(
-            list(observable_counter.callback()),
+            list(observable_counter.callback(CallbackOptions())),
             [
                 Measurement(
                     1,
@@ -235,7 +242,7 @@ class TestObservableCounter(TestCase):
         )
 
         self.assertEqual(
-            list(observable_counter.callback()),
+            list(observable_counter.callback(CallbackOptions())),
             [
                 Measurement(
                     1,
@@ -263,7 +270,7 @@ class TestObservableUpDownCounter(TestCase):
         )
 
         self.assertEqual(
-            list(observable_up_down_counter.callback()),
+            list(observable_up_down_counter.callback(CallbackOptions())),
             [
                 Measurement(
                     1,
@@ -289,7 +296,7 @@ class TestObservableUpDownCounter(TestCase):
         )
 
         self.assertEqual(
-            list(observable_up_down_counter.callback()),
+            list(observable_up_down_counter.callback(CallbackOptions())),
             [
                 Measurement(
                     1,


### PR DESCRIPTION
# Description

Add a `CallbackOptions` dataclass to be passed into observable callbacks. This is to pass along a `timeout_millis` param which the callbacks should respect. Any additional things we add in the future can be added to the dataclass in backward compatible way. The reason to use a dataclass over function arguments is:

1. it is easier for users to get right, while python signatures can be tricky. this is the one of the main things users will provide that the SDK will invoke, so it's important to get right
2. for the "generator form", where the callback is a generator that yields batches of Observations, we need a way to send the options in. Generators support a sending a _single value_ to become the result of the yield expression. See updated docs for examples.

Part of https://github.com/open-telemetry/opentelemetry-python/issues/2663

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Need to update tests still

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [x] Yes. - Link to PR: 

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
