### PR TITLE
Bump min required api version for OTLP exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3128](https://github.com/open-telemetry/opentelemetry-python/pull/3128))
 - Fix validation of baggage values
   ([#3058](https://github.com/open-telemetry/opentelemetry-python/pull/3058))
+- Bump min required api version for OTLP exporters
+  ([#3156](https://github.com/open-telemetry/opentelemetry-python/pull/3156))
 
 ## Version 1.15.0/0.36b0 (2022-12-09)
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "backoff >= 1.10.0, < 3.0.0; python_version>='3.7'",
   "googleapis-common-protos ~= 1.52",
   "grpcio >= 1.0.0, < 2.0.0",
-  "opentelemetry-api ~= 1.12",
+  "opentelemetry-api ~= 1.15",
   "opentelemetry-proto == 1.16.0.dev",
   "opentelemetry-sdk ~= 1.16.0.dev",
 ]

--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "backoff >= 1.10.0, < 2.0.0; python_version<'3.7'",
   "backoff >= 1.10.0, < 3.0.0; python_version>='3.7'",
   "googleapis-common-protos ~= 1.52",
-  "opentelemetry-api ~= 1.12",
+  "opentelemetry-api ~= 1.15",
   "opentelemetry-proto == 1.16.0.dev",
   "opentelemetry-sdk ~= 1.16.0.dev",
   "requests ~= 2.7",


### PR DESCRIPTION
# Description

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/3086