### PR TITLE
Change importlib-metadata requirement specification

### DIFF
--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "Deprecated >= 1.2.6",
     # FIXME This should be able to be removed after 3.12 is released if there is a reliable API
     # in importlib.metadata.
-    "importlib-metadata ~= 6.0",
+    "importlib-metadata >= 6.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
This is functionally equivalent to the previous state but it works around a bug in pypi.

Fixes #3382