### PR TITLE
Fixes #3088 updated import library for set_logger_provider

### DIFF
--- a/docs/examples/logs/example.py
+++ b/docs/examples/logs/example.py
@@ -1,13 +1,13 @@
 import logging
 
 from opentelemetry import trace
+from opentelemetry._logs import set_logger_provider
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
     OTLPLogExporter,
 )
 from opentelemetry.sdk._logs import (
     LoggerProvider,
     LoggingHandler,
-    set_logger_provider,
 )
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import Resource

--- a/docs/examples/logs/example.py
+++ b/docs/examples/logs/example.py
@@ -5,10 +5,7 @@ from opentelemetry._logs import set_logger_provider
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
     OTLPLogExporter,
 )
-from opentelemetry.sdk._logs import (
-    LoggerProvider,
-    LoggingHandler,
-)
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider


### PR DESCRIPTION
# Description

Updated import library for set_logger_provider in docs/examples/logs/example.py. The method has moved from opentelemetry.sdk._logs to opentelemetry._logs in release 1.15.0 thus causing import error for users running the examples.py with version 1.15.0.

Fixes #3088

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] tox

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
