### PR TITLE
Don't collect empty metrics from storage

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
@@ -106,7 +106,7 @@ class MetricExporter(ABC):
         """Exports a batch of telemetry data.
 
         Args:
-            metrics: The list of `opentelemetry.sdk.metrics.export.Metric` objects to be exported
+            metrics: The `opentelemetry.sdk.metrics.export.MetricsData` object to be exported
 
         Returns:
             The result of the export
@@ -217,7 +217,7 @@ class MetricReader(ABC):
                 "opentelemetry.sdk.metrics.export.MetricReader",
                 AggregationTemporality,
             ],
-            Iterable["opentelemetry.sdk.metrics.export.Metric"],
+            Optional["opentelemetry.sdk.metrics.export.MetricsData"],
         ] = None
 
         self._instrument_class_temporality = {
@@ -306,7 +306,8 @@ class MetricReader(ABC):
     @final
     def collect(self, timeout_millis: float = 10_000) -> None:
         """Collects the metrics from the internal SDK state and
-        invokes the `_receive_metrics` with the collection.
+        invokes the `_receive_metrics` with the collection if it
+        contains any data.
 
         Args:
             timeout_millis: Amount of time in milliseconds before this function
@@ -335,7 +336,7 @@ class MetricReader(ABC):
                 "opentelemetry.sdk.metrics.export.MetricReader",
                 AggregationTemporality,
             ],
-            Iterable["opentelemetry.sdk.metrics.export.Metric"],
+            Optional["opentelemetry.sdk.metrics.export.MetricsData"],
         ],
     ) -> None:
         """This function is internal to the SDK. It should not be called or overridden by users"""

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
@@ -17,7 +17,7 @@
 from abc import ABC, abstractmethod
 from threading import Lock
 from time import time_ns
-from typing import Iterable, List, Mapping
+from typing import Iterable, List, Mapping, Optional
 
 # This kind of import is needed to avoid Sphinx errors.
 import opentelemetry.sdk.metrics
@@ -29,7 +29,7 @@ from opentelemetry.sdk.metrics._internal.measurement import Measurement
 from opentelemetry.sdk.metrics._internal.metric_reader_storage import (
     MetricReaderStorage,
 )
-from opentelemetry.sdk.metrics._internal.point import Metric
+from opentelemetry.sdk.metrics._internal.point import MetricsData
 
 
 class MeasurementConsumer(ABC):
@@ -51,7 +51,7 @@ class MeasurementConsumer(ABC):
         self,
         metric_reader: "opentelemetry.sdk.metrics.MetricReader",
         timeout_millis: float = 10_000,
-    ) -> Iterable[Metric]:
+    ) -> Optional[MetricsData]:
         pass
 
 
@@ -94,7 +94,7 @@ class SynchronousMeasurementConsumer(MeasurementConsumer):
         self,
         metric_reader: "opentelemetry.sdk.metrics.MetricReader",
         timeout_millis: float = 10_000,
-    ) -> Iterable[Metric]:
+    ) -> Optional[MetricsData]:
 
         with self._lock:
             metric_reader_storage = self._reader_storages[metric_reader]

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_disable_default_views.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_disable_default_views.py
@@ -32,13 +32,7 @@ class TestDisableDefaultViews(TestCase):
         counter.add(10, {"label": "value2"})
         counter.add(10, {"label": "value3"})
         self.assertEqual(
-            (
-                reader.get_metrics_data()
-                .resource_metrics[0]
-                .scope_metrics[0]
-                .metrics
-            ),
-            [],
+            None, reader.get_metrics_data()
         )
 
     def test_disable_default_views_add_custom(self):

--- a/opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py
+++ b/opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py
@@ -314,15 +314,7 @@ class TestMetricReaderStorage(ConcurrencyTestBase):
         )
         metric_reader_storage.consume_measurement(Measurement(1, counter))
 
-        self.assertEqual(
-            [],
-            (
-                metric_reader_storage.collect()
-                .resource_metrics[0]
-                .scope_metrics[0]
-                .metrics
-            ),
-        )
+        self.assertEqual(None, (metric_reader_storage.collect()),)
 
     def test_same_collection_start(self):
 


### PR DESCRIPTION
# Description

Without doing this, the pb_metric2.Metric has no value for the oneof data field, which means it does not have any known type. This breaks many exporters. Instead, when faced with no data points for a metric, we should present that empty dataset.

Fixes #3277.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have tested this a little with tox, but I haven't written thorough tests. I'm not sure where I'd put those - this is a big, complicated repo, and writing good tests is a challenge.

# Does This PR Require a Contrib Repo Change?


- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
