### PR TITLE
Temporarily disable benchmarks workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,29 +59,29 @@ jobs:
         run: git config --system core.longpaths true
       - name: run tox
         run: tox -f ${{ matrix.python-version }}-${{ matrix.package }} -- --benchmark-json=${{ env.RUN_MATRIX_COMBINATION }}-benchmark.json
-      - name: Find and merge benchmarks
-        id: find_and_merge_benchmarks
-        run: >-
-          jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
-          | if .[0].benchmarks == null then null else .[0] end'
-          $(find . -name '*${{ matrix.package }}*-benchmark.json') > output.json
-          && echo "::set-output name=json_plaintext::$(cat output.json)"
-      - name: Report on benchmark results
-        if: steps.find_and_merge_benchmarks.outputs.json_plaintext != 'null'
-        uses: rhysd/github-action-benchmark@v1
-        with:
-          name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package }}
-          tool: pytest
-          output-file-path: output.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          max-items-in-chart: 100
-          # Alert with a commit comment on possible performance regression
-          alert-threshold: 200%
-          fail-on-alert: true
-          # Make a commit on `gh-pages` with benchmarks from previous step
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: benchmarks
+#       - name: Find and merge benchmarks
+#         id: find_and_merge_benchmarks
+#         run: >-
+#           jq -s '.[0].benchmarks = ([.[].benchmarks] | add)
+#           | if .[0].benchmarks == null then null else .[0] end'
+#           $(find . -name '*${{ matrix.package }}*-benchmark.json') > output.json
+#           && echo "::set-output name=json_plaintext::$(cat output.json)"
+#       - name: Report on benchmark results
+#         if: steps.find_and_merge_benchmarks.outputs.json_plaintext != 'null'
+#         uses: rhysd/github-action-benchmark@v1
+#         with:
+#           name: OpenTelemetry Python Benchmarks - Python ${{ env[matrix.python-version ]}} - ${{ matrix.package }}
+#           tool: pytest
+#           output-file-path: output.json
+#           github-token: ${{ secrets.GITHUB_TOKEN }}
+#           max-items-in-chart: 100
+#           # Alert with a commit comment on possible performance regression
+#           alert-threshold: 200%
+#           fail-on-alert: true
+#           # Make a commit on `gh-pages` with benchmarks from previous step
+#           auto-push: ${{ github.ref == 'refs/heads/main' }}
+#           gh-pages-branch: gh-pages
+#           benchmark-data-dir-path: benchmarks
   misc:
     strategy:
       fail-fast: false


### PR DESCRIPTION
Similar to:https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1031

We don't have a good place to publish benchmark test results (we are  trying to avoid gh-pages and using opentelemetry.io for docs instead).

