### PR TITLE
Change tracing to use `Resource.to_json()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.12.0rc1-0.31b0...HEAD)
 
+- Change tracing to use `Resource.to_json()`
+  ([#????](https://github.com/open-telemetry/opentelemetry-python/pull/????))
 - Add min/max fields to Histogram
   ([#2759](https://github.com/open-telemetry/opentelemetry-python/pull/2759))
 - `opentelemetry-exporter-otlp-proto-http` Add support for OTLP/HTTP log exporter

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -492,7 +492,7 @@ class ReadableSpan:
         f_span["attributes"] = self._format_attributes(self._attributes)
         f_span["events"] = self._format_events(self._events)
         f_span["links"] = self._format_links(self._links)
-        f_span["resource"] = self._format_attributes(self._resource.attributes)
+        f_span["resource"] = self._format_resource(self._resource)
 
         return json.dumps(f_span, indent=indent)
 
@@ -532,6 +532,15 @@ class ReadableSpan:
             f_link["attributes"] = Span._format_attributes(link.attributes)
             f_links.append(f_link)
         return f_links
+
+    @staticmethod
+    def _format_resource(resource):
+        resource_json_obj = json.loads(resource.to_json())
+        if not resource.attributes:
+            del resource_json_obj["attributes"]
+        if not resource.schema_url:
+            del resource_json_obj["schema_url"]
+        return resource_json_obj
 
 
 class SpanLimits:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # [2747](https://github.com/open-telemetry/opentelemetry-python/issues/2747)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
This change is really a reorganization/refactor and thus does not fit into the above categories.

# How Has This Been Tested?
Ran tests on Windows 11


Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `pytest opentelemetry-sdk/tests/trace/`
- [x] `python scripts/eachdist.py test`

# Does This PR Require a Contrib Repo Change?
No.

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
