### PR TITLE
Add OTEL_EXPORTER_JAEGER_INSECURE environment variable

### DIFF
--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/__init__.py
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/src/opentelemetry/exporter/jaeger/proto/grpc/__init__.py
@@ -57,6 +57,7 @@ You can configure the exporter with the following environment variables:
 - :envvar:`OTEL_EXPORTER_JAEGER_ENDPOINT`
 - :envvar:`OTEL_EXPORTER_JAEGER_CERTIFICATE`
 - :envvar:`OTEL_EXPORTER_JAEGER_TIMEOUT`
+- :envvar:`OTEL_EXPORTER_JAEGER_INSECURE`
 
 API
 ---
@@ -87,6 +88,7 @@ from opentelemetry.exporter.jaeger.proto.grpc.translate import (
 from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_JAEGER_ENDPOINT,
     OTEL_EXPORTER_JAEGER_TIMEOUT,
+    OTEL_EXPORTER_JAEGER_INSECURE,
 )
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
@@ -126,7 +128,8 @@ class JaegerExporter(SpanExporter):
             environ.get(OTEL_EXPORTER_JAEGER_TIMEOUT, DEFAULT_EXPORT_TIMEOUT)
         )
         self._grpc_client = None
-        self.insecure = insecure
+        self.insecure = insecure or environ.get(
+            OTEL_EXPORTER_JAEGER_INSECURE, False) == "True"
         self.credentials = util._get_credentials(credentials)
         tracer_provider = trace.get_tracer_provider()
         self.service_name = (

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables.py
@@ -210,6 +210,14 @@ Maximum time the Jaeger exporter will wait for each batch export.
 Default: 10
 """
 
+OTEL_EXPORTER_JAEGER_INSECURE = "OTEL_EXPORTER_JAEGER_INSECURE"
+"""
+.. envvar:: OTEL_EXPORTER_JAEGER_INSECURE
+
+True if Jaeger collector has no encryption or authentication.
+Default: False
+"""
+
 OTEL_EXPORTER_ZIPKIN_ENDPOINT = "OTEL_EXPORTER_ZIPKIN_ENDPOINT"
 """
 .. envvar:: OTEL_EXPORTER_ZIPKIN_ENDPOINT


### PR DESCRIPTION
# Description

Add OTEL_EXPORTER_JAEGER_INSECURE environment variable for OpenTelemetry Jaeger Protobuf exporter.

With OTEL_EXPORTER_JAEGER_INSECURE user can using a jaeger collector without https when using automatic instrumentation.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [X] Documentation has been updated
