### PR TITLE
Move the metrics basic test to TestBase class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add metrics basic tests to BaseTest class
+  ([#3092](https://github.com/open-telemetry/opentelemetry-python/pull/3092))
+
 ## Version 1.15.0/0.36b0 (2022-12-09)
 
 - Regenerate opentelemetry-proto to be compatible with protobuf 3 and 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Add metrics basic tests to BaseTest class
-  ([#3092](https://github.com/open-telemetry/opentelemetry-python/pull/3092))
-
 ## Version 1.15.0/0.36b0 (2022-12-09)
 
 - Regenerate opentelemetry-proto to be compatible with protobuf 3 and 4

--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
@@ -103,10 +103,31 @@ class TestBase(unittest.TestCase):
         resource_metrics = (
             self.memory_metrics_reader.get_metrics_data().resource_metrics
         )
+
+        all_metrics = []
         for metrics in resource_metrics:
             for scope_metrics in metrics.scope_metrics:
-                all_metrics = list(scope_metrics.metrics)
-                return self.sorted_metrics(all_metrics)
+                all_metrics.extend(scope_metrics.metrics)
+
+        return self.sorted_metrics(all_metrics)
+
+    def assert_histogram_expected(self, data_point, expected_value):
+        self.assertEqual(
+            data_point.count,
+            1,
+        )
+        self.assertEqual(
+            data_point.sum,
+            expected_value,
+        )
+        self.assertEqual(
+            data_point.max,
+            expected_value,
+        )
+        self.assertEqual(
+            data_point.min,
+            expected_value,
+        )
 
     def assert_metric_expected(
         self, metric, expected_value, expected_attributes
@@ -114,10 +135,7 @@ class TestBase(unittest.TestCase):
         data_point = next(iter(metric.data.data_points))
 
         if isinstance(data_point, HistogramDataPoint):
-            self.assertEqual(
-                data_point.sum,
-                expected_value,
-            )
+            self.assert_histogram_expected(data_point, expected_value)
         elif isinstance(data_point, NumberDataPoint):
             self.assertEqual(
                 data_point.value,

--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
@@ -90,7 +90,7 @@ class TestBase(unittest.TestCase):
             reverse=True,
         )
 
-    def sorted_metrics(self, metrics):
+    def sorted_metrics(self, metrics):  # pylint: disable=R0201
         """
         Sorts metrics by metric name.
         """

--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
@@ -20,9 +20,12 @@ from typing import Tuple
 from opentelemetry import metrics as metrics_api
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import (InMemoryMetricReader, MetricReader, HistogramDataPoint,
-    NumberDataPoint)
-
+from opentelemetry.sdk.metrics.export import (
+    HistogramDataPoint,
+    InMemoryMetricReader,
+    MetricReader,
+    NumberDataPoint,
+)
 from opentelemetry.sdk.trace import TracerProvider, export
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
@@ -106,7 +109,7 @@ class TestBase(unittest.TestCase):
                 return self.sorted_metrics(all_metrics)
 
     def assert_metric_expected(
-            self, metric, expected_value, expected_attributes
+        self, metric, expected_value, expected_attributes
     ):
         data_point = next(iter(metric.data.data_points))
 
@@ -127,7 +130,7 @@ class TestBase(unittest.TestCase):
         )
 
     def assert_duration_metric_expected(
-            self, metric, duration_estimated, expected_attributes, est_delta=200
+        self, metric, duration_estimated, expected_attributes, est_delta=200
     ):
         data_point = next(iter(metric.data.data_points))
 


### PR DESCRIPTION
# Description
Move the metrics basic test to TestBase class so each metric instrumentation could use those functions
The functions moved from the tornado instrumentation test:
https://github.com/open-telemetry/opentelemetry-python-contrib/blob/0f2451be26c87a366d44283022341fc904c88b22/instrumentation/opentelemetry-instrumentation-tornado/tests/test_metrics_instrumentation.py#L38

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
