### PR TITLE
Update `opentelemetry_metrics_exporter` entrypoint to a MetricReader factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Modify Prometheus exporter to translate non-monotonic Sums into Gauges
   ([#3306](https://github.com/open-telemetry/opentelemetry-python/pull/3306))
+- Update `opentelemetry_metrics_exporter` entrypoint to a MetricReader factory
+  ([#3412](https://github.com/open-telemetry/opentelemetry-python/pull/3412))
+
 
 
 ## Version 1.19.0/0.40b0 (2023-07-13)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
@@ -45,7 +45,7 @@ test = [
 otlp_proto_grpc = "opentelemetry.exporter.otlp.proto.grpc._log_exporter:OTLPLogExporter"
 
 [project.entry-points.opentelemetry_metrics_exporter]
-otlp_proto_grpc = "opentelemetry.exporter.otlp.proto.grpc.metric_exporter:OTLPMetricExporter"
+otlp_proto_grpc = "opentelemetry.exporter.otlp.proto.grpc.metric_exporter:_otlp_metric_exporter_entrypoint"
 
 [project.entry-points.opentelemetry_traces_exporter]
 otlp_proto_grpc = "opentelemetry.exporter.otlp.proto.grpc.trace_exporter:OTLPSpanExporter"

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/metric_exporter/__init__.py
@@ -54,7 +54,9 @@ from opentelemetry.sdk.metrics.export import (
     Metric,
     MetricExporter,
     MetricExportResult,
+    MetricReader,
     MetricsData,
+    PeriodicExportingMetricReader,
     ResourceMetrics,
     ScopeMetrics,
 )
@@ -102,7 +104,6 @@ class OTLPMetricExporter(
         preferred_aggregation: Dict[type, Aggregation] = None,
         max_export_batch_size: Optional[int] = None,
     ):
-
         if insecure is None:
             insecure = environ.get(OTEL_EXPORTER_OTLP_METRICS_INSECURE)
             if insecure is not None:
@@ -260,3 +261,8 @@ class OTLPMetricExporter(
     def force_flush(self, timeout_millis: float = 10_000) -> bool:
         """Nothing is buffered in this exporter, so this method does nothing."""
         return True
+
+
+def _otlp_metric_exporter_entrypoint() -> MetricReader:
+    """Implementation of opentelemetry_metrics_exporter entrypoint"""
+    return PeriodicExportingMetricReader(OTLPMetricExporter())

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_entrypoints.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_entrypoints.py
@@ -1,0 +1,55 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
+    OTLPLogExporter,
+)
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+    _otlp_metric_exporter_entrypoint,
+)
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+    OTLPSpanExporter,
+)
+from opentelemetry.sdk._configuration import _import_exporters
+
+
+class TestEntrypoints(TestCase):
+    def test_import_exporters(self) -> None:
+        """
+        Tests that the entrypoints can be loaded and don't have a typo in the names
+        """
+        (
+            trace_exporters,
+            metric_exporters,
+            logs_exporters,
+        ) = _import_exporters(
+            trace_exporter_names=["otlp_proto_grpc"],
+            metric_exporter_names=["otlp_proto_grpc"],
+            log_exporter_names=["otlp_proto_grpc"],
+        )
+
+        self.assertEqual(
+            trace_exporters,
+            {"otlp_proto_grpc": OTLPSpanExporter},
+        )
+        self.assertEqual(
+            metric_exporters,
+            {"otlp_proto_grpc": _otlp_metric_exporter_entrypoint},
+        )
+        self.assertEqual(
+            logs_exporters,
+            {"otlp_proto_grpc": OTLPLogExporter},
+        )

--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -45,7 +45,7 @@ test = [
 otlp_proto_http = "opentelemetry.exporter.otlp.proto.http.trace_exporter:OTLPSpanExporter"
 
 [project.entry-points.opentelemetry_metrics_exporter]
-otlp_proto_http = "opentelemetry.exporter.otlp.proto.http.metric_exporter:OTLPMetricExporter"
+otlp_proto_http = "opentelemetry.exporter.otlp.proto.http.metric_exporter:_otlp_metric_exporter_entrypoint"
 
 [project.entry-points.opentelemetry_logs_exporter]
 otlp_proto_http = "opentelemetry.exporter.otlp.proto.http._log_exporter:OTLPLogExporter"

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
@@ -63,7 +63,9 @@ from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
     MetricExporter,
     MetricExportResult,
+    MetricReader,
     MetricsData,
+    PeriodicExportingMetricReader,
 )
 from opentelemetry.sdk.metrics.export import (  # noqa: F401
     Gauge,
@@ -101,7 +103,6 @@ def _expo(*args, **kwargs):
 
 
 class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
-
     _MAX_RETRY_TIMEOUT = 64
 
     def __init__(
@@ -182,7 +183,6 @@ class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
     ) -> MetricExportResult:
         serialized_data = encode_metrics(metrics_data)
         for delay in _expo(max_value=self._MAX_RETRY_TIMEOUT):
-
             if delay == self._MAX_RETRY_TIMEOUT:
                 return MetricExportResult.FAILURE
 
@@ -247,3 +247,8 @@ def _append_metrics_path(endpoint: str) -> str:
     if endpoint.endswith("/"):
         return endpoint + DEFAULT_METRICS_EXPORT_PATH
     return endpoint + f"/{DEFAULT_METRICS_EXPORT_PATH}"
+
+
+def _otlp_metric_exporter_entrypoint() -> MetricReader:
+    """Implementation of opentelemetry_metrics_exporter entrypoint"""
+    return PeriodicExportingMetricReader(OTLPMetricExporter())

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_entrypoints.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_entrypoints.py
@@ -1,0 +1,55 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from opentelemetry.exporter.otlp.proto.http._log_exporter import (
+    OTLPLogExporter,
+)
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    _otlp_metric_exporter_entrypoint,
+)
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter,
+)
+from opentelemetry.sdk._configuration import _import_exporters
+
+
+class TestEntrypoints(TestCase):
+    def test_import_exporters(self) -> None:
+        """
+        Tests that the entrypoints can be loaded and don't have a typo in the names
+        """
+        (
+            trace_exporters,
+            metric_exporters,
+            logs_exporters,
+        ) = _import_exporters(
+            trace_exporter_names=["otlp_proto_http"],
+            metric_exporter_names=["otlp_proto_http"],
+            log_exporter_names=["otlp_proto_http"],
+        )
+
+        self.assertEqual(
+            trace_exporters,
+            {"otlp_proto_http": OTLPSpanExporter},
+        )
+        self.assertEqual(
+            metric_exporters,
+            {"otlp_proto_http": _otlp_metric_exporter_entrypoint},
+        )
+        self.assertEqual(
+            logs_exporters,
+            {"otlp_proto_http": OTLPLogExporter},
+        )

--- a/exporter/opentelemetry-exporter-otlp/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 otlp = "opentelemetry.exporter.otlp.proto.grpc._log_exporter:OTLPLogExporter"
 
 [project.entry-points.opentelemetry_metrics_exporter]
-otlp = "opentelemetry.exporter.otlp.proto.grpc.metric_exporter:OTLPMetricExporter"
+otlp = "opentelemetry.exporter.otlp.proto.grpc.metric_exporter:_otlp_metric_exporter_entrypoint"
 
 [project.entry-points.opentelemetry_traces_exporter]
 otlp = "opentelemetry.exporter.otlp.proto.grpc.trace_exporter:OTLPSpanExporter"

--- a/exporter/opentelemetry-exporter-otlp/tests/test_entrypoints.py
+++ b/exporter/opentelemetry-exporter-otlp/tests/test_entrypoints.py
@@ -1,0 +1,55 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
+    OTLPLogExporter,
+)
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+    _otlp_metric_exporter_entrypoint,
+)
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+    OTLPSpanExporter,
+)
+from opentelemetry.sdk._configuration import _import_exporters
+
+
+class TestEntrypoints(TestCase):
+    def test_import_exporters(self) -> None:
+        """
+        Tests that the entrypoints can be loaded and don't have a typo in the names
+        """
+        (
+            trace_exporters,
+            metric_exporters,
+            logs_exporters,
+        ) = _import_exporters(
+            trace_exporter_names=["otlp"],
+            metric_exporter_names=["otlp"],
+            log_exporter_names=["otlp"],
+        )
+
+        self.assertEqual(
+            trace_exporters,
+            {"otlp": OTLPSpanExporter},
+        )
+        self.assertEqual(
+            metric_exporters,
+            {"otlp": _otlp_metric_exporter_entrypoint},
+        )
+        self.assertEqual(
+            logs_exporters,
+            {"otlp": OTLPLogExporter},
+        )

--- a/opentelemetry-sdk/pyproject.toml
+++ b/opentelemetry-sdk/pyproject.toml
@@ -58,7 +58,7 @@ console = "opentelemetry.sdk._logs.export:ConsoleLogExporter"
 sdk_meter_provider = "opentelemetry.sdk.metrics:MeterProvider"
 
 [project.entry-points.opentelemetry_metrics_exporter]
-console = "opentelemetry.sdk.metrics.export:ConsoleMetricExporter"
+console = "opentelemetry.sdk.metrics._internal.export:_console_metric_exporter_entrypoint"
 
 [project.entry-points.opentelemetry_tracer_provider]
 sdk_tracer_provider = "opentelemetry.sdk.trace:TracerProvider"

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
@@ -392,7 +392,7 @@ class InMemoryMetricReader(MetricReader):
 
     def get_metrics_data(
         self,
-    ) -> ("opentelemetry.sdk.metrics.export.MetricsData"):
+    ) -> "opentelemetry.sdk.metrics.export.MetricsData":
         """Reads and returns current metrics from the SDK"""
         with self._lock:
             self.collect()
@@ -549,3 +549,8 @@ class PeriodicExportingMetricReader(MetricReader):
         super().force_flush(timeout_millis=timeout_millis)
         self._exporter.force_flush(timeout_millis=timeout_millis)
         return True
+
+
+def _console_metric_exporter_entrypoint() -> MetricReader:
+    """Implementation of opentelemetry_metrics_exporter entrypoint for the console exporter"""
+    return PeriodicExportingMetricReader(ConsoleMetricExporter())


### PR DESCRIPTION
# Description

- Update the SDK Configuration to expect `opentelemetry_metrics_exporter` entrypoint impl to be a `Callable[[], MetricReader]`
- Update the SDK's console exporter entrypoint to implement this new protocol
- Update the OTLP exporters' entrypoints to implement this new protocol

**Note this is a breaking change in an unstable component**

Fixes #3411 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Existing tests are passing
- Added new test cases in OTLP exporters to verify that entrypoints are being loaded by name

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated 