### PR TITLE
bugfix: indent not used in MetricsData to_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 - PeriodicExportingMetricReader will continue if collection times out 
   ([#3100](https://github.com/open-telemetry/opentelemetry-python/pull/3100))
-
+- Fix formatting of ConsoleMetricExporter.
+  ([#3197](https://github.com/open-telemetry/opentelemetry-python/pull/3197))
 
 ## Version 1.16.0/0.37b0 (2023-02-17)
 - Change ``__all__`` to be statically defined.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
@@ -212,5 +212,5 @@ class MetricsData:
                     for resource_metrics in self.resource_metrics
                 ]
             },
-            indent=indent
+            indent=indent,
         )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
@@ -211,5 +211,6 @@ class MetricsData:
                     loads(resource_metrics.to_json(indent=indent))
                     for resource_metrics in self.resource_metrics
                 ]
-            }
+            },
+            indent=indent
         )

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_console_exporter.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_console_exporter.py
@@ -49,7 +49,7 @@ class TestConsoleExporter(TestCase):
         provider.shutdown()
 
         output.seek(0)
-        result_0 = loads(output.readlines()[0])
+        result_0 = loads("".join(output.readlines()))
 
         self.assertGreater(len(result_0), 0)
 


### PR DESCRIPTION
# Description

The indent parameter was passed down to the resource metric's to_json method, but not used in MetricsData. This change fixes that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested this by running the getting started example code. The output used to be:

```json
{"resource_metrics": [{"resource": {"attributes": {"telemetry.sdk.language": "python", "telemetry.sdk.name": "opentelemetry", "telemetry.sdk.version": "1.17.0.dev0", "service.name": "unknown_service"}, "schema_url": ""}, "scope_metrics": [{"scope": {"name": "getting-started", "version": "0.1.2", "schema_url": ""}, "metrics": [{"name": "counter", "description": "", "unit": "", "data": {"data_points": [{"attributes": {}, "start_time_unix_nano": 1677187635593555000, "time_unix_nano": 1677187635593924000, "value": 1}], "aggregation_temporality": 2, "is_monotonic": true}}, {"name": "updown_counter", "description": "", "unit": "", "data": {"data_points": [{"attributes": {}, "start_time_unix_nano": 1677187635593610000, "time_unix_nano": 1677187635593924000, "value": -4}], "aggregation_temporality": 2, "is_monotonic": false}}, {"name": "histogram", "description": "", "unit": "", "data": {"data_points": [{"attributes": {}, "start_time_unix_nano": 1677187635593649000, "time_unix_nano": 1677187635593924000, "count": 1, "sum": 99.9, "bucket_counts": [0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0], "explicit_bounds": [0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0, 10000.0], "min": 99.9, "max": 99.9}], "aggregation_temporality": 2}}, {"name": "observable_counter", "description": "", "unit": "", "data": {"data_points": [{"attributes": {}, "start_time_unix_nano": 1677187635593837000, "time_unix_nano": 1677187635593924000, "value": 1}], "aggregation_temporality": 2, "is_monotonic": true}}, {"name": "observable_updown_counter", "description": "", "unit": "", "data": {"data_points": [{"attributes": {}, "start_time_unix_nano": 1677187635593869000, "time_unix_nano": 1677187635593924000, "value": -10}], "aggregation_temporality": 2, "is_monotonic": false}}, {"name": "gauge", "description": "", "unit": "", "data": {"data_points": [{"attributes": {}, "start_time_unix_nano": 0, "time_unix_nano": 1677187635593924000, "value": 9}]}}], "schema_url": ""}], "schema_url": ""}]}
```

It's now:

```json
{
    "resource_metrics": [
        {
            "resource": {
                "attributes": {
                    "telemetry.sdk.language": "python",
                    "telemetry.sdk.name": "opentelemetry",
                    "telemetry.sdk.version": "1.17.0.dev0",
                    "service.name": "unknown_service"
                },
                "schema_url": ""
            },
            "scope_metrics": [
                {
                    "scope": {
                        "name": "getting-started",
                        "version": "0.1.2",
                        "schema_url": ""
                    },
                    "metrics": [
                        {
                            "name": "counter",
                            "description": "",
                            "unit": "",
                            "data": {
                                "data_points": [
                                    {
                                        "attributes": {},
                                        "start_time_unix_nano": 1677187655866373000,
                                        "time_unix_nano": 1677187655866615000,
                                        "value": 1
                                    }
                                ],
                                "aggregation_temporality": 2,
                                "is_monotonic": true
                            }
                        },
                        {
                            "name": "updown_counter",
                            "description": "",
                            "unit": "",
                            "data": {
                                "data_points": [
                                    {
                                        "attributes": {},
                                        "start_time_unix_nano": 1677187655866404000,
                                        "time_unix_nano": 1677187655866615000,
                                        "value": -4
                                    }
                                ],
                                "aggregation_temporality": 2,
                                "is_monotonic": false
                            }
                        },
                        {
                            "name": "histogram",
                            "description": "",
                            "unit": "",
                            "data": {
                                "data_points": [
                                    {
                                        "attributes": {},
                                        "start_time_unix_nano": 1677187655866431000,
                                        "time_unix_nano": 1677187655866615000,
                                        "count": 1,
                                        "sum": 99.9,
                                        "bucket_counts": [
                                            0,
                                            0,
                                            0,
                                            0,
                                            0,
                                            0,
                                            1,
                                            0,
                                            0,
                                            0,
                                            0,
                                            0,
                                            0,
                                            0,
                                            0,
                                            0
                                        ],
                                        "explicit_bounds": [
                                            0.0,
                                            5.0,
                                            10.0,
                                            25.0,
                                            50.0,
                                            75.0,
                                            100.0,
                                            250.0,
                                            500.0,
                                            750.0,
                                            1000.0,
                                            2500.0,
                                            5000.0,
                                            7500.0,
                                            10000.0
                                        ],
                                        "min": 99.9,
                                        "max": 99.9
                                    }
                                ],
                                "aggregation_temporality": 2
                            }
                        },
                        {
                            "name": "observable_counter",
                            "description": "",
                            "unit": "",
                            "data": {
                                "data_points": [
                                    {
                                        "attributes": {},
                                        "start_time_unix_nano": 1677187655866561000,
                                        "time_unix_nano": 1677187655866615000,
                                        "value": 1
                                    }
                                ],
                                "aggregation_temporality": 2,
                                "is_monotonic": true
                            }
                        },
                        {
                            "name": "observable_updown_counter",
                            "description": "",
                            "unit": "",
                            "data": {
                                "data_points": [
                                    {
                                        "attributes": {},
                                        "start_time_unix_nano": 1677187655866578000,
                                        "time_unix_nano": 1677187655866615000,
                                        "value": -10
                                    }
                                ],
                                "aggregation_temporality": 2,
                                "is_monotonic": false
                            }
                        },
                        {
                            "name": "gauge",
                            "description": "",
                            "unit": "",
                            "data": {
                                "data_points": [
                                    {
                                        "attributes": {},
                                        "start_time_unix_nano": 0,
                                        "time_unix_nano": 1677187655866615000,
                                        "value": 9
                                    }
                                ]
                            }
                        }
                    ],
                    "schema_url": ""
                }
            ],
            "schema_url": ""
        }
    ]
}
```

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been update
- [ ] Documentation has been updated
