### PR TITLE
record_exception: Accept BaseException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3776](https://github.com/open-telemetry/opentelemetry-python/pull/3776))
 - Fix ValueError message for PeriodicExportingMetricsReader
   ([#3769](https://github.com/open-telemetry/opentelemetry-python/pull/3769))
+- Use `BaseException` instead of `Exception` in `record_exception`
+  ([#3354](https://github.com/open-telemetry/opentelemetry-python/pull/3354))
 
 ## Version 1.23.0/0.44b0 (2024-02-23)
 

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -169,7 +169,7 @@ class Span(abc.ABC):
     @abc.abstractmethod
     def record_exception(
         self,
-        exception: Exception,
+        exception: BaseException,
         attributes: types.Attributes = None,
         timestamp: typing.Optional[int] = None,
         escaped: bool = False,
@@ -563,7 +563,7 @@ class NonRecordingSpan(Span):
 
     def record_exception(
         self,
-        exception: Exception,
+        exception: BaseException,
         attributes: types.Attributes = None,
         timestamp: typing.Optional[int] = None,
         escaped: bool = False,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -981,7 +981,7 @@ class Span(trace_api.Span, ReadableSpan):
 
     def record_exception(
         self,
-        exception: Exception,
+        exception: BaseException,
         attributes: types.Attributes = None,
         timestamp: Optional[int] = None,
         escaped: bool = False,


### PR DESCRIPTION
This makes it possible to call on the exception returned by [sys.exc_info], which is a BaseException.

For ecosystem prior art, the [equivalent in Java] accepts a Throwable rather than Exception.

[sys.exc_info]: https://docs.python.org/3/library/sys.html#sys.exc_info
[equivalent in Java]: https://github.com/open-telemetry/opentelemetry-java/blob/7b8608591e1737ea0727d2373ddd813bc18cdaaa/api/all/src/main/java/io/opentelemetry/api/trace/Span.java#L344-L351

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/2652

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
