### PR TITLE
`exporter-otlp-proto-http`: add user agent string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update explicit histogram bucket boundaries
   ([#2947](https://github.com/open-telemetry/opentelemetry-python/pull/2947))
+- `exporter-otlp-proto-http`: add user agent string
+  ([#2959](https://github.com/open-telemetry/opentelemetry-python/pull/2959))
 
 ## [1.13.0-0.34b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.13.0) - 2022-09-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.13.0-0.34b0...HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.13.0...HEAD)
 
 - Update explicit histogram bucket boundaries
   ([#2947](https://github.com/open-telemetry/opentelemetry-python/pull/2947))

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/__init__.py
@@ -71,6 +71,13 @@ API
 """
 import enum
 
+from .version import __version__
+
+
+_OTLP_HTTP_HEADERS = {
+    "Content-Type": "application/x-protobuf",
+    "User-Agent": "OTel OTLP Exporter Python/" + __version__
+}
 
 class Compression(enum.Enum):
     NoCompression = "none"

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/__init__.py
@@ -76,8 +76,9 @@ from .version import __version__
 
 _OTLP_HTTP_HEADERS = {
     "Content-Type": "application/x-protobuf",
-    "User-Agent": "OTel OTLP Exporter Python/" + __version__
+    "User-Agent": "OTel OTLP Exporter Python/" + __version__,
 }
+
 
 class Compression(enum.Enum):
     NoCompression = "none"

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -35,7 +35,10 @@ from opentelemetry.sdk._logs.export import (
     LogExportResult,
     LogData,
 )
-from opentelemetry.exporter.otlp.proto.http import _OTLP_HTTP_HEADERS, Compression
+from opentelemetry.exporter.otlp.proto.http import (
+    _OTLP_HTTP_HEADERS,
+    Compression,
+)
 from opentelemetry.exporter.otlp.proto.http._log_exporter.encoder import (
     _ProtobufEncoder,
 )

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -35,7 +35,7 @@ from opentelemetry.sdk._logs.export import (
     LogExportResult,
     LogData,
 )
-from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.exporter.otlp.proto.http import _OTLP_HTTP_HEADERS, Compression
 from opentelemetry.exporter.otlp.proto.http._log_exporter.encoder import (
     _ProtobufEncoder,
 )
@@ -78,9 +78,7 @@ class OTLPLogExporter(LogExporter):
         self._compression = compression or _compression_from_env()
         self._session = session or requests.Session()
         self._session.headers.update(self._headers)
-        self._session.headers.update(
-            {"Content-Type": _ProtobufEncoder._CONTENT_TYPE}
-        )
+        self._session.headers.update(_OTLP_HTTP_HEADERS)
         if self._compression is not Compression.NoCompression:
             self._session.headers.update(
                 {"Content-Encoding": self._compression.value}

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/encoder/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/encoder/__init__.py
@@ -36,8 +36,6 @@ from opentelemetry.sdk._logs.export import LogData
 
 
 class _ProtobufEncoder:
-    _CONTENT_TYPE = "application/x-protobuf"
-
     @classmethod
     def serialize(cls, batch: Sequence[LogData]) -> str:
         return cls.encode(batch).SerializeToString()

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -36,7 +36,10 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_TIMEOUT,
 )
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
-from opentelemetry.exporter.otlp.proto.http import _OTLP_HTTP_HEADERS, Compression
+from opentelemetry.exporter.otlp.proto.http import (
+    _OTLP_HTTP_HEADERS,
+    Compression,
+)
 from opentelemetry.exporter.otlp.proto.http.trace_exporter.encoder import (
     _ProtobufEncoder,
 )

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -36,7 +36,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_TIMEOUT,
 )
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
-from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.exporter.otlp.proto.http import _OTLP_HTTP_HEADERS, Compression
 from opentelemetry.exporter.otlp.proto.http.trace_exporter.encoder import (
     _ProtobufEncoder,
 )
@@ -89,9 +89,7 @@ class OTLPSpanExporter(SpanExporter):
         self._compression = compression or _compression_from_env()
         self._session = session or requests.Session()
         self._session.headers.update(self._headers)
-        self._session.headers.update(
-            {"Content-Type": _ProtobufEncoder._CONTENT_TYPE}
-        )
+        self._session.headers.update(_OTLP_HTTP_HEADERS)
         if self._compression is not Compression.NoCompression:
             self._session.headers.update(
                 {"Content-Encoding": self._compression.value}

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/encoder/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/encoder/__init__.py
@@ -60,8 +60,6 @@ _logger = logging.getLogger(__name__)
 
 
 class _ProtobufEncoder:
-    _CONTENT_TYPE = "application/x-protobuf"
-
     @classmethod
     def serialize(cls, sdk_spans: Sequence[SDKSpan]) -> str:
         return cls.encode(sdk_spans).SerializeToString()

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
@@ -84,6 +84,8 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         self.assertIs(exporter._compression, DEFAULT_COMPRESSION)
         self.assertEqual(exporter._headers, {})
         self.assertIsInstance(exporter._session, requests.Session)
+        self.assertIn("User-Agent", exporter._session.headers)
+        self.assertEqual(exporter._session.headers.get("Content-Type"), "application/x-protobuf")
 
     @patch.dict(
         "os.environ",
@@ -152,11 +154,6 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         self.assertEqual(
             _ProtobufEncoder().serialize(sdk_logs),
             expected_encoding.SerializeToString(),
-        )
-
-    def test_content_type(self):
-        self.assertEqual(
-            _ProtobufEncoder._CONTENT_TYPE, "application/x-protobuf"
         )
 
     @staticmethod

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
@@ -85,7 +85,10 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         self.assertEqual(exporter._headers, {})
         self.assertIsInstance(exporter._session, requests.Session)
         self.assertIn("User-Agent", exporter._session.headers)
-        self.assertEqual(exporter._session.headers.get("Content-Type"), "application/x-protobuf")
+        self.assertEqual(
+            exporter._session.headers.get("Content-Type"),
+            "application/x-protobuf",
+        )
 
     @patch.dict(
         "os.environ",

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
@@ -58,6 +58,8 @@ class TestOTLPSpanExporter(unittest.TestCase):
         self.assertIs(exporter._compression, DEFAULT_COMPRESSION)
         self.assertEqual(exporter._headers, {})
         self.assertIsInstance(exporter._session, requests.Session)
+        self.assertIn("User-Agent", exporter._session.headers)
+        self.assertEqual(exporter._session.headers.get("Content-Type"), "application/x-protobuf")
 
     @patch.dict(
         "os.environ",

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
@@ -59,7 +59,10 @@ class TestOTLPSpanExporter(unittest.TestCase):
         self.assertEqual(exporter._headers, {})
         self.assertIsInstance(exporter._session, requests.Session)
         self.assertIn("User-Agent", exporter._session.headers)
-        self.assertEqual(exporter._session.headers.get("Content-Type"), "application/x-protobuf")
+        self.assertEqual(
+            exporter._session.headers.get("Content-Type"),
+            "application/x-protobuf",
+        )
 
     @patch.dict(
         "os.environ",

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_protobuf_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_protobuf_encoder.py
@@ -69,11 +69,6 @@ class TestProtobufEncoder(unittest.TestCase):
             expected_encoding.SerializeToString(),
         )
 
-    def test_content_type(self):
-        self.assertEqual(
-            _ProtobufEncoder._CONTENT_TYPE, "application/x-protobuf"
-        )
-
     @staticmethod
     def get_exhaustive_otel_span_list() -> List[SDKSpan]:
         trace_id = 0x3E0C63257DE34C926F9EFCD03927272E


### PR DESCRIPTION
# Description

Adding user agent string to OTLP HTTP exporter. As part of the change, I refactored the content-type header as well.

Part of #2958

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added unit test

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
