### PR TITLE
Fix documentation to reflect changes with BatchSpanProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2843](https://github.com/open-telemetry/opentelemetry-python/pull/2843))
 -  Instrument instances are always created through a Meter
   ([#2844](https://github.com/open-telemetry/opentelemetry-python/pull/2844))
+-  Fix documentation on BatchSpanProcessor's fork-safety
+  ([#2689](https://github.com/open-telemetry/opentelemetry-python/pull/2869))
 
 ## [1.12.0rc2-0.32b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0rc2) - 2022-07-04
 

--- a/docs/examples/fork-process-model/README.rst
+++ b/docs/examples/fork-process-model/README.rst
@@ -1,7 +1,7 @@
 Working With Fork Process Models
 ================================
 
-The `BatchSpanProcessor` is not fork-safe and doesn't work well with application servers
+`In python versions 3.6 and older <https://github.com/open-telemetry/opentelemetry-python/pull/2242>`_, the `BatchSpanProcessor` is not fork-safe and doesn't work well with application servers
 (Gunicorn, uWSGI) which are based on the pre-fork web server model. The `BatchSpanProcessor`
 spawns a thread to run in the background to export spans to the telemetry backend. During the fork, the child
 process inherits the lock which is held by the parent process and deadlock occurs. We can use fork hooks to


### PR DESCRIPTION
# Description

Fix the documentation to state BatchSpanProcessor's fork-safety

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [] Unit tests have been added
- [x] Documentation has been updated
