### PR TITLE
Avoid generator in _ViewInstrumentMatch.collect()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: c6134843900e2eeb1b8b3383a897b38cc0905c38
+  CONTRIB_REPO_SHA: main
   # This is needed because we do not clone the core repo in contrib builds anymore.
   # When running contrib builds as part of core builds, we use actions/checkout@v2 which
   # does not set an environment variable (simply just runs tox), which is different when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3026](https://github.com/open-telemetry/opentelemetry-python/pull/3026))
 - Add missing entry points for OTLP/HTTP exporter
   ([#3027](https://github.com/open-telemetry/opentelemetry-python/pull/3027))
+- Fix: Avoid generator in metrics _ViewInstrumentMatch.collect()
+  ([#3035](https://github.com/open-telemetry/opentelemetry-python/pull/3035)
 
 ## Version 1.14.0/0.35b0 (2022-11-04)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Please take a look at this list first, your contributions may belong in one of t
 
 # Find the right branch
 
-The default branch for this repo is `main`. Changes that pertain to `metrics` go into the `metrics` branch. Any changes that pertain to components marked as `stable` in the [specifications](https://github.com/open-telemetry/opentelemetry-specification) or anything that is not `metrics` related go into this branch.
+The default branch for this repo is `main`. All feature work is accomplished on branches from `main`.
 
 ## Find a Buddy and get Started Quickly!
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/_view_instrument_match.py
@@ -16,7 +16,7 @@
 from logging import getLogger
 from threading import Lock
 from time import time_ns
-from typing import Dict, Iterable
+from typing import Dict, List, Sequence
 
 from opentelemetry.metrics import Instrument
 from opentelemetry.sdk.metrics._internal.aggregation import (
@@ -126,12 +126,14 @@ class _ViewInstrumentMatch:
         self,
         aggregation_temporality: AggregationTemporality,
         collection_start_nanos: int,
-    ) -> Iterable[DataPointT]:
+    ) -> Sequence[DataPointT]:
 
+        data_points: List[DataPointT] = []
         with self._lock:
             for aggregation in self._attributes_aggregation.values():
                 data_point = aggregation.collect(
                     aggregation_temporality, collection_start_nanos
                 )
                 if data_point is not None:
-                    yield data_point
+                    data_points.append(data_point)
+        return data_points

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -514,11 +514,11 @@ class TestDuplicateInstrumentAggregateData(TestCase):
         self.assertEqual(metric_0.name, "counter")
         self.assertEqual(metric_0.unit, "unit")
         self.assertEqual(metric_0.description, "description")
-        self.assertEqual(next(metric_0.data.data_points).value, 3)
+        self.assertEqual(next(iter(metric_0.data.data_points)).value, 3)
 
         metric_1 = scope_metrics[1].metrics[0]
 
         self.assertEqual(metric_1.name, "counter")
         self.assertEqual(metric_1.unit, "unit")
         self.assertEqual(metric_1.description, "description")
-        self.assertEqual(next(metric_1.data.data_points).value, 7)
+        self.assertEqual(next(iter(metric_1.data.data_points)).value, 7)


### PR DESCRIPTION
# Description

Alter `_ViewInstrumentMatch.collect()` to return a realized `List` of `data_points` rather than a `Generator`. This probably has some memory implications, but I don't have a good handle on how impactful they are likely to be.

Also updates CONTRIBUTING.md to remove mention of `metrics` branch.

Fixes #3021 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

This does change a return type, but it appears effectively internal and nothing within the SDK seemed to attempt to use the result in an incompatible way. The tests were actually assuming it was an `Iterator` rather than just an `Iterable`, I believe, so updating them felt like a fix.

# How Has This Been Tested?

Installed in editable mode with 3.9 and an external script to send signals to the console and a remote collector. Not a load test, but everything was collected and sent as expected.

# Does This PR Require a Contrib Repo Change?
I did remove reference to the `metrics` branch in CONTRIBUTING.md, but that does not seem relevant.
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
