### PR TITLE
Propagate API module & propagators package missing from API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2748](https://github.com/open-telemetry/opentelemetry-python/pull/2748))
 - Fix Jaeger propagator usage with NonRecordingSpan
   ([#2762](https://github.com/open-telemetry/opentelemetry-python/pull/2762))
+- Add `opentelemetry.propagate` moddule to the API reference documentation
+  ([#2785](https://github.com/open-telemetry/opentelemetry-python/pull/2785))
 
 
 ## [1.12.0rc1-0.31b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0rc1-0.31b0) - 2022-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2748](https://github.com/open-telemetry/opentelemetry-python/pull/2748))
 - Fix Jaeger propagator usage with NonRecordingSpan
   ([#2762](https://github.com/open-telemetry/opentelemetry-python/pull/2762))
-- Add `opentelemetry.propagate` moddule to the API reference documentation
+- Add `opentelemetry.propagate` module and `opentelemetry.propagators` package
+  to the API reference documentation
   ([#2785](https://github.com/open-telemetry/opentelemetry-python/pull/2785))
 
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -8,6 +8,7 @@ OpenTelemetry Python API
 
     baggage
     context
+    propagate
     trace
     metrics
     environment_variables

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -9,6 +9,7 @@ OpenTelemetry Python API
     baggage
     context
     propagate
+    propagators
     trace
     metrics
     environment_variables

--- a/docs/api/propagate.rst
+++ b/docs/api/propagate.rst
@@ -1,0 +1,7 @@
+opentelemetry.propagate package
+========================================
+
+Module contents
+---------------
+
+.. automodule:: opentelemetry.propagate

--- a/docs/api/propagators.composite.rst
+++ b/docs/api/propagators.composite.rst
@@ -1,0 +1,7 @@
+opentelemetry.propagators.textmap
+====================================================
+
+Module contents
+---------------
+
+.. automodule:: opentelemetry.propagators.textmap

--- a/docs/api/propagators.composite.rst
+++ b/docs/api/propagators.composite.rst
@@ -1,7 +1,7 @@
-opentelemetry.propagators.textmap
+opentelemetry.propagators.composite
 ====================================================
 
 Module contents
 ---------------
 
-.. automodule:: opentelemetry.propagators.textmap
+.. automodule:: opentelemetry.propagators.composite

--- a/docs/api/propagators.rst
+++ b/docs/api/propagators.rst
@@ -1,0 +1,10 @@
+opentelemetry.propagators package
+========================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+   propagators.textmap
+   propagators.composite

--- a/docs/api/propagators.textmap.rst
+++ b/docs/api/propagators.textmap.rst
@@ -1,0 +1,7 @@
+opentelemetry.propagators.textmap
+====================================================
+
+Module contents
+---------------
+
+.. automodule:: opentelemetry.propagators.textmap

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,9 @@ nitpicky = True
 # https://github.com/sphinx-doc/sphinx/pull/3744
 nitpick_ignore = [
     ("py:class", "ValueT"),
+    ("py:class", "CarrierT"),
+    ("py:obj", "opentelemetry.propagators.textmap.CarrierT"),
+    ("py:obj", "Union"),
     (
         "py:class",
         "opentelemetry.sdk.metrics._internal.instrument._Synchronous",
@@ -111,23 +114,6 @@ nitpick_ignore = [
     (
         "py:class",
         "opentelemetry.trace._LinkBase",
-    ),
-    # TODO: Understand why sphinx is not able to find this local class
-    (
-        "py:class",
-        "opentelemetry.propagators.textmap.TextMapPropagator",
-    ),
-    (
-        "py:class",
-        "opentelemetry.propagators.textmap.DefaultGetter",
-    ),
-    (
-        "any",
-        "opentelemetry.propagators.textmap.TextMapPropagator.extract",
-    ),
-    (
-        "any",
-        "opentelemetry.propagators.textmap.TextMapPropagator.inject",
     ),
 ]
 


### PR DESCRIPTION
Looks like this important core module was completely missing from the docs (it is also not mentioned at https://opentelemetry.io/docs/instrumentation/python/manual/ and I believe https://opentelemetry.io/docs/instrumentation/python/cookbook/#manually-setting-span-context mentions something either outdated or a bad practice, namely instantiating TraceContextTextMapPropagator directly instead of going through the global accessor)