### PR TITLE
Allow git to check out files with long names in Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: 7b42e4354dc3244ef2878bfd0d7d4c80d25cba0a
+  CONTRIB_REPO_SHA: ac84e9968fc5bfb16016a4e0ca82059bf1e86511
   # This is needed because we do not clone the core repo in contrib builds anymore.
   # When running contrib builds as part of core builds, we use actions/checkout@v2 which
   # does not set an environment variable (simply just runs tox), which is different when

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,9 @@ jobs:
         if: ${{ matrix.os == 'windows-2019' && matrix.python-version == 'py36' }} 
         shell: pwsh
         run: Remove-Item .\.tox\ -Force -Recurse -ErrorAction Ignore
+      - name: Windows does not let git check out files with long names
+        if: ${{ matrix.os == 'windows-2019'}} 
+        run: git config --system core.longpaths true
       - name: run tox
         run: tox -f ${{ matrix.python-version }}-${{ matrix.package }} -- --benchmark-json=${{ env.RUN_MATRIX_COMBINATION }}-benchmark.json
       - name: Find and merge benchmarks


### PR DESCRIPTION
Fixes #2789