### PR TITLE
Fix #2348, add handling for non recording span in jaeger propagator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2705](https://github.com/open-telemetry/opentelemetry-python/pull/2705))
 - Add entrypoint for metrics exporter
   ([#2748](https://github.com/open-telemetry/opentelemetry-python/pull/2748))
+- Fix Jaeger propagator usage with NonRecordingSpan
+  ([#2762](https://github.com/open-telemetry/opentelemetry-python/pull/2762))
 
 ## [1.12.0rc1-0.31b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0rc1-0.31b0) - 2022-05-17
 

--- a/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
+++ b/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
@@ -81,7 +81,8 @@ class JaegerPropagator(TextMapPropagator):
         if span_context == trace.INVALID_SPAN_CONTEXT:
             return
 
-        span_parent_id = span.parent.span_id if span.parent else 0
+        # Non-recording spans do not have a parent
+        span_parent_id = span.parent.span_id if span.is_recording() and span.parent else 0
         trace_flags = span_context.trace_flags
         if trace_flags.sampled:
             trace_flags |= self.DEBUG_FLAG

--- a/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
+++ b/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
@@ -82,7 +82,9 @@ class JaegerPropagator(TextMapPropagator):
             return
 
         # Non-recording spans do not have a parent
-        span_parent_id = span.parent.span_id if span.is_recording() and span.parent else 0
+        span_parent_id = (
+            span.parent.span_id if span.is_recording() and span.parent else 0
+        )
         trace_flags = span_context.trace_flags
         if trace_flags.sampled:
             trace_flags |= self.DEBUG_FLAG

--- a/propagator/opentelemetry-propagator-jaeger/tests/test_jaeger_propagator.py
+++ b/propagator/opentelemetry-propagator-jaeger/tests/test_jaeger_propagator.py
@@ -239,4 +239,4 @@ class TestJaegerPropagator(unittest.TestCase):
             try:
                 FORMAT.inject({}, setter=mock_setter)
             except Exception as exc:  # pylint: disable=broad-except
-                self.fail(f'Injecting failed for NonRecordingSpan with {exc}')
+                self.fail(f"Injecting failed for NonRecordingSpan with {exc}")

--- a/propagator/opentelemetry-propagator-jaeger/tests/test_jaeger_propagator.py
+++ b/propagator/opentelemetry-propagator-jaeger/tests/test_jaeger_propagator.py
@@ -233,12 +233,10 @@ class TestJaegerPropagator(unittest.TestCase):
 
     def test_non_recording_span_does_not_crash(self):
         """Make sure propagator does not crash when working with NonRecordingSpan"""
-        tracer = trace.TracerProvider().get_tracer("sdk_tracer_provider")
         mock_setter = Mock()
         span = trace_api.NonRecordingSpan(trace_api.SpanContext(1, 1, True))
         with trace_api.use_span(span, end_on_exit=True):
             try:
                 FORMAT.inject({}, setter=mock_setter)
-            except Exception as exc:
+            except Exception as exc:  # pylint: disable=broad-except
                 self.fail(f'Injecting failed for NonRecordingSpan with {exc}')
-

--- a/propagator/opentelemetry-propagator-jaeger/tests/test_jaeger_propagator.py
+++ b/propagator/opentelemetry-propagator-jaeger/tests/test_jaeger_propagator.py
@@ -230,3 +230,15 @@ class TestJaegerPropagator(unittest.TestCase):
 
                 ctx = FORMAT.extract(carrier)
                 self.assertDictEqual(Context(), ctx)
+
+    def test_non_recording_span_does_not_crash(self):
+        """Make sure propagator does not crash when working with NonRecordingSpan"""
+        tracer = trace.TracerProvider().get_tracer("sdk_tracer_provider")
+        mock_setter = Mock()
+        span = trace_api.NonRecordingSpan(trace_api.SpanContext(1, 1, True))
+        with trace_api.use_span(span, end_on_exit=True):
+            try:
+                FORMAT.inject({}, setter=mock_setter)
+            except Exception as exc:
+                self.fail(f'Injecting failed for NonRecordingSpan with {exc}')
+


### PR DESCRIPTION
Fixes #2348

# Description

This is a simple fix for #2348, where the jaeger exporter fails to handle a NonRecordingSpan correctly. It just basically skips the parent ID retrieval and moves along as if nothing else happened. This only occurs when a NonRecordingSpan has a valid context, which apparently we have trigged periodically in our app.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I created a new unit test inspired by an existing test, but done with a NonRecordingSpan to ensure that this doesn't cause the process to fail.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [n/a] Changelogs have been updated
- [x] Unit tests have been added
- [n/a] Documentation has been updated
