### PR TITLE
Initialize package and docs for OpenCensus shim

### DIFF
--- a/docs/examples/opencensus-shim/README.rst
+++ b/docs/examples/opencensus-shim/README.rst
@@ -1,0 +1,71 @@
+OpenCensus Shim
+================
+
+This example shows how to use the :doc:`opentelemetry-opencensus-shim
+package <../../shim/opencensus_shim/opencensus_shim>`
+to interact with libraries instrumented with
+`opencensus-python <https://github.com/census-instrumentation/opencensus-python>`_.
+
+
+The source files required to run this example are available :scm_web:`here <docs/examples/opencensus-shim/>`.
+
+Installation
+------------
+
+Jaeger
+******
+
+Start Jaeger
+
+.. code-block:: sh
+
+    docker run --rm \
+        -p 6831:6831/udp \
+        -p 6832:6832/udp \
+        -p 16686:16686 \
+        jaegertracing/all-in-one:1.13 \
+        --log-level=debug
+
+Python Dependencies
+*******************
+
+Install the Python dependencies in :scm_raw_web:`requirements.txt <docs/examples/opencensus-shim/requirements.txt >`
+
+.. code-block:: sh
+
+    pip install -r requirements.txt
+
+
+Alternatively, you can install the Python dependencies separately:
+
+.. code-block:: sh
+
+    pip install \
+        opentelemetry-api \
+        opentelemetry-sdk \
+        opentelemetry-exporter-jaeger \
+        opentelemetry-opencensus-shim
+
+
+Run the Application
+-------------------
+
+.. TODO implement the example
+
+Jaeger UI
+*********
+
+Open the Jaeger UI in your browser at
+`<http://localhost:16686>`_ and view traces for the
+"OpenCensus Shim Example" service.
+
+Note that tags and logs (OpenCensus) and attributes and events (OpenTelemetry)
+from both tracing systems appear in the exported trace.
+
+Useful links
+------------
+
+- OpenTelemetry_
+- :doc:`../../shim/opencensus_shim/opencensus_shim`
+
+.. _OpenTelemetry: https://github.com/open-telemetry/opentelemetry-python/

--- a/docs/examples/opencensus-shim/requirements.txt
+++ b/docs/examples/opencensus-shim/requirements.txt
@@ -1,0 +1,4 @@
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-jaeger
+opentelemetry-opencensus-shim

--- a/docs/shim/opencensus_shim/opentracing_shim.rst
+++ b/docs/shim/opencensus_shim/opentracing_shim.rst
@@ -1,0 +1,5 @@
+OpenCensus Shim for OpenTelemetry
+==================================
+
+.. automodule:: opentelemetry.shim.opencensus
+   :no-show-inheritance:

--- a/shim/opentelemetry-opencensus-shim/LICENSE
+++ b/shim/opentelemetry-opencensus-shim/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/shim/opentelemetry-opencensus-shim/README.rst
+++ b/shim/opentelemetry-opencensus-shim/README.rst
@@ -1,0 +1,20 @@
+OpenCensus Shim for OpenTelemetry
+==================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-opencensus-shim.svg
+   :target: https://pypi.org/project/opentelemetry-opencensus-shim/
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-opencensus-shim
+
+References
+----------
+
+* `OpenCensus Shim for OpenTelemetry <https://opentelemetry-python.readthedocs.io/en/latest/shim/opencensus_shim/opencensus_shim.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/shim/opentelemetry-opencensus-shim/pyproject.toml
+++ b/shim/opentelemetry-opencensus-shim/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opentelemetry-opencensus-shim"
+dynamic = ["version"]
+description = "OpenCensus Shim for OpenTelemetry"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.7"
+authors = [
+  { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Typing :: Typed",
+]
+dependencies = [
+  "opentelemetry-api ~= 1.3",
+  "wrapt ~= 1.0",
+  # may work with older versions but this is the oldest confirmed version
+  "opencensus >= 0.11.0",
+]
+
+[project.optional-dependencies]
+test = ["opentelemetry-test-utils == 0.38b0.dev", "opencensus == 0.11.1"]
+
+[project.urls]
+Homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/shim/opentelemetry-opencensus-shim"
+
+[tool.hatch.version]
+path = "src/opentelemetry/shim/opencensus/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = ["/src", "/tests"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]

--- a/shim/opentelemetry-opencensus-shim/src/opentelemetry/shim/opencensus/__init__.py
+++ b/shim/opentelemetry-opencensus-shim/src/opentelemetry/shim/opencensus/__init__.py
@@ -1,0 +1,24 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The OpenTelemetry OpenCensus shim is a library which allows an easy migration from OpenCensus
+to OpenTelemetry. Additional details can be found `in the specification
+<https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/opencensus.md>`_.
+
+The shim consists of a set of classes which implement the OpenCensus Python API while using
+OpenTelemetry constructs behind the scenes. Its purpose is to allow applications which are
+already instrumented using OpenCensus to start using OpenTelemetry with minimal effort, without
+having to rewrite large portions of the codebase.
+"""

--- a/shim/opentelemetry-opencensus-shim/src/opentelemetry/shim/opencensus/version.py
+++ b/shim/opentelemetry-opencensus-shim/src/opentelemetry/shim/opencensus/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.38b0.dev"

--- a/shim/opentelemetry-opencensus-shim/tests/test_shim.py
+++ b/shim/opentelemetry-opencensus-shim/tests/test_shim.py
@@ -17,4 +17,4 @@ import unittest
 
 class TestShim(unittest.TestCase):
     def test_shim(self):
-        self.assertTrue(True)
+        pass

--- a/shim/opentelemetry-opencensus-shim/tests/test_shim.py
+++ b/shim/opentelemetry-opencensus-shim/tests/test_shim.py
@@ -1,0 +1,20 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+
+class TestShim(unittest.TestCase):
+    def test_shim(self):
+        self.assertTrue(True)

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,10 @@ envlist =
     py3{7,8,9,10,11}-opentelemetry-opentracing-shim
     pypy3-opentelemetry-opentracing-shim
 
+    py3{7,8,9,10,11}-opentelemetry-opencensus-shim
+    pypy3-opentelemetry-opencensus-shim
+    ; opencensus-shim intentionally excluded from pypy3 (grpcio install fails)
+
     py3{7,8,9,10,11}-opentelemetry-exporter-jaeger-combined
 
     py3{7,8,9,10,11}-opentelemetry-exporter-jaeger-proto-grpc
@@ -100,6 +104,7 @@ changedir =
   semantic-conventions: opentelemetry-semantic-conventions/tests
   getting-started: docs/getting_started/tests
   opentracing-shim: shim/opentelemetry-opentracing-shim/tests
+  opencensus-shim: shim/opentelemetry-opencensus-shim/tests
 
   exporter-jaeger-combined: exporter/opentelemetry-exporter-jaeger/tests
   exporter-jaeger-proto-grpc: exporter/opentelemetry-exporter-jaeger-proto-grpc/tests
@@ -151,6 +156,9 @@ commands_pre =
 
   opentracing-shim: pip install {toxinidir}/opentelemetry-sdk
   opentracing-shim: pip install {toxinidir}/shim/opentelemetry-opentracing-shim
+
+  opencensus-shim: pip install {toxinidir}/opentelemetry-sdk
+  opencensus-shim: pip install {toxinidir}/shim/opentelemetry-opencensus-shim
 
   exporter-prometheus: pip install {toxinidir}/exporter/opentelemetry-exporter-prometheus
 
@@ -217,12 +225,10 @@ commands_pre =
   python -m pip install -e {toxinidir}/opentelemetry-api[test]
   python -m pip install -e {toxinidir}/opentelemetry-semantic-conventions[test]
   python -m pip install -e {toxinidir}/opentelemetry-sdk[test]
-  # Pin protobuf version due to lint failing on v3.20.0
-  # https://github.com/protocolbuffers/protobuf/issues/9730
-  python -m pip install protobuf==3.19.4
   python -m pip install -e {toxinidir}/opentelemetry-proto[test]
   python -m pip install -e {toxinidir}/tests/opentelemetry-test-utils[test]
   python -m pip install -e {toxinidir}/shim/opentelemetry-opentracing-shim[test]
+  python -m pip install -e {toxinidir}/shim/opentelemetry-opencensus-shim[test]
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-jaeger-proto-grpc[test]
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-jaeger-thrift[test]
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-jaeger[test]
@@ -236,6 +242,9 @@ commands_pre =
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-zipkin[test]
   python -m pip install -e {toxinidir}/propagator/opentelemetry-propagator-b3[test]
   python -m pip install -e {toxinidir}/propagator/opentelemetry-propagator-jaeger[test]
+  # Pin protobuf version due to lint failing on v3.20.0
+  # https://github.com/protocolbuffers/protobuf/issues/9730
+  python -m pip install protobuf==3.19.4
 
 commands =
   python scripts/eachdist.py lint --check-only

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ envlist =
     pypy3-opentelemetry-opentracing-shim
 
     py3{7,8,9,10,11}-opentelemetry-opencensus-shim
-    pypy3-opentelemetry-opencensus-shim
     ; opencensus-shim intentionally excluded from pypy3 (grpcio install fails)
 
     py3{7,8,9,10,11}-opentelemetry-exporter-jaeger-combined


### PR DESCRIPTION
# Description

Scaffold a package for the OpenCensus shim. This includes empty docs, example, package directory, and test setup.

The subsequent PR will implement the Trace shim/bridge.

Part of #3203

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tox tests run and pass. I have a draft of the actual shim in a dependent branch.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated – I will add an entry when the actual implementation is added in the next PR.
- [ ] Unit tests have been added
- [x] Documentation has been updated
