### PR TITLE
Adds user agent string to grpc headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3038](https://github.com/open-telemetry/opentelemetry-python/pull/3038))
 - Fix: Avoid generator in metrics _ViewInstrumentMatch.collect()
   ([#3035](https://github.com/open-telemetry/opentelemetry-python/pull/3035)
+- [exporter-otlp-proto-grpc] add user agent string
+  ([#3009](https://github.com/open-telemetry/opentelemetry-python/pull/3009))
 
 ## Version 1.14.0/0.35b0 (2022-11-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3038](https://github.com/open-telemetry/opentelemetry-python/pull/3038))
 - Fix: Avoid generator in metrics _ViewInstrumentMatch.collect()
   ([#3035](https://github.com/open-telemetry/opentelemetry-python/pull/3035)
-- [exporter-otlp-proto-grpc] add user agent string
-  ([#3009](https://github.com/open-telemetry/opentelemetry-python/pull/3009))
+
 
 ## Version 1.14.0/0.35b0 (2022-11-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3038](https://github.com/open-telemetry/opentelemetry-python/pull/3038))
 - Fix: Avoid generator in metrics _ViewInstrumentMatch.collect()
   ([#3035](https://github.com/open-telemetry/opentelemetry-python/pull/3035)
-
+- [exporter-otlp-proto-grpc] add user agent string
+  ([#3009](https://github.com/open-telemetry/opentelemetry-python/pull/3009))
 
 ## Version 1.14.0/0.35b0 (2022-11-04)
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/__init__.py
@@ -71,5 +71,5 @@ API
 """
 from .version import __version__
 
-_user_agent_header_value = "OTel OTLP Exporter Python/" + __version__
-_OTLP_GRPC_HEADERS = [("user-agent", _user_agent_header_value)]
+_USER_AGENT_HEADER_VALUE = "OTel OTLP Exporter Python/" + __version__
+_OTLP_GRPC_HEADERS = [("user-agent", _USER_AGENT_HEADER_VALUE)]

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/__init__.py
@@ -71,5 +71,5 @@ API
 """
 from .version import __version__
 
-otel_string = "OTel OTLP Exporter Python/" + __version__
-_OTLP_GRPC_HEADERS = [("user-agent", otel_string)]
+_user_agent_header_value = "OTel OTLP Exporter Python/" + __version__
+_OTLP_GRPC_HEADERS = [("user-agent", _user_agent_header_value)]

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/__init__.py
@@ -69,3 +69,7 @@ You can configure the exporter with the following environment variables:
 API
 ---
 """
+from .version import __version__
+
+otel_string = "OTel OTLP Exporter Python/" + __version__
+_OTLP_GRPC_HEADERS = [("user-agent", otel_string)]

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -54,6 +54,9 @@ from opentelemetry.sdk.environment_variables import (
 from opentelemetry.sdk.resources import Resource as SDKResource
 from opentelemetry.sdk.metrics.export import MetricsData
 from opentelemetry.util.re import parse_env_headers
+from opentelemetry.exporter.otlp.proto.grpc import (
+    _OTLP_GRPC_HEADERS,
+)
 
 logger = getLogger(__name__)
 SDKDataT = TypeVar("SDKDataT")
@@ -251,6 +254,10 @@ class OTLPExporterMixin(
             self._headers = tuple(temp_headers.items())
         elif isinstance(self._headers, dict):
             self._headers = tuple(self._headers.items())
+        if self._headers is None:
+            self._headers = tuple(_OTLP_GRPC_HEADERS)
+        else:
+            self._headers = self._headers +  tuple(_OTLP_GRPC_HEADERS)
 
         self._timeout = timeout or int(
             environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, 10)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -257,7 +257,7 @@ class OTLPExporterMixin(
         if self._headers is None:
             self._headers = tuple(_OTLP_GRPC_HEADERS)
         else:
-            self._headers = self._headers +  tuple(_OTLP_GRPC_HEADERS)
+            self._headers = self._headers + tuple(_OTLP_GRPC_HEADERS)
 
         self._timeout = timeout or int(
             environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, 10)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
@@ -25,9 +25,8 @@ from opentelemetry._logs import SeverityNumber
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
     OTLPLogExporter,
 )
-from opentelemetry.exporter.otlp.proto.grpc.version import __version__
-
 from opentelemetry.exporter.otlp.proto.grpc.exporter import _translate_value
+from opentelemetry.exporter.otlp.proto.grpc.version import __version__
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
     ExportLogsServiceRequest,
     ExportLogsServiceResponse,
@@ -253,7 +252,8 @@ class TestOTLPLogExporter(TestCase):
 
     def test_otlp_headers_from_env(self):
         self.assertEqual(
-            self.exporter._headers, (("user-agent", "OTel OTLP Exporter Python/" + __version__),)
+            self.exporter._headers,
+            (("user-agent", "OTel OTLP Exporter Python/" + __version__),),
         )
 
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter._expo")

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
@@ -251,6 +251,7 @@ class TestOTLPLogExporter(TestCase):
             mock_method.reset_mock()
 
     def test_otlp_headers_from_env(self):
+        # pylint: disable=protected-access
         self.assertEqual(
             self.exporter._headers,
             (("user-agent", "OTel OTLP Exporter Python/" + __version__),),

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
@@ -25,6 +25,8 @@ from opentelemetry._logs import SeverityNumber
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
     OTLPLogExporter,
 )
+from opentelemetry.exporter.otlp.proto.grpc.version import __version__
+
 from opentelemetry.exporter.otlp.proto.grpc.exporter import _translate_value
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
     ExportLogsServiceRequest,
@@ -248,6 +250,11 @@ class TestOTLPLogExporter(TestCase):
                 ),
             )
             mock_method.reset_mock()
+
+    def test_otlp_headers_from_env(self):
+        self.assertEqual(
+            self.exporter._headers, (("user-agent", "OTel OTLP Exporter Python/" + __version__),)
+        )
 
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter._expo")
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
@@ -26,6 +26,7 @@ from grpc import ChannelCredentials, Compression, StatusCode, server
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
     OTLPMetricExporter,
 )
+from opentelemetry.exporter.otlp.proto.grpc.version import __version__
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
     ExportMetricsServiceRequest,
     ExportMetricsServiceResponse,
@@ -77,9 +78,6 @@ from opentelemetry.sdk.util.instrumentation import (
     InstrumentationScope as SDKInstrumentationScope,
 )
 from opentelemetry.test.metrictestutil import _generate_gauge, _generate_sum
-
-from opentelemetry.exporter.otlp.proto.grpc.version import __version__
-
 
 THIS_DIR = dirname(__file__)
 
@@ -416,14 +414,24 @@ class TestOTLPMetricExporter(TestCase):
         exporter = OTLPMetricExporter()
         # pylint: disable=protected-access
         self.assertEqual(
-            exporter._headers, (("key1", "value1"), ("key2", "VALUE=2"),("user-agent", "OTel OTLP Exporter Python/" + __version__))
+            exporter._headers,
+            (
+                ("key1", "value1"),
+                ("key2", "VALUE=2"),
+                ("user-agent", "OTel OTLP Exporter Python/" + __version__),
+            ),
         )
         exporter = OTLPMetricExporter(
             headers=(("key3", "value3"), ("key4", "value4"))
         )
         # pylint: disable=protected-access
         self.assertEqual(
-            exporter._headers, (("key3", "value3"), ("key4", "value4"),("user-agent", "OTel OTLP Exporter Python/" + __version__))
+            exporter._headers,
+            (
+                ("key3", "value3"),
+                ("key4", "value4"),
+                ("user-agent", "OTel OTLP Exporter Python/" + __version__),
+            ),
         )
 
     @patch.dict(

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
@@ -78,6 +78,9 @@ from opentelemetry.sdk.util.instrumentation import (
 )
 from opentelemetry.test.metrictestutil import _generate_gauge, _generate_sum
 
+from opentelemetry.exporter.otlp.proto.grpc.version import __version__
+
+
 THIS_DIR = dirname(__file__)
 
 
@@ -413,14 +416,14 @@ class TestOTLPMetricExporter(TestCase):
         exporter = OTLPMetricExporter()
         # pylint: disable=protected-access
         self.assertEqual(
-            exporter._headers, (("key1", "value1"), ("key2", "VALUE=2"))
+            exporter._headers, (("key1", "value1"), ("key2", "VALUE=2"),("user-agent", "OTel OTLP Exporter Python/" + __version__))
         )
         exporter = OTLPMetricExporter(
             headers=(("key3", "value3"), ("key4", "value4"))
         )
         # pylint: disable=protected-access
         self.assertEqual(
-            exporter._headers, (("key3", "value3"), ("key4", "value4"))
+            exporter._headers, (("key3", "value3"), ("key4", "value4"),("user-agent", "OTel OTLP Exporter Python/" + __version__))
         )
 
     @patch.dict(

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -455,6 +455,7 @@ class TestOTLPSpanExporter(TestCase):
             exporter._headers,
             (("user-agent", "OTel OTLP Exporter Python/" + __version__),),
         )
+
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.backoff")
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
     def test_handles_backoff_v2_api(self, mock_sleep, mock_backoff):

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -69,6 +69,8 @@ from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.test.spantestutil import (
     get_span_with_dropped_attributes_events_links,
 )
+from opentelemetry.exporter.otlp.proto.grpc.version import __version__
+
 
 THIS_DIR = os.path.dirname(__file__)
 
@@ -275,21 +277,21 @@ class TestOTLPSpanExporter(TestCase):
         exporter = OTLPSpanExporter()
         # pylint: disable=protected-access
         self.assertEqual(
-            exporter._headers, (("key1", "value1"), ("key2", "VALUE=2"))
+            exporter._headers, (("key1", "value1"),("key2", "VALUE=2"), ("user-agent", "OTel OTLP Exporter Python/" + __version__))
         )
         exporter = OTLPSpanExporter(
             headers=(("key3", "value3"), ("key4", "value4"))
         )
         # pylint: disable=protected-access
         self.assertEqual(
-            exporter._headers, (("key3", "value3"), ("key4", "value4"))
+            exporter._headers, (("key3", "value3"), ("key4", "value4"), ("user-agent", "OTel OTLP Exporter Python/" + __version__))
         )
         exporter = OTLPSpanExporter(
             headers={"key5": "value5", "key6": "value6"}
         )
         # pylint: disable=protected-access
         self.assertEqual(
-            exporter._headers, (("key5", "value5"), ("key6", "value6"))
+            exporter._headers, (("key5", "value5"), ("key6", "value6"), ("user-agent", "OTel OTLP Exporter Python/" + __version__))
         )
 
     @patch.dict(
@@ -434,8 +436,8 @@ class TestOTLPSpanExporter(TestCase):
     def test_otlp_headers(self, mock_ssl_channel, mock_secure):
         exporter = OTLPSpanExporter()
         # pylint: disable=protected-access
-        self.assertIsNone(exporter._headers, None)
-
+        #This ensures that there is no other header than standard user-agent.
+        self.assertEqual(exporter._headers, (("user-agent", "OTel OTLP Exporter Python/" + __version__),))
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.backoff")
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
     def test_handles_backoff_v2_api(self, mock_sleep, mock_backoff):

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -29,6 +29,7 @@ from opentelemetry.exporter.otlp.proto.grpc.exporter import (
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
     OTLPSpanExporter,
 )
+from opentelemetry.exporter.otlp.proto.grpc.version import __version__
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
     ExportTraceServiceResponse,
@@ -69,8 +70,6 @@ from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.test.spantestutil import (
     get_span_with_dropped_attributes_events_links,
 )
-from opentelemetry.exporter.otlp.proto.grpc.version import __version__
-
 
 THIS_DIR = os.path.dirname(__file__)
 
@@ -277,21 +276,36 @@ class TestOTLPSpanExporter(TestCase):
         exporter = OTLPSpanExporter()
         # pylint: disable=protected-access
         self.assertEqual(
-            exporter._headers, (("key1", "value1"),("key2", "VALUE=2"), ("user-agent", "OTel OTLP Exporter Python/" + __version__))
+            exporter._headers,
+            (
+                ("key1", "value1"),
+                ("key2", "VALUE=2"),
+                ("user-agent", "OTel OTLP Exporter Python/" + __version__),
+            ),
         )
         exporter = OTLPSpanExporter(
             headers=(("key3", "value3"), ("key4", "value4"))
         )
         # pylint: disable=protected-access
         self.assertEqual(
-            exporter._headers, (("key3", "value3"), ("key4", "value4"), ("user-agent", "OTel OTLP Exporter Python/" + __version__))
+            exporter._headers,
+            (
+                ("key3", "value3"),
+                ("key4", "value4"),
+                ("user-agent", "OTel OTLP Exporter Python/" + __version__),
+            ),
         )
         exporter = OTLPSpanExporter(
             headers={"key5": "value5", "key6": "value6"}
         )
         # pylint: disable=protected-access
         self.assertEqual(
-            exporter._headers, (("key5", "value5"), ("key6", "value6"), ("user-agent", "OTel OTLP Exporter Python/" + __version__))
+            exporter._headers,
+            (
+                ("key5", "value5"),
+                ("key6", "value6"),
+                ("user-agent", "OTel OTLP Exporter Python/" + __version__),
+            ),
         )
 
     @patch.dict(
@@ -436,8 +450,11 @@ class TestOTLPSpanExporter(TestCase):
     def test_otlp_headers(self, mock_ssl_channel, mock_secure):
         exporter = OTLPSpanExporter()
         # pylint: disable=protected-access
-        #This ensures that there is no other header than standard user-agent.
-        self.assertEqual(exporter._headers, (("user-agent", "OTel OTLP Exporter Python/" + __version__),))
+        # This ensures that there is no other header than standard user-agent.
+        self.assertEqual(
+            exporter._headers,
+            (("user-agent", "OTel OTLP Exporter Python/" + __version__),),
+        )
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.backoff")
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
     def test_handles_backoff_v2_api(self, mock_sleep, mock_backoff):


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/2958

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
