### PR TITLE
Add attribute name to type warning message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add attribute name to type warning message.
+  ([3124](https://github.com/open-telemetry/opentelemetry-python/pull/3124))
+
 ## Version 1.15.0/0.36b0 (2022-12-09)
 
 - Regenerate opentelemetry-proto to be compatible with protobuf 3 and 4

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -97,9 +97,10 @@ def _clean_attribute(
         return tuple(cleaned_seq)
 
     _logger.warning(
-        "Invalid type %s for attribute value. Expected one of %s or a "
+        "Invalid type %s for attribute '%s' value. Expected one of %s or a "
         "sequence of those types",
         type(value).__name__,
+        key,
         [valid_type.__name__ for valid_type in _VALID_ATTR_VALUE_TYPES],
     )
     return None


### PR DESCRIPTION
Without this, the error message simply specifies that some attribute has the incorrect type, but this is very difficult to debug without knowing which attribute it was.

For example, my google cloud run logs are littered with this line;
```
[__init__:99]: Invalid type NoneType for attribute value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Loggin format

# Does This PR Require a Contrib Repo Change?
No

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
