### PR TITLE
Update flask example dependencies

### DIFF
--- a/docs/examples/fork-process-model/flask-gunicorn/requirements.txt
+++ b/docs/examples/fork-process-model/flask-gunicorn/requirements.txt
@@ -6,12 +6,12 @@ gunicorn==20.0.4
 itsdangerous==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
-opentelemetry-api==0.18b0
-opentelemetry-exporter-otlp==0.18b0
+opentelemetry-api==1.20.0
+opentelemetry-exporter-otlp==1.20.0
 opentelemetry-instrumentation==0.41b0
-opentelemetry-instrumentation-flask==0.18b1
-opentelemetry-instrumentation-wsgi==0.18b1
-opentelemetry-sdk==0.18b0
+opentelemetry-instrumentation-flask==0.41b0
+opentelemetry-instrumentation-wsgi==0.41b0
+opentelemetry-sdk==1.20.0
 protobuf==3.18.3
 six==1.15.0
 thrift==0.13.0

--- a/docs/examples/fork-process-model/flask-uwsgi/requirements.txt
+++ b/docs/examples/fork-process-model/flask-uwsgi/requirements.txt
@@ -6,12 +6,12 @@ gunicorn==20.0.4
 itsdangerous==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
-opentelemetry-api==0.18b0
-opentelemetry-exporter-otlp==0.18b0
+opentelemetry-api==1.20.0
+opentelemetry-exporter-otlp==1.20.0
 opentelemetry-instrumentation==0.41b0
-opentelemetry-instrumentation-flask==0.18b1
-opentelemetry-instrumentation-wsgi==0.18b1
-opentelemetry-sdk==0.18b0
+opentelemetry-instrumentation-flask==0.41b0
+opentelemetry-instrumentation-wsgi==0.41b0
+opentelemetry-sdk==1.20.0
 protobuf==3.18.3
 six==1.15.0
 thrift==0.13.0


### PR DESCRIPTION
Following https://github.com/open-telemetry/opentelemetry-python/pull/3457 and https://github.com/open-telemetry/opentelemetry-python/pull/3456, bump other library versions to match `opentelemetry-instrument==0.41b0`