### PR TITLE
LabelValue can be list of strings

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -71,8 +71,9 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_SERVICE_NAME,
 )
 from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.util.types import AttributeValue
 
-LabelValue = typing.Union[str, bool, int, float, list[str]]
+LabelValue = AttributeValue
 Attributes = typing.Dict[str, LabelValue]
 logger = logging.getLogger(__name__)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -72,7 +72,7 @@ from opentelemetry.sdk.environment_variables import (
 )
 from opentelemetry.semconv.resource import ResourceAttributes
 
-LabelValue = typing.Union[str, bool, int, float]
+LabelValue = typing.Union[str, bool, int, float, list[str]]
 Attributes = typing.Dict[str, LabelValue]
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

As per [this documentation](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/cloud_provider/aws/logs/), it's possible for `LabelValue` to be a list of strings.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Presumably, if type checks pass then this should be good to go.

# Does This PR Require a Contrib Repo Change?

From what I can tell, no.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
