### PR TITLE
Add metrics_exporter entrypoints for OTLP grpc exporter

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/setup.cfg
@@ -60,3 +60,5 @@ opentelemetry_traces_exporter =
     otlp_proto_grpc = opentelemetry.exporter.otlp.proto.grpc.trace_exporter:OTLPSpanExporter
 opentelemetry_logs_exporter =
     otlp_proto_grpc = opentelemetry.exporter.otlp.proto.grpc._log_exporter:OTLPLogExporter
+opentelemetry_metrics_exporter =
+    otlp_proto_grpc = opentelemetry.exporter.otlp.proto.grpc.metric_exporter:OTLPMetricExporter

--- a/exporter/opentelemetry-exporter-otlp/setup.cfg
+++ b/exporter/opentelemetry-exporter-otlp/setup.cfg
@@ -52,3 +52,5 @@ opentelemetry_traces_exporter =
     otlp = opentelemetry.exporter.otlp.proto.grpc.trace_exporter:OTLPSpanExporter
 opentelemetry_logs_exporter =
     otlp = opentelemetry.exporter.otlp.proto.grpc._log_exporter:OTLPLogExporter
+opentelemetry_metrics_exporter =
+    otlp = opentelemetry.exporter.otlp.proto.grpc.metric_exporter:OTLPMetricExporter


### PR DESCRIPTION
# Description

As part of revamping the getting started and autoinstrumentation documentation to include metrics, I noticed this was missing. This adds entry points for OTLP exporter

Part of #2732

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested locally with `opentelemetry-instrument --metrics_exporter otlp ...`

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- ~[ ] Documentation has been updated~ (coming in separate PR to opentelemetry.io repo)
