### PR TITLE
Remove setuptools runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 
-- Add max_scale option to Exponential Bucket Histogram Aggregation 
+- Drop `setuptools` runtime requirement.
+  ([#3372](https://github.com/open-telemetry/opentelemetry-python/pull/3372))
+- Add max_scale option to Exponential Bucket Histogram Aggregation
   ([#3323](https://github.com/open-telemetry/opentelemetry-python/pull/3323))
 - Use BoundedAttributes instead of raw dict to extract attributes from LogRecord
-  ([#3310](https://github.com/open-telemetry/opentelemetry-python/pull/3310)) 
+  ([#3310](https://github.com/open-telemetry/opentelemetry-python/pull/3310))
 - Support dropped_attributes_count in LogRecord and exporters
   ([#3351](https://github.com/open-telemetry/opentelemetry-python/pull/3351))
 - Add unit to view instrument selection criteria

--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 ]
 dependencies = [
     "Deprecated >= 1.2.6",
-    "setuptools >= 16.0",
     # FIXME This should be able to be removed after 3.12 is released if there is a reliable API
     # in importlib.metadata.
     "importlib-metadata ~= 6.0",

--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -143,7 +143,7 @@ class LoggerProvider(ABC):
 
             version: Optional. The version string of the
                 instrumenting library.  Usually this should be the same as
-                ``pkg_resources.get_distribution(instrumenting_library_name).version``.
+                ``importlib.metadata.version(instrumenting_library_name)``.
 
             schema_url: Optional. Specifies the Schema URL of the emitted telemetry.
         """

--- a/opentelemetry-sdk/pyproject.toml
+++ b/opentelemetry-sdk/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 dependencies = [
   "opentelemetry-api == 1.19.0.dev",
   "opentelemetry-semantic-conventions == 0.40b0.dev",
-  "setuptools >= 16.0",
   "typing-extensions >= 3.7.4",
 ]
 


### PR DESCRIPTION
# Description

This was originally added in #2334 but the runtime dependency on pkg_resources was since dropped in #3047 so the dependency can be dropped

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have verified that setuptools or pkg_resources is not imported anywhere within the packages.
I have updated the one docstring that was still using pkg_resources

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added (N/A)
- [x] Documentation has been updated (N/A)
