### PR TITLE
remove ability to set a global metric prefix for prometheus exporter

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
@@ -115,13 +115,9 @@ def _convert_buckets(
 
 class PrometheusMetricReader(MetricReader):
     """Prometheus metric exporter for OpenTelemetry.
-
-    Args:
-        prefix: single-word application prefix relevant to the domain
-            the metric belongs to.
     """
 
-    def __init__(self, prefix: str = "") -> None:
+    def __init__(self) -> None:
 
         super().__init__(
             preferred_temporality={
@@ -133,7 +129,7 @@ class PrometheusMetricReader(MetricReader):
                 ObservableGauge: AggregationTemporality.CUMULATIVE,
             }
         )
-        self._collector = _CustomCollector(prefix)
+        self._collector = _CustomCollector()
         REGISTRY.register(self._collector)
         self._collector._callback = self.collect
 
@@ -158,8 +154,7 @@ class _CustomCollector:
     https://github.com/prometheus/client_python#custom-collectors
     """
 
-    def __init__(self, prefix: str = ""):
-        self._prefix = prefix
+    def __init__(self):
         self._callback = None
         self._metrics_datas = deque()
         self._non_letters_digits_underscore_re = compile(
@@ -210,8 +205,6 @@ class _CustomCollector:
             pre_metric_family_ids = []
 
             metric_name = ""
-            if self._prefix != "":
-                metric_name = self._prefix + "_"
             metric_name += self._sanitize(metric.name)
 
             metric_description = metric.description or ""

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -275,7 +275,7 @@ class TestPrometheusMetricReader(TestCase):
 
     def test_check_value(self):
 
-        collector = _CustomCollector("")
+        collector = _CustomCollector()
 
         self.assertEqual(collector._check_value(1), "1")
         self.assertEqual(collector._check_value(1.0), "1.0")
@@ -289,7 +289,7 @@ class TestPrometheusMetricReader(TestCase):
 
     def test_multiple_collection_calls(self):
 
-        metric_reader = PrometheusMetricReader(prefix="prefix")
+        metric_reader = PrometheusMetricReader()
         provider = MeterProvider(metric_readers=[metric_reader])
         meter = provider.get_meter("getting-started", "0.1.2")
         counter = meter.create_counter("counter")

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -52,8 +52,7 @@ class TestPrometheusMetricReader(TestCase):
     def test_constructor(self):
         """Test the constructor."""
         with self._registry_register_patch:
-            exporter = PrometheusMetricReader(prefix="testprefix")
-            self.assertEqual(exporter._collector._prefix, "testprefix")
+            exporter = PrometheusMetricReader()
             self.assertTrue(self._mock_registry_register.called)
 
     def test_shutdown(self):
@@ -102,7 +101,7 @@ class TestPrometheusMetricReader(TestCase):
             ]
         )
 
-        collector = _CustomCollector("testprefix")
+        collector = _CustomCollector()
         collector.add_metrics_data(metrics_data)
         result_bytes = generate_latest(collector)
         result = result_bytes.decode("utf-8")
@@ -110,13 +109,13 @@ class TestPrometheusMetricReader(TestCase):
             result,
             dedent(
                 """\
-                # HELP testprefix_test_name_s foo
-                # TYPE testprefix_test_name_s histogram
-                testprefix_test_name_s_bucket{histo="1",le="123.0"} 1.0
-                testprefix_test_name_s_bucket{histo="1",le="456.0"} 4.0
-                testprefix_test_name_s_bucket{histo="1",le="+Inf"} 6.0
-                testprefix_test_name_s_count{histo="1"} 6.0
-                testprefix_test_name_s_sum{histo="1"} 579.0
+                # HELP test_name_s foo
+                # TYPE test_name_s histogram
+                test_name_s_bucket{histo="1",le="123.0"} 1.0
+                test_name_s_bucket{histo="1",le="456.0"} 4.0
+                test_name_s_bucket{histo="1",le="+Inf"} 6.0
+                test_name_s_count{histo="1"} 6.0
+                test_name_s_sum{histo="1"} 579.0
                 """
             ),
         )
@@ -147,13 +146,13 @@ class TestPrometheusMetricReader(TestCase):
             ]
         )
 
-        collector = _CustomCollector("testprefix")
+        collector = _CustomCollector()
         collector.add_metrics_data(metrics_data)
 
         for prometheus_metric in collector.collect():
             self.assertEqual(type(prometheus_metric), CounterMetricFamily)
             self.assertEqual(
-                prometheus_metric.name, "testprefix_test_sum_testunit"
+                prometheus_metric.name, "test_sum_testunit"
             )
             self.assertEqual(prometheus_metric.documentation, "testdesc")
             self.assertTrue(len(prometheus_metric.samples) == 1)
@@ -192,13 +191,13 @@ class TestPrometheusMetricReader(TestCase):
             ]
         )
 
-        collector = _CustomCollector("testprefix")
+        collector = _CustomCollector()
         collector.add_metrics_data(metrics_data)
 
         for prometheus_metric in collector.collect():
             self.assertEqual(type(prometheus_metric), GaugeMetricFamily)
             self.assertEqual(
-                prometheus_metric.name, "testprefix_test_gauge_testunit"
+                prometheus_metric.name, "test_gauge_testunit"
             )
             self.assertEqual(prometheus_metric.documentation, "testdesc")
             self.assertTrue(len(prometheus_metric.samples) == 1)
@@ -217,13 +216,13 @@ class TestPrometheusMetricReader(TestCase):
             description="testdesc",
             unit="testunit",
         )
-        collector = _CustomCollector("testprefix")
+        collector = _CustomCollector()
         collector.add_metrics_data([record])
         collector.collect()
         self.assertLogs("opentelemetry.exporter.prometheus", level="WARNING")
 
     def test_sanitize(self):
-        collector = _CustomCollector("testprefix")
+        collector = _CustomCollector()
         self.assertEqual(
             collector._sanitize("1!2@3#4$5%6^7&8*9(0)_-"),
             "1_2_3_4_5_6_7_8_9_0___",
@@ -256,13 +255,13 @@ class TestPrometheusMetricReader(TestCase):
                 )
             ]
         )
-        collector = _CustomCollector("testprefix")
+        collector = _CustomCollector()
         collector.add_metrics_data(metrics_data)
 
         for prometheus_metric in collector.collect():
             self.assertEqual(type(prometheus_metric), GaugeMetricFamily)
             self.assertEqual(
-                prometheus_metric.name, "testprefix_test_gauge_testunit"
+                prometheus_metric.name, "test_gauge_testunit"
             )
             self.assertEqual(prometheus_metric.documentation, "testdesc")
             self.assertTrue(len(prometheus_metric.samples) == 1)


### PR DESCRIPTION
# Description

Remove the ability to set a global metric prefix for Prometheus exporter.

Fixes # 3077

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tox -e py39-opentelemetry-exporter-prometheus

# Does This PR Require a Contrib Repo Change?
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
