### PR TITLE
Create Suppress HTTP Instrumentation key in opentelemetry context

### DIFF
--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -163,3 +163,4 @@ def detach(token: object) -> None:
 # Once the decision around how to suppress instrumentation is made in the
 # spec, this key should be moved accordingly.
 _SUPPRESS_INSTRUMENTATION_KEY = create_key("suppress_instrumentation")
+_SUPPRESS_HTTP_INSTRUMENTATION_KEY = create_key("suppress_http_instrumentation")


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This change aims to fix the issue outlined in [opentelemetry-python-contrib issue #930](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/930) where urllib3 downstream spans are not being suppressed with a requests upstream, causing an extra span to be created.

The root cause of this bug lies in the create_key() method in opentelemetry context which adds a unique `uuid` to the end of each key created. Since a new `_SUPPRESS_HTTP_INSTRUMENTATION` key is being created in the instrumentation for each library, this results in a different key being created by each instrumentation instead of the creation of a single key that suppresses HTTP instrumentation so proceeding libraries know not to instrument further. This change also aligns with the [context specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.1.0/specification/context/context.md#context).

Fixes [#930 in opentelemetry-python-contrib](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/930)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1116

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
