### PR TITLE
fix(docker-tests): pin requests version to < 2.29

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -300,6 +300,7 @@ commands =
 deps =
   pytest
   docker-compose >= 1.25.2
+  requests < 2.29.0
 
   ; proto 3 and 4 tests install the respective version of protobuf
   proto3: protobuf~=3.19.0


### PR DESCRIPTION
# Description

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/3295
