### PR TITLE
Temp fix for opencensus missing dependency on six

### DIFF
--- a/shim/opentelemetry-opencensus-shim/pyproject.toml
+++ b/shim/opentelemetry-opencensus-shim/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
 test = [
   "opentelemetry-test-utils == 0.42b0.dev",
   "opencensus == 0.11.1",
+  # Temporary fix for https://github.com/census-instrumentation/opencensus-python/issues/1219
+  "six == 1.16.0",
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -166,7 +166,7 @@ commands_pre =
   opentracing-shim: pip install {toxinidir}/shim/opentelemetry-opentracing-shim
 
   opencensus-shim: pip install {toxinidir}/opentelemetry-sdk
-  opencensus-shim: pip install {toxinidir}/shim/opentelemetry-opencensus-shim
+  opencensus-shim: pip install {toxinidir}/shim/opentelemetry-opencensus-shim[test]
 
   exporter-prometheus: pip install {toxinidir}/exporter/opentelemetry-exporter-prometheus
 

--- a/tox.ini
+++ b/tox.ini
@@ -299,6 +299,8 @@ commands =
 [testenv:docker-tests-proto{3,4}]
 deps =
   pytest
+  # Pinning PyYAML for issue: https://github.com/yaml/pyyaml/issues/724
+  PyYAML == 5.3.1
   docker-compose >= 1.25.2
   requests < 2.29.0
 


### PR DESCRIPTION
CI is currently broken because OpenCensus is missing a dependency on `six`. See https://github.com/open-telemetry/opentelemetry-python/actions/runs/6162506119/job/16758832817?pr=3428 and https://github.com/census-instrumentation/opencensus-python/issues/1219