### PR TITLE
refactor code to accomodate Nuitka compilation to C++ code

### DIFF
--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -57,14 +57,14 @@ def _load_runtime_context(func: _F) -> _F:
                 )  # type: str
                 try:
 
-                    _RUNTIME_CONTEXT = next(  # type: ignore
-                        iter(  # type: ignore
-                            entry_points(  # type: ignore
-                                group="opentelemetry_context",
-                                name=configured_context,
-                            )
+                    for entry_point in entry_points(group="opentelemetry_context"):
+                        if entry_point.name==configured_context:
+                            _RUNTIME_CONTEXT = entry_point.load()()
+                            break
+                    if _RUNTIME_CONTEXT is None:
+                        logger.exception(
+                            "Failed to load context (no such entry point): %s", configured_context
                         )
-                    ).load()()
 
                 except Exception:  # pylint: disable=broad-except
                     logger.exception(

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -55,11 +55,14 @@ def _load_runtime_context(func: _F) -> _F:
                     OTEL_PYTHON_CONTEXT, default_context
                 )  # type: str
                 try:
-                    _RUNTIME_CONTEXT = next(
-                        iter_entry_points(
-                            "opentelemetry_context", configured_context
+                    for entry_point in iter_entry_points("opentelemetry_context"):
+                        if entry_point.name==configured_context:
+                            _RUNTIME_CONTEXT = entry_point.load()()
+                            break
+                    if _RUNTIME_CONTEXT is None:
+                        logger.error(
+                            "Failed to load context (no such entry point): %s", configured_context
                         )
-                    ).load()()
                 except Exception:  # pylint: disable=broad-except
                     logger.error(
                         "Failed to load context: %s", configured_context

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -64,6 +64,7 @@ def _load_runtime_context(func: _F) -> _F:
                                 name=configured_context,
                             )
                         )
+                    ).load()()
 
                 except Exception:  # pylint: disable=broad-except
                     logger.exception(

--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -133,17 +133,12 @@ for propagator in environ_propagators.split(","):
     propagator = propagator.strip()
 
     try:
-
-        propagators.append(  # type: ignore
-            next(  # type: ignore
-                iter(  # type: ignore
-                    entry_points(  # type: ignore
-                        group="opentelemetry_propagator",
-                        name=propagator,
-                    )
+        for entry in entry_points(group="opentelemetry_propagator"):
+            if entry.name==propagator:
+                propagators.append(  # type: ignore
+                    entry.load()()
                 )
-            ).load()()
-        )
+                break
 
     except Exception:  # pylint: disable=broad-except
         logger.exception(

--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -132,11 +132,12 @@ environ_propagators = environ.get(
 for propagator in environ_propagators.split(","):
     propagator = propagator.strip()
     try:
-        propagators.append(  # type: ignore
-            next(  # type: ignore
-                iter_entry_points("opentelemetry_propagator", propagator)
-            ).load()()
-        )
+        for entry in iter_entry_points("opentelemetry_propagator"):
+            if entry.name==propagator:
+                propagators.append(  # type: ignore
+                    entry.load()()
+                )
+                break
     except Exception:  # pylint: disable=broad-except
         logger.exception(
             "Failed to load configured propagator `%s`", propagator


### PR DESCRIPTION
# Description
this is the proposed solution for [Issue 3153](https://github.com/open-telemetry/opentelemetry-python/issues/3153)

The inlined Python code used to retrieve the _RUNTIME_CONTEXT , although non-ambiguous in Python, is not clear enough 
 for Nuitka compiler to generate C++ functionality with the same functionality as the one in original Python code

Nuitka generates C++ code that compiles and link successfully, but it generates error at runtime.

Fixes # (issue)

The code to retrieve _RUNTIME_CONTEXT is refactored without alteration of functionality, using a slightly explicit coding style that accommodates the Nuitka compiler and facilitates generation of C++ code with the same functionality as the original OpenTelemetry code 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
Python functionality is unchanged. 
The new feature is that OpenTelemetry code can be compiled with Nuitka without this runtime error

# How Has This Been Tested?

Tests were performed using the test case in [Issue 3153](https://github.com/open-telemetry/opentelemetry-python/issues/3153)

test results before the change:
```
(dev_venv) D:\opentelemetry_nuitka_issue>test_case.exe
Logging foo from test_case.exe
Failed to load context: contextvars_context
Traceback (most recent call last):
  File "C:\Users\smuntean\AppData\Local\Temp\ONE57C~1\test_case.py", line 18, in <module>
    log.info(f"Logging foo from {sys.argv[0]} ")
  File "C:\Users\xxxxxxxxx\AppData\Local\Temp\ONE57C~1\logging\__init__.py", line 1477, in info
  File "C:\Users\xxxxxxxxx\AppData\Local\Temp\ONE57C~1\logging\__init__.py", line 1624, in _log
  File "C:\Users\xxxxxxxxx\AppData\Local\Temp\ONE57C~1\logging\__init__.py", line 1634, in handle
  File "C:\Users\xxxxxxxxx\AppData\Local\Temp\ONE57C~1\logging\__init__.py", line 1696, in callHandlers
  File "C:\Users\xxxxxxxxx\AppData\Local\Temp\ONE57C~1\logging\__init__.py", line 968, in handle
  File "C:\Users\xxxxxxxxx\AppData\Local\Temp\ONE57C~1\opentelemetry\sdk\_logs\_internal\__init__.py", line 382, in emit
  File "C:\Users\xxxxxxxxx\AppData\Local\Temp\ONE57C~1\opentelemetry\sdk\_logs\_internal\__init__.py", line 361, in _translate
  File "C:\Users\xxxxxxxxx\AppData\Local\Temp\ONE57C~1\opentelemetry\trace\propagation\__init__.py", line 48, in get_current_span
  File "C:\Users\xxxxxxxxx\AppData\Local\Temp\ONE57C~1\opentelemetry\context\__init__.py", line 96, in get_value
  File "C:\Users\xxxxxxxxx\AppData\Local\Temp\ONE57C~1\opentelemetry\context\__init__.py", line 67, in wrapper
  File "C:\Users\xxxxxxxxx\AppData\Local\Temp\ONE57C~1\opentelemetry\context\__init__.py", line 131, in get_current
AttributeError: 'NoneType' object has no attribute 'get_current'

(dev_venv) D:\opentelemetry_nuitka_issue>
```
Test result after change:
test results before the change:
```
(dev_venv) D:\opentelemetry_nuitka_issue>test_case.exe
Logging foo from test_case.exe
(dev_venv) D:\opentelemetry_nuitka_issue>
```

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
