### PR TITLE
Improve to json support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- LogRecord now JSON serializes resource objects to match ReadableSpan and MetricsData equivalents
+  ([#3365](https://github.com/open-telemetry/opentelemetry-python/issues/3365))
 - Include key in attribute sequence warning
   ([#3639](https://github.com/open-telemetry/opentelemetry-python/pull/3639))
 - Upgrade markupsafe, Flask and related dependencies to dev and test

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -103,6 +103,7 @@ from opentelemetry.trace.span import (
     NonRecordingSpan,
     Span,
     SpanContext,
+    SpanContextDict,
     TraceFlags,
     TraceState,
     format_span_id,
@@ -130,6 +131,13 @@ class _LinkBase(ABC):
         pass
 
 
+class LinkDict(typing.TypedDict):
+    """Dictionary representation of a span Link."""
+
+    context: SpanContextDict
+    attributes: types.Attributes
+
+
 class Link(_LinkBase):
     """A link to a `Span`. The attributes of a Link are immutable.
 
@@ -151,6 +159,12 @@ class Link(_LinkBase):
     @property
     def attributes(self) -> types.Attributes:
         return self._attributes
+
+    def to_dict(self) -> LinkDict:
+        return {
+            "context": self.context.to_dict(),
+            "attributes": dict(self._attributes),
+        }
 
 
 _Links = Optional[Sequence[Link]]

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -403,6 +403,14 @@ _TRACE_ID_MAX_VALUE = 2**128 - 1
 _SPAN_ID_MAX_VALUE = 2**64 - 1
 
 
+class SpanContextDict(typing.TypedDict):
+    """Dictionary representation of a SpanContext."""
+
+    trace_id: str
+    span_id: str
+    trace_state: typing.Dict[str, str]
+
+
 class SpanContext(
     typing.Tuple[int, int, bool, "TraceFlags", "TraceState", bool]
 ):
@@ -476,6 +484,13 @@ class SpanContext(
     @property
     def is_valid(self) -> bool:
         return self[5]  # pylint: disable=unsubscriptable-object
+
+    def to_dict(self) -> SpanContextDict:
+        return {
+            "trace_id": f"0x{format_trace_id(self.trace_id)}",
+            "span_id": f"0x{format_span_id(self.span_id)}",
+            "trace_state": dict(self.trace_state),
+        }
 
     def __setattr__(self, *args: str) -> None:
         _logger.debug(

--- a/opentelemetry-api/src/opentelemetry/trace/status.py
+++ b/opentelemetry-api/src/opentelemetry/trace/status.py
@@ -32,6 +32,13 @@ class StatusCode(enum.Enum):
     """The operation contains an error."""
 
 
+class StatusDict(typing.TypedDict):
+    """Dictionary representation of a trace Status."""
+
+    status_code: str
+    description: typing.Optional[str]
+
+
 class Status:
     """Represents the status of a finished Span.
 
@@ -80,3 +87,10 @@ class Status:
     def is_unset(self) -> bool:
         """Returns true if unset, false otherwise."""
         return self._status_code is StatusCode.UNSET
+
+    def to_dict(self) -> StatusDict:
+        """Convert to a dictionary representation of the status."""
+        return {
+            "status_code": str(self.status_code.name),
+            "description": self.description,
+        }

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -213,9 +213,9 @@ class LogRecord(APILogRecord):
                 if self.span_id is not None
                 else "",
                 "trace_flags": self.trace_flags,
-                "resource": repr(self.resource.attributes)
+                "resource": json.loads(self.resource.to_json())
                 if self.resource
-                else "",
+                else None,
             },
             indent=indent,
         )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
@@ -11,18 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # pylint: disable=unused-import
-
-from dataclasses import asdict, dataclass
-from json import dumps, loads
+import typing
+from dataclasses import dataclass
+from json import dumps
 from typing import Optional, Sequence, Union
 
 # This kind of import is needed to avoid Sphinx errors.
 import opentelemetry.sdk.metrics._internal
-from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.resources import Resource, ResourceDict
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.util.types import Attributes
+
+
+class NumberDataPointDict(typing.TypedDict):
+    """Dictionary representation of a NumberDataPoint."""
+
+    attributes: Attributes
+    start_time_unix_nano: int
+    time_unix_nano: int
+    value: Union[int, float]
 
 
 @dataclass(frozen=True)
@@ -36,8 +44,30 @@ class NumberDataPoint:
     time_unix_nano: int
     value: Union[int, float]
 
+    def to_dict(self) -> NumberDataPointDict:
+        return {
+            "attributes": dict(self.attributes),
+            "start_time_unix_nano": self.start_time_unix_nano,
+            "time_unix_nano": self.time_unix_nano,
+            "value": self.value,
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(asdict(self), indent=indent)
+        return dumps(self.to_dict(), indent=indent)
+
+
+class HistogramDataPointDict(typing.TypedDict):
+    """Dictionary representation of a HistogramDataPoint."""
+
+    attributes: Attributes
+    start_time_unix_nano: int
+    time_unix_nano: int
+    count: int
+    sum: Union[int, float]
+    bucket_counts: typing.List[int]
+    explicit_bounds: typing.List[float]
+    min: float
+    max: float
 
 
 @dataclass(frozen=True)
@@ -56,14 +86,57 @@ class HistogramDataPoint:
     min: float
     max: float
 
+    def to_dict(self) -> HistogramDataPointDict:
+        return {
+            "attributes": dict(self.attributes),
+            "start_time_unix_nano": self.start_time_unix_nano,
+            "time_unix_nano": self.time_unix_nano,
+            "count": self.count,
+            "sum": self.sum,
+            "bucket_counts": list(self.bucket_counts),
+            "explicit_bounds": list(self.explicit_bounds),
+            "min": self.min,
+            "max": self.max,
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(asdict(self), indent=indent)
+        return dumps(self.to_dict(), indent=indent)
+
+
+class BucketsDict(typing.TypedDict):
+    """Dictionary representation of a Buckets object."""
+
+    offset: int
+    bucket_counts: typing.List[int]
 
 
 @dataclass(frozen=True)
 class Buckets:
     offset: int
     bucket_counts: Sequence[int]
+
+    def to_dict(self) -> BucketsDict:
+        return {
+            "offset": self.offset,
+            "bucket_counts": list(self.bucket_counts),
+        }
+
+
+class ExponentialHistogramDataPointDict(typing.TypedDict):
+    """Dictionary representation of an ExponentialHistogramDataPoint."""
+
+    attributes: Attributes
+    start_time_unix_nano: int
+    time_unix_nano: int
+    count: int
+    sum: Union[int, float]
+    scale: int
+    zero_count: int
+    positive: BucketsDict
+    negative: BucketsDict
+    flags: int
+    min: float
+    max: float
 
 
 @dataclass(frozen=True)
@@ -86,8 +159,31 @@ class ExponentialHistogramDataPoint:
     min: float
     max: float
 
+    def to_dict(self) -> ExponentialHistogramDataPointDict:
+        return {
+            "attributes": dict(self.attributes),
+            "start_time_unix_nano": self.start_time_unix_nano,
+            "time_unix_nano": self.time_unix_nano,
+            "count": self.count,
+            "sum": self.sum,
+            "scale": self.scale,
+            "zero_count": self.zero_count,
+            "positive": self.positive.to_dict(),
+            "negative": self.negative.to_dict(),
+            "flags": self.flags,
+            "min": self.min,
+            "max": self.max,
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(asdict(self), indent=indent)
+        return dumps(self.to_dict(), indent=indent)
+
+
+class ExponentialHistogramDict(typing.TypedDict):
+    """Dictionary representation of an ExponentialHistogram."""
+
+    data_points: typing.List[ExponentialHistogramDataPointDict]
+    aggregation_temporality: int
 
 
 @dataclass(frozen=True)
@@ -101,6 +197,22 @@ class ExponentialHistogram:
         "opentelemetry.sdk.metrics.export.AggregationTemporality"
     )
 
+    def to_dict(self) -> ExponentialHistogramDict:
+        return {
+            "data_points": [
+                data_point.to_dict() for data_point in self.data_points
+            ],
+            "aggregation_temporality": self.aggregation_temporality.value,
+        }
+
+
+class SumDict(typing.TypedDict):
+    """Dictionary representation of a Sum."""
+
+    data_points: typing.List[NumberDataPointDict]
+    aggregation_temporality: int
+    is_monotonic: bool
+
 
 @dataclass(frozen=True)
 class Sum:
@@ -113,18 +225,23 @@ class Sum:
     )
     is_monotonic: bool
 
+    def to_dict(self) -> SumDict:
+        return {
+            "data_points": [
+                data_point.to_dict() for data_point in self.data_points
+            ],
+            "aggregation_temporality": self.aggregation_temporality.value,
+            "is_monotonic": self.is_monotonic,
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(
-            {
-                "data_points": [
-                    loads(data_point.to_json(indent=indent))
-                    for data_point in self.data_points
-                ],
-                "aggregation_temporality": self.aggregation_temporality,
-                "is_monotonic": self.is_monotonic,
-            },
-            indent=indent,
-        )
+        return dumps(self.to_dict(), indent=indent)
+
+
+class GaugeDict(typing.TypedDict):
+    """Dictionary representation of a Gauge."""
+
+    data_points: typing.List[NumberDataPointDict]
 
 
 @dataclass(frozen=True)
@@ -135,16 +252,22 @@ class Gauge:
 
     data_points: Sequence[NumberDataPoint]
 
+    def to_dict(self) -> GaugeDict:
+        return {
+            "data_points": [
+                data_point.to_dict() for data_point in self.data_points
+            ],
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(
-            {
-                "data_points": [
-                    loads(data_point.to_json(indent=indent))
-                    for data_point in self.data_points
-                ],
-            },
-            indent=indent,
-        )
+        return dumps(self.to_dict(), indent=indent)
+
+
+class HistogramDict(typing.TypedDict):
+    """Dictionary representation of a Histogram."""
+
+    data_points: typing.List[HistogramDataPointDict]
+    aggregation_temporality: int
 
 
 @dataclass(frozen=True)
@@ -157,22 +280,34 @@ class Histogram:
         "opentelemetry.sdk.metrics.export.AggregationTemporality"
     )
 
+    def to_dict(self) -> HistogramDict:
+        return {
+            "data_points": [
+                data_point.to_dict() for data_point in self.data_points
+            ],
+            "aggregation_temporality": self.aggregation_temporality.value,
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(
-            {
-                "data_points": [
-                    loads(data_point.to_json(indent=indent))
-                    for data_point in self.data_points
-                ],
-                "aggregation_temporality": self.aggregation_temporality,
-            },
-            indent=indent,
-        )
+        return dumps(self.to_dict(), indent=indent)
 
 
 # pylint: disable=invalid-name
-DataT = Union[Sum, Gauge, Histogram]
-DataPointT = Union[NumberDataPoint, HistogramDataPoint]
+DataT = Union[Sum, Gauge, Histogram, ExponentialHistogram]
+DataPointT = Union[
+    NumberDataPoint, HistogramDataPoint, ExponentialHistogramDataPoint
+]
+
+
+class MetricDict(typing.TypedDict):
+    """Dictionary representation of a Metric."""
+
+    name: str
+    description: str
+    unit: str
+    data: typing.Union[
+        SumDict, GaugeDict, HistogramDict, ExponentialHistogramDict
+    ]
 
 
 @dataclass(frozen=True)
@@ -185,16 +320,24 @@ class Metric:
     unit: Optional[str]
     data: DataT
 
+    def to_dict(self) -> MetricDict:
+        return {
+            "name": self.name,
+            "description": self.description or "",
+            "unit": self.unit or "",
+            "data": self.data.to_dict(),
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(
-            {
-                "name": self.name,
-                "description": self.description or "",
-                "unit": self.unit or "",
-                "data": loads(self.data.to_json(indent=indent)),
-            },
-            indent=indent,
-        )
+        return dumps(self.to_dict(), indent=indent)
+
+
+class ScopeMetricsDict(typing.TypedDict):
+    """Dictionary representation of a ScopeMetrics object."""
+
+    scope: typing.Any
+    metrics: typing.List[typing.Any]
+    schema_url: str
 
 
 @dataclass(frozen=True)
@@ -205,18 +348,23 @@ class ScopeMetrics:
     metrics: Sequence[Metric]
     schema_url: str
 
+    def to_dict(self) -> ScopeMetricsDict:
+        return {
+            "scope": self.scope.to_dict(),
+            "metrics": [metric.to_dict() for metric in self.metrics],
+            "schema_url": self.schema_url,
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(
-            {
-                "scope": loads(self.scope.to_json(indent=indent)),
-                "metrics": [
-                    loads(metric.to_json(indent=indent))
-                    for metric in self.metrics
-                ],
-                "schema_url": self.schema_url,
-            },
-            indent=indent,
-        )
+        return dumps(self.to_dict(), indent=indent)
+
+
+class ResourceMetricsDict(typing.TypedDict):
+    """Dictionary representation of a ResourceMetrics object."""
+
+    resource: ResourceDict
+    scope_metrics: typing.List[ScopeMetricsDict]
+    schema_url: str
 
 
 @dataclass(frozen=True)
@@ -227,18 +375,23 @@ class ResourceMetrics:
     scope_metrics: Sequence[ScopeMetrics]
     schema_url: str
 
+    def to_dict(self) -> ResourceMetricsDict:
+        return {
+            "resource": self.resource.to_dict(),
+            "scope_metrics": [
+                scope_metrics.to_dict() for scope_metrics in self.scope_metrics
+            ],
+            "schema_url": self.schema_url,
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(
-            {
-                "resource": loads(self.resource.to_json(indent=indent)),
-                "scope_metrics": [
-                    loads(scope_metrics.to_json(indent=indent))
-                    for scope_metrics in self.scope_metrics
-                ],
-                "schema_url": self.schema_url,
-            },
-            indent=indent,
-        )
+        return dumps(self.to_dict(), indent=indent)
+
+
+class MetricsDataDict(typing.TypedDict):
+    """Dictionary representation of a MetricsData object."""
+
+    resource_metrics: typing.List[ResourceMetricsDict]
 
 
 @dataclass(frozen=True)
@@ -247,13 +400,13 @@ class MetricsData:
 
     resource_metrics: Sequence[ResourceMetrics]
 
+    def to_dict(self) -> MetricsDataDict:
+        return {
+            "resource_metrics": [
+                resource_metrics.to_dict()
+                for resource_metrics in self.resource_metrics
+            ]
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(
-            {
-                "resource_metrics": [
-                    loads(resource_metrics.to_json(indent=indent))
-                    for resource_metrics in self.resource_metrics
-                ]
-            },
-            indent=indent,
-        )
+        return dumps(self.to_dict(), indent=indent)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -144,6 +144,13 @@ TELEMETRY_SDK_LANGUAGE = ResourceAttributes.TELEMETRY_SDK_LANGUAGE
 _OPENTELEMETRY_SDK_VERSION = version("opentelemetry-sdk")
 
 
+class ResourceDict(typing.TypedDict):
+    """Dictionary representation of a Resource."""
+
+    attributes: Attributes
+    schema_url: typing.Optional[str]
+
+
 class Resource:
     """A Resource is an immutable representation of the entity producing telemetry as Attributes."""
 
@@ -273,14 +280,14 @@ class Resource:
             f"{dumps(self._attributes.copy(), sort_keys=True)}|{self._schema_url}"
         )
 
+    def to_dict(self) -> ResourceDict:
+        return {
+            "attributes": dict(self._attributes),
+            "schema_url": self._schema_url,
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(
-            {
-                "attributes": dict(self._attributes),
-                "schema_url": self._schema_url,
-            },
-            indent=indent,
-        )
+        return dumps(self.to_dict(), indent=indent)
 
 
 _EMPTY_RESOURCE = Resource({})

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/instrumentation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/instrumentation.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import typing
 from json import dumps
 from typing import Optional
 
@@ -74,6 +75,14 @@ class InstrumentationInfo:
         return self._name
 
 
+class InstrumentationScopeDict(typing.TypedDict):
+    """Dictionary representation of an InstrumentationScope."""
+
+    name: str
+    version: typing.Optional[str]
+    schema_url: typing.Optional[str]
+
+
 class InstrumentationScope:
     """A logical unit of the application code with which the emitted telemetry can be
     associated.
@@ -132,12 +141,12 @@ class InstrumentationScope:
     def name(self) -> str:
         return self._name
 
+    def to_dict(self) -> InstrumentationScopeDict:
+        return {
+            "name": self._name,
+            "version": self._version,
+            "schema_url": self._schema_url,
+        }
+
     def to_json(self, indent=4) -> str:
-        return dumps(
-            {
-                "name": self._name,
-                "version": self._version,
-                "schema_url": self._schema_url,
-            },
-            indent=indent,
-        )
+        return dumps(self.to_dict(), indent=indent)

--- a/opentelemetry-sdk/tests/logs/test_log_record.py
+++ b/opentelemetry-sdk/tests/logs/test_log_record.py
@@ -17,6 +17,7 @@ import unittest
 
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk._logs import LogLimits, LogRecord
+from opentelemetry.sdk.resources import Resource
 
 
 class TestLogRecord(unittest.TestCase):
@@ -32,13 +33,37 @@ class TestLogRecord(unittest.TestCase):
                 "trace_id": "",
                 "span_id": "",
                 "trace_flags": None,
-                "resource": "",
+                "resource": None,
             },
             indent=4,
         )
         actual = LogRecord(
             timestamp=0,
             body="a log line",
+        ).to_json()
+        self.assertEqual(expected, actual)
+
+    def test_log_record_to_json_with_resource(self):
+        """Should JSON serialize/deserialize Resource objects within log records."""
+        expected = json.dumps(
+            {
+                "body": "a log line",
+                "severity_number": "None",
+                "severity_text": None,
+                "attributes": None,
+                "timestamp": "1970-01-01T00:00:00.000000Z",
+                "trace_id": "",
+                "span_id": "",
+                "trace_flags": None,
+                "resource": {"attributes": {"foo": "bar"}, "schema_url": ""},
+            },
+            indent=4,
+        )
+
+        actual = LogRecord(
+            timestamp=0,
+            body="a log line",
+            resource=Resource(attributes={"foo": "bar"}),
         ).to_json()
         self.assertEqual(expected, actual)
 

--- a/opentelemetry-sdk/tests/logs/test_log_record.py
+++ b/opentelemetry-sdk/tests/logs/test_log_record.py
@@ -25,9 +25,9 @@ class TestLogRecord(unittest.TestCase):
         expected = json.dumps(
             {
                 "body": "a log line",
-                "severity_number": "None",
+                "severity_number": 0,
                 "severity_text": None,
-                "attributes": None,
+                "attributes": {},
                 "dropped_attributes": 0,
                 "timestamp": "1970-01-01T00:00:00.000000Z",
                 "trace_id": "",
@@ -48,9 +48,10 @@ class TestLogRecord(unittest.TestCase):
         expected = json.dumps(
             {
                 "body": "a log line",
-                "severity_number": "None",
+                "severity_number": 0,
                 "severity_text": None,
-                "attributes": None,
+                "attributes": {},
+                "dropped_attributes": 0,
                 "timestamp": "1970-01-01T00:00:00.000000Z",
                 "trace_id": "",
                 "span_id": "",

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1376,10 +1376,15 @@ class TestSpanProcessor(unittest.TestCase):
             is_remote=False,
             trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         )
-        parent = trace._Span("parent-name", context, resource=Resource({}))
+        parent = trace._Span(
+            "parent-name",
+            context,
+            resource=Resource({"hello": "world"}),
+        )
         span = trace._Span(
             "span-name", context, resource=Resource({}), parent=parent.context
         )
+        span.add_event("foo", {"spam": "ham"}, 1234567890987654321)
 
         self.assertEqual(
             span.to_json(),
@@ -1388,17 +1393,26 @@ class TestSpanProcessor(unittest.TestCase):
     "context": {
         "trace_id": "0x000000000000000000000000deadbeef",
         "span_id": "0x00000000deadbef0",
-        "trace_state": "[]"
+        "trace_state": {}
     },
     "kind": "SpanKind.INTERNAL",
     "parent_id": "0x00000000deadbef0",
     "start_time": null,
     "end_time": null,
     "status": {
-        "status_code": "UNSET"
+        "status_code": "UNSET",
+        "description": null
     },
     "attributes": {},
-    "events": [],
+    "events": [
+        {
+            "name": "foo",
+            "timestamp": "2009-02-13T23:31:30.987654Z",
+            "attributes": {
+                "spam": "ham"
+            }
+        }
+    ],
     "links": [],
     "resource": {
         "attributes": {},
@@ -1408,7 +1422,7 @@ class TestSpanProcessor(unittest.TestCase):
         )
         self.assertEqual(
             span.to_json(indent=None),
-            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "[]"}, "kind": "SpanKind.INTERNAL", "parent_id": "0x00000000deadbef0", "start_time": null, "end_time": null, "status": {"status_code": "UNSET"}, "attributes": {}, "events": [], "links": [], "resource": {"attributes": {}, "schema_url": ""}}',
+            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": {}}, "kind": "SpanKind.INTERNAL", "parent_id": "0x00000000deadbef0", "start_time": null, "end_time": null, "status": {"status_code": "UNSET", "description": null}, "attributes": {}, "events": [{"name": "foo", "timestamp": "2009-02-13T23:31:30.987654Z", "attributes": {"spam": "ham"}}], "links": [], "resource": {"attributes": {}, "schema_url": ""}}',
         )
 
     def test_attributes_to_json(self):
@@ -1424,7 +1438,7 @@ class TestSpanProcessor(unittest.TestCase):
         date_str = ns_to_iso_str(123)
         self.assertEqual(
             span.to_json(indent=None),
-            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": "[]"}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "status": {"status_code": "UNSET"}, "attributes": {"key": "value"}, "events": [{"name": "event", "timestamp": "'
+            '{"name": "span-name", "context": {"trace_id": "0x000000000000000000000000deadbeef", "span_id": "0x00000000deadbef0", "trace_state": {}}, "kind": "SpanKind.INTERNAL", "parent_id": null, "start_time": null, "end_time": null, "status": {"status_code": "UNSET", "description": null}, "attributes": {"key": "value"}, "events": [{"name": "event", "timestamp": "'
             + date_str
             + '", "attributes": {"key2": "value2"}}], "links": [], "resource": {"attributes": {}, "schema_url": ""}}',
         )


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Introduce `to_dict` to the objects included in the existing
JSON serialization process for `ReadableSpan`, `MetricsData`,
`LogRecord`, and `Resource` objects. This includes adding
`to_dict` to objects that are included within the serialized
data structures of these objects. In places where `repr()`
serialization was used, it has been replaced by a
JSON-compatible serialization instead. Inconsistencies between
null and empty string values were preserved, but in cases
where attributes are optional, an empty dictionary is provided
as well to be more consistent with cases where attributes are
not optional and an empty dictionary represents no attributes
were specified on the containing object.

These changes also included:
1. Dictionary typing was included for all the `to_dict`
   methods for clarity in subsequent usage.
2. `DataT` and `DataPointT` were did not include the
   exponential histogram types in point.py, and so those
   were added with new `to_json` and `to_dict` methods as
   well for consistency. It appears that the exponential
   types were added later and including them in the types
   might have been overlooked. Please let me know if that
   is a misunderstanding on my part.
3. OrderedDict was removed in a number of places
   associated with the existing `to_json` functionality
   given its redundancy for Python 3.7+ compatibility.
   I was assuming this was legacy code for previous
   compatibility, but please let me know if that's not
   the case as well.
4. `to_dict` was added to objects like `SpanContext`,
   `Link`, and `Event` that were previously being
   serialized by static methods within the `ReadableSpan`
   class and accessing private/protected members.
   This simplified the serialization in the `ReadableSpan`
   class and those methods were removed. However, once
   again, let me know if there was a larger purpose to
   those I could not find.

Finally, I used `to_dict` as the method names here to be
consistent with other related usages. For example,
`dataclasses.asdict()`. But, mostly because that was by
far the most popular usage within the larger community:

328k files found on GitHub that define `to_dict` functions,
which include some of the most popular Python libraries
to date:
https://github.com/search?q=%22def+to_dict%28%22+language%3APython&type=code&p=1&l=Python

versus

3.3k files found on GitHub that define `to_dictionary`
functions:
https://github.com/search?q=%22def+to_dictionary%28%22+language%3APython&type=code&l=Python

However, if there is a preference for this library to use
`to_dictionary` instead let me know and I will adjust.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Passes tox testing as outlined in CONTRIBUTING.md

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
