### PR TITLE
Pin googleapis-common-protos version

### DIFF
--- a/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.cfg
+++ b/exporter/opentelemetry-exporter-jaeger-proto-grpc/setup.cfg
@@ -42,7 +42,7 @@ package_dir=
 packages=find_namespace:
 install_requires =
     grpcio >= 1.0.0, < 2.0.0
-    googleapis-common-protos ~= 1.52
+    googleapis-common-protos ~= 1.52, < 1.56.3
     opentelemetry-api ~= 1.3
     opentelemetry-sdk ~= 1.11
 


### PR DESCRIPTION
Failing build
https://github.com/open-telemetry/opentelemetry-python/runs/7010024626?check_suite_focus=true

Latest version of [googleapis-common-protos](https://pypi.org/project/googleapis-common-protos/1.56.3/) causing tests in jaeger to fail.

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/2778