### PR TITLE
[WIP] Adding support for setting OTLP exporter protocol by env vars

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables.py
@@ -234,6 +234,27 @@ The :envvar:`OTEL_EXPORTER_OTLP_PROTOCOL` represents the the transport protocol 
 OTLP exporter.
 """
 
+OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
+"""
+.. envvar:: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+
+The :envvar:`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` represents the the transport protocol for spans.
+"""
+
+OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
+"""
+.. envvar:: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+
+The :envvar:`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` represents the the transport protocol for metrics.
+"""
+
+OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"
+"""
+.. envvar:: OTEL_EXPORTER_OTLP_LOGS_PROTOCOL
+
+The :envvar:`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` represents the the transport protocol for logs.
+"""
+
 OTEL_EXPORTER_OTLP_CERTIFICATE = "OTEL_EXPORTER_OTLP_CERTIFICATE"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_CERTIFICATE
@@ -312,13 +333,6 @@ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
 The :envvar:`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` target to which the span exporter is going to send spans.
 The endpoint MUST be a valid URL host, and MAY contain a scheme (http or https), port and path.
 A scheme of https indicates a secure connection and takes precedence over this configuration setting.
-"""
-
-OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
-"""
-.. envvar:: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
-
-The :envvar:`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` represents the the transport protocol for spans.
 """
 
 OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE = "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE"

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -413,25 +413,34 @@ class TestMetricsInit(TestCase):
 
 
 class TestExporterNames(TestCase):
-    def test_otlp_exporter_overwrite(self):
-        for exporter in [_EXPORTER_OTLP, _EXPORTER_OTLP_PROTO_GRPC]:
-            self.assertEqual(
-                _get_exporter_names(exporter), [_EXPORTER_OTLP_PROTO_GRPC]
-            )
-
-    def test_multiple_exporters(self):
+    @patch.dict(environ, {"OTEL_TRACES_EXPORTER": _EXPORTER_OTLP})
+    def test_otlp_exporter(self):
         self.assertEqual(
-            sorted(_get_exporter_names("jaeger,zipkin")), ["jaeger", "zipkin"]
+            sorted(_get_exporter_names("traces")), [_EXPORTER_OTLP_PROTO_GRPC]
         )
 
+    @patch.dict(environ, {"OTEL_TRACES_EXPORTER": _EXPORTER_OTLP_PROTO_GRPC})
+    def test_otlp_grpc_exporter(self):
+        self.assertEqual(
+            sorted(_get_exporter_names("traces")), [_EXPORTER_OTLP_PROTO_GRPC]
+        )
+
+    @patch.dict(environ, {"OTEL_TRACES_EXPORTER": "jaeger,zipkin"})
+    def test_multiple_exporters(self):
+        self.assertEqual(
+            sorted(_get_exporter_names("traces")), ["jaeger", "zipkin"]
+        )
+
+    @patch.dict(environ, {"OTEL_TRACES_EXPORTER": "none"})
     def test_none_exporters(self):
-        self.assertEqual(sorted(_get_exporter_names("none")), [])
+        self.assertEqual(sorted(_get_exporter_names("traces")), [])
 
     def test_no_exporters(self):
-        self.assertEqual(sorted(_get_exporter_names(None)), [])
+        self.assertEqual(sorted(_get_exporter_names("traces")), [])
 
+    @patch.dict(environ, {"OTEL_TRACES_EXPORTER": ""})
     def test_empty_exporters(self):
-        self.assertEqual(sorted(_get_exporter_names("")), [])
+        self.assertEqual(sorted(_get_exporter_names("traces")), [])
 
 
 class TestImportExporters(TestCase):


### PR DESCRIPTION
# Description

Fixes #2586 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
