### PR TITLE
fix: clear unwanted global variables in module init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Clean `key`, `value` at module `__init__` after dynamically adding to `__all__`
+  ([#3095](https://github.com/open-telemetry/opentelemetry-python/pull/3095))
+
 ## Version 1.15.0/0.36b0 (2022-12-09)
 
 - Regenerate opentelemetry-proto to be compatible with protobuf 3 and 4

--- a/opentelemetry-api/src/opentelemetry/_logs/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/__init__.py
@@ -56,4 +56,4 @@ for key, value in globals().copy().items():  # type: ignore
     if not key.startswith("_"):
         value.__module__ = __name__  # type: ignore
         __all__.append(key)
-    del key, value
+    del key, value  # type: ignore

--- a/opentelemetry-api/src/opentelemetry/_logs/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/__init__.py
@@ -56,3 +56,4 @@ for key, value in globals().copy().items():  # type: ignore
     if not key.startswith("_"):
         value.__module__ = __name__  # type: ignore
         __all__.append(key)
+    del key, value

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -28,4 +28,4 @@ for key, value in globals().copy().items():
     if not key.startswith("_"):
         value.__module__ = __name__
         __all__.append(key)
-    del key, value
+    del key, value  # type: ignore

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -28,3 +28,4 @@ for key, value in globals().copy().items():
     if not key.startswith("_"):
         value.__module__ = __name__
         __all__.append(key)
+    del key, value

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/export/__init__.py
@@ -32,3 +32,4 @@ for key, value in globals().copy().items():
     if not key.startswith("_"):
         value.__module__ = __name__
         __all__.append(key)
+    del key, value

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/export/__init__.py
@@ -32,4 +32,4 @@ for key, value in globals().copy().items():
     if not key.startswith("_"):
         value.__module__ = __name__
         __all__.append(key)
-    del key, value
+    del key, value  # type: ignore

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -35,3 +35,4 @@ for key, value in globals().copy().items():
     if not key.startswith("_"):
         value.__module__ = __name__
         __all__.append(key)
+    del key, value

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -35,4 +35,4 @@ for key, value in globals().copy().items():
     if not key.startswith("_"):
         value.__module__ = __name__
         __all__.append(key)
-    del key, value
+    del key, value  # type: ignore

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
@@ -44,3 +44,4 @@ for key, value in globals().copy().items():
     if not key.startswith("_"):
         value.__module__ = __name__
         __all__.append(key)
+    del key, value

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
@@ -44,4 +44,4 @@ for key, value in globals().copy().items():
     if not key.startswith("_"):
         value.__module__ = __name__
         __all__.append(key)
-    del key, value
+    del key, value  # type: ignore

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/view/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/view/__init__.py
@@ -29,3 +29,4 @@ for key, value in globals().copy().items():
     if not key.startswith("_"):
         value.__module__ = __name__
         __all__.append(key)
+    del key, value

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/view/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/view/__init__.py
@@ -29,4 +29,4 @@ for key, value in globals().copy().items():
     if not key.startswith("_"):
         value.__module__ = __name__
         __all__.append(key)
-    del key, value
+    del key, value  # type: ignore


### PR DESCRIPTION
# Description

I found this by trying to use `importlib.reload`. 

```python
import importlib
import opentelemetry.sdk.metrics as metrics
importlib.reload(metrics)
```
will raise error like this
```python
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/gen/.pyenv/versions/3.11.1/lib/python3.11/importlib/__init__.py", line 169, in reload
    _bootstrap._exec(spec, module)
  File "<frozen importlib._bootstrap>", line 621, in _exec
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/gen/.pyenv/versions/3.11.1/lib/python3.11/site-packages/opentelemetry/sdk/metrics/__init__.py", line 36, in <module>
    value.__module__ = __name__
    ^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute '__module__'
```

The `str` above is basically the `key` in the previous run of this loop.

Though I understand that reload isn't any guaranteed behavior, but without `del key, value` it polluted the module level globals, that I think is unexected.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


```python
import importlib
import opentelemetry.sdk.metrics as metrics
importlib.reload(metrics)
```

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
