### PR TITLE
Add missing entry points for OTLP/HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add missing entry points for OTLP/HTTP exporter
+  ([#3027](https://github.com/open-telemetry/opentelemetry-python/pull/3027))
+
 ## Version 1.14.0/0.35b0 (2022-11-04)
 
 - Add logarithm and exponent mappings

--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -42,6 +42,12 @@ test = [
 [project.entry-points.opentelemetry_traces_exporter]
 otlp_proto_http = "opentelemetry.exporter.otlp.proto.http.trace_exporter:OTLPSpanExporter"
 
+[project.entry-points.opentelemetry_metrics_exporter]
+otlp_proto_http = "opentelemetry.exporter.otlp.proto.http.metric_exporter:OTLPMetricExporter"
+
+[project.entry-points.opentelemetry_logs_exporter]
+otlp_proto_http = "opentelemetry.exporter.otlp.proto.http._log_exporter:OTLPLogExporter"
+
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http"
 


### PR DESCRIPTION
# Description

Can't use `OTEL_{}_EXPORTER` or `opentelemetry-instrument --{}_exporter` without them.