### PR TITLE
Fixing logging example 

### DIFF
--- a/docs/examples/logs/example.py
+++ b/docs/examples/logs/example.py
@@ -1,7 +1,7 @@
 import logging
 
 from opentelemetry import trace
-from opentelemetry._logs import set_logger_provider
+from opentelemetry.sdk._logs import set_logger_provider
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
     OTLPLogExporter,
 )
@@ -38,6 +38,8 @@ logging.getLogger().addHandler(handler)
 
 # Log directly
 logging.info("Jackdaws love my big sphinx of quartz.")
+logging.warning("But, the sphinx is broken")
+logging.error("Alas, can't be fixed")
 
 # Create different namespaced loggers
 logger1 = logging.getLogger("myapp.area1")


### PR DESCRIPTION
# Description
1. Fixing 
```
Traceback (most recent call last):
  File "workspace/opentelemetry-python/docs/examples/logs/example.py", line 4, in <module>
    from opentelemetry._logs import set_logger_provider
ModuleNotFoundError: No module named 'opentelemetry._logs'
```
2. Adding `logging.warning()` and `logging.error()` for completeness

Fixes # (issue)
`ModuleNotFoundError`

## Type of change
- [*] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
By running the fixed code

# Does This PR Require a Contrib Repo Change?
- [* ] No.

# Checklist:
- [*] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
