### PR TITLE
PeriodicExportingMetricReader will continue collection times out (#3098)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- PeriodicExportingMetricReader will continue if collection times out 
+  ([#3100](https://github.com/open-telemetry/opentelemetry-python/pull/3100))
+
 
 ## Version 1.16.0/0.37b0 (2023-02-17)
 - Change ``__all__`` to be statically defined.
@@ -28,9 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3156](https://github.com/open-telemetry/opentelemetry-python/pull/3156))
 - deprecate jaeger exporters
   ([#3158](https://github.com/open-telemetry/opentelemetry-python/pull/3158))
-
 - Create a single resource instance
   ([#3118](https://github.com/open-telemetry/opentelemetry-python/pull/3118))
+
 
 ## Version 1.15.0/0.36b0 (2022-12-09)
 


### PR DESCRIPTION
# Description

In cases where collection times out, the period exporting reader thread should not terminate, but instead catch, log, and continue on after the regular interval seconds.

Prior to this commit, a metric collection timeout would terminate the thread and stop reporting metrics to the wrapped exporter resulting in the appearance in observability tooling of metrics just stopping without reason.

Fixes #3098

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Added a new test to ensure the `OtelPeriodicExportingMetricReader` thread remains alive after a `MetricsTimeoutError` timeout error is raised by the collection process
- [X] Added a new test to ensure the `OtelPeriodicExportingMetricReader` thread is killed for other exception types


# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No. This is an SDK bugfix only.

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
