### PR TITLE
Revert "Python 3.11: Enhanced error locations in tracebacks (#2771)"

### DIFF
--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -15,7 +15,6 @@
 # pylint: disable=too-many-lines
 import shutil
 import subprocess
-import sys
 import unittest
 from importlib import reload
 from logging import ERROR, WARNING
@@ -1187,13 +1186,6 @@ class TestSpan(unittest.TestCase):
             stacktrace = """in test_record_exception_context_manager
     raise RuntimeError("example error")
 RuntimeError: example error"""
-            if sys.version_info >= (3, 11):
-                # https://docs.python.org/3.11/whatsnew/3.11.html#enhanced-error-locations-in-tracebacks
-                tracelines = stacktrace.splitlines()
-                tracelines.insert(
-                    -1, "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
-                )
-                stacktrace = "\n".join(tracelines)
             self.assertIn(stacktrace, event.attributes["exception.stacktrace"])
 
         try:


### PR DESCRIPTION
# Description

This reverts commit aa367302989978a1ae04badee7e3948502b96616.

It is no longer required on Python 3.11.0b4 and later; see https://github.com/open-telemetry/opentelemetry-python/pull/2771#issuecomment-1193421508 and https://mail.python.org/archives/list/python-dev@python.org/message/73YP4RS4QOJXUS63BQZVLTQHK3OP3L3H/.

Specifically, the `^^^^…` are now omitted when they would “underline” the whole preceding line, which is the case here, so the expected output is the same as for Python 3.10 and earlier.

Fixes (no issue file)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've built the Fedora package on Python 3.11.0b4; it fails with https://github.com/open-telemetry/opentelemetry-python/commit/aa367302989978a1ae04badee7e3948502b96616 applied as a patch, and succeeds with the patch removed as in this PR.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
