### PR TITLE
Add celery metrics to semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([3124](https://github.com/open-telemetry/opentelemetry-python/pull/3124))
 - Add db metric name to semantic conventions
   ([#3115](https://github.com/open-telemetry/opentelemetry-python/pull/3115))
+- Add celery task runtime metric name to semantic conventions
+  ([#3191](https://github.com/open-telemetry/opentelemetry-python/pull/3191))
 
 ## Version 1.15.0/0.36b0 (2022-12-09)
 

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/metrics/__init__.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/metrics/__init__.py
@@ -32,3 +32,5 @@ class MetricInstruments:
     HTTP_CLIENT_RESPONSE_SIZE = "http.client.response.size"
 
     DB_CLIENT_CONNECTIONS_USAGE = "db.client.connections.usage"
+
+    FLOWER_TASK_RUNTIME_SECONDS = "flower.task.runtime.seconds"


### PR DESCRIPTION
# Description

I started to implement celery metrics instrumentation and
I figure out that flower.task.runtime.seconds metric name is missing in the semantic conventions

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
