### PR TITLE
Shutting down exporters before calling threads.join()

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -182,6 +182,7 @@ class OTLPExporterMixin(
             OTEL_EXPORTER_OTLP_ENDPOINT, "http://localhost:4317"
         )
 
+        self.shutdown_event = threading.Event()
         parsed_url = urlparse(self._endpoint)
 
         if parsed_url.scheme == "https":
@@ -313,7 +314,7 @@ class OTLPExporterMixin(
                             self._endpoint,
                             delay,
                         )
-                        sleep(delay)
+                        self.shutdown_event.wait(delay)
                         continue
                     else:
                         logger.error(
@@ -337,6 +338,7 @@ class OTLPExporterMixin(
         # wait for the last export if any
         self._export_lock.acquire(timeout=timeout_millis)
         self._shutdown = True
+        self.shutdown_event.set()
         self._export_lock.release()
 
     @property

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -364,8 +364,8 @@ class BatchLogRecordProcessor(LogRecordProcessor):
         self._shutdown = True
         with self._condition:
             self._condition.notify_all()
-        self._worker_thread.join()
         self._exporter.shutdown()
+        self._worker_thread.join()
 
     def force_flush(self, timeout_millis: Optional[int] = None) -> bool:
         if timeout_millis is None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
@@ -539,11 +539,11 @@ class PeriodicExportingMetricReader(MetricReader):
             return
 
         self._shutdown_event.set()
+        self._exporter.shutdown(timeout=(deadline_ns - time_ns()) / 10**6)
         if self._daemon_thread:
             self._daemon_thread.join(
                 timeout=(deadline_ns - time_ns()) / 10**9
             )
-        self._exporter.shutdown(timeout=(deadline_ns - time_ns()) / 10**6)
 
     def force_flush(self, timeout_millis: float = 10_000) -> bool:
         super().force_flush(timeout_millis=timeout_millis)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -409,8 +409,8 @@ class BatchSpanProcessor(SpanProcessor):
         self.done = True
         with self.condition:
             self.condition.notify_all()
-        self.worker_thread.join()
         self.span_exporter.shutdown()
+        self.worker_thread.join()
 
     @staticmethod
     def _default_max_queue_size():


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #3309 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
