### PR TITLE
Add db metric name to semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add db metric name to semantic conventions
+  ([#3115](https://github.com/open-telemetry/opentelemetry-python/pull/3115))
+
 ## Version 1.15.0/0.36b0 (2022-12-09)
 
 - Regenerate opentelemetry-proto to be compatible with protobuf 3 and 4

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/metrics/__init__.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/metrics/__init__.py
@@ -30,3 +30,5 @@ class MetricInstruments:
     HTTP_CLIENT_REQUEST_SIZE = "http.client.request.size"
 
     HTTP_CLIENT_RESPONSE_SIZE = "http.client.response.size"
+
+    DB_CLIENT_CONNECTIONS_USAGE = "db.client.connections.usage"


### PR DESCRIPTION
# Description

I started to implement dbapi metrics instrumentation and  
I figure out that db.client.connections.usage metric name is missing in the semantic conventions

According to the specs: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/database-metrics.md

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
