### PR TITLE
Fix bagage key lowercasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3128](https://github.com/open-telemetry/opentelemetry-python/pull/3128))
 - Fix validation of baggage values
   ([#3058](https://github.com/open-telemetry/opentelemetry-python/pull/3058))
+- Fix capitalization of baggage keys
+  ([#3151](https://github.com/open-telemetry/opentelemetry-python/pull/3151))
 
 ## Version 1.15.0/0.36b0 (2022-12-09)
 

--- a/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
@@ -93,7 +93,7 @@ class W3CBaggagePropagator(textmap.TextMapPropagator):
                 _logger.warning("Invalid baggage entry: `%s`", entry)
                 continue
 
-            name = unquote_plus(name).strip().lower()
+            name = unquote_plus(name).strip()
             value = unquote_plus(value).strip()
 
             context = set_baggage(

--- a/opentelemetry-api/tests/baggage/propagation/test_propagation.py
+++ b/opentelemetry-api/tests/baggage/propagation/test_propagation.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# type: ignore
 
 from unittest import TestCase
 

--- a/opentelemetry-api/tests/baggage/propagation/test_propagation.py
+++ b/opentelemetry-api/tests/baggage/propagation/test_propagation.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from opentelemetry.baggage import (
-    get_baggage,
-    set_baggage,
-)
-from opentelemetry.baggage.propagation import W3CBaggagePropagator
 from unittest import TestCase
+
+from opentelemetry.baggage import get_baggage, set_baggage
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
 
 
 class TestBaggageManager(TestCase):
@@ -25,9 +23,15 @@ class TestBaggageManager(TestCase):
         carrier = {}
         propagator = W3CBaggagePropagator()
 
-        ctx = set_baggage('Test1', 'value1')
-        ctx = set_baggage('test2', 'value2', context=ctx)
+        ctx = set_baggage("Test1", "value1")
+        ctx = set_baggage("test2", "value2", context=ctx)
+
         propagator.inject(carrier, ctx)
         ctx_propagated = propagator.extract(carrier)
-        self.assertEqual(get_baggage("Test1", context=ctx_propagated), "value1")
-        self.assertEqual(get_baggage("test2", context=ctx_propagated), "value2")
+
+        self.assertEqual(
+            get_baggage("Test1", context=ctx_propagated), "value1"
+        )
+        self.assertEqual(
+            get_baggage("test2", context=ctx_propagated), "value2"
+        )

--- a/opentelemetry-api/tests/baggage/propagation/test_propagation.py
+++ b/opentelemetry-api/tests/baggage/propagation/test_propagation.py
@@ -1,0 +1,33 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opentelemetry.baggage import (
+    get_baggage,
+    set_baggage,
+)
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
+from unittest import TestCase
+
+
+class TestBaggageManager(TestCase):
+    def test_propagate_baggage(self):
+        carrier = {}
+        propagator = W3CBaggagePropagator()
+
+        ctx = set_baggage('Test1', 'value1')
+        ctx = set_baggage('test2', 'value2', context=ctx)
+        propagator.inject(carrier, ctx)
+        ctx_propagated = propagator.extract(carrier)
+        self.assertEqual(get_baggage("Test1", context=ctx_propagated), "value1")
+        self.assertEqual(get_baggage("test2", context=ctx_propagated), "value2")


### PR DESCRIPTION
# Description

This makes the capitalisation in-line with the W3C standard and the Otel go implementation where keys in baggage are allowed to have capital letters.

It might be a breaking change though as users who rely on keys being lower cased will see their code broken.

Fixes #3146

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit test

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
