### PR TITLE
Update `__all__` to statically define reexports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Change ``__all__`` to be statically defined.
+  ([#3143](https://github.com/open-telemetry/opentelemetry-python/pull/3143))
 - Adds environment variables for log exporter
   ([#3037](https://github.com/open-telemetry/opentelemetry-python/pull/3037))
 - Add attribute name to type warning message.

--- a/opentelemetry-api/src/opentelemetry/_logs/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/__init__.py
@@ -34,9 +34,7 @@ The following code shows how to obtain a logger using the global :class:`.Logger
 .. versionadded:: 1.15.0
 """
 
-# pylint: disable=unused-import
-
-from opentelemetry._logs._internal import (  # noqa: F401
+from opentelemetry._logs._internal import (
     Logger,
     LoggerProvider,
     LogRecord,
@@ -46,13 +44,17 @@ from opentelemetry._logs._internal import (  # noqa: F401
     get_logger_provider,
     set_logger_provider,
 )
-from opentelemetry._logs.severity import (  # noqa: F401
-    SeverityNumber,
-    std_to_otel,
-)
+from opentelemetry._logs.severity import SeverityNumber, std_to_otel
 
-__all__ = []
-for key, value in globals().copy().items():  # type: ignore
-    if not key.startswith("_"):
-        value.__module__ = __name__  # type: ignore
-        __all__.append(key)
+__all__ = [
+    "Logger",
+    "LoggerProvider",
+    "LogRecord",
+    "NoOpLogger",
+    "NoOpLoggerProvider",
+    "get_logger",
+    "get_logger_provider",
+    "set_logger_provider",
+    "SeverityNumber",
+    "std_to_otel",
+]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=unused-import
 
-from opentelemetry.sdk._logs._internal import (  # noqa: F401
+from opentelemetry.sdk._logs._internal import (
     LogData,
     Logger,
     LoggerProvider,
@@ -23,8 +22,11 @@ from opentelemetry.sdk._logs._internal import (  # noqa: F401
     LogRecordProcessor,
 )
 
-__all__ = []
-for key, value in globals().copy().items():
-    if not key.startswith("_"):
-        value.__module__ = __name__
-        __all__.append(key)
+__all__ = [
+    "LogData",
+    "Logger",
+    "LoggerProvider",
+    "LoggingHandler",
+    "LogRecord",
+    "LogRecordProcessor",
+]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/export/__init__.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=unused-import
-
-from opentelemetry.sdk._logs._internal.export import (  # noqa: F401
+from opentelemetry.sdk._logs._internal.export import (
     BatchLogRecordProcessor,
     ConsoleLogExporter,
     LogExporter,
@@ -23,12 +21,15 @@ from opentelemetry.sdk._logs._internal.export import (  # noqa: F401
 )
 
 # The point module is not in the export directory to avoid a circular import.
-from opentelemetry.sdk._logs._internal.export.in_memory_log_exporter import (  # noqa: F401
+from opentelemetry.sdk._logs._internal.export.in_memory_log_exporter import (
     InMemoryLogExporter,
 )
 
-__all__ = []
-for key, value in globals().copy().items():
-    if not key.startswith("_"):
-        value.__module__ = __name__
-        __all__.append(key)
+__all__ = [
+    "BatchLogRecordProcessor",
+    "ConsoleLogExporter",
+    "LogExporter",
+    "LogExportResult",
+    "SimpleLogRecordProcessor",
+    "InMemoryLogExporter",
+]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/__init__.py
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=unused-import
 
-from opentelemetry.sdk.metrics._internal import (  # noqa: F401
-    Meter,
-    MeterProvider,
-)
-from opentelemetry.sdk.metrics._internal.exceptions import (  # noqa: F401
-    MetricsTimeoutError,
-)
-from opentelemetry.sdk.metrics._internal.instrument import (  # noqa: F401
+from opentelemetry.sdk.metrics._internal import Meter, MeterProvider
+from opentelemetry.sdk.metrics._internal.exceptions import MetricsTimeoutError
+from opentelemetry.sdk.metrics._internal.instrument import (
     Counter,
     Histogram,
     ObservableCounter,
@@ -30,8 +24,14 @@ from opentelemetry.sdk.metrics._internal.instrument import (  # noqa: F401
     UpDownCounter,
 )
 
-__all__ = []
-for key, value in globals().copy().items():
-    if not key.startswith("_"):
-        value.__module__ = __name__
-        __all__.append(key)
+__all__ = [
+    "Meter",
+    "MeterProvider",
+    "MetricsTimeoutError",
+    "Counter",
+    "Histogram",
+    "ObservableCounter",
+    "ObservableGauge",
+    "ObservableUpDownCounter",
+    "UpDownCounter",
+]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=unused-import
 
-from opentelemetry.sdk.metrics._internal.export import (  # noqa: F401
+from opentelemetry.sdk.metrics._internal.export import (
     AggregationTemporality,
     ConsoleMetricExporter,
     InMemoryMetricReader,
@@ -25,7 +24,7 @@ from opentelemetry.sdk.metrics._internal.export import (  # noqa: F401
 )
 
 # The point module is not in the export directory to avoid a circular import.
-from opentelemetry.sdk.metrics._internal.point import (  # noqa: F401
+from opentelemetry.sdk.metrics._internal.point import (
     DataPointT,
     DataT,
     Gauge,
@@ -39,8 +38,23 @@ from opentelemetry.sdk.metrics._internal.point import (  # noqa: F401
     Sum,
 )
 
-__all__ = []
-for key, value in globals().copy().items():
-    if not key.startswith("_"):
-        value.__module__ = __name__
-        __all__.append(key)
+__all__ = [
+    "AggregationTemporality",
+    "ConsoleMetricExporter",
+    "InMemoryMetricReader",
+    "MetricExporter",
+    "MetricExportResult",
+    "MetricReader",
+    "PeriodicExportingMetricReader",
+    "DataPointT",
+    "DataT",
+    "Gauge",
+    "Histogram",
+    "HistogramDataPoint",
+    "Metric",
+    "MetricsData",
+    "NumberDataPoint",
+    "ResourceMetrics",
+    "ScopeMetrics",
+    "Sum",
+]

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/view/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/view/__init__.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=unused-import
-
-from opentelemetry.sdk.metrics._internal.aggregation import (  # noqa: F401
+from opentelemetry.sdk.metrics._internal.aggregation import (
     Aggregation,
     DefaultAggregation,
     DropAggregation,
@@ -22,10 +20,14 @@ from opentelemetry.sdk.metrics._internal.aggregation import (  # noqa: F401
     LastValueAggregation,
     SumAggregation,
 )
-from opentelemetry.sdk.metrics._internal.view import View  # noqa: F401
+from opentelemetry.sdk.metrics._internal.view import View
 
-__all__ = []
-for key, value in globals().copy().items():
-    if not key.startswith("_"):
-        value.__module__ = __name__
-        __all__.append(key)
+__all__ = [
+    "Aggregation",
+    "DefaultAggregation",
+    "DropAggregation",
+    "ExplicitBucketHistogramAggregation",
+    "LastValueAggregation",
+    "SumAggregation",
+    "View",
+]


### PR DESCRIPTION
# Description

Update all `__all__` declarations to statically define all members. This resolves error messages from IDE/static type checkers

Fixes #3141

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran tox locally.
No new functionality 

This enables static checkers such as pylint to now verify that imported objects are being used
 so removed a bunch of now redundant supress comments 

# Does This PR Require a Contrib Repo Change?

- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added N/A
- [x] Documentation has been updated. Workaround removed from page in https://github.com/open-telemetry/opentelemetry.io/pull/2243
