### PR TITLE
fix: tracer should not instantiate deprecated object

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -1159,11 +1159,7 @@ class TracerProvider(trace_api.TracerProvider):
             self.resource,
             self._active_span_processor,
             self.id_generator,
-            InstrumentationInfo(
-                instrumenting_module_name,
-                instrumenting_library_version,
-                schema_url,
-            ),
+            None,
             self._span_limits,
             InstrumentationScope(
                 instrumenting_module_name,


### PR DESCRIPTION
# Description

Fixes #2831 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Modified the line in local install and tested that my application works fine
- Haven't gone through how to set up test environment. Since it's a small change, I figured it wasn't necessary.
- I have looked through all the other instances of InstrumentationInfo and it doesn't seem to be useful. [This PR](https://github.com/open-telemetry/opentelemetry-python/pull/2583/files) also seems to have gone around replacing all the places intrumentation_info used to be used.
- Any breaking changes should be caught in CI


# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
