### PR TITLE
adds None check for backoff.expo() iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2947](https://github.com/open-telemetry/opentelemetry-python/pull/2947))
 - `exporter-otlp-proto-http`: add user agent string
   ([#2959](https://github.com/open-telemetry/opentelemetry-python/pull/2959))
+- Fix: Handle breaking change in `backoff` dependency version 2.0
+  ([#2970](https://github.com/open-telemetry/opentelemetry-python/pull/2970))
 
 ## [1.13.0-0.34b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.13.0) - 2022-09-26
 
@@ -83,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2726](https://github.com/open-telemetry/opentelemetry-python/pull/2726))
 - fix: frozenset object has no attribute items
   ([#2727](https://github.com/open-telemetry/opentelemetry-python/pull/2727))
-- fix: create suppress HTTP instrumentation key in opentelemetry context 
+- fix: create suppress HTTP instrumentation key in opentelemetry context
   ([#2729](https://github.com/open-telemetry/opentelemetry-python/pull/2729))
 - Support logs SDK auto instrumentation enable/disable with env
   ([#2728](https://github.com/open-telemetry/opentelemetry-python/pull/2728))

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
@@ -24,8 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-  "backoff >= 1.10.0, < 2.0.0; python_version<'3.7'",
-  "backoff >= 1.10.0, < 3.0.0; python_version>='3.7'",
+  "backoff ~= 2.0",
   "googleapis-common-protos ~= 1.52",
   "grpcio >= 1.0.0, < 2.0.0",
   "opentelemetry-api ~= 1.12",

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -298,6 +298,10 @@ class OTLPExporterMixin(
         # value will remain constant.
         for delay in expo(max_value=max_value):
 
+            # expo returns None on the first iteration
+            if delay is None:
+                delay = 1
+
             if delay == max_value:
                 return self._result.FAILURE
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -300,7 +300,7 @@ class OTLPExporterMixin(
 
             # expo() returns None on the first iteration
             if delay is None:
-                delay = 1
+                continue
 
             if delay == max_value:
                 return self._result.FAILURE

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -298,7 +298,7 @@ class OTLPExporterMixin(
         # value will remain constant.
         for delay in expo(max_value=max_value):
 
-            # expo returns None on the first iteration
+            # expo() returns None on the first iteration
             if delay is None:
                 delay = 1
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
@@ -255,7 +255,7 @@ class TestOTLPLogExporter(TestCase):
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
     def test_unavailable(self, mock_sleep, mock_expo):
 
-        mock_expo.configure_mock(**{"return_value": [1]})
+        mock_expo.configure_mock(**{"return_value": [None]})
 
         add_LogsServiceServicer_to_server(
             LogsServiceServicerUNAVAILABLE(), self.server
@@ -269,7 +269,7 @@ class TestOTLPLogExporter(TestCase):
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
     def test_unavailable_delay(self, mock_sleep, mock_expo):
 
-        mock_expo.configure_mock(**{"return_value": [1]})
+        mock_expo.configure_mock(**{"return_value": [None]})
 
         add_LogsServiceServicer_to_server(
             LogsServiceServicerUNAVAILABLEDelay(), self.server

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/metrics/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/metrics/test_otlp_metrics_exporter.py
@@ -453,7 +453,7 @@ class TestOTLPMetricExporter(TestCase):
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
     def test_unavailable(self, mock_sleep, mock_expo):
 
-        mock_expo.configure_mock(**{"return_value": [1]})
+        mock_expo.configure_mock(**{"return_value": [None]})
 
         add_MetricsServiceServicer_to_server(
             MetricsServiceServicerUNAVAILABLE(), self.server
@@ -468,7 +468,7 @@ class TestOTLPMetricExporter(TestCase):
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
     def test_unavailable_delay(self, mock_sleep, mock_expo):
 
-        mock_expo.configure_mock(**{"return_value": [1]})
+        mock_expo.configure_mock(**{"return_value": [None]})
 
         add_MetricsServiceServicer_to_server(
             MetricsServiceServicerUNAVAILABLEDelay(), self.server

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
@@ -119,6 +119,7 @@ class TestOTLPExporterMixin(TestCase):
 
         def trailing_metadata(self):
             return {}
+
         rpc_error.code = MethodType(code, rpc_error)
         rpc_error.trailing_metadata = MethodType(trailing_metadata, rpc_error)
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
@@ -95,30 +95,13 @@ class TestOTLPExporterMixin(TestCase):
             )
 
         def code(self):  # pylint: disable=function-redefined
-            return StatusCode.UNAVAILABLE
+            return StatusCode.CANCELLED
 
         def trailing_metadata(self):
             return {}
 
         rpc_error.code = MethodType(code, rpc_error)
         rpc_error.trailing_metadata = MethodType(trailing_metadata, {})
-
-        with self.assertLogs(level=WARNING) as warning:
-            # pylint: disable=protected-access
-            otlp_mock_exporter._export([])
-            self.assertEqual(
-                warning.records[0].message,
-                (
-                    "Transient error StatusCode.UNAVAILABLE encountered "
-                    "while exporting mock, retrying in 1s."
-                ),
-            )
-
-        def code(self):  # pylint: disable=function-redefined
-            return StatusCode.CANCELLED
-
-        def trailing_metadata(self):
-            return {}
 
         rpc_error.code = MethodType(code, rpc_error)
         rpc_error.trailing_metadata = MethodType(trailing_metadata, rpc_error)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -440,7 +440,7 @@ class TestOTLPSpanExporter(TestCase):
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
     def test_unavailable(self, mock_sleep, mock_expo):
 
-        mock_expo.configure_mock(**{"return_value": [1]})
+        mock_expo.configure_mock(**{"return_value": [None]})
 
         add_TraceServiceServicer_to_server(
             TraceServiceServicerUNAVAILABLE(), self.server
@@ -454,7 +454,7 @@ class TestOTLPSpanExporter(TestCase):
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
     def test_unavailable_delay(self, mock_sleep, mock_expo):
 
-        mock_expo.configure_mock(**{"return_value": [1]})
+        mock_expo.configure_mock(**{"return_value": [None]})
 
         add_TraceServiceServicer_to_server(
             TraceServiceServicerUNAVAILABLEDelay(), self.server

--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -24,8 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-  "backoff >= 1.10.0, < 2.0.0; python_version<'3.7'",
-  "backoff >= 1.10.0, < 3.0.0; python_version>='3.7'",
+  "backoff ~= 2.0",
   "googleapis-common-protos ~= 1.52",
   "opentelemetry-api ~= 1.12",
   "opentelemetry-proto == 1.13.0",

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -124,6 +124,10 @@ class OTLPLogExporter(LogExporter):
 
         for delay in expo(max_value=self._MAX_RETRY_TIMEOUT):
 
+            # expo() returns None on the first iteration
+            if delay is None:
+                delay = 1
+
             if delay == self._MAX_RETRY_TIMEOUT:
                 return LogExportResult.FAILURE
 

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -126,7 +126,7 @@ class OTLPLogExporter(LogExporter):
 
             # expo() returns None on the first iteration
             if delay is None:
-                delay = 1
+                continue
 
             if delay == self._MAX_RETRY_TIMEOUT:
                 return LogExportResult.FAILURE

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -137,7 +137,7 @@ class OTLPSpanExporter(SpanExporter):
 
             # expo() returns None on the first iteration
             if delay is None:
-                delay = 1
+                continue
 
             if delay == self._MAX_RETRY_TIMEOUT:
                 return SpanExportResult.FAILURE

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -135,6 +135,10 @@ class OTLPSpanExporter(SpanExporter):
 
         for delay in expo(max_value=self._MAX_RETRY_TIMEOUT):
 
+            # expo() returns None on the first iteration
+            if delay is None:
+                delay = 1
+
             if delay == self._MAX_RETRY_TIMEOUT:
                 return SpanExportResult.FAILURE
 


### PR DESCRIPTION
# Description
Periodic back off in exporter is broken. Full description in issue #2829.

Fixes #2829

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tests Suite
  - Run tox tests locally

- [x] Recreate and fix locally
  - pull down https://github.com/topleft/otel-bug-fix-sample (sample code from issue #2829)
  - run `poetry install && poetry run uvicorn main:app`
  - notice error
  - fix bug in local copy of opentelemetry-python
  - update pyproject.toml to reference local opentelemetry-python:
    - `opentelemetry-exporter-otlp-proto-grpc = { path = "$HOME/.../opentelemetry-python/exporter/opentelemetry-exporter-otlp-proto-grpc" }`
  - run `poetry lock && poetry install --sync && poetry run uvicorn main:app`
  - notice working code


# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
