### PR TITLE
Add meter provider and in memory reader to TestBase

### DIFF
--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
@@ -16,12 +16,18 @@ import logging
 import unittest
 from contextlib import contextmanager
 
+from opentelemetry import metrics as metrics_api
 from opentelemetry import trace as trace_api
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.trace import TracerProvider, export
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
-from opentelemetry.test.globals_test import reset_trace_globals
+from opentelemetry.test.globals_test import (
+    reset_metrics_globals,
+    reset_trace_globals,
+)
 
 
 class TestBase(unittest.TestCase):
@@ -35,6 +41,11 @@ class TestBase(unittest.TestCase):
         # current tracer provider.
         reset_trace_globals()
         trace_api.set_tracer_provider(cls.tracer_provider)
+
+        result = cls.create_meter_provider()
+        cls.meter_provider, cls.memory_metrics_reader = result
+        reset_metrics_globals()
+        metrics_api.set_meter_provider(cls.meter_provider)
 
     @classmethod
     def tearDownClass(cls):
@@ -91,6 +102,21 @@ class TestBase(unittest.TestCase):
         tracer_provider.add_span_processor(span_processor)
 
         return tracer_provider, memory_exporter
+
+    @staticmethod
+    def create_meter_provider(**kwargs):
+        """Helper to create a configured meter provider
+        Creates a `MeterProvider` and an `InMemoryMetricReader`.
+        Returns:
+            A list with the meter provider in the first element and the
+            in-memory metrics exporter in the second
+        """
+        memory_reader = InMemoryMetricReader()
+        metric_readers = kwargs.get("metric_readers", [])
+        metric_readers.append(memory_reader)
+        kwargs["metric_readers"] = metric_readers
+        meter_provider = MeterProvider(**kwargs)
+        return meter_provider, memory_reader
 
     @staticmethod
     @contextmanager

--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import logging
-from typing import Tuple
 import unittest
 from contextlib import contextmanager
+from typing import Tuple
 
 from opentelemetry import metrics as metrics_api
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import MetricReader, InMemoryMetricReader
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader, MetricReader
 from opentelemetry.sdk.trace import TracerProvider, export
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,

--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 import logging
+from typing import Tuple
 import unittest
 from contextlib import contextmanager
 
 from opentelemetry import metrics as metrics_api
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.metrics.export import MetricReader, InMemoryMetricReader
 from opentelemetry.sdk.trace import TracerProvider, export
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
@@ -104,11 +105,11 @@ class TestBase(unittest.TestCase):
         return tracer_provider, memory_exporter
 
     @staticmethod
-    def create_meter_provider(**kwargs):
+    def create_meter_provider(**kwargs) -> Tuple[MeterProvider, MetricReader]:
         """Helper to create a configured meter provider
         Creates a `MeterProvider` and an `InMemoryMetricReader`.
         Returns:
-            A list with the meter provider in the first element and the
+            A tuple with the meter provider in the first element and the
             in-memory metrics exporter in the second
         """
         memory_reader = InMemoryMetricReader()


### PR DESCRIPTION
# Description

As we start writing instrumentation for contrib packages, it is common need to have the global meter provider set with an in memory metrics reader to easily write the assertions. This commit introduces those changes to TestBase.