### PR TITLE
Add missing sem conv value for cloud.resource_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add missing sem conv value for cloud.resource_id
+  ([#3394](https://github.com/open-telemetry/opentelemetry-python/pull/3394))
+
 ## Version 1.19.0/0.40b0 (2023-07-13)
 
 - Drop `setuptools` runtime requirement.

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/resource/__init__.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/resource/__init__.py
@@ -32,6 +32,12 @@ class ResourceAttributes:
     Note: Refer to your provider's docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), [Google Cloud regions](https://cloud.google.com/about/locations), or [Tencent Cloud regions](https://intl.cloud.tencent.com/document/product/213/6091).
     """
 
+    CLOUD_RESOURCE_ID = "cloud.resource_id"
+    """
+    Cloud provider-specific native identifier of the monitored cloud resource (e.g. an [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) on AWS, a [fully qualified resource ID on Azure](https://learn.microsoft.com/en-us/rest/api/resources/resources/get-by-id), a [full resource name on GCP](https://cloud.google.com/apis/design/resource_names#full_resource_name)
+    Note: On some cloud providers, it may not be possible to determine the full ID at startup, so it may be necessary to set cloud.resource_id as a span attribute instead.
+    """
+
     CLOUD_AVAILABILITY_ZONE = "cloud.availability_zone"
     """
     Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.


### PR DESCRIPTION
# Description

Adding missing field from [cloud sem conv](https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/cloud/)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
