### PR TITLE
Fixes typo in OTEL_EXPORTER_OTLP_METRRICS_CERTIFICATE

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables.py
@@ -431,7 +431,7 @@ A scheme of https indicates a secure connection and takes precedence over this c
 """
 
 OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE = (
-    "OTEL_EXPORTER_OTLP_METRRICS_CERTIFICATE"
+    "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE"
 )
 """
 .. envvar:: OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE


### PR DESCRIPTION
There is a typo in the spelling of METRICS.


Fixes #[ (3036)](https://github.com/open-telemetry/opentelemetry-python/issues/3036)
