### PR TITLE
Fix use of built-in samplers in SDK configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3100](https://github.com/open-telemetry/opentelemetry-python/pull/3100))
 - Fix formatting of ConsoleMetricExporter.
   ([#3197](https://github.com/open-telemetry/opentelemetry-python/pull/3197))
+- Fix use of built-in samplers in SDK configuration
+  ([#3176](https://github.com/open-telemetry/opentelemetry-python/pull/3176))
 
 ## Version 1.16.0/0.37b0 (2023-02-17)
 - Change ``__all__`` to be statically defined.

--- a/opentelemetry-sdk/pyproject.toml
+++ b/opentelemetry-sdk/pyproject.toml
@@ -41,6 +41,14 @@ sdk = "opentelemetry.sdk.environment_variables"
 [project.entry-points.opentelemetry_id_generator]
 random = "opentelemetry.sdk.trace.id_generator:RandomIdGenerator"
 
+[project.entry-points.opentelemetry_traces_sampler]
+always_on = "opentelemetry.sdk.trace.sampling:_AlwaysOn"
+always_off = "opentelemetry.sdk.trace.sampling:_AlwaysOff"
+parentbased_always_on = "opentelemetry.sdk.trace.sampling:_DefaultOn"
+parentbased_always_off = "opentelemetry.sdk.trace.sampling:_DefaultOff"
+traceidratio = "opentelemetry.sdk.trace.sampling:TraceIdRatioBased"
+parentbased_traceidratio = "opentelemetry.sdk.trace.sampling:ParentBasedTraceIdRatio"
+
 [project.entry-points.opentelemetry_logger_provider]
 sdk_logger_provider = "opentelemetry.sdk._logs:LoggerProvider"
 

--- a/opentelemetry-sdk/pyproject.toml
+++ b/opentelemetry-sdk/pyproject.toml
@@ -44,8 +44,8 @@ random = "opentelemetry.sdk.trace.id_generator:RandomIdGenerator"
 [project.entry-points.opentelemetry_traces_sampler]
 always_on = "opentelemetry.sdk.trace.sampling:_AlwaysOn"
 always_off = "opentelemetry.sdk.trace.sampling:_AlwaysOff"
-parentbased_always_on = "opentelemetry.sdk.trace.sampling:_DefaultOn"
-parentbased_always_off = "opentelemetry.sdk.trace.sampling:_DefaultOff"
+parentbased_always_on = "opentelemetry.sdk.trace.sampling:_ParentBasedAlwaysOn"
+parentbased_always_off = "opentelemetry.sdk.trace.sampling:_ParentBasedAlwaysOff"
 traceidratio = "opentelemetry.sdk.trace.sampling:TraceIdRatioBased"
 parentbased_traceidratio = "opentelemetry.sdk.trace.sampling:ParentBasedTraceIdRatio"
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -295,8 +295,20 @@ def _import_sampler(sampler_name: str) -> Optional[Sampler]:
         return None
     try:
         sampler_factory = _import_sampler_factory(sampler_name)
-        sampler_arg = os.getenv(OTEL_TRACES_SAMPLER_ARG, "")
-        sampler = sampler_factory(sampler_arg)
+        arg = None
+        if sampler_name in ("traceidratio", "parentbased_traceidratio"):
+            try:
+                rate = float(os.getenv(OTEL_TRACES_SAMPLER_ARG))
+            except (ValueError, TypeError):
+                _logger.warning(
+                    "Could not convert TRACES_SAMPLER_ARG to float. Using default value 1.0."
+                )
+                rate = 1.0
+            arg = rate
+        else:
+            arg = os.getenv(OTEL_TRACES_SAMPLER_ARG)
+
+        sampler = sampler_factory(arg)
         if not isinstance(sampler, Sampler):
             message = f"Sampler factory, {sampler_factory}, produced output, {sampler}, which is not a Sampler."
             _logger.warning(message)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -304,7 +304,7 @@ def _import_sampler(sampler_name: str) -> Optional[Sampler]:
         return sampler
     except Exception as exc:  # pylint: disable=broad-except
         _logger.warning(
-            "Using default sampler. Failed to initialize custom sampler, %s: %s",
+            "Using default sampler. Failed to initialize sampler, %s: %s",
             sampler_name,
             exc,
         )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -393,21 +393,26 @@ class ParentBasedTraceIdRatio(ParentBased):
         root = TraceIdRatioBased(rate=rate)
         super().__init__(root=root)
 
+
 class _AlwaysOff(StaticSampler):
     def __init__(self, _):
         super().__init__(Decision.DROP)
-    
+
+
 class _AlwaysOn(StaticSampler):
     def __init__(self, _):
         super().__init__(Decision.RECORD_AND_SAMPLE)
-    
-class _DefaultOff(ParentBased):
+
+
+class _ParentBasedAlwaysOff(ParentBased):
     def __init__(self, _):
         super().__init__(ALWAYS_OFF)
-    
-class _DefaultOn(ParentBased):
+
+
+class _ParentBasedAlwaysOn(ParentBased):
     def __init__(self, _):
         super().__init__(ALWAYS_ON)
+
 
 _KNOWN_SAMPLERS = {
     "always_on": ALWAYS_ON,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -393,6 +393,21 @@ class ParentBasedTraceIdRatio(ParentBased):
         root = TraceIdRatioBased(rate=rate)
         super().__init__(root=root)
 
+class _AlwaysOff(StaticSampler):
+    def __init__(self, _):
+        super().__init__(Decision.DROP)
+    
+class _AlwaysOn(StaticSampler):
+    def __init__(self, _):
+        super().__init__(Decision.RECORD_AND_SAMPLE)
+    
+class _DefaultOff(ParentBased):
+    def __init__(self, _):
+        super().__init__(ALWAYS_OFF)
+    
+class _DefaultOn(ParentBased):
+    def __init__(self, _):
+        super().__init__(ALWAYS_ON)
 
 _KNOWN_SAMPLERS = {
     "always_on": ALWAYS_ON,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -430,7 +430,7 @@ def _get_from_env_or_default() -> Sampler:
     if trace_sampler in ("traceidratio", "parentbased_traceidratio"):
         try:
             rate = float(os.getenv(OTEL_TRACES_SAMPLER_ARG))
-        except ValueError:
+        except (ValueError, TypeError):
             _logger.warning("Could not convert TRACES_SAMPLER_ARG to float.")
             rate = 1.0
         return _KNOWN_SAMPLERS[trace_sampler](rate)


### PR DESCRIPTION
# Description

Fixes a configuration bug which causes the instrumentation to fall back on the default sampler when a built-in sampler is specified, due to the samplers missing from entry points. For details see description of #3175.

P.S. I'm not a Python developer, so feedback on if this should be done other way is welcome.

Fixes #3175

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- Existing unit tests
- Reproduced the scenario described in #3175 with expected behavior

# Does This PR Require a Contrib Repo Change?
- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:
- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
