### PR TITLE
Fixes warning filter being reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3128](https://github.com/open-telemetry/opentelemetry-python/pull/3128))
 - Fix validation of baggage values
   ([#3058](https://github.com/open-telemetry/opentelemetry-python/pull/3058))
+- Fix warning filters being reset when instrumenting
+  ([#3147](https://github.com/open-telemetry/opentelemetry-python/pull/3147))
 
 ## Version 1.15.0/0.36b0 (2022-12-09)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -37,7 +37,7 @@ from typing import (
     Type,
     Union,
 )
-from warnings import filterwarnings, resetwarnings
+from warnings import filterwarnings, catch_warnings
 
 from deprecated import deprecated
 
@@ -1169,13 +1169,14 @@ class TracerProvider(trace_api.TracerProvider):
         if instrumenting_library_version is None:
             instrumenting_library_version = ""
 
-        filterwarnings("ignore", category=DeprecationWarning)
-        instrumentation_info = InstrumentationInfo(
-            instrumenting_module_name,
-            instrumenting_library_version,
-            schema_url,
-        )
-        resetwarnings()
+        with catch_warnings():
+            filterwarnings("ignore", category=DeprecationWarning)
+            instrumentation_info = InstrumentationInfo(
+                instrumenting_module_name,
+                instrumenting_library_version,
+                schema_url,
+            )
+
         return Tracer(
             self.sampler,
             self.resource,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -37,7 +37,7 @@ from typing import (
     Type,
     Union,
 )
-from warnings import filterwarnings, catch_warnings
+from warnings import catch_warnings, filterwarnings
 
 from deprecated import deprecated
 


### PR DESCRIPTION
# Description

Warning filters were being reset, resulting in warnings suddenly popping up in unrelated spots due to instrumenting with OTel.

Fixes based on https://docs.python.org/3/library/warnings.html#temporarily-suppressing-warnings although there it is noted that this is not threadsafe. I haven't been able to make sure if this is an issue yet. @ocelotl was this the reason you used a different approach? In my opinion this non-thread safe approach makes more sense than just throwing away all filters.

Fixes #3102 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

-

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
