### PR TITLE
Add spec compliance comments

### DIFF
--- a/opentelemetry-api/src/opentelemetry/metrics/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/_internal/__init__.py
@@ -87,9 +87,12 @@ _ProxyInstrumentT = Union[
 
 class MeterProvider(ABC):
     """
-    MeterProvider is the entry point of the API. It provides access to `Meter` instances.
+    MeterProvider is the entry point of the API. It provides access to `Meter`
+    instances.
     """
 
+    # SPEC: `MeterProvider` provides a way to get a `Meter`.
+    # SPEC: `get_meter` accepts name, `version` and `schema_url`.
     @abstractmethod
     def get_meter(
         self,
@@ -125,9 +128,12 @@ class MeterProvider(ABC):
         """
 
 
+# SPEC: It is possible to create any number of `MeterProvider`s.
 class NoOpMeterProvider(MeterProvider):
     """The default MeterProvider used when no MeterProvider implementation is available."""
 
+    # SPEC: `MeterProvider` provides a way to get a `Meter`.
+    # SPEC: `get_meter` accepts name, `version` and `schema_url`.
     def get_meter(
         self,
         name: str,
@@ -145,6 +151,8 @@ class _ProxyMeterProvider(MeterProvider):
         self._meters: List[_ProxyMeter] = []
         self._real_meter_provider: Optional[MeterProvider] = None
 
+    # SPEC: `MeterProvider` provides a way to get a `Meter`.
+    # SPEC: `get_meter` accepts name, `version` and `schema_url`.
     def get_meter(
         self,
         name: str,
@@ -209,6 +217,11 @@ class Meter(ABC):
         """
         return self._schema_url
 
+    # SPEC: A valid instrument MUST be created and warning SHOULD be emitted
+    # when multiple instruments are registered under the same `Meter` using the
+    # same `name`.
+    # SPEC: It is possible to register two instruments with same `name` under
+    # different `Meter`s.
     def _is_instrument_registered(
         self, name: str, type_: type, unit: str, description: str
     ) -> Tuple[bool, str]:
@@ -235,6 +248,7 @@ class Meter(ABC):
 
         return (result, instrument_id)
 
+    # SPEC: The meter provides functions to create a new `Counter`.
     @abstractmethod
     def create_counter(
         self,
@@ -251,6 +265,7 @@ class Meter(ABC):
             description: A description for this instrument and what it measures.
         """
 
+    # SPEC: The meter provides functions to create a new `UpDownCounter`.
     @abstractmethod
     def create_up_down_counter(
         self,
@@ -267,6 +282,7 @@ class Meter(ABC):
             description: A description for this instrument and what it measures.
         """
 
+    # SPEC: The meter provides functions to create a new `AsynchronousCounter`.
     @abstractmethod
     def create_observable_counter(
         self,
@@ -364,6 +380,7 @@ class Meter(ABC):
             description: A description for this instrument and what it measures.
         """
 
+    # SPEC: The meter provides functions to create a new `AsynchronousGauge`.
     @abstractmethod
     def create_histogram(
         self,
@@ -400,6 +417,7 @@ class Meter(ABC):
             description: A description for this instrument and what it measures.
         """
 
+    # SPEC: The meter provides functions to create a new `AsynchronousUpDownCounter`.
     @abstractmethod
     def create_observable_up_down_counter(
         self,
@@ -450,6 +468,10 @@ class _ProxyMeter(Meter):
             for instrument in self._instruments:
                 instrument.on_meter_set(real_meter)
 
+    # SPEC: The meter provides functions to create a new `Counter`.
+    # SPEC: `create_counter` returns a `Counter`.
+    # SPEC: The API for `Counter` accepts the name, unit and description of the
+    # instrument.
     def create_counter(
         self,
         name: str,
@@ -463,6 +485,10 @@ class _ProxyMeter(Meter):
             self._instruments.append(proxy)
             return proxy
 
+    # SPEC: The meter provides functions to create a new `UpDownCounter`.
+    # SPEC: `create_up_down_counter` returns an `UpDownCounter`.
+    # SPEC: The API for `UpDownCounter` accepts the name, unit and description
+    # of the instrument.
     def create_up_down_counter(
         self,
         name: str,
@@ -478,6 +504,11 @@ class _ProxyMeter(Meter):
             self._instruments.append(proxy)
             return proxy
 
+    # SPEC: The meter provides functions to create a new `AsynchronousCounter`.
+    # SPEC: `create_asynchronous_counter` creates an `AsynchronousCounter`.
+    # SPEC: The API for `AsynchronousCounter` accepts the name, unit and
+    # description of the instrument.
+    # SPEC: The API for `AsynchronousCounter` accepts a callback.
     def create_observable_counter(
         self,
         name: str,
@@ -496,6 +527,8 @@ class _ProxyMeter(Meter):
             self._instruments.append(proxy)
             return proxy
 
+    # SPEC: The meter provides functions to create a new `AsynchronousGauge`.
+    # SPEC: The API for `Histogram` accepts the name, unit and description of the instrument.
     def create_histogram(
         self,
         name: str,
@@ -511,6 +544,8 @@ class _ProxyMeter(Meter):
             self._instruments.append(proxy)
             return proxy
 
+    # SPEC: `create_asynchronous_gauge` creates an `Asynchronous Gauge`.
+    # SPEC: The API for `AsynchronousGauge` accepts the name, unit and description of the instrument.
     def create_observable_gauge(
         self,
         name: str,
@@ -529,6 +564,10 @@ class _ProxyMeter(Meter):
             self._instruments.append(proxy)
             return proxy
 
+    # SPEC: The meter provides functions to create a new `AsynchronousUpDownCounter`.
+    # SPEC: `create_asynchronous_up_down_counter` creates an `AsynchronousUpDownCounter`.
+    # SPEC: The API for `AsynchronousUpDownCounter` accepts the name, unit and description of the instrument.
+    # SPEC: The API for `AsynchronousUpDownCounter` accepts a callback.
     def create_observable_up_down_counter(
         self,
         name: str,
@@ -557,6 +596,7 @@ class NoOpMeter(Meter):
     All operations are no-op.
     """
 
+    # SPEC: The meter provides functions to create a new `Counter`.
     def create_counter(
         self,
         name: str,
@@ -578,6 +618,7 @@ class NoOpMeter(Meter):
             )
         return NoOpCounter(name, unit=unit, description=description)
 
+    # SPEC: The meter provides functions to create a new `UpDownCounter`.
     def create_up_down_counter(
         self,
         name: str,
@@ -601,6 +642,7 @@ class NoOpMeter(Meter):
             )
         return NoOpUpDownCounter(name, unit=unit, description=description)
 
+    # SPEC: The meter provides functions to create a new `AsynchronousCounter`.
     def create_observable_counter(
         self,
         name: str,
@@ -630,6 +672,8 @@ class NoOpMeter(Meter):
             description=description,
         )
 
+    # SPEC: The meter provides functions to create a new `AsynchronousGauge`.
+    # SPEC: `create_histogram` returns a `Histogram`.
     def create_histogram(
         self,
         name: str,
@@ -680,6 +724,7 @@ class NoOpMeter(Meter):
             description=description,
         )
 
+    # SPEC: The meter provides functions to create a new `AsynchronousUpDownCounter`.
     def create_observable_up_down_counter(
         self,
         name: str,
@@ -715,6 +760,7 @@ _METER_PROVIDER: Optional[MeterProvider] = None
 _PROXY_METER_PROVIDER = _ProxyMeterProvider()
 
 
+# SPEC: `get_meter` accepts name, `version` and `schema_url`.
 def get_meter(
     name: str,
     version: str = "",
@@ -746,6 +792,7 @@ def _set_meter_provider(meter_provider: MeterProvider, log: bool) -> None:
         _logger.warning("Overriding of current MeterProvider is not allowed")
 
 
+# SPEC: The API provides a way to set and get a global default `MeterProvider`.
 def set_meter_provider(meter_provider: MeterProvider) -> None:
     """Sets the current global :class:`~.MeterProvider` object.
 
@@ -755,6 +802,7 @@ def set_meter_provider(meter_provider: MeterProvider) -> None:
     _set_meter_provider(meter_provider, log=True)
 
 
+# SPEC: The API provides a way to set and get a global default `MeterProvider`.
 def get_meter_provider() -> MeterProvider:
     """Gets the current global :class:`~.MeterProvider` object."""
 

--- a/opentelemetry-api/src/opentelemetry/metrics/_internal/instrument.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/_internal/instrument.py
@@ -61,18 +61,24 @@ CallbackT = Union[
 ]
 
 
+# SPEC: Instruments have kind.
 class Instrument(ABC):
     """Abstract class that serves as base for all instruments."""
 
     @abstractmethod
     def __init__(
         self,
+        # SPEC: Instruments have `name`
         name: str,
+        # SPEC: Instruments have an optional unit of measure.
         unit: str = "",
+        # SPEC: Instruments have an optional description.
         description: str = "",
     ) -> None:
         pass
 
+    # SPEC: Instrument names conform to the specified syntax.
+    # SPEC: Instrument units conform to the specified syntax.
     @staticmethod
     def _check_name_unit_description(
         name: str, unit: str, description: str
@@ -150,6 +156,9 @@ class Synchronous(Instrument):
     """Base class for all synchronous instruments"""
 
 
+# SPEC: The API for `AsynchronousCounter` accepts a callback.
+# SPEC: The API for `AsynchronousUpDownCounter` accepts a callback.
+# SPEC: The API for `AsynchronousGauge` accepts a callback.
 class Asynchronous(Instrument):
     """Base class for all asynchronous instruments"""
 
@@ -167,6 +176,10 @@ class Asynchronous(Instrument):
 class Counter(Synchronous):
     """A Counter is a synchronous `Instrument` which supports non-negative increments."""
 
+    # SPEC: `Counter` has an `add` method.
+    # SPEC: The `add` method returns no (or dummy) value.
+    # SPEC: The `add` method accepts optional attributes.
+    # SPEC: The `add` method accepts the increment amount.
     @abstractmethod
     def add(
         self,
@@ -211,6 +224,10 @@ class _ProxyCounter(_ProxyInstrument[Counter], Counter):
 class UpDownCounter(Synchronous):
     """An UpDownCounter is a synchronous `Instrument` which supports increments and decrements."""
 
+    # SPEC: `UpDownCounter` has an `add` method.
+    # SPEC: The `add` method returns no (or dummy) value.
+    # SPEC: The `add` method accepts optional attributes.
+    # SPEC: The `add` method accepts the increment amount.
     @abstractmethod
     def add(
         self,
@@ -322,6 +339,10 @@ class Histogram(Synchronous):
     histograms, summaries, and percentile.
     """
 
+    # SPEC: `Histogram` has a `record` method.
+    # SPEC: The `record` method return no (or dummy) value.
+    # SPEC: The `record` method accepts optional attributes.
+    # SPEC: The `record` method accepts a value.
     @abstractmethod
     def record(
         self,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py
@@ -59,6 +59,7 @@ class Meter(APIMeter):
 
     def __init__(
         self,
+        # SPEC: Associate `Meter` with `InstrumentationScope`.
         instrumentation_scope: InstrumentationScope,
         measurement_consumer: MeasurementConsumer,
     ):
@@ -102,6 +103,7 @@ class Meter(APIMeter):
             self._instrument_id_instrument[instrument_id] = instrument
             return instrument
 
+    # SPEC: The meter provides functions to create a new `UpDownCounter`.
     def create_up_down_counter(
         self, name, unit="", description=""
     ) -> APIUpDownCounter:
@@ -140,6 +142,7 @@ class Meter(APIMeter):
             self._instrument_id_instrument[instrument_id] = instrument
             return instrument
 
+    # SPEC: The meter provides functions to create a new `AsynchronousCounter`.
     def create_observable_counter(
         self, name, callbacks=None, unit="", description=""
     ) -> APIObservableCounter:
@@ -181,6 +184,7 @@ class Meter(APIMeter):
             self._instrument_id_instrument[instrument_id] = instrument
             return instrument
 
+    # SPEC: The meter provides functions to create a new `AsynchronousGauge`.
     def create_histogram(self, name, unit="", description="") -> APIHistogram:
 
         (
@@ -255,6 +259,7 @@ class Meter(APIMeter):
             self._instrument_id_instrument[instrument_id] = instrument
             return instrument
 
+    # SPEC: The meter provides functions to create a new `AsynchronousUpDownCounter`.
     def create_observable_up_down_counter(
         self, name, callbacks=None, unit="", description=""
     ) -> APIObservableUpDownCounter:
@@ -297,6 +302,7 @@ class Meter(APIMeter):
             return instrument
 
 
+# SPEC: It is possible to create any number of `MeterProvider`s.
 class MeterProvider(APIMeterProvider):
     r"""See `opentelemetry.metrics.MeterProvider`.
 
@@ -332,13 +338,16 @@ class MeterProvider(APIMeterProvider):
     _all_metric_readers_lock = Lock()
     _all_metric_readers = set()
 
+    # SPEC: Configuration is managed solely by the `MeterProvider`.
     def __init__(
         self,
         metric_readers: Sequence[
             "opentelemetry.sdk.metrics.export.MetricReader"
         ] = (),
+        # SPEC: `MeterProvider` allows a `Resource` to be specified.
         resource: Resource = Resource.create({}),
         shutdown_on_exit: bool = True,
+        # SPEC: There is a way to register `View`s with a `MeterProvider`.
         views: Sequence["opentelemetry.sdk.metrics.view.View"] = (),
     ):
         self._lock = Lock()
@@ -463,6 +472,8 @@ class MeterProvider(APIMeterProvider):
                 )
             )
 
+    # SPEC: `MeterProvider` provides a way to get a `Meter`.
+    # SPEC: `get_meter` accepts name, `version` and `schema_url`.
     def get_meter(
         self,
         name: str,
@@ -476,10 +487,15 @@ class MeterProvider(APIMeterProvider):
             )
             return NoOpMeter(name, version=version, schema_url=schema_url)
 
+        # SPEC: When an invalid `name` is specified a working `Meter`
+        # implementation is returned as a fallback.
         if not name:
             _logger.warning("Meter name cannot be None or empty.")
+            # SPEC: The fallback `Meter` `name` property keeps its original
+            # invalid value.
             return NoOpMeter(name, version=version, schema_url=schema_url)
 
+        # SPEC: The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope` instance stored in the `Meter`.
         info = InstrumentationScope(name, version, schema_url)
         with self._meter_lock:
             if not self._meters.get(info):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -83,6 +83,7 @@ class _DropAggregation(_Aggregation):
     def aggregate(self, measurement: Measurement) -> None:
         pass
 
+    # SPEC: The `Drop` aggregation drops all measurements and does not produce a metric stream.
     def collect(
         self,
         aggregation_temporality: AggregationTemporality,
@@ -116,6 +117,7 @@ class _SumAggregation(_Aggregation[Sum]):
                 self._value = 0
             self._value = self._value + measurement.value
 
+    # SPEC: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
     def collect(
         self,
         aggregation_temporality: AggregationTemporality,
@@ -190,6 +192,7 @@ class _LastValueAggregation(_Aggregation[Gauge]):
         with self._lock:
             self._value = measurement.value
 
+    # SPEC: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
     def collect(
         self,
         aggregation_temporality: AggregationTemporality,
@@ -265,6 +268,7 @@ class _ExplicitBucketHistogramAggregation(_Aggregation[HistogramPoint]):
 
         self._bucket_counts[bisect_left(self._boundaries, value)] += 1
 
+    # SPEC: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
     def collect(
         self,
         aggregation_temporality: AggregationTemporality,
@@ -433,6 +437,8 @@ class DefaultAggregation(Aggregation):
         raise Exception(f"Invalid instrument type {type(instrument)} found")
 
 
+# SPEC: The explicit bucket `Histogram` aggregation is available.
+# SPEC: The explicit bucket `Histogram` aggregation performs as specified.
 class ExplicitBucketHistogramAggregation(Aggregation):
     """This aggregation informs the SDK to collect:
 
@@ -485,6 +491,8 @@ class ExplicitBucketHistogramAggregation(Aggregation):
         )
 
 
+# SPEC: The `Sum` aggregation is available.
+# SPEC: The `Sum` aggregation performs as specified.
 class SumAggregation(Aggregation):
     """This aggregation informs the SDK to collect:
 
@@ -512,6 +520,8 @@ class SumAggregation(Aggregation):
         )
 
 
+# SPEC: The `LastValue` aggregation is available.
+# SPEC: The `LastValue` aggregation performs as specified.
 class LastValueAggregation(Aggregation):
     """
     This aggregation informs the SDK to collect:
@@ -529,6 +539,7 @@ class LastValueAggregation(Aggregation):
         return _LastValueAggregation(attributes)
 
 
+# SPEC: The `Drop` aggregation is available.
 class DropAggregation(Aggregation):
     """Using this aggregation will make all measurements be ignored."""
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
@@ -94,6 +94,8 @@ class MetricExporter(ABC):
         self._preferred_temporality = preferred_temporality
         self._preferred_aggregation = preferred_aggregation
 
+    # SPEC: The metrics Exporter `export` function receives a batch of metrics.
+    # SPEC: The metrics Exporter `export` function returns `Success` or `Failure`.
     @abstractmethod
     def export(
         self,
@@ -171,6 +173,8 @@ class ConsoleMetricExporter(MetricExporter):
 
 class MetricReader(ABC):
     # pylint: disable=too-many-branches
+    # SPEC: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+    # SPEC: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
     """
     Base class for all metric readers
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py
@@ -106,6 +106,9 @@ class _Asynchronous:
 
             for callback in callbacks:
 
+                # SPEC: There is a way to pass state to the callback.
+                # Callbacks can be generators or functions, both natively
+                # support having state passed to them via closures.
                 if isinstance(callback, Generator):
 
                     # advance generator to it's first yield
@@ -150,6 +153,7 @@ class Counter(_Synchronous, APICounter):
     def add(
         self, amount: Union[int, float], attributes: Dict[str, str] = None
     ):
+        # SPEC: The `add` method of `Counter` accepts only positive amounts.
         if amount < 0:
             _logger.warning(
                 "Add amount must be non-negative on Counter %s.", self.name
@@ -201,6 +205,7 @@ class Histogram(_Synchronous, APIHistogram):
     def record(
         self, amount: Union[int, float], attributes: Dict[str, str] = None
     ):
+        # SPEC: The `record` method of `Histogram` accepts only positive amounts.
         if amount < 0:
             _logger.warning(
                 "Record amount must be non-negative on Histogram %s.",

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
@@ -114,8 +114,10 @@ class SynchronousMeasurementConsumer(MeasurementConsumer):
                         timeout_millis=remaining_time
                     )
 
+                # SPEC: The callback function reports `Measurement`s.
                 measurements = async_instrument.callback(callback_options)
                 if time_ns() >= deadline_ns:
+                    # SPEC: The callback function of an `Asynchronous` instrument does not block indefinitely.
                     raise MetricsTimeoutError(
                         "Timed out while executing callback"
                     )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/metric_reader_storage.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/metric_reader_storage.py
@@ -97,6 +97,7 @@ class MetricReaderStorage:
             # if no view targeted the instrument, use the default
             if not view_instrument_matches:
                 view_instrument_matches.append(
+                    # SPEC: The SDK allows more than one `View` to be specified per instrument.
                     _ViewInstrumentMatch(
                         view=_DEFAULT_VIEW,
                         instrument=instrument,
@@ -220,6 +221,7 @@ class MetricReaderStorage:
         return MetricsData(
             resource_metrics=[
                 ResourceMetrics(
+                    # SPEC: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
                     resource=self._sdk_config.resource,
                     scope_metrics=list(
                         instrumentation_scope_scope_metrics.values()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/view.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/view.py
@@ -81,6 +81,7 @@ class View:
 
     _default_aggregation = DefaultAggregation()
 
+    # SPEC: The `View` instrument selection criteria is as specified.
     def __init__(
         self,
         instrument_type: Optional[Type[Instrument]] = None,
@@ -88,6 +89,8 @@ class View:
         meter_name: Optional[str] = None,
         meter_version: Optional[str] = None,
         meter_schema_url: Optional[str] = None,
+        # SPEC: The name of the `View` can be specified.
+        # SPEC: The `View` allows configuring the name description, attributes keys and aggregation of the resulting metric stream.
         name: Optional[str] = None,
         description: Optional[str] = None,
         attribute_keys: Optional[Set[str]] = None,
@@ -139,6 +142,8 @@ class View:
             if not isinstance(instrument, self._instrument_type):
                 return False
 
+        # SPEC: The `View` instrument selection criteria supports wildcards.
+        # SPEC: The `View` instrument selection criteria supports the match-all wildcard.
         if self._instrument_name is not None:
             if not fnmatch(instrument.name, self._instrument_name):
                 return False


### PR DESCRIPTION
Related to #2889

Adds comments that should help TC Metrics reviewers find the part of the implementation that implements each specification matrix requirement.