### PR TITLE
[grpc exporter] Handle backoff 1.0 and 2.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for setting OTLP export protocol with env vars, as defined in the
   [specifications](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specify-protocol)
   ([#2893](https://github.com/open-telemetry/opentelemetry-python/pull/2893))
+- Fix: Handle `backoff` dependency version 1.0 and 2.0
+  ([#2915](https://github.com/open-telemetry/opentelemetry-python/pull/2915))
 
 ## [1.12.0-0.33b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.12.0) - 2022-08-08
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
@@ -24,8 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-  "backoff >= 1.10.0, < 2.0.0; python_version<'3.7'",
-  "backoff >= 1.10.0, < 3.0.0; python_version>='3.7'",
+  "backoff ~= 2.0",
   "googleapis-common-protos ~= 1.52",
   "grpcio >= 1.0.0, < 2.0.0",
   "opentelemetry-api ~= 1.12",

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -80,9 +80,7 @@ class InvalidCompressionValueException(Exception):
 
 def environ_to_compression(environ_key: str) -> Optional[Compression]:
     environ_value = (
-        environ[environ_key].lower().strip()
-        if environ_key in environ
-        else None
+        environ[environ_key].lower().strip() if environ_key in environ else None
     )
     if environ_value not in _ENVIRON_TO_COMPRESSION:
         raise InvalidCompressionValueException(environ_key, environ_value)
@@ -147,9 +145,7 @@ def get_resource_data(
 
             try:
                 # pylint: disable=no-member
-                collector_resource.attributes.append(
-                    _translate_key_values(key, value)
-                )
+                collector_resource.attributes.append(_translate_key_values(key, value))
             except Exception as error:  # pylint: disable=broad-except
                 logger.exception(error)
 
@@ -185,9 +181,7 @@ def _get_credentials(creds, environ_key):
 
 
 # pylint: disable=no-member
-class OTLPExporterMixin(
-    ABC, Generic[SDKDataT, ExportServiceRequestT, ExportResultT]
-):
+class OTLPExporterMixin(ABC, Generic[SDKDataT, ExportServiceRequestT, ExportResultT]):
     """OTLP span exporter
 
     Args:
@@ -240,9 +234,7 @@ class OTLPExporterMixin(
         elif isinstance(self._headers, dict):
             self._headers = tuple(self._headers.items())
 
-        self._timeout = timeout or int(
-            environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, 10)
-        )
+        self._timeout = timeout or int(environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, 10))
         self._collector_kwargs = None
 
         compression = (
@@ -256,17 +248,13 @@ class OTLPExporterMixin(
                 insecure_channel(endpoint, compression=compression)
             )
         else:
-            credentials = _get_credentials(
-                credentials, OTEL_EXPORTER_OTLP_CERTIFICATE
-            )
+            credentials = _get_credentials(credentials, OTEL_EXPORTER_OTLP_CERTIFICATE)
             self._client = self._stub(
                 secure_channel(endpoint, credentials, compression=compression)
             )
 
     @abstractmethod
-    def _translate_data(
-        self, data: TypingSequence[SDKDataT]
-    ) -> ExportServiceRequestT:
+    def _translate_data(self, data: TypingSequence[SDKDataT]) -> ExportServiceRequestT:
         pass
 
     def _translate_attributes(self, attributes) -> TypingSequence[KeyValue]:
@@ -295,16 +283,13 @@ class OTLPExporterMixin(
         assert isinstance(error, RpcError)
         wait_delay = details["wait"]
         logger.warning(
-            (
-                "Transient error %s encountered while exporting "
-                "%s, retrying in %ss."
-            ),
+            ("Transient error %s encountered while exporting " "%s, retrying in %ss."),
             error.code(),
             this._exporting,
             round(wait_delay, 1),
         )
 
-    @backoff.on_exception( backoff.expo, RpcError, max_time=60, on_backoff=_on_backoff)
+    @backoff.on_exception(backoff.expo, RpcError, max_time=60, on_backoff=_on_backoff)
     def _export_backoff(
         self, data: Union[TypingSequence[ReadableSpan], MetricsData]
     ) -> ExportResultT:

--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -24,8 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-  "backoff >= 1.10.0, < 2.0.0; python_version<'3.7'",
-  "backoff >= 1.10.0, < 3.0.0; python_version>='3.7'",
+  "backoff ~= 2.0",
   "googleapis-common-protos ~= 1.52",
   "opentelemetry-api ~= 1.12",
   "opentelemetry-proto == 1.12.0",

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -78,13 +78,9 @@ class OTLPLogExporter(LogExporter):
         self._compression = compression or _compression_from_env()
         self._session = session or requests.Session()
         self._session.headers.update(self._headers)
-        self._session.headers.update(
-            {"Content-Type": _ProtobufEncoder._CONTENT_TYPE}
-        )
+        self._session.headers.update({"Content-Type": _ProtobufEncoder._CONTENT_TYPE})
         if self._compression is not Compression.NoCompression:
-            self._session.headers.update(
-                {"Content-Encoding": self._compression.value}
-            )
+            self._session.headers.update({"Content-Encoding": self._compression.value})
         self._shutdown = False
 
     def _export(self, serialized_data: str):
@@ -130,7 +126,9 @@ class OTLPLogExporter(LogExporter):
             round(details["wait"], 1),
         )
 
-    @backoff.on_predicate(backoff.expo, lambda result: result is None, max_time=60, on_backoff=_on_backoff)
+    @backoff.on_predicate(
+        backoff.expo, lambda result: result is None, max_time=60, on_backoff=_on_backoff
+    )
     def _export_backoff(self, serialized_data) -> LogExportResult:
         try:
             resp = self._export(serialized_data)
@@ -158,9 +156,7 @@ class OTLPLogExporter(LogExporter):
 
 
 def _compression_from_env() -> Compression:
-    compression = (
-        environ.get(OTEL_EXPORTER_OTLP_COMPRESSION, "none").lower().strip()
-    )
+    compression = environ.get(OTEL_EXPORTER_OTLP_COMPRESSION, "none").lower().strip()
     return Compression(compression)
 
 

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -21,7 +21,7 @@ from typing import Dict, Optional
 from time import sleep
 
 import requests
-from backoff import expo
+import backoff
 
 from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
@@ -132,31 +132,33 @@ class OTLPSpanExporter(SpanExporter):
 
         serialized_data = _ProtobufEncoder.serialize(spans)
 
-        for delay in expo(max_value=self._MAX_RETRY_TIMEOUT):
+        return self._export_backoff(serialized_data)
 
-            if delay == self._MAX_RETRY_TIMEOUT:
-                return SpanExportResult.FAILURE
+    @staticmethod
+    def _on_backoff(details):
+        _logger.warning(
+            "Transient error encountered while exporting span batch, retrying in %ss.",
+            round(details["wait"], 1),
+        )
 
+    @backoff.on_predicate(backoff.expo, lambda result: result is None, max_time=60, on_backoff=_on_backoff)
+    def _export_backoff(self, serialized_data) -> SpanExportResult:
+        try:
             resp = self._export(serialized_data)
-            # pylint: disable=no-else-return
-            if resp.status_code in (200, 202):
-                return SpanExportResult.SUCCESS
-            elif self._retryable(resp):
-                _logger.warning(
-                    "Transient error %s encountered while exporting span batch, retrying in %ss.",
-                    resp.reason,
-                    delay,
-                )
-                sleep(delay)
-                continue
-            else:
-                _logger.error(
-                    "Failed to export batch code: %s, reason: %s",
-                    resp.status_code,
-                    resp.text,
-                )
-                return SpanExportResult.FAILURE
-        return SpanExportResult.FAILURE
+        except requests.exceptions.ConnectionError:
+            return None
+
+        if resp.status_code in (200, 202):
+            return SpanExportResult.SUCCESS
+        elif self._retryable(resp):
+            return None
+        else:
+            _logger.error(
+                "Failed to export batch code: %s, reason: %s",
+                resp.status_code,
+                resp.text,
+            )
+            return SpanExportResult.FAILURE
 
     def shutdown(self):
         if self._shutdown:

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -89,13 +89,9 @@ class OTLPSpanExporter(SpanExporter):
         self._compression = compression or _compression_from_env()
         self._session = session or requests.Session()
         self._session.headers.update(self._headers)
-        self._session.headers.update(
-            {"Content-Type": _ProtobufEncoder._CONTENT_TYPE}
-        )
+        self._session.headers.update({"Content-Type": _ProtobufEncoder._CONTENT_TYPE})
         if self._compression is not Compression.NoCompression:
-            self._session.headers.update(
-                {"Content-Encoding": self._compression.value}
-            )
+            self._session.headers.update({"Content-Encoding": self._compression.value})
         self._shutdown = False
 
     def _export(self, serialized_data: str):
@@ -141,7 +137,9 @@ class OTLPSpanExporter(SpanExporter):
             round(details["wait"], 1),
         )
 
-    @backoff.on_predicate(backoff.expo, lambda result: result is None, max_time=60, on_backoff=_on_backoff)
+    @backoff.on_predicate(
+        backoff.expo, lambda result: result is None, max_time=60, on_backoff=_on_backoff
+    )
     def _export_backoff(self, serialized_data) -> SpanExportResult:
         try:
             resp = self._export(serialized_data)


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-python/issues/2829.

# Description
Prevents the use of backoff >= 2.0.0 which has breaking changes that are not handled by the code.

Fixes #2829 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Run locally with pinned version to 1.11.1

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
