### PR TITLE
Remove LogEmitter.flush() to align with OTel Log Spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2873](https://github.com/open-telemetry/opentelemetry-python/pull/2873))
 - Add param for `indent` size to `LogRecord.to_json()`
   ([#2870](https://github.com/open-telemetry/opentelemetry-python/pull/2870))
-- Fix: Remove LogEmitter.flush() to align with OTel Log spec
+- Fix: Remove `LogEmitter.flush()` to align with OTel Log spec
   ([#2863](https://github.com/open-telemetry/opentelemetry-python/pull/2863))
 
 ## [1.12.0-0.33b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0-0.33b0) - 2022-08-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add temporality and aggregation configuration for metrics exporters,
   use `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` only for OTLP metrics exporter
   ([#2843](https://github.com/open-telemetry/opentelemetry-python/pull/2843))
--  Instrument instances are always created through a Meter
+- Instrument instances are always created through a Meter
   ([#2844](https://github.com/open-telemetry/opentelemetry-python/pull/2844))
--  Fix: Remove LogEmitter.flush() to align with OTel Log spec
+- Fix: Remove LogEmitter.flush() to align with OTel Log spec
   ([#2863](https://github.com/open-telemetry/opentelemetry-python/pull/2863))
 
 ## [1.12.0rc2-0.32b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0rc2) - 2022-07-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2873](https://github.com/open-telemetry/opentelemetry-python/pull/2873))
 - Add param for `indent` size to `LogRecord.to_json()`
   ([#2870](https://github.com/open-telemetry/opentelemetry-python/pull/2870))
+- Fix: Remove LogEmitter.flush() to align with OTel Log spec
+  ([#2863](https://github.com/open-telemetry/opentelemetry-python/pull/2863))
 
 ## [1.12.0-0.33b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0-0.33b0) - 2022-08-08
 
@@ -31,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2843](https://github.com/open-telemetry/opentelemetry-python/pull/2843))
 - Instrument instances are always created through a Meter
   ([#2844](https://github.com/open-telemetry/opentelemetry-python/pull/2844))
-- Fix: Remove LogEmitter.flush() to align with OTel Log spec
-  ([#2863](https://github.com/open-telemetry/opentelemetry-python/pull/2863))
 
 ## [1.12.0rc2-0.32b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0rc2) - 2022-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2843](https://github.com/open-telemetry/opentelemetry-python/pull/2843))
 -  Instrument instances are always created through a Meter
   ([#2844](https://github.com/open-telemetry/opentelemetry-python/pull/2844))
+-  Fix: Remove LogEmitter.flush() to align with OTel Log spec
+  ([#2863](https://github.com/open-telemetry/opentelemetry-python/pull/2863))
 
 ## [1.12.0rc2-0.32b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0rc2) - 2022-07-04
 

--- a/docs/examples/logs/example.py
+++ b/docs/examples/logs/example.py
@@ -34,8 +34,7 @@ set_log_emitter_provider(log_emitter_provider)
 
 exporter = OTLPLogExporter(insecure=True)
 log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
-log_emitter = log_emitter_provider.get_log_emitter(__name__, "0.1")
-handler = LoggingHandler(level=logging.NOTSET, log_emitter=log_emitter)
+handler = LoggingHandler(level=logging.NOTSET, log_emitter_provider=log_emitter_provider)
 
 # Attach OTLP handler to root logger
 logging.getLogger().addHandler(handler)

--- a/docs/examples/logs/example.py
+++ b/docs/examples/logs/example.py
@@ -34,7 +34,9 @@ set_log_emitter_provider(log_emitter_provider)
 
 exporter = OTLPLogExporter(insecure=True)
 log_emitter_provider.add_log_processor(BatchLogProcessor(exporter))
-handler = LoggingHandler(level=logging.NOTSET, log_emitter_provider=log_emitter_provider)
+handler = LoggingHandler(
+    level=logging.NOTSET, log_emitter_provider=log_emitter_provider
+)
 
 # Attach OTLP handler to root logger
 logging.getLogger().addHandler(handler)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -151,7 +151,9 @@ def _init_logging(
             BatchLogProcessor(exporter_class(**exporter_args))
         )
 
-    handler = LoggingHandler(level=logging.NOTSET, log_emitter_provider=provider)
+    handler = LoggingHandler(
+        level=logging.NOTSET, log_emitter_provider=provider
+    )
 
     logging.getLogger().addHandler(handler)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -151,8 +151,7 @@ def _init_logging(
             BatchLogProcessor(exporter_class(**exporter_args))
         )
 
-    log_emitter = provider.get_log_emitter(__name__)
-    handler = LoggingHandler(level=logging.NOTSET, log_emitter=log_emitter)
+    handler = LoggingHandler(level=logging.NOTSET, log_emitter_provider=provider)
 
     logging.getLogger().addHandler(handler)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -314,8 +314,12 @@ class LoggingHandler(logging.Handler):
         log_emitter_provider=None,
     ) -> None:
         super().__init__(level=level)
-        self._log_emitter_provider = log_emitter_provider or get_log_emitter_provider()
-        self._log_emitter = get_log_emitter(__name__, log_emitter_provider=self._log_emitter_provider)
+        self._log_emitter_provider = (
+            log_emitter_provider or get_log_emitter_provider()
+        )
+        self._log_emitter = get_log_emitter(
+            __name__, log_emitter_provider=self._log_emitter_provider
+        )
 
     @staticmethod
     def _get_attributes(record: logging.LogRecord) -> Attributes:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -311,10 +311,11 @@ class LoggingHandler(logging.Handler):
     def __init__(
         self,
         level=logging.NOTSET,
-        log_emitter=None,
+        log_emitter_provider=None,
     ) -> None:
         super().__init__(level=level)
-        self._log_emitter = log_emitter or get_log_emitter(__name__)
+        self._log_emitter_provider = log_emitter_provider or get_log_emitter_provider()
+        self._log_emitter = get_log_emitter(__name__, log_emitter_provider=self._log_emitter_provider)
 
     @staticmethod
     def _get_attributes(record: logging.LogRecord) -> Attributes:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -370,7 +370,7 @@ class LoggingHandler(logging.Handler):
         """
         Flushes the logging output.
         """
-        self._log_emitter.flush()
+        self._log_emitter_provider.force_flush()
 
 
 class LogEmitter:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -396,12 +396,6 @@ class LogEmitter:
         log_data = LogData(record, self._instrumentation_scope)
         self._multi_log_processor.emit(log_data)
 
-    # TODO: Should this flush everything in pipeline?
-    # Prior discussion https://github.com/open-telemetry/opentelemetry-python/pull/1916#discussion_r659945290
-    def flush(self):
-        """Ensure all logging output has been flushed."""
-        self._multi_log_processor.force_flush()
-
 
 class LogEmitterProvider:
     def __init__(

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -48,12 +48,11 @@ class TestSimpleLogProcessor(unittest.TestCase):
     def test_simple_log_processor_default_level(self):
         exporter = InMemoryLogExporter()
         log_emitter_provider = LogEmitterProvider()
-        log_emitter = log_emitter_provider.get_log_emitter(__name__)
 
         log_emitter_provider.add_log_processor(SimpleLogProcessor(exporter))
 
         logger = logging.getLogger("default_level")
-        logger.addHandler(LoggingHandler(log_emitter=log_emitter))
+        logger.addHandler(LoggingHandler(log_emitter_provider=log_emitter_provider))
 
         logger.warning("Something is wrong")
         finished_logs = exporter.get_finished_logs()
@@ -68,13 +67,12 @@ class TestSimpleLogProcessor(unittest.TestCase):
     def test_simple_log_processor_custom_level(self):
         exporter = InMemoryLogExporter()
         log_emitter_provider = LogEmitterProvider()
-        log_emitter = log_emitter_provider.get_log_emitter(__name__)
 
         log_emitter_provider.add_log_processor(SimpleLogProcessor(exporter))
 
         logger = logging.getLogger("custom_level")
         logger.setLevel(logging.ERROR)
-        logger.addHandler(LoggingHandler(log_emitter=log_emitter))
+        logger.addHandler(LoggingHandler(log_emitter_provider=log_emitter_provider))
 
         logger.warning("Warning message")
         logger.debug("Debug message")
@@ -99,12 +97,11 @@ class TestSimpleLogProcessor(unittest.TestCase):
     def test_simple_log_processor_trace_correlation(self):
         exporter = InMemoryLogExporter()
         log_emitter_provider = LogEmitterProvider()
-        log_emitter = log_emitter_provider.get_log_emitter("name", "version")
 
         log_emitter_provider.add_log_processor(SimpleLogProcessor(exporter))
 
         logger = logging.getLogger("trace_correlation")
-        logger.addHandler(LoggingHandler(log_emitter=log_emitter))
+        logger.addHandler(LoggingHandler(log_emitter_provider=log_emitter_provider))
 
         logger.warning("Warning message")
         finished_logs = exporter.get_finished_logs()
@@ -137,12 +134,11 @@ class TestSimpleLogProcessor(unittest.TestCase):
     def test_simple_log_processor_shutdown(self):
         exporter = InMemoryLogExporter()
         log_emitter_provider = LogEmitterProvider()
-        log_emitter = log_emitter_provider.get_log_emitter(__name__)
 
         log_emitter_provider.add_log_processor(SimpleLogProcessor(exporter))
 
         logger = logging.getLogger("shutdown")
-        logger.addHandler(LoggingHandler(log_emitter=log_emitter))
+        logger.addHandler(LoggingHandler(log_emitter_provider=log_emitter_provider))
 
         logger.warning("Something is wrong")
         finished_logs = exporter.get_finished_logs()
@@ -167,9 +163,8 @@ class TestBatchLogProcessor(ConcurrencyTestBase):
         provider = LogEmitterProvider()
         provider.add_log_processor(log_processor)
 
-        emitter = provider.get_log_emitter(__name__)
         logger = logging.getLogger("emit_call")
-        logger.addHandler(LoggingHandler(log_emitter=emitter))
+        logger.addHandler(LoggingHandler(log_emitter_provider=provider))
 
         logger.error("error")
         self.assertEqual(log_processor.emit.call_count, 1)
@@ -181,9 +176,8 @@ class TestBatchLogProcessor(ConcurrencyTestBase):
         provider = LogEmitterProvider()
         provider.add_log_processor(log_processor)
 
-        emitter = provider.get_log_emitter(__name__)
         logger = logging.getLogger("shutdown")
-        logger.addHandler(LoggingHandler(log_emitter=emitter))
+        logger.addHandler(LoggingHandler(log_emitter_provider=provider))
 
         logger.warning("warning message: %s", "possible upcoming heatwave")
         logger.error("Very high rise in temperatures across the globe")
@@ -214,9 +208,8 @@ class TestBatchLogProcessor(ConcurrencyTestBase):
         provider = LogEmitterProvider()
         provider.add_log_processor(log_processor)
 
-        emitter = provider.get_log_emitter(__name__)
         logger = logging.getLogger("force_flush")
-        logger.addHandler(LoggingHandler(log_emitter=emitter))
+        logger.addHandler(LoggingHandler(log_emitter_provider=provider))
 
         logger.critical("Earth is burning")
         log_processor.force_flush()
@@ -233,9 +226,8 @@ class TestBatchLogProcessor(ConcurrencyTestBase):
         provider = LogEmitterProvider()
         provider.add_log_processor(log_processor)
 
-        emitter = provider.get_log_emitter(__name__)
         logger = logging.getLogger("many_logs")
-        logger.addHandler(LoggingHandler(log_emitter=emitter))
+        logger.addHandler(LoggingHandler(log_emitter_provider=provider))
 
         for log_no in range(1000):
             logger.critical("Log no: %s", log_no)
@@ -251,9 +243,8 @@ class TestBatchLogProcessor(ConcurrencyTestBase):
         provider = LogEmitterProvider()
         provider.add_log_processor(log_processor)
 
-        emitter = provider.get_log_emitter(__name__)
         logger = logging.getLogger("threads")
-        logger.addHandler(LoggingHandler(log_emitter=emitter))
+        logger.addHandler(LoggingHandler(log_emitter_provider=provider))
 
         def bulk_log_and_flush(num_logs):
             for _ in range(num_logs):
@@ -286,9 +277,8 @@ class TestBatchLogProcessor(ConcurrencyTestBase):
         provider = LogEmitterProvider()
         provider.add_log_processor(log_processor)
 
-        emitter = provider.get_log_emitter(__name__)
         logger = logging.getLogger("test-fork")
-        logger.addHandler(LoggingHandler(log_emitter=emitter))
+        logger.addHandler(LoggingHandler(log_emitter_provider=provider))
 
         logger.critical("yolo")
         time.sleep(0.5)  # give some time for the exporter to upload

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -52,7 +52,9 @@ class TestSimpleLogProcessor(unittest.TestCase):
         log_emitter_provider.add_log_processor(SimpleLogProcessor(exporter))
 
         logger = logging.getLogger("default_level")
-        logger.addHandler(LoggingHandler(log_emitter_provider=log_emitter_provider))
+        logger.addHandler(
+            LoggingHandler(log_emitter_provider=log_emitter_provider)
+        )
 
         logger.warning("Something is wrong")
         finished_logs = exporter.get_finished_logs()
@@ -72,7 +74,9 @@ class TestSimpleLogProcessor(unittest.TestCase):
 
         logger = logging.getLogger("custom_level")
         logger.setLevel(logging.ERROR)
-        logger.addHandler(LoggingHandler(log_emitter_provider=log_emitter_provider))
+        logger.addHandler(
+            LoggingHandler(log_emitter_provider=log_emitter_provider)
+        )
 
         logger.warning("Warning message")
         logger.debug("Debug message")
@@ -101,7 +105,9 @@ class TestSimpleLogProcessor(unittest.TestCase):
         log_emitter_provider.add_log_processor(SimpleLogProcessor(exporter))
 
         logger = logging.getLogger("trace_correlation")
-        logger.addHandler(LoggingHandler(log_emitter_provider=log_emitter_provider))
+        logger.addHandler(
+            LoggingHandler(log_emitter_provider=log_emitter_provider)
+        )
 
         logger.warning("Warning message")
         finished_logs = exporter.get_finished_logs()
@@ -138,7 +144,9 @@ class TestSimpleLogProcessor(unittest.TestCase):
         log_emitter_provider.add_log_processor(SimpleLogProcessor(exporter))
 
         logger = logging.getLogger("shutdown")
-        logger.addHandler(LoggingHandler(log_emitter_provider=log_emitter_provider))
+        logger.addHandler(
+            LoggingHandler(log_emitter_provider=log_emitter_provider)
+        )
 
         logger.warning("Something is wrong")
         finished_logs = exporter.get_finished_logs()

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -16,7 +16,11 @@ import unittest
 from unittest.mock import Mock
 
 from opentelemetry.sdk import trace
-from opentelemetry.sdk._logs import get_log_emitter, LogEmitterProvider, LoggingHandler
+from opentelemetry.sdk._logs import (
+    LogEmitterProvider,
+    LoggingHandler,
+    get_log_emitter,
+)
 from opentelemetry.sdk._logs.severity import SeverityNumber
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import INVALID_SPAN_CONTEXT

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -28,7 +28,9 @@ from opentelemetry.trace import INVALID_SPAN_CONTEXT
 
 def get_logger(level=logging.NOTSET, log_emitter_provider=None):
     logger = logging.getLogger(__name__)
-    handler = LoggingHandler(level=level, log_emitter_provider=log_emitter_provider)
+    handler = LoggingHandler(
+        level=level, log_emitter_provider=log_emitter_provider
+    )
     logger.addHandler(handler)
     return logger
 
@@ -36,7 +38,9 @@ def get_logger(level=logging.NOTSET, log_emitter_provider=None):
 class TestLoggingHandler(unittest.TestCase):
     def test_handler_default_log_level(self):
         emitter_provider_mock = Mock(spec=LogEmitterProvider)
-        emitter_mock = get_log_emitter(__name__, log_emitter_provider=emitter_provider_mock)
+        emitter_mock = get_log_emitter(
+            __name__, log_emitter_provider=emitter_provider_mock
+        )
         logger = get_logger(log_emitter_provider=emitter_provider_mock)
         # Make sure debug messages are ignored by default
         logger.debug("Debug message")
@@ -47,8 +51,12 @@ class TestLoggingHandler(unittest.TestCase):
 
     def test_handler_custom_log_level(self):
         emitter_provider_mock = Mock(spec=LogEmitterProvider)
-        emitter_mock = get_log_emitter(__name__, log_emitter_provider=emitter_provider_mock)
-        logger = get_logger(level=logging.ERROR, log_emitter_provider=emitter_provider_mock)
+        emitter_mock = get_log_emitter(
+            __name__, log_emitter_provider=emitter_provider_mock
+        )
+        logger = get_logger(
+            level=logging.ERROR, log_emitter_provider=emitter_provider_mock
+        )
         logger.warning("Warning message test custom log level")
         # Make sure any log with level < ERROR is ignored
         self.assertEqual(emitter_mock.emit.call_count, 0)
@@ -58,7 +66,9 @@ class TestLoggingHandler(unittest.TestCase):
 
     def test_log_record_no_span_context(self):
         emitter_provider_mock = Mock(spec=LogEmitterProvider)
-        emitter_mock = get_log_emitter(__name__, log_emitter_provider=emitter_provider_mock)
+        emitter_mock = get_log_emitter(
+            __name__, log_emitter_provider=emitter_provider_mock
+        )
         logger = get_logger(log_emitter_provider=emitter_provider_mock)
         # Assert emit gets called for warning message
         logger.warning("Warning message")
@@ -75,7 +85,9 @@ class TestLoggingHandler(unittest.TestCase):
     def test_log_record_user_attributes(self):
         """Attributes can be injected into logs by adding them to the LogRecord"""
         emitter_provider_mock = Mock(spec=LogEmitterProvider)
-        emitter_mock = get_log_emitter(__name__, log_emitter_provider=emitter_provider_mock)
+        emitter_mock = get_log_emitter(
+            __name__, log_emitter_provider=emitter_provider_mock
+        )
         logger = get_logger(log_emitter_provider=emitter_provider_mock)
         # Assert emit gets called for warning message
         logger.warning("Warning message", extra={"http.status_code": 200})
@@ -88,7 +100,9 @@ class TestLoggingHandler(unittest.TestCase):
     def test_log_record_exception(self):
         """Exception information will be included in attributes"""
         emitter_provider_mock = Mock(spec=LogEmitterProvider)
-        emitter_mock = get_log_emitter(__name__, log_emitter_provider=emitter_provider_mock)
+        emitter_mock = get_log_emitter(
+            __name__, log_emitter_provider=emitter_provider_mock
+        )
         logger = get_logger(log_emitter_provider=emitter_provider_mock)
         try:
             raise ZeroDivisionError("division by zero")
@@ -119,7 +133,9 @@ class TestLoggingHandler(unittest.TestCase):
     def test_log_exc_info_false(self):
         """Exception information will be included in attributes"""
         emitter_provider_mock = Mock(spec=LogEmitterProvider)
-        emitter_mock = get_log_emitter(__name__, log_emitter_provider=emitter_provider_mock)
+        emitter_mock = get_log_emitter(
+            __name__, log_emitter_provider=emitter_provider_mock
+        )
         logger = get_logger(log_emitter_provider=emitter_provider_mock)
         try:
             raise ZeroDivisionError("division by zero")
@@ -140,7 +156,9 @@ class TestLoggingHandler(unittest.TestCase):
 
     def test_log_record_trace_correlation(self):
         emitter_provider_mock = Mock(spec=LogEmitterProvider)
-        emitter_mock = get_log_emitter(__name__, log_emitter_provider=emitter_provider_mock)
+        emitter_mock = get_log_emitter(
+            __name__, log_emitter_provider=emitter_provider_mock
+        )
         logger = get_logger(log_emitter_provider=emitter_provider_mock)
 
         tracer = trace.TracerProvider().get_tracer(__name__)

--- a/opentelemetry-sdk/tests/logs/test_multi_log_prcessor.py
+++ b/opentelemetry-sdk/tests/logs/test_multi_log_prcessor.py
@@ -57,8 +57,7 @@ class AnotherLogProcessor(LogProcessor):
 class TestLogProcessor(unittest.TestCase):
     def test_log_processor(self):
         provider = LogEmitterProvider()
-        log_emitter = provider.get_log_emitter(__name__)
-        handler = LoggingHandler(log_emitter=log_emitter)
+        handler = LoggingHandler(log_emitter_provider=provider)
 
         logs_list_1 = []
         processor1 = AnotherLogProcessor(Mock(), logs_list_1)

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -71,6 +71,9 @@ class DummyLogEmitterProvider:
     def get_log_emitter(self, name):
         return DummyLogEmitter(name, self.resource, self.processor)
 
+    def force_flush(self, *args, **kwargs):
+        pass
+
 
 class DummyMeterProvider(MeterProvider):
     pass

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -88,9 +88,6 @@ class DummyLogEmitter:
     def emit(self, record):
         self.processor.emit(record)
 
-    def flush(self):
-        pass
-
 
 class DummyLogProcessor:
     def __init__(self, exporter):

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -68,7 +68,7 @@ class DummyLogEmitterProvider:
     def add_log_processor(self, processor):
         self.processor = processor
 
-    def get_log_emitter(self, name):
+    def get_log_emitter(self, name, *args, **kwargs):
         return DummyLogEmitter(name, self.resource, self.processor)
 
     def force_flush(self, *args, **kwargs):


### PR DESCRIPTION
# Description

Fixes #2584

**Motivation:** Align `LogEmitter` implementation with OTel Log spec

**Summary:**
- Remove `LogEmitter.flush()`
- Modify `LoggingHandler.__init__()`: 
  - Replace `log_emitter` arg with `log_emitter_provider`
  - Obtain `log_emitter` via `log_emitter_provider`
- Modify `LoggingHandler.flush()`: Replace `LogEmitter.flush()` with `LogEmitterProvider.force_flush()`
- Update code and tests to adhere to new `LoggingHandler.__init__()` signature
- Fix bugs in test mock `DummyLogEmitterProvider`
- Remove `DummyLogEmitter.flush()` to align with removal of `LogEmitter.flush()`

**ps:** First time contributing -- let me know if you need me to change/add anything!


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [x] Ran `opentelemetry-sdk` test suite

<details>
  <summary>Test Results</summary>

```
> tox -e opentelemetry-sdk
opentelemetry-sdk installed: asgiref==3.5.2,atomicwrites==1.4.1,attrs==22.1.0,colorama==0.4.5,Deprecated==1.2.13,flaky==3.7.0,iniconfig==1.1.1,opentelemetry-api @ file:///C:/.../opentelemetry-api,opentelemetry-sdk @ file:///C:/.../opentelemetry-sdk,opentelemetry-semantic-conventions @ file:///C:/.../opentelemetry-semantic-conventions,opentelemetry-test-utils @ file:///C:/.../tests/opentelemetry-test-utils,packaging==21.3,pluggy==1.0.0,py==1.11.0,py-cpuinfo==8.0.0,pyparsing==3.0.9,pytest==7.1.2,pytest-benchmark==3.4.1,tomli==2.0.1,typing_extensions==4.3.0,wrapt==1.14.1
opentelemetry-sdk run-test-pre: PYTHONHASHSEED='7'
opentelemetry-sdk run-test-pre: commands[0] | pip install 'C:\.../opentelemetry-api' 'C:\.../opentelemetry-semantic-conventions' 'C:\.../opentelemetry-sdk' 'C:\.../tests/opentelemetry-test-utils'
Processing c:\...\opentelemetry-api
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Processing c:\...\opentelemetry-semantic-conventions
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Processing c:\...\opentelemetry-sdk
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Processing c:\...\tests\opentelemetry-test-utils
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Requirement already satisfied: Deprecated>=1.2.6 in c:\...\.tox\opentelemetry-sdk\lib\site-packages (from opentelemetry-api==1.12.0rc2) (1.2.13)
Requirement already satisfied: setuptools>=16.0 in c:\...\.tox\opentelemetry-sdk\lib\site-packages (from opentelemetry-api==1.12.0rc2) (63.4.1)
Requirement already satisfied: typing-extensions>=3.7.4 in c:\...\.tox\opentelemetry-sdk\lib\site-packages (from opentelemetry-sdk==1.12.0rc2) (4.3.0)
Requirement already satisfied: asgiref~=3.0 in c:\...\.tox\opentelemetry-sdk\lib\site-packages (from opentelemetry-test-utils==0.32b0) (3.5.2)
Requirement already satisfied: wrapt<2,>=1.10 in c:\...\.tox\opentelemetry-sdk\lib\site-packages (from Deprecated>=1.2.6->opentelemetry-api==1.12.0rc2) (1.14.1)
Building wheels for collected packages: opentelemetry-api, opentelemetry-semantic-conventions, opentelemetry-sdk, opentelemetry-test-utils
  Building wheel for opentelemetry-api (setup.py): started
  Building wheel for opentelemetry-api (setup.py): finished with status 'done'
  Created wheel for opentelemetry-api: filename=opentelemetry_api-1.12.0rc2-py3-none-any.whl size=52560 sha256=3456e8cc09b6a47cf7b1e49c8343623225caedfdc8a12139446fb72a05a6d08c
  Stored in directory: c:\...\appdata\local\pip\cache\wheels\1f\ed\bf\08d0b67ea47bd58b9e700afdb8c2dc35d5e78b8f81880bf69b
  Building wheel for opentelemetry-semantic-conventions (setup.py): started
  Building wheel for opentelemetry-semantic-conventions (setup.py): finished with status 'done'
  Created wheel for opentelemetry-semantic-conventions: filename=opentelemetry_semantic_conventions-0.32b0-py3-none-any.whl size=26138 sha256=004869e164b12a2aefcfb83600b65a1698a97771d275076144656b23c8e8be7d
  Stored in directory: c:\...\appdata\local\pip\cache\wheels\b8\24\3b\753e6fa716fd75596fb89495e2d51dd0948cb2fd9821c133e5
  Building wheel for opentelemetry-sdk (setup.py): started
  Building wheel for opentelemetry-sdk (setup.py): finished with status 'done'
  Created wheel for opentelemetry-sdk: filename=opentelemetry_sdk-1.12.0rc2-py3-none-any.whl size=81066 sha256=8b7ded3c556b414c925aaf0cbb175796ed9df47bf8dfc39225c09e096609a479
  Stored in directory: c:\...\appdata\local\pip\cache\wheels\14\f1\ba\8919d6e32851a7c14fa95985942d5f01d5893d6c5763c04dbb
  Building wheel for opentelemetry-test-utils (setup.py): started
  Building wheel for opentelemetry-test-utils (setup.py): finished with status 'done'
  Created wheel for opentelemetry-test-utils: filename=opentelemetry_test_utils-0.32b0-py3-none-any.whl size=12524 sha256=8dbb7f93d9d70bf0c1ae20934377af63286862450747de06df96170b5b37eea7
  Stored in directory: c:\...\appdata\local\pip\cache\wheels\c1\2d\cc\27240f795744c0e9500c2d5896726c85bbdcde69cfaacf8359
Successfully built opentelemetry-api opentelemetry-semantic-conventions opentelemetry-sdk opentelemetry-test-utils
Installing collected packages: opentelemetry-semantic-conventions, opentelemetry-api, opentelemetry-sdk, opentelemetry-test-utils
  Attempting uninstall: opentelemetry-semantic-conventions
    Found existing installation: opentelemetry-semantic-conventions 0.32b0
    Uninstalling opentelemetry-semantic-conventions-0.32b0:
      Successfully uninstalled opentelemetry-semantic-conventions-0.32b0
  Attempting uninstall: opentelemetry-api
    Found existing installation: opentelemetry-api 1.12.0rc2
    Uninstalling opentelemetry-api-1.12.0rc2:
      Successfully uninstalled opentelemetry-api-1.12.0rc2
  Attempting uninstall: opentelemetry-sdk
    Found existing installation: opentelemetry-sdk 1.12.0rc2
    Uninstalling opentelemetry-sdk-1.12.0rc2:
      Successfully uninstalled opentelemetry-sdk-1.12.0rc2
  Attempting uninstall: opentelemetry-test-utils
    Found existing installation: opentelemetry-test-utils 0.32b0
    Uninstalling opentelemetry-test-utils-0.32b0:
      Successfully uninstalled opentelemetry-test-utils-0.32b0
Successfully installed opentelemetry-api-1.12.0rc2 opentelemetry-sdk-1.12.0rc2 opentelemetry-semantic-conventions-0.32b0 opentelemetry-test-utils-0.32b0
opentelemetry-sdk run-test: commands[0] | pytest
============================= test session starts =============================
platform win32 -- Python 3.9.1, pytest-7.1.2, pluggy-1.0.0 -- C:\...\.tox\opentelemetry-sdk\Scripts\python.EXE
cachedir: .tox\opentelemetry-sdk\.pytest_cache
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: C:\..., configfile: pyproject.toml
plugins: flaky-3.7.0, benchmark-3.4.1
collecting ... collected 346 items

test_configurator.py::TestTraceInit::test_trace_init_custom_id_generator PASSED [  0%]
test_configurator.py::TestTraceInit::test_trace_init_default PASSED      [  0%]
test_configurator.py::TestTraceInit::test_trace_init_otlp PASSED         [  0%]
test_configurator.py::TestLoggingInit::test_logging_init_disable_default PASSED [  1%]
test_configurator.py::TestLoggingInit::test_logging_init_empty PASSED    [  1%]
test_configurator.py::TestLoggingInit::test_logging_init_enable_env 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.metrics._internal:__init__.py:746 Overriding of current MeterProvider is not allowed
PASSED                                                                   [  1%]
test_configurator.py::TestLoggingInit::test_logging_init_exporter 
-------------------------------- live log call --------------------------------
ERROR    tests.test_configurator:test_configurator.py:331 hello
PASSED                                                                   [  2%]
test_configurator.py::TestMetricsInit::test_metrics_init_empty PASSED    [  2%]
test_configurator.py::TestMetricsInit::test_metrics_init_exporter PASSED [  2%]
test_configurator.py::TestExporterNames::test_empty_exporters PASSED     [  2%]
test_configurator.py::TestExporterNames::test_multiple_exporters PASSED  [  3%]
test_configurator.py::TestExporterNames::test_no_exporters PASSED        [  3%]
test_configurator.py::TestExporterNames::test_none_exporters PASSED      [  3%]
test_configurator.py::TestExporterNames::test_otlp_exporter_overwrite PASSED [  4%]
test_configurator.py::TestImportExporters::test_console_exporters PASSED [  4%]
test_util.py::TestBoundedList::test_append_drop PASSED                   [  4%]
test_util.py::TestBoundedList::test_append_no_drop PASSED                [  4%]
test_util.py::TestBoundedList::test_extend_drop PASSED                   [  5%]
test_util.py::TestBoundedList::test_extend_no_drop PASSED                [  5%]
test_util.py::TestBoundedList::test_from_seq PASSED                      [  5%]
test_util.py::TestBoundedList::test_no_limit PASSED                      [  6%]
test_util.py::TestBoundedList::test_raises PASSED                        [  6%]
context\test_asyncio.py::TestAsyncio::test_with_asyncio PASSED           [  6%]
error_handler\test_error_handler.py::TestErrorHandler::test_default_error_handler PASSED [  6%]
error_handler\test_error_handler.py::TestErrorHandler::test_error_in_handler PASSED [  7%]
error_handler\test_error_handler.py::TestErrorHandler::test_plugin_error_handler PASSED [  7%]
error_handler\test_error_handler.py::TestErrorHandler::test_plugin_error_handler_context_manager PASSED [  7%]
logs\test_export.py::TestSimpleLogProcessor::test_simple_log_processor_custom_level 
-------------------------------- live log call --------------------------------
ERROR    custom_level:test_export.py:79 Error message
CRITICAL custom_level:test_export.py:80 Critical message
PASSED                                                                   [  8%]
logs\test_export.py::TestSimpleLogProcessor::test_simple_log_processor_default_level 
-------------------------------- live log call --------------------------------
WARNING  default_level:test_export.py:57 Something is wrong
PASSED                                                                   [  8%]
logs\test_export.py::TestSimpleLogProcessor::test_simple_log_processor_shutdown 
-------------------------------- live log call --------------------------------
WARNING  shutdown:test_export.py:143 Something is wrong
WARNING  opentelemetry.sdk._logs.export:__init__.py:106 Processor is already shutdown, ignoring call
WARNING  shutdown:test_export.py:154 Log after shutdown
PASSED                                                                   [  8%]
logs\test_export.py::TestSimpleLogProcessor::test_simple_log_processor_trace_correlation 
-------------------------------- live log call --------------------------------
WARNING  trace_correlation:test_export.py:106 Warning message
CRITICAL trace_correlation:test_export.py:122 Critical message within span
PASSED                                                                   [  8%]
logs\test_export.py::TestBatchLogProcessor::test_batch_log_processor_fork SKIPPED [  9%]
logs\test_export.py::TestBatchLogProcessor::test_emit_call_log_record 
-------------------------------- live log call --------------------------------
ERROR    emit_call:test_export.py:169 error
PASSED                                                                   [  9%]
logs\test_export.py::TestBatchLogProcessor::test_force_flush 
-------------------------------- live log call --------------------------------
CRITICAL force_flush:test_export.py:214 Earth is burning
PASSED                                                                   [  9%]
logs\test_export.py::TestBatchLogProcessor::test_log_processor_too_many_logs 
-------------------------------- live log call --------------------------------
CRITICAL many_logs:test_export.py:233 Log no: 0
...
CRITICAL many_logs:test_export.py:233 Log no: 999
PASSED                                                                   [ 10%]
logs\test_export.py::TestBatchLogProcessor::test_shutdown 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk._logs.export:__init__.py:106 Processor is already shutdown, ignoring call
WARNING  shutdown:test_export.py:182 warning message: possible upcoming heatwave
WARNING  opentelemetry.sdk._logs.export:__init__.py:106 Processor is already shutdown, ignoring call
ERROR    shutdown:test_export.py:183 Very high rise in temperatures across the globe
WARNING  opentelemetry.sdk._logs.export:__init__.py:106 Processor is already shutdown, ignoring call
CRITICAL shutdown:test_export.py:184 Temparature hits high 420 C in Hyderabad
PASSED                                                                   [ 10%]
logs\test_export.py::TestBatchLogProcessor::test_with_multiple_threads 
-------------------------------- live log call --------------------------------
CRITICAL threads:test_export.py:251 Critical message
...
CRITICAL threads:test_export.py:251 Critical message
PASSED                                                                   [ 10%]
logs\test_export.py::TestConsoleLogExporter::test_export PASSED          [ 10%]
logs\test_export.py::TestConsoleLogExporter::test_export_custom PASSED   [ 11%]
logs\test_global_provider.py::TestGlobals::test_sdk_log_emitter_provider PASSED [ 11%]
logs\test_global_provider.py::TestGlobals::test_set_tracer_provider PASSED [ 11%]
logs\test_global_provider.py::TestGlobals::test_tracer_provider_override_warning PASSED [ 12%]
logs\test_global_provider.py::TestGlobals::test_unknown_log_emitter_provider 
-------------------------------- live log call --------------------------------
ERROR    opentelemetry.util._providers:_providers.py:51 Failed to load configured provider log_emitter_provider
PASSED                                                                   [ 12%]
logs\test_handler.py::TestLoggingHandler::test_handler_custom_log_level 
-------------------------------- live log call --------------------------------
WARNING  tests.logs.test_handler:test_handler.py:48 Warning message test custom log level
ERROR    tests.logs.test_handler:test_handler.py:51 Mumbai, we have a major problem
CRITICAL tests.logs.test_handler:test_handler.py:52 No Time For Caution
PASSED                                                                   [ 12%]
logs\test_handler.py::TestLoggingHandler::test_handler_default_log_level 
-------------------------------- live log call --------------------------------
WARNING  tests.logs.test_handler:test_handler.py:41 Warning message
PASSED                                                                   [ 13%]
logs\test_handler.py::TestLoggingHandler::test_log_exc_info_false 
-------------------------------- live log call --------------------------------
ERROR    tests.logs.test_handler:test_handler.py:123 Zero Division Error
PASSED                                                                   [ 13%]
logs\test_handler.py::TestLoggingHandler::test_log_record_exception 
-------------------------------- live log call --------------------------------
ERROR    tests.logs.test_handler:test_handler.py:92 Zero Division Error
Traceback (most recent call last):
  File "C:\...\opentelemetry-sdk\tests\logs\test_handler.py", line 90, in test_log_record_exception
    raise ZeroDivisionError("division by zero")
ZeroDivisionError: division by zero
PASSED                                                                   [ 13%]
logs\test_handler.py::TestLoggingHandler::test_log_record_no_span_context 
-------------------------------- live log call --------------------------------
WARNING  tests.logs.test_handler:test_handler.py:60 Warning message
PASSED                                                                   [ 13%]
logs\test_handler.py::TestLoggingHandler::test_log_record_trace_correlation 
-------------------------------- live log call --------------------------------
CRITICAL tests.logs.test_handler:test_handler.py:144 Critical message within span
PASSED                                                                   [ 14%]
logs\test_handler.py::TestLoggingHandler::test_log_record_user_attributes 
-------------------------------- live log call --------------------------------
WARNING  tests.logs.test_handler:test_handler.py:77 Warning message
PASSED                                                                   [ 14%]
logs\test_log_record.py::TestLogRecord::test_log_record_to_json PASSED   [ 14%]
logs\test_multi_log_prcessor.py::TestLogProcessor::test_log_processor 
-------------------------------- live log call --------------------------------
CRITICAL test.span.processor:test_multi_log_prcessor.py:71 Odisha, we have another major cyclone
WARNING  test.span.processor:test_multi_log_prcessor.py:78 Brace yourself
ERROR    test.span.processor:test_multi_log_prcessor.py:79 Some error message
CRITICAL test.span.processor:test_multi_log_prcessor.py:89 Something disastrous
PASSED                                                                   [ 15%]
logs\test_multi_log_prcessor.py::TestSynchronousMultiLogProcessor::test_force_flush_delayed PASSED [ 15%]
logs\test_multi_log_prcessor.py::TestSynchronousMultiLogProcessor::test_on_emit PASSED [ 15%]
logs\test_multi_log_prcessor.py::TestSynchronousMultiLogProcessor::test_on_force_flush PASSED [ 15%]
logs\test_multi_log_prcessor.py::TestSynchronousMultiLogProcessor::test_on_shutdown PASSED [ 16%]
logs\test_multi_log_prcessor.py::TestConcurrentMultiLogProcessor::test_force_flush_delayed PASSED [ 16%]
logs\test_multi_log_prcessor.py::TestConcurrentMultiLogProcessor::test_on_emit PASSED [ 16%]
logs\test_multi_log_prcessor.py::TestConcurrentMultiLogProcessor::test_on_force_flush PASSED [ 17%]
logs\test_multi_log_prcessor.py::TestConcurrentMultiLogProcessor::test_on_shutdown PASSED [ 17%]
metrics\test_aggregation.py::TestSynchronousSumAggregation::test_aggregate_cumulative PASSED [ 17%]
metrics\test_aggregation.py::TestSynchronousSumAggregation::test_aggregate_delta PASSED [ 17%]
metrics\test_aggregation.py::TestSynchronousSumAggregation::test_collect_cumulative PASSED [ 18%]
metrics\test_aggregation.py::TestSynchronousSumAggregation::test_collect_delta PASSED [ 18%]
metrics\test_aggregation.py::TestLastValueAggregation::test_aggregate PASSED [ 18%]
metrics\test_aggregation.py::TestLastValueAggregation::test_collect PASSED [ 19%]
metrics\test_aggregation.py::TestExplicitBucketHistogramAggregation::test_aggregate PASSED [ 19%]
metrics\test_aggregation.py::TestExplicitBucketHistogramAggregation::test_collect PASSED [ 19%]
metrics\test_aggregation.py::TestExplicitBucketHistogramAggregation::test_min_max PASSED [ 19%]
metrics\test_aggregation.py::TestAggregationFactory::test_explicit_bucket_histogram_factory PASSED [ 20%]
metrics\test_aggregation.py::TestAggregationFactory::test_last_value_factory PASSED [ 20%]
metrics\test_aggregation.py::TestAggregationFactory::test_sum_factory PASSED [ 20%]
metrics\test_aggregation.py::TestDefaultAggregation::test_counter PASSED [ 21%]
metrics\test_aggregation.py::TestDefaultAggregation::test_histogram PASSED [ 21%]
metrics\test_aggregation.py::TestDefaultAggregation::test_observable_counter PASSED [ 21%]
metrics\test_aggregation.py::TestDefaultAggregation::test_observable_gauge PASSED [ 21%]
metrics\test_aggregation.py::TestDefaultAggregation::test_observable_up_down_counter PASSED [ 22%]
metrics\test_aggregation.py::TestDefaultAggregation::test_up_down_counter PASSED [ 22%]
metrics\test_backward_compat.py::TestBackwardCompat::test_metric_exporter PASSED [ 22%]
metrics\test_backward_compat.py::TestBackwardCompat::test_metric_reader PASSED [ 23%]
metrics\test_backward_compat.py::TestBackwardCompat::test_observable_callback PASSED [ 23%]
metrics\test_import.py::TestImport::test_import_export PASSED            [ 23%]
metrics\test_import.py::TestImport::test_import_init PASSED              [ 23%]
metrics\test_import.py::TestImport::test_import_view PASSED              [ 24%]
metrics\test_in_memory_metric_reader.py::TestInMemoryMetricReader::test_converts_metrics_to_list PASSED [ 24%]
metrics\test_in_memory_metric_reader.py::TestInMemoryMetricReader::test_cumulative_multiple_collect PASSED [ 24%]
metrics\test_in_memory_metric_reader.py::TestInMemoryMetricReader::test_integration PASSED [ 25%]
metrics\test_in_memory_metric_reader.py::TestInMemoryMetricReader::test_no_metrics PASSED [ 25%]
metrics\test_in_memory_metric_reader.py::TestInMemoryMetricReader::test_shutdown PASSED [ 25%]
metrics\test_instrument.py::TestCounter::test_add PASSED                 [ 26%]
metrics\test_instrument.py::TestCounter::test_add_non_monotonic 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk.metrics._internal.instrument:instrument.py:154 Add amount must be non-negative on Counter name.
PASSED                                                                   [ 26%]
metrics\test_instrument.py::TestCounter::test_disallow_direct_counter_creation PASSED [ 26%]
metrics\test_instrument.py::TestCounter::testname PASSED                 [ 26%]
metrics\test_instrument.py::TestUpDownCounter::test_add PASSED           [ 27%]
metrics\test_instrument.py::TestUpDownCounter::test_add_non_monotonic PASSED [ 27%]
metrics\test_instrument.py::TestUpDownCounter::test_disallow_direct_up_down_counter_creation PASSED [ 27%]
metrics\test_instrument.py::TestObservableGauge::test_callable_callback_0 PASSED [ 28%]
metrics\test_instrument.py::TestObservableGauge::test_callable_multiple_callable_callback PASSED [ 28%]
metrics\test_instrument.py::TestObservableGauge::test_disallow_direct_observable_gauge_creation PASSED [ 28%]
metrics\test_instrument.py::TestObservableGauge::test_generator_callback_0 PASSED [ 28%]
metrics\test_instrument.py::TestObservableGauge::test_generator_multiple_generator_callback PASSED [ 29%]
metrics\test_instrument.py::TestObservableGauge::testname PASSED         [ 29%]
metrics\test_instrument.py::TestObservableCounter::test_callable_callback_0 PASSED [ 29%]
metrics\test_instrument.py::TestObservableCounter::test_disallow_direct_observable_counter_creation PASSED [ 30%]
metrics\test_instrument.py::TestObservableCounter::test_generator_callback_0 PASSED [ 30%]
metrics\test_instrument.py::TestObservableUpDownCounter::test_callable_callback_0 PASSED [ 30%]
metrics\test_instrument.py::TestObservableUpDownCounter::test_disallow_direct_observable_up_down_counter_creation PASSED [ 30%]
metrics\test_instrument.py::TestObservableUpDownCounter::test_generator_callback_0 PASSED [ 31%]
metrics\test_instrument.py::TestHistogram::test_disallow_direct_histogram_creation PASSED [ 31%]
metrics\test_instrument.py::TestHistogram::test_record PASSED            [ 31%]
metrics\test_instrument.py::TestHistogram::test_record_non_monotonic 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk.metrics._internal.instrument:instrument.py:205 Record amount must be non-negative on Histogram name.
PASSED                                                                   [ 32%]
metrics\test_measurement_consumer.py::TestSynchronousMeasurementConsumer::test_collect_calls_async_instruments PASSED [ 32%]
metrics\test_measurement_consumer.py::TestSynchronousMeasurementConsumer::test_collect_passed_to_reader_stage PASSED [ 32%]
metrics\test_measurement_consumer.py::TestSynchronousMeasurementConsumer::test_creates_metric_reader_storages PASSED [ 32%]
metrics\test_measurement_consumer.py::TestSynchronousMeasurementConsumer::test_measurements_passed_to_each_reader_storage PASSED [ 33%]
metrics\test_measurement_consumer.py::TestSynchronousMeasurementConsumer::test_parent PASSED [ 33%]
metrics\test_metric_reader.py::TestMetricReader::test_configure_aggregation PASSED [ 33%]
metrics\test_metric_reader.py::TestMetricReader::test_configure_temporality PASSED [ 34%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_conflicting_view_configuration PASSED [ 34%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_creates_view_instrument_matches 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk.metrics._internal.metric_reader_storage:metric_reader_storage.py:263 Views <MagicMock name='_ViewInstrumentMatch()._view' id='1977855825280'> and <MagicMock name='_ViewInstrumentMatch()._view' id='1977855825280'> will cause conflicting metrics identities
WARNING  opentelemetry.sdk.metrics._internal.metric_reader_storage:metric_reader_storage.py:263 Views <MagicMock name='_ViewInstrumentMatch()._view' id='1977855825280'> and <MagicMock name='_ViewInstrumentMatch()._view' id='1977855825280'> will cause conflicting metrics identities
PASSED                                                                   [ 34%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_default_view_enabled PASSED [ 34%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_drop_aggregation PASSED [ 35%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_forwards_calls_to_view_instrument_match 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk.metrics._internal.metric_reader_storage:metric_reader_storage.py:263 Views <Mock name='mock._view' id='1977856123664'> and <Mock name='mock._view' id='1977856123616'> will cause conflicting metrics identities
WARNING  opentelemetry.sdk.metrics._internal.metric_reader_storage:metric_reader_storage.py:263 Views <Mock name='mock._view' id='1977856124096'> and <Mock name='mock._view' id='1977856123616'> will cause conflicting metrics identities
PASSED                                                                   [ 35%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_race_concurrent_measurements PASSED [ 35%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_same_collection_start PASSED [ 36%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_view_instrument_match_conflict_0 PASSED [ 36%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_view_instrument_match_conflict_1 PASSED [ 36%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_view_instrument_match_conflict_2 PASSED [ 36%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_view_instrument_match_conflict_3 PASSED [ 37%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_view_instrument_match_conflict_4 PASSED [ 37%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_view_instrument_match_conflict_5 PASSED [ 37%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_view_instrument_match_conflict_6 PASSED [ 38%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_view_instrument_match_conflict_7 PASSED [ 38%]
metrics\test_metric_reader_storage.py::TestMetricReaderStorage::test_view_instrument_match_conflict_8 PASSED [ 38%]
metrics\test_metrics.py::TestMeterProvider::test_consume_measurement_counter PASSED [ 39%]
metrics\test_metrics.py::TestMeterProvider::test_consume_measurement_histogram PASSED [ 39%]
metrics\test_metrics.py::TestMeterProvider::test_consume_measurement_up_down_counter PASSED [ 39%]
metrics\test_metrics.py::TestMeterProvider::test_creates_sync_measurement_consumer PASSED [ 39%]
metrics\test_metrics.py::TestMeterProvider::test_get_meter PASSED        [ 40%]
metrics\test_metrics.py::TestMeterProvider::test_get_meter_duplicate PASSED [ 40%]
metrics\test_metrics.py::TestMeterProvider::test_get_meter_empty 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk.metrics._internal:__init__.py:478 Meter name cannot be None or empty.
WARNING  opentelemetry.sdk.metrics._internal:__init__.py:478 Meter name cannot be None or empty.
PASSED                                                                   [ 40%]
metrics\test_metrics.py::TestMeterProvider::test_measurement_collect_callback PASSED [ 41%]
metrics\test_metrics.py::TestMeterProvider::test_register_asynchronous_instrument PASSED [ 41%]
metrics\test_metrics.py::TestMeterProvider::test_register_metric_readers PASSED [ 41%]
metrics\test_metrics.py::TestMeterProvider::test_resource PASSED         [ 41%]
metrics\test_metrics.py::TestMeterProvider::test_shutdown PASSED         [ 42%]
metrics\test_metrics.py::TestMeterProvider::test_shutdown_race PASSED    [ 42%]
metrics\test_metrics.py::TestMeterProvider::test_shutdown_subsequent_calls PASSED [ 42%]
metrics\test_metrics.py::TestMeter::test_create_counter PASSED           [ 43%]
metrics\test_metrics.py::TestMeter::test_create_histogram PASSED         [ 43%]
metrics\test_metrics.py::TestMeter::test_create_observable_counter PASSED [ 43%]
metrics\test_metrics.py::TestMeter::test_create_observable_gauge PASSED  [ 43%]
metrics\test_metrics.py::TestMeter::test_create_observable_up_down_counter PASSED [ 44%]
metrics\test_metrics.py::TestMeter::test_create_up_down_counter PASSED   [ 44%]
metrics\test_metrics.py::TestMeter::test_repeated_instrument_names PASSED [ 44%]
metrics\test_metrics.py::TestDuplicateInstrumentAggregateData::test_duplicate_instrument_aggregate_data 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk.metrics._internal:__init__.py:81 An instrument with name counter, type Counter, unit unit and description description has been created already.
WARNING  opentelemetry.sdk.metrics._internal.metric_reader_storage:metric_reader_storage.py:263 Views <opentelemetry.sdk.metrics.view.View object at 0x000001CC81681FA0> and <opentelemetry.sdk.metrics.view.View object at 0x000001CC81681FA0> will cause conflicting metrics identities
PASSED                                                                   [ 45%]
metrics\test_periodic_exporting_metric_reader.py::TestPeriodicExportingMetricReader::test_defaults 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk.metrics._internal.export:__init__.py:299 Cannot call collect on a MetricReader until it is registered on a MeterProvider
PASSED                                                                   [ 45%]
metrics\test_periodic_exporting_metric_reader.py::TestPeriodicExportingMetricReader::test_exporter_aggregation_preference PASSED [ 45%]
metrics\test_periodic_exporting_metric_reader.py::TestPeriodicExportingMetricReader::test_exporter_temporality_preference PASSED [ 45%]
metrics\test_periodic_exporting_metric_reader.py::TestPeriodicExportingMetricReader::test_shutdown PASSED [ 46%]
metrics\test_periodic_exporting_metric_reader.py::TestPeriodicExportingMetricReader::test_shutdown_multiple_times 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk.metrics._internal.export:__init__.py:482 Can't shutdown multiple times
PASSED                                                                   [ 46%]
metrics\test_periodic_exporting_metric_reader.py::TestPeriodicExportingMetricReader::test_ticker_called PASSED [ 46%]
metrics\test_periodic_exporting_metric_reader.py::TestPeriodicExportingMetricReader::test_ticker_collects_metrics PASSED [ 47%]
metrics\test_point.py::TestToJson::test_gauge PASSED                     [ 47%]
metrics\test_point.py::TestToJson::test_histogram PASSED                 [ 47%]
metrics\test_point.py::TestToJson::test_histogram_data_point PASSED      [ 47%]
metrics\test_point.py::TestToJson::test_metric PASSED                    [ 48%]
metrics\test_point.py::TestToJson::test_metrics_data PASSED              [ 48%]
metrics\test_point.py::TestToJson::test_number_data_point PASSED         [ 48%]
metrics\test_point.py::TestToJson::test_resource_metrics PASSED          [ 49%]
metrics\test_point.py::TestToJson::test_scope_metrics PASSED             [ 49%]
metrics\test_point.py::TestToJson::test_sum PASSED                       [ 49%]
metrics\test_view.py::TestView::test_additive_criteria PASSED            [ 50%]
metrics\test_view.py::TestView::test_instrument_name PASSED              [ 50%]
metrics\test_view.py::TestView::test_instrument_type PASSED              [ 50%]
metrics\test_view.py::TestView::test_meter_name PASSED                   [ 50%]
metrics\test_view.py::TestView::test_meter_schema_url PASSED             [ 51%]
metrics\test_view.py::TestView::test_meter_version PASSED                [ 51%]
metrics\test_view.py::TestView::test_required_instrument_criteria PASSED [ 51%]
metrics\test_view.py::TestView::test_view_name PASSED                    [ 52%]
metrics\test_view_instrument_match.py::Test_ViewInstrumentMatch::test_collect PASSED [ 52%]
metrics\test_view_instrument_match.py::Test_ViewInstrumentMatch::test_consume_measurement PASSED [ 52%]
metrics\test_view_instrument_match.py::Test_ViewInstrumentMatch::test_data_point_check PASSED [ 52%]
metrics\test_view_instrument_match.py::Test_ViewInstrumentMatch::test_setting_aggregation PASSED [ 53%]
metrics\integration_test\test_console_exporter.py::TestConsoleExporter::test_console_exporter 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.metrics._internal:__init__.py:746 Overriding of current MeterProvider is not allowed
PASSED                                                                   [ 53%]
metrics\integration_test\test_cpu_time.py::TestCpuTimeIntegration::test_cpu_time_callback PASSED [ 53%]
metrics\integration_test\test_cpu_time.py::TestCpuTimeIntegration::test_cpu_time_generator PASSED [ 54%]
metrics\integration_test\test_disable_default_views.py::TestDisableDefaultViews::test_disable_default_views PASSED [ 54%]
metrics\integration_test\test_disable_default_views.py::TestDisableDefaultViews::test_disable_default_views_add_custom PASSED [ 54%]
metrics\integration_test\test_time_align.py::TestTimeAlign::test_time_align_cumulative PASSED [ 54%]
metrics\integration_test\test_time_align.py::TestTimeAlign::test_time_align_delta SKIPPED [ 55%]
performance\benchmarks\trace\test_benchmark_trace.py::test_simple_start_span PASSED [ 55%]
performance\benchmarks\trace\test_benchmark_trace.py::test_simple_start_as_current_span PASSED [ 55%]
resources\test_resources.py::TestResources::test_aggregated_resources_different_schema_urls PASSED [ 56%]
resources\test_resources.py::TestResources::test_aggregated_resources_multiple_detectors PASSED [ 56%]
resources\test_resources.py::TestResources::test_aggregated_resources_no_detectors PASSED [ 56%]
resources\test_resources.py::TestResources::test_aggregated_resources_with_default_destroying_static_resource PASSED [ 56%]
resources\test_resources.py::TestResources::test_create PASSED           [ 57%]
resources\test_resources.py::TestResources::test_env_priority PASSED     [ 57%]
resources\test_resources.py::TestResources::test_immutability PASSED     [ 57%]
resources\test_resources.py::TestResources::test_invalid_resource_attribute_values 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.attributes:__init__.py:99 Invalid type dict for attribute value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
WARNING  opentelemetry.attributes:__init__.py:118 Byte attribute could not be decoded.
WARNING  opentelemetry.attributes:__init__.py:51 invalid key ``. must be non-empty string.
WARNING  opentelemetry.attributes:__init__.py:51 invalid key `None`. must be non-empty string.
WARNING  opentelemetry.attributes:__init__.py:99 Invalid type UUID for attribute value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
PASSED                                                                   [ 58%]
resources\test_resources.py::TestResources::test_resource_detector_ignore_error 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk.resources:__init__.py:347 Exception  in detector <Mock spec='ResourceDetector' id='1977856035568'>, ignoring
PASSED                                                                   [ 58%]
resources\test_resources.py::TestResources::test_resource_detector_raise_error PASSED [ 58%]
resources\test_resources.py::TestResources::test_resource_merge PASSED   [ 58%]
resources\test_resources.py::TestResources::test_resource_merge_empty_string PASSED [ 59%]
resources\test_resources.py::TestResources::test_service_name_env PASSED [ 59%]
resources\test_resources.py::TestResources::test_service_name_using_process_name PASSED [ 59%]
resources\test_resources.py::TestOTELResourceDetector::test_empty PASSED [ 60%]
resources\test_resources.py::TestOTELResourceDetector::test_invalid_key_value_pairs 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk.resources:__init__.py:286 Invalid key value resource attribute pair invalid: not enough values to unpack (expected 2, got 1)
WARNING  opentelemetry.sdk.resources:__init__.py:286 Invalid key value resource attribute pair : not enough values to unpack (expected 2, got 1)
WARNING  opentelemetry.sdk.resources:__init__.py:286 Invalid key value resource attribute pair : not enough values to unpack (expected 2, got 1)
PASSED                                                                   [ 60%]
resources\test_resources.py::TestOTELResourceDetector::test_multiple PASSED [ 60%]
resources\test_resources.py::TestOTELResourceDetector::test_multiple_with_whitespace PASSED [ 60%]
resources\test_resources.py::TestOTELResourceDetector::test_one PASSED   [ 61%]
resources\test_resources.py::TestOTELResourceDetector::test_one_with_whitespace PASSED [ 61%]
resources\test_resources.py::TestOTELResourceDetector::test_process_detector PASSED [ 61%]
resources\test_resources.py::TestOTELResourceDetector::test_service_name_env PASSED [ 62%]
resources\test_resources.py::TestOTELResourceDetector::test_service_name_env_precedence PASSED [ 62%]
trace\test_globals.py::TestGlobals::test_tracer_provider_override_warning PASSED [ 62%]
trace\test_implementation.py::TestTracerImplementation::test_span PASSED [ 63%]
trace\test_implementation.py::TestTracerImplementation::test_tracer PASSED [ 63%]
trace\test_sampling.py::TestDecision::test_is_recording PASSED           [ 63%]
trace\test_sampling.py::TestDecision::test_is_sampled PASSED             [ 63%]
trace\test_sampling.py::TestSamplingResult::test_ctr PASSED              [ 64%]
trace\test_sampling.py::TestSampler::test_always_off PASSED              [ 64%]
trace\test_sampling.py::TestSampler::test_always_on PASSED               [ 64%]
trace\test_sampling.py::TestSampler::test_default_off PASSED             [ 65%]
trace\test_sampling.py::TestSampler::test_default_on PASSED              [ 65%]
trace\test_sampling.py::TestSampler::test_parent_based_explicit_parent_context PASSED [ 65%]
trace\test_sampling.py::TestSampler::test_parent_based_implicit_parent_context PASSED [ 65%]
trace\test_sampling.py::TestSampler::test_probability_sampler PASSED     [ 66%]
trace\test_sampling.py::TestSampler::test_probability_sampler_limits PASSED [ 66%]
trace\test_sampling.py::TestSampler::test_probability_sampler_one PASSED [ 66%]
trace\test_sampling.py::TestSampler::test_probability_sampler_zero PASSED [ 67%]
trace\test_span_processor.py::TestSpanProcessor::test_add_span_processor_after_span_creation PASSED [ 67%]
trace\test_span_processor.py::TestSpanProcessor::test_span_processor PASSED [ 67%]
trace\test_span_processor.py::TestSynchronousMultiSpanProcessor::test_force_flush PASSED [ 67%]
trace\test_span_processor.py::TestSynchronousMultiSpanProcessor::test_force_flush_late_by_span_processor PASSED [ 68%]
trace\test_span_processor.py::TestSynchronousMultiSpanProcessor::test_force_flush_late_by_timeout PASSED [ 68%]
trace\test_span_processor.py::TestSynchronousMultiSpanProcessor::test_on_end PASSED [ 68%]
trace\test_span_processor.py::TestSynchronousMultiSpanProcessor::test_on_shutdown PASSED [ 69%]
trace\test_span_processor.py::TestSynchronousMultiSpanProcessor::test_on_start PASSED [ 69%]
trace\test_span_processor.py::TestConcurrentMultiSpanProcessor::test_force_flush PASSED [ 69%]
trace\test_span_processor.py::TestConcurrentMultiSpanProcessor::test_force_flush_late_by_span_processor PASSED [ 69%]
trace\test_span_processor.py::TestConcurrentMultiSpanProcessor::test_force_flush_late_by_timeout PASSED [ 70%]
trace\test_span_processor.py::TestConcurrentMultiSpanProcessor::test_on_end PASSED [ 70%]
trace\test_span_processor.py::TestConcurrentMultiSpanProcessor::test_on_shutdown PASSED [ 70%]
trace\test_span_processor.py::TestConcurrentMultiSpanProcessor::test_on_start PASSED [ 71%]
trace\test_trace.py::TestTracer::test_extends_api PASSED                 [ 71%]
trace\test_trace.py::TestTracer::test_shutdown PASSED                    [ 71%]
trace\test_trace.py::TestTracer::test_tracer_provider_accepts_concurrent_multi_span_processor PASSED [ 71%]
trace\test_trace.py::TestTracerSampling::test_default_sampler PASSED     [ 72%]
trace\test_trace.py::TestTracerSampling::test_default_sampler_type PASSED [ 72%]
trace\test_trace.py::TestTracerSampling::test_ratio_sampler_with_env PASSED [ 72%]
trace\test_trace.py::TestTracerSampling::test_sampler_no_sampling PASSED [ 73%]
trace\test_trace.py::TestTracerSampling::test_sampler_with_env PASSED    [ 73%]
trace\test_trace.py::TestSpanCreation::test_default_span_resource PASSED [ 73%]
trace\test_trace.py::TestSpanCreation::test_disallow_direct_span_creation PASSED [ 73%]
trace\test_trace.py::TestSpanCreation::test_explicit_span_resource PASSED [ 74%]
trace\test_trace.py::TestSpanCreation::test_instrumentation_info PASSED  [ 74%]
trace\test_trace.py::TestSpanCreation::test_invalid_instrumentation_info PASSED [ 74%]
trace\test_trace.py::TestSpanCreation::test_span_context_remote_flag PASSED [ 75%]
trace\test_trace.py::TestSpanCreation::test_span_processor_for_source PASSED [ 75%]
trace\test_trace.py::TestSpanCreation::test_start_as_current_span_decorator PASSED [ 75%]
trace\test_trace.py::TestSpanCreation::test_start_as_current_span_explicit PASSED [ 76%]
trace\test_trace.py::TestSpanCreation::test_start_as_current_span_implicit PASSED [ 76%]
trace\test_trace.py::TestSpanCreation::test_start_as_current_span_no_end_on_exit PASSED [ 76%]
trace\test_trace.py::TestSpanCreation::test_start_span_explicit PASSED   [ 76%]
trace\test_trace.py::TestSpanCreation::test_start_span_implicit PASSED   [ 77%]
trace\test_trace.py::TestSpanCreation::test_start_span_invalid_spancontext PASSED [ 77%]
trace\test_trace.py::TestSpanCreation::test_surplus_span_attributes PASSED [ 77%]
trace\test_trace.py::TestSpanCreation::test_surplus_span_links PASSED    [ 78%]
trace\test_trace.py::TestReadableSpan::test_events PASSED                [ 78%]
trace\test_trace.py::TestReadableSpan::test_links PASSED                 [ 78%]
trace\test_trace.py::TestSpan::test_attributes PASSED                    [ 78%]
trace\test_trace.py::TestSpan::test_basic_span PASSED                    [ 79%]
trace\test_trace.py::TestSpan::test_byte_type_attribute_value PASSED     [ 79%]
trace\test_trace.py::TestSpan::test_ended_span PASSED                    [ 79%]
trace\test_trace.py::TestSpan::test_error_status PASSED                  [ 80%]
trace\test_trace.py::TestSpan::test_event_attributes_are_immutable PASSED [ 80%]
trace\test_trace.py::TestSpan::test_events PASSED                        [ 80%]
trace\test_trace.py::TestSpan::test_events_are_immutable PASSED          [ 80%]
trace\test_trace.py::TestSpan::test_invalid_attribute_values 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.attributes:__init__.py:99 Invalid type dict for attribute value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
WARNING  opentelemetry.attributes:__init__.py:99 Invalid type dict for attribute value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
WARNING  opentelemetry.attributes:__init__.py:87 Mixed types int and bool in attribute value sequence
WARNING  opentelemetry.attributes:__init__.py:87 Mixed types bool and int in attribute value sequence
WARNING  opentelemetry.attributes:__init__.py:70 Invalid type dict in attribute value sequence. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or None
WARNING  opentelemetry.attributes:__init__.py:87 Mixed types int and bool in attribute value sequence
WARNING  opentelemetry.attributes:__init__.py:51 invalid key ``. must be non-empty string.
WARNING  opentelemetry.attributes:__init__.py:51 invalid key `None`. must be non-empty string.
PASSED                                                                   [ 81%]
trace\test_trace.py::TestSpan::test_invalid_event_attributes 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.attributes:__init__.py:87 Mixed types str and bool in attribute value sequence
WARNING  opentelemetry.attributes:__init__.py:99 Invalid type dict for attribute value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
WARNING  opentelemetry.attributes:__init__.py:70 Invalid type list in attribute value sequence. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or None
WARNING  opentelemetry.attributes:__init__.py:70 Invalid type dict in attribute value sequence. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or None
PASSED                                                                   [ 81%]
trace\test_trace.py::TestSpan::test_last_status_wins PASSED              [ 81%]
trace\test_trace.py::TestSpan::test_links PASSED                         [ 82%]
trace\test_trace.py::TestSpan::test_record_exception PASSED              [ 82%]
trace\test_trace.py::TestSpan::test_record_exception_context_manager PASSED [ 82%]
trace\test_trace.py::TestSpan::test_record_exception_escaped PASSED      [ 82%]
trace\test_trace.py::TestSpan::test_record_exception_with_attributes PASSED [ 83%]
trace\test_trace.py::TestSpan::test_record_exception_with_attributes_and_timestamp PASSED [ 83%]
trace\test_trace.py::TestSpan::test_record_exception_with_timestamp PASSED [ 83%]
trace\test_trace.py::TestSpan::test_sampling_attributes PASSED           [ 84%]
trace\test_trace.py::TestSpan::test_span_override_start_and_end_time PASSED [ 84%]
trace\test_trace.py::TestSpan::test_span_set_status PASSED               [ 84%]
trace\test_trace.py::TestSpan::test_start_accepts_context PASSED         [ 84%]
trace\test_trace.py::TestSpan::test_start_span PASSED                    [ 85%]
trace\test_trace.py::TestSpan::test_status_cannot_override_ok PASSED     [ 85%]
trace\test_trace.py::TestSpan::test_status_cannot_set_unset 
-------------------------------- live log call --------------------------------
WARNING  opentelemetry.sdk.trace:__init__.py:343 Tried calling set_status on an ended span.
WARNING  opentelemetry.sdk.trace:__init__.py:343 Tried calling set_status on an ended span.
PASSED                                                                   [ 85%]
trace\test_trace.py::TestSpan::test_update_name PASSED                   [ 86%]
trace\test_trace.py::TestSpanProcessor::test_add_span_processor_after_span_creation PASSED [ 86%]
trace\test_trace.py::TestSpanProcessor::test_attributes_to_json PASSED   [ 86%]
trace\test_trace.py::TestSpanProcessor::test_span_processor PASSED       [ 86%]
trace\test_trace.py::TestSpanProcessor::test_to_json PASSED              [ 87%]
trace\test_trace.py::TestSpanLimits::test_dropped_attributes PASSED      [ 87%]
trace\test_trace.py::TestSpanLimits::test_limits_attribute_length_limits_code PASSED [ 87%]
trace\test_trace.py::TestSpanLimits::test_limits_defaults PASSED         [ 88%]
trace\test_trace.py::TestSpanLimits::test_limits_values_code PASSED      [ 88%]
trace\test_trace.py::TestSpanLimits::test_limits_values_env PASSED       [ 88%]
trace\test_trace.py::TestSpanLimits::test_span_limits_code PASSED        [ 89%]
trace\test_trace.py::TestSpanLimits::test_span_limits_default_to_env PASSED [ 89%]
trace\test_trace.py::TestSpanLimits::test_span_limits_env PASSED         [ 89%]
trace\test_trace.py::TestSpanLimits::test_span_limits_global_env PASSED  [ 89%]
trace\test_trace.py::TestSpanLimits::test_span_no_limits_code PASSED     [ 90%]
trace\test_trace.py::TestSpanLimits::test_span_no_limits_env PASSED      [ 90%]
trace\test_trace.py::TestSpanLimits::test_span_zero_global_limit PASSED  [ 90%]
trace\test_trace.py::TestSpanLimits::test_span_zero_global_nonzero_model PASSED [ 91%]
trace\test_trace.py::TestSpanLimits::test_span_zero_global_unset_model PASSED [ 91%]
trace\test_trace.py::TestTraceFlags::test_constant_default PASSED        [ 91%]
trace\test_trace.py::TestTraceFlags::test_constant_default_trace_options PASSED [ 91%]
trace\test_trace.py::TestTraceFlags::test_constant_sampled PASSED        [ 92%]
trace\test_trace.py::TestTraceFlags::test_get_default PASSED             [ 92%]
trace\test_trace.py::TestTraceFlags::test_sampled_false PASSED           [ 92%]
trace\test_trace.py::TestTraceFlags::test_sampled_true PASSED            [ 93%]
trace\export\test_export.py::TestSimpleSpanProcessor::test_on_start_accepts_context PASSED [ 93%]
trace\export\test_export.py::TestSimpleSpanProcessor::test_simple_span_processor PASSED [ 93%]
trace\export\test_export.py::TestSimpleSpanProcessor::test_simple_span_processor_no_context PASSED [ 93%]
trace\export\test_export.py::TestSimpleSpanProcessor::test_simple_span_processor_not_sampled PASSED [ 94%]
trace\export\test_export.py::TestBatchSpanProcessor::test_batch_span_processor_environment_variables PASSED [ 94%]
trace\export\test_export.py::TestBatchSpanProcessor::test_batch_span_processor_fork SKIPPED [ 94%]
trace\export\test_export.py::TestBatchSpanProcessor::test_batch_span_processor_lossless PASSED [ 95%]
trace\export\test_export.py::TestBatchSpanProcessor::test_batch_span_processor_many_spans PASSED [ 95%]
trace\export\test_export.py::TestBatchSpanProcessor::test_batch_span_processor_not_sampled PASSED [ 95%]
trace\export\test_export.py::TestBatchSpanProcessor::test_batch_span_processor_parameters PASSED [ 95%]
trace\export\test_export.py::TestBatchSpanProcessor::test_batch_span_processor_reset_timeout PASSED [ 96%]
trace\export\test_export.py::TestBatchSpanProcessor::test_batch_span_processor_scheduled_delay PASSED [ 96%]
trace\export\test_export.py::TestBatchSpanProcessor::test_flush PASSED   [ 96%]
trace\export\test_export.py::TestBatchSpanProcessor::test_flush_empty PASSED [ 97%]
trace\export\test_export.py::TestBatchSpanProcessor::test_flush_from_multiple_threads PASSED [ 97%]
trace\export\test_export.py::TestBatchSpanProcessor::test_flush_timeout PASSED [ 97%]
trace\export\test_export.py::TestBatchSpanProcessor::test_on_start_accepts_parent_context PASSED [ 97%]
trace\export\test_export.py::TestBatchSpanProcessor::test_shutdown PASSED [ 98%]
trace\export\test_export.py::TestConsoleSpanExporter::test_export PASSED [ 98%]
trace\export\test_export.py::TestConsoleSpanExporter::test_export_custom PASSED [ 98%]
trace\export\test_in_memory_span_exporter.py::TestInMemorySpanExporter::test_clear PASSED [ 99%]
trace\export\test_in_memory_span_exporter.py::TestInMemorySpanExporter::test_get_finished_spans PASSED [ 99%]
trace\export\test_in_memory_span_exporter.py::TestInMemorySpanExporter::test_return_code PASSED [ 99%]
trace\export\test_in_memory_span_exporter.py::TestInMemorySpanExporter::test_shutdown PASSED [100%]

============================== warnings summary ===============================
..\..\.tox\opentelemetry-sdk\lib\site-packages\opentelemetry\sdk\trace\__init__.py:1162: 1 warning
opentelemetry-sdk/tests/context/test_asyncio.py: 1 warning
opentelemetry-sdk/tests/logs/test_export.py: 1 warning
opentelemetry-sdk/tests/logs/test_handler.py: 1 warning
opentelemetry-sdk/tests/trace/test_implementation.py: 1 warning
opentelemetry-sdk/tests/trace/test_span_processor.py: 2 warnings
opentelemetry-sdk/tests/trace/test_trace.py: 69 warnings
opentelemetry-sdk/tests/trace/export/test_export.py: 6 warnings
opentelemetry-sdk/tests/trace/export/test_in_memory_span_exporter.py: 4 warnings
  C:\...\.tox\opentelemetry-sdk\lib\site-packages\opentelemetry\sdk\trace\__init__.py:1162: DeprecationWarning: Call to deprecated method __init__. (You should use InstrumentationScope) -- Deprecated since version 1.11.1.
    InstrumentationInfo(

opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_instrumentation_info
  C:\...\opentelemetry-sdk\tests\trace\test_trace.py:246: DeprecationWarning: Call to deprecated function (or staticmethod) instrumentation_info. (You should use instrumentation_scope) -- Deprecated since version 1.11.1.
    span1.instrumentation_info, InstrumentationInfo("instr1", "")

opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_instrumentation_info
  C:\...\opentelemetry-sdk\tests\trace\test_trace.py:246: DeprecationWarning: Call to deprecated method __init__. (You should use InstrumentationScope) -- Deprecated since version 1.11.1.
    span1.instrumentation_info, InstrumentationInfo("instr1", "")

opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_instrumentation_info
  C:\...\opentelemetry-sdk\tests\trace\test_trace.py:249: DeprecationWarning: Call to deprecated function (or staticmethod) instrumentation_info. (You should use instrumentation_scope) -- Deprecated since version 1.11.1.
    span2.instrumentation_info,

opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_instrumentation_info
  C:\...\opentelemetry-sdk\tests\trace\test_trace.py:250: DeprecationWarning: Call to deprecated method __init__. (You should use InstrumentationScope) -- Deprecated since version 1.11.1.
    InstrumentationInfo("instr2", "1.3b3", schema_url),

opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_instrumentation_info
  C:\...\opentelemetry-sdk\tests\trace\test_trace.py:253: DeprecationWarning: Call to deprecated function (or staticmethod) instrumentation_info. (You should use instrumentation_scope) -- Deprecated since version 1.11.1.
    self.assertEqual(span2.instrumentation_info.schema_url, schema_url)

opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_instrumentation_info
  C:\...\opentelemetry-sdk\tests\trace\test_trace.py:254: DeprecationWarning: Call to deprecated function (or staticmethod) instrumentation_info. (You should use instrumentation_scope) -- Deprecated since version 1.11.1.
    self.assertEqual(span2.instrumentation_info.version, "1.3b3")

opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_instrumentation_info
  C:\...\opentelemetry-sdk\tests\trace\test_trace.py:255: DeprecationWarning: Call to deprecated function (or staticmethod) instrumentation_info. (You should use instrumentation_scope) -- Deprecated since version 1.11.1.
    self.assertEqual(span2.instrumentation_info.name, "instr2")

opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_instrumentation_info
opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_instrumentation_info
  C:\...\opentelemetry-sdk\tests\trace\test_trace.py:258: DeprecationWarning: Call to deprecated function (or staticmethod) instrumentation_info. (You should use instrumentation_scope) -- Deprecated since version 1.11.1.
    span1.instrumentation_info, span2.instrumentation_info

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

-------------------------------------------------------------------------------------------- benchmark: 2 tests -------------------------------------------------------------------------------------------
Name (time in us)                         Min                 Max               Mean            StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_simple_start_span                28.0000 (1.0)      124.7000 (1.0)      31.6529 (1.0)      3.6020 (1.0)      31.8000 (1.0)      2.0000 (1.0)       171;165       31.5927 (1.0)        6799           1
test_simple_start_as_current_span     38.0000 (1.36)     204.2000 (1.64)     43.6937 (1.38)     6.2809 (1.74)     43.8000 (1.38)     3.4000 (1.70)      383;385       22.8866 (0.72)      10788           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
===Flaky Test Report===

test_ticker_collects_metrics passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
=========================== short test summary info ===========================
SKIPPED [1] logs\test_export.py:265: needs *nix
SKIPPED [1] metrics\integration_test\test_time_align.py:149: test failing in CI when run in Windows
SKIPPED [1] trace\export\test_export.py:370: needs *nix
================ 343 passed, 3 skipped, 95 warnings in 13.44s =================
Exception while exporting metrics I/O operation on closed file.
Traceback (most recent call last):
  File "C:\...\.tox\opentelemetry-sdk\lib\site-packages\opentelemetry\sdk\metrics\_internal\export\__init__.py", line 469, in _receive_metrics
    self._exporter.export(metrics_data, timeout_millis=timeout_millis)
  File "C:\...\.tox\opentelemetry-sdk\lib\site-packages\opentelemetry\sdk\metrics\_internal\export\__init__.py", line 150, in export
    self.out.write(self.formatter(metrics_data))
ValueError: I/O operation on closed file.
Can't shutdown multiple times
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "C:\...\.tox\opentelemetry-sdk\lib\site-packages\opentelemetry\sdk\metrics\_internal\__init__.py", line 419, in shutdown
    did_shutdown = self._shutdown_once.do_once(_shutdown)
AttributeError: 'MeterProvider' object has no attribute '_shutdown_once'
___________________________________ summary ___________________________________
  opentelemetry-sdk: commands succeeded
  congratulations :)
```

</details>


- [x] Ran linters

<details>
  <summary>Test Results</summary>

```
> .tox/lint/Scripts/isort.exe . --check
Skipped 25 files

> .tox/lint/Scripts/black.exe . --check --extend-exclude="\.venv"
All done!
432 files would be left unchanged.
```

</details>


- [x] Confirmed that code does not add any public symbols

<details>
  <summary>Test Results</summary>

```
> tox -e public-symbols-check
public-symbols-check recreate: C:\...\.tox\public-symbols-check
public-symbols-check installdeps: GitPython
public-symbols-check installed: gitdb==4.0.9,GitPython==3.1.27,smmap==5.0.0
public-symbols-check run-test-pre: PYTHONHASHSEED='150'
public-symbols-check run-test: commands[0] | python 'C:\.../scripts/public_symbols_checker.py'
The code in this branch will not add any public symbols
___________________________________ summary ___________________________________
  public-symbols-check: commands succeeded
  congratulations :)
```

</details>


- [x] Ran spellcheck

<details>
  <summary>Test Results</summary>

```
> .tox/spellcheck/Scripts/codespell.exe --skip=".venv"

```

</details>


# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [x] Yes. (I _think_ so, based on the first example)

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated