### PR TITLE
Fixing bug where BLRP export tracked as tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#3355](https://github.com/open-telemetry/opentelemetry-python/pull/3355))
 - Include endpoint in Grpc transient error warning
   [#3362](https://github.com/open-telemetry/opentelemetry-python/pull/3362))
+- Fixed bug where logging export is tracked as trace
+  [#3375](https://github.com/open-telemetry/opentelemetry-python/pull/3375))
 
 ## Version 1.18.0/0.39b0 (2023-05-04)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -307,7 +307,7 @@ class BatchLogRecordProcessor(LogRecordProcessor):
             record = self._queue.pop()
             self._log_records[idx] = record
             idx += 1
-        token = attach(set_value("suppress_instrumentation", True))
+        token = attach(set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
         try:
             self._exporter.export(self._log_records[:idx])  # type: ignore
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
# Description

I noticed some export calls being tracked when using request and urllib3 instrumentations along with logging. It turns out the BLRP was failing to suppress the export call because of a typo.

Fixes #3376

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested manually to confirm bug exists before change and is removed after change.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
