### PR TITLE
Loosen googleapis-common-protos requirement in opentelemetry-exporter-otlp-proto-http

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "Deprecated >= 1.2.6",
   "backoff >= 1.10.0, < 2.0.0; python_version<'3.7'",
   "backoff >= 1.10.0, < 3.0.0; python_version>='3.7'",
-  "googleapis-common-protos ~= 1.52",
+  "googleapis-common-protos ~= 1.52, < 1.60.0",
   "opentelemetry-api ~= 1.15",
   "opentelemetry-proto == 1.19.0.dev",
   "opentelemetry-sdk ~= 1.19.0.dev",


### PR DESCRIPTION
# Description

Loosen the upper bound on the `googleapis-common-protos` requirement to avoid unnecessary dependency conflicts with other libraries (e.g. more recent versions of `google-api-core`).

Fixes # (issue)

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Automated tests