### PR TITLE
Fix tox version for CI

### DIFF
--- a/.github/workflows/public-api-check.yml
+++ b/.github/workflows/public-api-check.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: 3.9
 
       - name: Install tox
-        run: pip install -U tox-factor
+        run: pip install tox==3.27.1 -U tox-factor
 
       - name: Public API Check
         run: tox -e public-symbols-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: ${{ env[matrix.python-version] }}
           architecture: 'x64'
       - name: Install tox
-        run: pip install -U tox-factor
+        run: pip install tox==3.27.1 -U tox-factor
       - name: Cache tox environment
         # Preserves .tox directory between runs for faster installs
         uses: actions/cache@v2
@@ -99,7 +99,7 @@ jobs:
           python-version: 3.9
           architecture: 'x64'
       - name: Install tox
-        run: pip install -U tox
+        run: pip install tox==3.27.1
       - name: Cache tox environment
         # Preserves .tox directory between runs for faster installs
         uses: actions/cache@v2
@@ -142,7 +142,7 @@ jobs:
           python-version: ${{ env[matrix.python-version] }}
           architecture: 'x64'
       - name: Install tox
-        run: pip install -U tox-factor
+        run: pip install tox==3.27.1 -U tox-factor
       - name: Cache tox environment
         # Preserves .tox directory between runs for faster installs
         uses: actions/cache@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,11 +47,13 @@ during their normal contribution hours.
 
 This project uses [tox](https://tox.readthedocs.io) to automate
 some aspects of development, including testing against multiple Python versions.
-To install `tox`, run:
+To install `tox`, run[^1]:
 
 ```console
-$ pip install tox
+$ pip install tox==3.27.1
 ```
+
+[^1]: Right now we are experiencing issues with `tox==4.x.y`, so we recommend you use this version.
 
 You can run `tox` with the following arguments:
 


### PR DESCRIPTION
Fixes #3079

@tox-dev we had to pin `tox` to `3.27.1` for test cases to work again, just in case this information helps you debug the issue.