### PR TITLE
fixed extra colon typos in code documentation

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -373,7 +373,7 @@ class Tracer(ABC):
 
         This can also be used as a decorator::
 
-            @tracer.start_as_current_span("name"):
+            @tracer.start_as_current_span("name")
             def function():
                 ...
 


### PR DESCRIPTION
# Description

Fixed all found instances of 
`@tracer.start_as_current_span("name"):`
to
`@tracer.start_as_current_span("name")`
as my understanding is decorators don't have trailing colons

Fixes #3093 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Purely commented code has changed. Shouldn't need to be tested. But very happy to run any suggested tests.

# Does This PR Require a Contrib Repo Change?

No

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
