### PR TITLE
Update PeriodicExportingMetricReader to never call export() concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update PeriodicExportingMetricReader to never call export() concurrently
+  ([#2873](https://github.com/open-telemetry/opentelemetry-python/pull/2873))
+
 ## [1.12.0-0.33b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0-0.33b0) - 2022-08-08
 
 - Add `force_flush` method to metrics exporter

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_exporter_concurrency.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_exporter_concurrency.py
@@ -1,0 +1,105 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from threading import Lock
+
+from opentelemetry.metrics import CallbackOptions, Observation
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    MetricExporter,
+    MetricExportResult,
+    MetricsData,
+    PeriodicExportingMetricReader,
+)
+from opentelemetry.test.concurrency_test import ConcurrencyTestBase
+
+
+class MaxCountExporter(MetricExporter):
+    def __init__(self) -> None:
+        super().__init__(None, None)
+        self._lock = Lock()
+
+        # the number of threads inside of export()
+        self.count_in_export = 0
+
+        # the total count of calls to export()
+        self.export_count = 0
+
+        # the maximum number of threads in export() ever
+        self.max_count_in_export = 0
+
+    def export(
+        self,
+        metrics_data: MetricsData,
+        timeout_millis: float = 10_000,
+        **kwargs,
+    ) -> MetricExportResult:
+        with self._lock:
+            self.export_count += 1
+            self.count_in_export += 1
+
+        # yield to other threads
+        time.sleep(0)
+
+        with self._lock:
+            self.max_count_in_export = max(
+                self.max_count_in_export, self.count_in_export
+            )
+            self.count_in_export -= 1
+
+    def force_flush(self, timeout_millis: float = 10_000) -> bool:
+        return True
+
+    def shutdown(self, timeout_millis: float = 30_000, **kwargs) -> None:
+        pass
+
+
+class TestExporterConcurrency(ConcurrencyTestBase):
+    """
+    Tests the requirement that:
+
+    > `Export` will never be called concurrently for the same exporter instance.  `Export` can
+    > be called again only after the current call returns.
+
+    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exportbatch
+    """
+
+    def test_exporter_not_called_concurrently(self):
+        exporter = MaxCountExporter()
+        reader = PeriodicExportingMetricReader(
+            exporter=exporter,
+            export_interval_millis=100_000,
+        )
+        meter_provider = MeterProvider(metric_readers=[reader])
+
+        def counter_cb(options: CallbackOptions):
+            yield Observation(2)
+
+        meter_provider.get_meter(__name__).create_observable_counter(
+            "testcounter", callbacks=[counter_cb]
+        )
+
+        # call collect from a bunch of threads to try and enter export() concurrently
+        def test_many_threads():
+            reader.collect()
+
+        self.run_with_many_threads(test_many_threads, num_threads=100)
+
+        # no thread should be in export() now
+        self.assertEqual(exporter.count_in_export, 0)
+        # should be one call for each thread
+        self.assertEqual(exporter.export_count, 100)
+        # should never have been more than one concurrent call
+        self.assertEqual(exporter.max_count_in_export, 1)


### PR DESCRIPTION
# Description

Add a lock in `PeriodicExportingMetricReader` which is held whenever its paired exporter is called.

Fixes #2859

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new test (verified it the test was failing before the fix)

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
