### PR TITLE
Use imporlib.metadata on python >=3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 
-- Add max_scale option to Exponential Bucket Histogram Aggregation 
+- Use importlib.metadata and drop importlib_metadata dependency on
+  python 3.10 and newer
+  ([#3373](https://github.com/open-telemetry/opentelemetry-python/pull/3373))
+- Add max_scale option to Exponential Bucket Histogram Aggregation
   ([#3323](https://github.com/open-telemetry/opentelemetry-python/pull/3323))
 - Use BoundedAttributes instead of raw dict to extract attributes from LogRecord
-  ([#3310](https://github.com/open-telemetry/opentelemetry-python/pull/3310)) 
+  ([#3310](https://github.com/open-telemetry/opentelemetry-python/pull/3310))
 - Support dropped_attributes_count in LogRecord and exporters
   ([#3351](https://github.com/open-telemetry/opentelemetry-python/pull/3351))
 - Add unit to view instrument selection criteria

--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -27,9 +27,7 @@ classifiers = [
 dependencies = [
     "Deprecated >= 1.2.6",
     "setuptools >= 16.0",
-    # FIXME This should be able to be removed after 3.12 is released if there is a reliable API
-    # in importlib.metadata.
-    "importlib-metadata ~= 6.0",
+    "importlib-metadata ~= 6.0; python_version < '3.10'",
 ]
 dynamic = [
     "version",

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -12,18 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# FIXME: Use importlib.metadata when support for 3.11 is dropped if the rest of
-# the supported versions at that time have the same API.
-from importlib_metadata import (  # type: ignore
-    EntryPoint,
-    EntryPoints,
-    entry_points,
-    version,
-)
+# this module is a shim between the std lib importlib.metadata and
+# the backport importlib_metadata for python 3.9 and older
+# once support for these versions has been dropped this shim
+# can be removed.
 
-# The importlib-metadata library has introduced breaking changes before to its
-# API, this module is kept just to act as a layer between the
-# importlib-metadata library and our project if in any case it is necessary to
-# do so.
+import sys
+
+if sys.version_info > (3,10):
+    from importlib.metadata import (
+        EntryPoint,
+        EntryPoints,
+        entry_points,
+        version,
+    )
+else:
+    from importlib_metadata import (  # type: ignore
+        EntryPoint,
+        EntryPoints,
+        entry_points,
+        version,
+    )
 
 __all__ = ["entry_points", "version", "EntryPoint", "EntryPoints"]


### PR DESCRIPTION
# Description

This api is no longer provisional in 3.10 and this reduces the number of dependencies for any instrumented code on >= 3.10

```
Changed in version 3.10: importlib.metadata is no longer provisional.
```
See the [official docs](https://docs.python.org/3.10/library/importlib.metadata.html)

This was suggested in #3234 but never implemented.

Fixes #3234

and avoids issues such as #3333 on those versions in the future. 

In my opinion it's a really nice feature of opentelemetry (compared to opencensus) that the api only has
very light dependencies. Currently it has 5 dependencies. Of these one is setuptools which can be dropped (#3372)
and 2 are importlib-metadata and iss dependency zipp. Both or these are std lib backports so with these changes they
are dropped. 

(The remaining dependencies are Deprecated and its dependency wrapt) 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The used importlib functionality is well tested within the codebase. These tests are 

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added (N/A)
- [x] Documentation has been updated (N/A)
