### PR TITLE
modify eachdist.py so `develop` subcommand works by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3335](https://github.com/open-telemetry/opentelemetry-python/pull/3335))
 - Fix error when no LoggerProvider configured for LoggingHandler
   ([#3423](https://github.com/open-telemetry/opentelemetry-python/pull/3423))
-
+- Tweak eachdist.py so "develop" subcommand works by default
+  ([#3435](https://github.com/open-telemetry/opentelemetry-python/pull/3435))
 
 ## Version 1.20.0/0.41b0 (2023-09-04)
 

--- a/eachdist.ini
+++ b/eachdist.ini
@@ -3,11 +3,19 @@
 [DEFAULT]
 
 sortfirst=
+    opentelemetry-semantic-conventions
     opentelemetry-api
     opentelemetry-sdk
     opentelemetry-proto
     opentelemetry-distro
     tests/opentelemetry-test-utils
+    exporter/opentelemetry-exporter-otlp-proto-common
+    exporter/opentelemetry-exporter-otlp-proto-http
+    exporter/opentelemetry-exporter-otlp-proto-grpc
+    exporter/opentelemetry-exporter-jaeger-proto-grpc
+    exporter/opentelemetry-exporter-jaeger-thrift
+    exporter/opentelemetry-exporter-zipkin-json
+    exporter/opentelemetry-exporter-zipkin-proto-http
     exporter/*
 
 [stable]

--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -208,8 +208,9 @@ def parse_args(args=None):
         editable=True,
         with_dev_deps=True,
         eager_upgrades=True,
-        with_test_deps=True,
+        with_test_deps=False,
     )
+    devparser.add_argument("--with-test-deps", action="store_true")
 
     lintparser = subparsers.add_parser(
         "lint", help="Lint everything, autofixing if possible."

--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -208,9 +208,8 @@ def parse_args(args=None):
         editable=True,
         with_dev_deps=True,
         eager_upgrades=True,
-        with_test_deps=False,
+        with_test_deps=True,
     )
-    devparser.add_argument("--with-test-deps", action="store_true")
 
     lintparser = subparsers.add_parser(
         "lint", help="Lint everything, autofixing if possible."


### PR DESCRIPTION
# Description

By default and with a clean checkout,`eachdist.py develop` fails with a `no matching distribution` error.

However, if you modify the script, setting [with_test_deps](https://github.com/open-telemetry/opentelemetry-python/blob/191b21a49d21c78eb4ad561835aef9429605ad82/scripts/eachdist.py#L211) to False, the script issues a pip command that does not indicate `[test]` extras for each package, and it completes successfully.

This PR makes a small change to `eachdist.py`, defaulting `with_test_deps` to `False` and adding a flag so users can still turn this capability on.

Possible workaround for #1846

Related to #1462

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested manually by running `eachdist.py develop` in a clean Python environment.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [x] Yes?
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
