### PR TITLE
Add line-specific filter to catch warning

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import os
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -23,7 +24,6 @@ from time import time_ns
 from typing import IO, Callable, Dict, Iterable, Optional
 
 from typing_extensions import final
-import math
 
 # This kind of import is needed to avoid Sphinx errors.
 import opentelemetry.sdk.metrics._internal

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -24,7 +24,6 @@ import typing
 from collections import OrderedDict
 from contextlib import contextmanager
 from os import environ
-from sys import version_info
 from time import time_ns
 from types import MappingProxyType, TracebackType
 from typing import (
@@ -1170,23 +1169,15 @@ class TracerProvider(trace_api.TracerProvider):
         if instrumenting_library_version is None:
             instrumenting_library_version = ""
 
-        kwargs = {
-            "message": (
-                "Call to deprecated method __init__. \(You should use "
-                "InstrumentationScope\) -- Deprecated since version 1.11.1."
+        filterwarnings(
+            "ignore",
+            message=(
+                r"Call to deprecated method __init__. \(You should use "
+                r"InstrumentationScope\) -- Deprecated since version 1.11.1."
             ),
-            "category": DeprecationWarning,
-            "module": "opentelemetry.sdk.trace",
-        }
-
-        # FIXME: Remove when 3.7 is no longer supported.
-        # For some reason the lineno argument in 3.7 does not seem to work.
-        # This is still safe enough because we also filter by message and
-        # module.
-        if version_info.minor > 7:
-            kwargs["lineno"]: 1191
-
-        filterwarnings("ignore", **kwargs)
+            category=DeprecationWarning,
+            module="opentelemetry.sdk.trace",
+        )
 
         instrumentation_info = InstrumentationInfo(
             instrumenting_module_name,

--- a/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
+++ b/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from time import sleep, time_ns
 from typing import Sequence
 from unittest.mock import Mock
 
 from flaky import flaky
-import math
 
 from opentelemetry.sdk.metrics import Counter
 from opentelemetry.sdk.metrics._internal import _Counter
@@ -139,7 +139,9 @@ class TestPeriodicExportingMetricReader(ConcurrencyTestBase):
         collect_mock = Mock()
         exporter = FakeMetricsExporter()
         exporter.export = Mock()
-        pmr = PeriodicExportingMetricReader(exporter, export_interval_millis=math.inf)
+        pmr = PeriodicExportingMetricReader(
+            exporter, export_interval_millis=math.inf
+        )
         pmr._set_collect_callback(collect_mock)
         sleep(0.1)
         self.assertTrue(collect_mock.assert_not_called)
@@ -149,16 +151,20 @@ class TestPeriodicExportingMetricReader(ConcurrencyTestBase):
         exporter = FakeMetricsExporter()
         exporter.export = Mock()
         self.assertRaises(
-            ValueError, PeriodicExportingMetricReader,
-            exporter, export_interval_millis=0
+            ValueError,
+            PeriodicExportingMetricReader,
+            exporter,
+            export_interval_millis=0,
         )
 
     def test_ticker_value_exception_on_negative(self):
         exporter = FakeMetricsExporter()
         exporter.export = Mock()
         self.assertRaises(
-            ValueError, PeriodicExportingMetricReader,
-            exporter, export_interval_millis=-100
+            ValueError,
+            PeriodicExportingMetricReader,
+            exporter,
+            export_interval_millis=-100,
         )
 
     @flaky(max_runs=3, min_passes=1)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -20,7 +20,6 @@ import unittest
 from importlib import reload
 from logging import ERROR, WARNING
 from random import randint
-from sys import version_info
 from time import time_ns
 from typing import Optional
 from unittest import mock
@@ -58,28 +57,12 @@ from opentelemetry.test.spantestutil import (
 )
 from opentelemetry.trace import Status, StatusCode
 
-message = """
-
-If this test fails it may be because a change was made in
-opentelemetry-sdk/src/trace/__init__.py. That file has a call to
-warnings.filterwarnings that needs the line number where an of the line where
-InstrumentationInfo instance is created to catch the DeprecationWarning that is
-raised. Make sure to update the line number in the warnings.filterwarnings call
-if necessary.
-"""
-
 
 class TestTracer(unittest.TestCase):
     def test_no_deprecated_warning(self):
-        try:
-            with self.assertRaises(AssertionError):
-                with self.assertWarns(DeprecationWarning) as the_warning:
-                    the_warning = the_warning
-                    TracerProvider(Mock(), Mock()).get_tracer(Mock(), Mock())
-        except AssertionError as assertion_error:
-            if version_info > 7:
-                raise AssertionError(f"{assertion_error.args[0]}:{message}")
-            raise
+        with self.assertRaises(AssertionError):
+            with self.assertWarns(DeprecationWarning):
+                TracerProvider(Mock(), Mock()).get_tracer(Mock(), Mock())
 
         # This is being added here to make sure the filter on
         # InstrumentationInfo does not affect other DeprecationWarnings that


### PR DESCRIPTION
Fixes #3163

This is another approach to solve the issue #3147 intends to solve but without using [`catch_warnings`](https://docs.python.org/3/library/warnings.html#warnings.catch_warnings) which is not thread-safe.