### PR TITLE
Skip LICENSE files for spellcheck

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 # skipping auto generated folders
-skip = ./.tox,./.mypy_cache,./docs/_build,./target
-ignore-words-list = ans,ue,ot,hist
+skip = ./.tox,./.mypy_cache,./docs/_build,./target,*/LICENSE,./venv
+ignore-words-list = ans,ue,ot,hist,ro


### PR DESCRIPTION
Not sure why this didn't fail in the original PR but the spell check is failing for LICENSE on main which we don't modify and copy as is.