### PR TITLE
Python 3.11: Enhanced error locations in tracebacks

### DIFF
--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1190,7 +1190,9 @@ RuntimeError: example error"""
             if sys.version_info >= (3, 11):
                 # https://docs.python.org/3.11/whatsnew/3.11.html#enhanced-error-locations-in-tracebacks
                 tracelines = stacktrace.splitlines()
-                tracelines.insert(-1, "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
+                tracelines.insert(
+                    -1, "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+                )
                 stacktrace = "\n".join(tracelines)
             self.assertIn(stacktrace, event.attributes["exception.stacktrace"])
 

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -15,6 +15,7 @@
 # pylint: disable=too-many-lines
 import shutil
 import subprocess
+import sys
 import unittest
 from importlib import reload
 from logging import ERROR, WARNING
@@ -1186,6 +1187,11 @@ class TestSpan(unittest.TestCase):
             stacktrace = """in test_record_exception_context_manager
     raise RuntimeError("example error")
 RuntimeError: example error"""
+            if sys.version_info >= (3, 11):
+                # https://docs.python.org/3.11/whatsnew/3.11.html#enhanced-error-locations-in-tracebacks
+                tracelines = stacktrace.splitlines()
+                tracelines.insert(-1, "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
+                stacktrace = "\n".join(tracelines)
             self.assertIn(stacktrace, event.attributes["exception.stacktrace"])
 
         try:


### PR DESCRIPTION


# Description

Expect ^^^^^^^^^ in tracebacks when testing them

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've built the Fedora package on Python 3.11.0b3.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated

I've opened this here because I needed it in Fedora, but I am currently herding dozens of similar issues as the Fedora's Python 3.11 mass rebuild is in progress. I won't be able to dedicate my time to fixing any style issues, changelog fragments, or similar things. Sorry about that. Feel free to adjust this in any way you see fit or even close it if it's not up to the project's standards.