### PR TITLE
Loosen dependency on backoff for newer Python versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2714](https://github.com/open-telemetry/opentelemetry-python/pull/2714))
 - narrow protobuf dependencies to exclude protobuf >= 4
   ([#2720](https://github.com/open-telemetry/opentelemetry-python/pull/2720))
+- Loosen dependency on `backoff` for newer Python versions
+  ([#2726](https://github.com/open-telemetry/opentelemetry-python/pull/2726))
 
 ## [1.12.0rc1-0.31b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0rc1-0.31b0) - 2022-05-17
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
@@ -45,7 +45,8 @@ install_requires =
     opentelemetry-api ~= 1.3
     opentelemetry-sdk ~= 1.11
     opentelemetry-proto == 1.12.0rc1
-    backoff >= 1.10.0, < 2.0.0
+    backoff >= 1.10.0, < 2.0.0; python_version<'3.7'
+    backoff >= 1.10.0, < 3.0.0; python_version>='3.7'
 
 [options.extras_require]
 test =

--- a/exporter/opentelemetry-exporter-otlp-proto-http/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/setup.cfg
@@ -45,7 +45,8 @@ install_requires =
     opentelemetry-api ~= 1.3
     opentelemetry-sdk ~= 1.11
     opentelemetry-proto == 1.12.0rc1
-    backoff >= 1.10.0, < 2.0.0
+    backoff >= 1.10.0, < 2.0.0; python_version<'3.7'
+    backoff >= 1.10.0, < 3.0.0; python_version>='3.7'
 
 [options.extras_require]
 test =


### PR DESCRIPTION
# Description

The `backoff` library made a major version bump to `2.0.0` when dropping support for Python 3.6:
https://github.com/litl/backoff/blob/master/CHANGELOG.md

This PR allows for using newer `backoff` versions under Python versions 3.7 and above, I can add an upper bound on `3.0.0` if that's preferred, but in my experience it's best to skip capping upper bounds by default and only add them when necessary.

Fixes #2693