### PR TITLE
Update contrib repo SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
   # Otherwise, set variable to the commit of your branch on
   # opentelemetry-python-contrib which is compatible with these Core repo
   # changes.
-  CONTRIB_REPO_SHA: e4d8f10ecd7bcd29c119af0e3ea7c30d4a383f4b
+  CONTRIB_REPO_SHA: 511709802466a751786047b7d98c2eb84801b34f
   # This is needed because we do not clone the core repo in contrib builds anymore.
   # When running contrib builds as part of core builds, we use actions/checkout@v2 which
   # does not set an environment variable (simply just runs tox), which is different when


### PR DESCRIPTION
This is being done in order to fix CI, the underlying issue being a test case in the aiohttp instrumentation that is failing.

Fixes #3278