### PR TITLE
Cleanup console for SDK tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,28 @@ behind this is that every PR that adds/removes public symbols fails in CI, forci
 If after checking them, it is considered that they are indeed necessary, the PR will be labeled with `Skip Public API check` so that this check is not
 run.
 
+Also, we try to keep our console output as clean as possible. Most of the time this means catching expected log messages in the test cases:
+
+``` python
+from logging import WARNING
+
+...
+
+    def test_case(self):
+        with self.assertLogs(level=WARNING):
+            some_function_that_will_log_a_warning_message()
+```
+
+Other options can be to disable logging propagation or disabling a logger altogether.
+
+A similar approach can be followed to catch warnings:
+
+``` python
+    def test_case(self):
+        with self.assertWarns(DeprecationWarning):
+            some_function_that_will_raise_a_deprecation_warning()
+```
+
 See
 [`tox.ini`](https://github.com/open-telemetry/opentelemetry-python/blob/main/tox.ini)
 for more detail on available tox commands.

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -42,7 +42,8 @@ class TestLoggingHandler(unittest.TestCase):
         logger.debug("Debug message")
         self.assertEqual(emitter_mock.emit.call_count, 0)
         # Assert emit gets called for warning message
-        logger.warning("Warning message")
+        with self.assertLogs(level=logging.WARNING):
+            logger.warning("Warning message")
         self.assertEqual(emitter_mock.emit.call_count, 1)
 
     def test_handler_custom_log_level(self):
@@ -53,11 +54,14 @@ class TestLoggingHandler(unittest.TestCase):
         logger = get_logger(
             level=logging.ERROR, logger_provider=emitter_provider_mock
         )
-        logger.warning("Warning message test custom log level")
+        with self.assertLogs(level=logging.WARNING):
+            logger.warning("Warning message test custom log level")
         # Make sure any log with level < ERROR is ignored
         self.assertEqual(emitter_mock.emit.call_count, 0)
-        logger.error("Mumbai, we have a major problem")
-        logger.critical("No Time For Caution")
+        with self.assertLogs(level=logging.ERROR):
+            logger.error("Mumbai, we have a major problem")
+        with self.assertLogs(level=logging.CRITICAL):
+            logger.critical("No Time For Caution")
         self.assertEqual(emitter_mock.emit.call_count, 2)
 
     def test_log_record_no_span_context(self):
@@ -67,7 +71,8 @@ class TestLoggingHandler(unittest.TestCase):
         )
         logger = get_logger(logger_provider=emitter_provider_mock)
         # Assert emit gets called for warning message
-        logger.warning("Warning message")
+        with self.assertLogs(level=logging.WARNING):
+            logger.warning("Warning message")
         args, _ = emitter_mock.emit.call_args_list[0]
         log_record = args[0]
 
@@ -86,7 +91,8 @@ class TestLoggingHandler(unittest.TestCase):
         )
         logger = get_logger(logger_provider=emitter_provider_mock)
         # Assert emit gets called for warning message
-        logger.warning("Warning message", extra={"http.status_code": 200})
+        with self.assertLogs(level=logging.WARNING):
+            logger.warning("Warning message", extra={"http.status_code": 200})
         args, _ = emitter_mock.emit.call_args_list[0]
         log_record = args[0]
 
@@ -104,7 +110,8 @@ class TestLoggingHandler(unittest.TestCase):
         try:
             raise ZeroDivisionError("division by zero")
         except ZeroDivisionError:
-            logger.exception("Zero Division Error")
+            with self.assertLogs(level=logging.ERROR):
+                logger.exception("Zero Division Error")
         args, _ = emitter_mock.emit.call_args_list[0]
         log_record = args[0]
 
@@ -137,7 +144,8 @@ class TestLoggingHandler(unittest.TestCase):
         try:
             raise ZeroDivisionError("division by zero")
         except ZeroDivisionError:
-            logger.error("Zero Division Error", exc_info=False)
+            with self.assertLogs(level=logging.ERROR):
+                logger.error("Zero Division Error", exc_info=False)
         args, _ = emitter_mock.emit.call_args_list[0]
         log_record = args[0]
 
@@ -160,7 +168,8 @@ class TestLoggingHandler(unittest.TestCase):
 
         tracer = trace.TracerProvider().get_tracer(__name__)
         with tracer.start_as_current_span("test") as span:
-            logger.critical("Critical message within span")
+            with self.assertLogs(level=logging.CRITICAL):
+                logger.critical("Critical message within span")
 
             args, _ = emitter_mock.emit.call_args_list[0]
             log_record = args[0]

--- a/opentelemetry-sdk/tests/logs/test_multi_log_processor.py
+++ b/opentelemetry-sdk/tests/logs/test_multi_log_processor.py
@@ -68,15 +68,18 @@ class TestLogRecordProcessor(unittest.TestCase):
         logger.addHandler(handler)
 
         # Test no proessor added
-        logger.critical("Odisha, we have another major cyclone")
+        with self.assertLogs(level=logging.CRITICAL):
+            logger.critical("Odisha, we have another major cyclone")
 
         self.assertEqual(len(logs_list_1), 0)
         self.assertEqual(len(logs_list_2), 0)
 
         # Add one processor
         provider.add_log_record_processor(processor1)
-        logger.warning("Brace yourself")
-        logger.error("Some error message")
+        with self.assertLogs(level=logging.WARNING):
+            logger.warning("Brace yourself")
+        with self.assertLogs(level=logging.ERROR):
+            logger.error("Some error message")
 
         expected_list_1 = [
             ("Brace yourself", "WARNING"),
@@ -86,7 +89,8 @@ class TestLogRecordProcessor(unittest.TestCase):
 
         # Add another processor
         provider.add_log_record_processor(processor2)
-        logger.critical("Something disastrous")
+        with self.assertLogs(level=logging.CRITICAL):
+            logger.critical("Something disastrous")
         expected_list_1.append(("Something disastrous", "CRITICAL"))
 
         expected_list_2 = [("Something disastrous", "CRITICAL")]

--- a/opentelemetry-sdk/tests/metrics/test_instrument.py
+++ b/opentelemetry-sdk/tests/metrics/test_instrument.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from logging import WARNING
 from unittest import TestCase
 from unittest.mock import Mock
 
@@ -50,7 +51,8 @@ class TestCounter(TestCase):
     def test_add_non_monotonic(self):
         mc = Mock()
         counter = _Counter("name", Mock(), mc)
-        counter.add(-1.0)
+        with self.assertLogs(level=WARNING):
+            counter.add(-1.0)
         mc.consume_measurement.assert_not_called()
 
     def test_disallow_direct_counter_creation(self):
@@ -360,7 +362,8 @@ class TestHistogram(TestCase):
     def test_record_non_monotonic(self):
         mc = Mock()
         hist = _Histogram("name", Mock(), mc)
-        hist.record(-1.0)
+        with self.assertLogs(level=WARNING):
+            hist.record(-1.0)
         mc.consume_measurement.assert_not_called()
 
     def test_disallow_direct_histogram_creation(self):

--- a/opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py
+++ b/opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py
@@ -99,7 +99,8 @@ class TestMetricReaderStorage(ConcurrencyTestBase):
         # instrument2 matches view2, so should create a single
         # ViewInstrumentMatch
         MockViewInstrumentMatch.call_args_list.clear()
-        storage.consume_measurement(Measurement(1, instrument2))
+        with self.assertLogs(level=WARNING):
+            storage.consume_measurement(Measurement(1, instrument2))
         self.assertEqual(len(MockViewInstrumentMatch.call_args_list), 1)
 
     @patch(
@@ -150,7 +151,8 @@ class TestMetricReaderStorage(ConcurrencyTestBase):
         view_instrument_match3.consume_measurement.assert_not_called()
 
         measurement = Measurement(1, instrument2)
-        storage.consume_measurement(measurement)
+        with self.assertLogs(level=WARNING):
+            storage.consume_measurement(measurement)
         view_instrument_match3.consume_measurement.assert_called_once_with(
             measurement
         )

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -122,19 +122,21 @@ class TestMeterProvider(ConcurrencyTestBase):
         should return a NoOpMeter.
         """
 
-        meter = MeterProvider().get_meter(
-            None,
-            version="version",
-            schema_url="schema_url",
-        )
+        with self.assertLogs(level=WARNING):
+            meter = MeterProvider().get_meter(
+                None,
+                version="version",
+                schema_url="schema_url",
+            )
         self.assertIsInstance(meter, NoOpMeter)
         self.assertEqual(meter._name, None)
 
-        meter = MeterProvider().get_meter(
-            "",
-            version="version",
-            schema_url="schema_url",
-        )
+        with self.assertLogs(level=WARNING):
+            meter = MeterProvider().get_meter(
+                "",
+                version="version",
+                schema_url="schema_url",
+            )
         self.assertIsInstance(meter, NoOpMeter)
         self.assertEqual(meter._name, "")
 
@@ -483,9 +485,10 @@ class TestDuplicateInstrumentAggregateData(TestCase):
         counter_0_0 = meter_0.create_counter(
             "counter", unit="unit", description="description"
         )
-        counter_0_1 = meter_0.create_counter(
-            "counter", unit="unit", description="description"
-        )
+        with self.assertLogs(level=WARNING):
+            counter_0_1 = meter_0.create_counter(
+                "counter", unit="unit", description="description"
+            )
         counter_1_0 = meter_1.create_counter(
             "counter", unit="unit", description="description"
         )
@@ -496,7 +499,8 @@ class TestDuplicateInstrumentAggregateData(TestCase):
         counter_0_0.add(1, {})
         counter_0_1.add(2, {})
 
-        counter_1_0.add(7, {})
+        with self.assertLogs(level=WARNING):
+            counter_1_0.add(7, {})
 
         sleep(1)
 

--- a/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
+++ b/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+from logging import WARNING
 from time import sleep, time_ns
 from typing import Optional, Sequence
 from unittest.mock import Mock
@@ -127,7 +128,8 @@ class TestPeriodicExportingMetricReader(ConcurrencyTestBase):
         pmr = PeriodicExportingMetricReader(FakeMetricsExporter())
         self.assertEqual(pmr._export_interval_millis, 60000)
         self.assertEqual(pmr._export_timeout_millis, 30000)
-        pmr.shutdown()
+        with self.assertLogs(level=WARNING):
+            pmr.shutdown()
 
     def _create_periodic_reader(
         self, metrics, exporter, collect_wait=0, interval=60000, timeout=30000
@@ -212,8 +214,9 @@ class TestPeriodicExportingMetricReader(ConcurrencyTestBase):
         pmr = self._create_periodic_reader([], FakeMetricsExporter())
         with self.assertLogs(level="WARNING") as w:
             self.run_with_many_threads(pmr.shutdown)
-            self.assertTrue("Can't shutdown multiple times", w.output[0])
-        pmr.shutdown()
+        self.assertTrue("Can't shutdown multiple times", w.output[0])
+        with self.assertLogs(level="WARNING") as w:
+            pmr.shutdown()
 
     def test_exporter_temporality_preference(self):
         exporter = FakeMetricsExporter(

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -14,7 +14,7 @@
 # type: ignore
 # pylint: skip-file
 
-from logging import getLogger
+from logging import WARNING, getLogger
 from os import environ
 from typing import Dict, Iterable, Optional, Sequence
 from unittest import TestCase
@@ -377,7 +377,8 @@ class TestTraceInit(TestCase):
     )
     def test_trace_init_custom_sampler_with_env_non_existent_entry_point(self):
         sampler_name = _get_sampler()
-        sampler = _import_sampler(sampler_name)
+        with self.assertLogs(level=WARNING):
+            sampler = _import_sampler(sampler_name)
         _init_tracing({}, sampler=sampler)
         provider = self.set_provider_mock.call_args[0][0]
         self.assertIsNone(provider.sampler)
@@ -415,7 +416,8 @@ class TestTraceInit(TestCase):
         )
 
         sampler_name = _get_sampler()
-        sampler = _import_sampler(sampler_name)
+        with self.assertLogs(level=WARNING):
+            sampler = _import_sampler(sampler_name)
         _init_tracing({}, sampler=sampler)
         provider = self.set_provider_mock.call_args[0][0]
         self.assertIsNone(provider.sampler)
@@ -492,7 +494,8 @@ class TestTraceInit(TestCase):
         )
 
         sampler_name = _get_sampler()
-        sampler = _import_sampler(sampler_name)
+        with self.assertLogs(level=WARNING):
+            sampler = _import_sampler(sampler_name)
         _init_tracing({}, sampler=sampler)
         provider = self.set_provider_mock.call_args[0][0]
         self.assertIsNone(provider.sampler)
@@ -517,7 +520,8 @@ class TestTraceInit(TestCase):
         )
 
         sampler_name = _get_sampler()
-        sampler = _import_sampler(sampler_name)
+        with self.assertLogs(level=WARNING):
+            sampler = _import_sampler(sampler_name)
         _init_tracing({}, sampler=sampler)
         provider = self.set_provider_mock.call_args[0][0]
         self.assertIsNone(provider.sampler)
@@ -642,7 +646,8 @@ class TestLoggingInit(TestCase):
     @patch("opentelemetry.sdk._configuration._init_tracing")
     @patch("opentelemetry.sdk._configuration._init_logging")
     def test_logging_init_enable_env(self, logging_mock, tracing_mock):
-        _initialize_components("auto-version")
+        with self.assertLogs(level=WARNING):
+            _initialize_components("auto-version")
         self.assertEqual(logging_mock.call_count, 1)
         self.assertEqual(tracing_mock.call_count, 1)
 

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -34,6 +34,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_BSP_SCHEDULE_DELAY,
 )
 from opentelemetry.sdk.trace import export
+from opentelemetry.sdk.trace.export import logger
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
@@ -208,9 +209,11 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
     )
     def test_args_env_var_value_error(self):
 
+        logger.disabled = True
         batch_span_processor = export.BatchSpanProcessor(
             MySpanExporter(destination=[])
         )
+        logger.disabled = False
 
         self.assertEqual(batch_span_processor.max_queue_size, 2048)
         self.assertEqual(batch_span_processor.schedule_delay_millis, 5000)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -265,21 +265,27 @@ class TestSpanCreation(unittest.TestCase):
         tracer2 = tracer_provider.get_tracer("instr2", "1.3b3", schema_url)
         span1 = tracer1.start_span("s1")
         span2 = tracer2.start_span("s2")
-        self.assertEqual(
-            span1.instrumentation_info, InstrumentationInfo("instr1", "")
-        )
-        self.assertEqual(
-            span2.instrumentation_info,
-            InstrumentationInfo("instr2", "1.3b3", schema_url),
-        )
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                span1.instrumentation_info, InstrumentationInfo("instr1", "")
+            )
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                span2.instrumentation_info,
+                InstrumentationInfo("instr2", "1.3b3", schema_url),
+            )
 
-        self.assertEqual(span2.instrumentation_info.schema_url, schema_url)
-        self.assertEqual(span2.instrumentation_info.version, "1.3b3")
-        self.assertEqual(span2.instrumentation_info.name, "instr2")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(span2.instrumentation_info.schema_url, schema_url)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(span2.instrumentation_info.version, "1.3b3")
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(span2.instrumentation_info.name, "instr2")
 
-        self.assertLess(
-            span1.instrumentation_info, span2.instrumentation_info
-        )  # Check sortability.
+        with self.assertWarns(DeprecationWarning):
+            self.assertLess(
+                span1.instrumentation_info, span2.instrumentation_info
+            )  # Check sortability.
 
     def test_invalid_instrumentation_info(self):
         tracer_provider = trace.TracerProvider()
@@ -690,24 +696,34 @@ class TestSpan(unittest.TestCase):
 
     def test_invalid_attribute_values(self):
         with self.tracer.start_as_current_span("root") as root:
-            root.set_attributes(
-                {"correct-value": "foo", "non-primitive-data-type": {}}
-            )
+            with self.assertLogs(level=WARNING):
+                root.set_attributes(
+                    {"correct-value": "foo", "non-primitive-data-type": {}}
+                )
 
-            root.set_attribute("non-primitive-data-type", {})
-            root.set_attribute(
-                "list-of-mixed-data-types-numeric-first",
-                [123, False, "string"],
-            )
-            root.set_attribute(
-                "list-of-mixed-data-types-non-numeric-first",
-                [False, 123, "string"],
-            )
-            root.set_attribute("list-with-non-primitive-data-type", [{}, 123])
-            root.set_attribute("list-with-numeric-and-bool", [1, True])
+            with self.assertLogs(level=WARNING):
+                root.set_attribute("non-primitive-data-type", {})
+            with self.assertLogs(level=WARNING):
+                root.set_attribute(
+                    "list-of-mixed-data-types-numeric-first",
+                    [123, False, "string"],
+                )
+            with self.assertLogs(level=WARNING):
+                root.set_attribute(
+                    "list-of-mixed-data-types-non-numeric-first",
+                    [False, 123, "string"],
+                )
+            with self.assertLogs(level=WARNING):
+                root.set_attribute(
+                    "list-with-non-primitive-data-type", [{}, 123]
+                )
+            with self.assertLogs(level=WARNING):
+                root.set_attribute("list-with-numeric-and-bool", [1, True])
 
-            root.set_attribute("", 123)
-            root.set_attribute(None, 123)
+            with self.assertLogs(level=WARNING):
+                root.set_attribute("", 123)
+            with self.assertLogs(level=WARNING):
+                root.set_attribute(None, 123)
 
             self.assertEqual(len(root.attributes), 1)
             self.assertEqual(root.attributes["correct-value"], "foo")
@@ -823,10 +839,16 @@ class TestSpan(unittest.TestCase):
         self.assertEqual(trace_api.get_current_span(), trace_api.INVALID_SPAN)
 
         with self.tracer.start_as_current_span("root") as root:
-            root.add_event("event0", {"attr1": True, "attr2": ["hi", False]})
-            root.add_event("event0", {"attr1": {}})
-            root.add_event("event0", {"attr1": [[True]]})
-            root.add_event("event0", {"attr1": [{}], "attr2": [1, 2]})
+            with self.assertLogs(level=WARNING):
+                root.add_event(
+                    "event0", {"attr1": True, "attr2": ["hi", False]}
+                )
+            with self.assertLogs(level=WARNING):
+                root.add_event("event0", {"attr1": {}})
+            with self.assertLogs(level=WARNING):
+                root.add_event("event0", {"attr1": [[True]]})
+            with self.assertLogs(level=WARNING):
+                root.add_event("event0", {"attr1": [{}], "attr2": [1, 2]})
 
             self.assertEqual(len(root.events), 4)
             self.assertEqual(root.events[0].attributes, {"attr1": True})
@@ -1047,14 +1069,16 @@ class TestSpan(unittest.TestCase):
                 root.status.description, "AssertionError: unknown"
             )
 
-        unset_status_test(
-            trace.TracerProvider().get_tracer(__name__).start_span("root")
-        )
-        unset_status_test(
-            trace.TracerProvider()
-            .get_tracer(__name__)
-            .start_as_current_span("root")
-        )
+        with self.assertLogs(level=WARNING):
+            unset_status_test(
+                trace.TracerProvider().get_tracer(__name__).start_span("root")
+            )
+        with self.assertLogs(level=WARNING):
+            unset_status_test(
+                trace.TracerProvider()
+                .get_tracer(__name__)
+                .start_as_current_span("root")
+            )
 
     def test_last_status_wins(self):
         def error_status_test(context):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,3 @@ exclude = '''
 [tool.pytest.ini_options]
 addopts = "-rs -v"
 log_cli = true
-log_cli_level = "warning"


### PR DESCRIPTION
Fixes #3359

Not perfect (it's hard to be), but cleans up most of the SDK testing output. This way it should be easier to detect an unexpected warning in our tests.