### PR TITLE
Exclude OpenCensus shim from update & build scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ DISTDIR=dist
   mkdir -p $DISTDIR
   rm -rf $DISTDIR/*
 
- for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-proto/ opentelemetry-semantic-conventions/ exporter/*/ shim/*/ propagator/*/ tests/opentelemetry-test-utils/; do
+ for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-proto/ opentelemetry-semantic-conventions/ exporter/*/ shim/opentelemetry-opentracing-shim/ propagator/*/ tests/opentelemetry-test-utils/; do
    (
      echo "building $d"
      cd "$d"

--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -576,6 +576,7 @@ def update_version_files(targets, version, packages):
 
 def update_dependencies(targets, version, packages):
     print("updating dependencies")
+    targets = filter_packages(targets, packages)
     for pkg in packages:
         update_files(
             targets,


### PR DESCRIPTION
# Description

Excluding OpenCensus shim since it's not ready yet.

When we want to release this, we should add an entry here and update the build script again to include OC shim. https://github.com/open-telemetry/opentelemetry-python/blob/42f87368a0714ed064645895e5a2c41915633dc5/eachdist.ini#L32-L42 