### PR TITLE
Refactor BatchSpanProcessor queue logic into a BatchAccumulator

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.pyi
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.pyi
@@ -11,19 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import collections
 import threading
 from typing import (
+    Deque,
+    Generic,
     Iterable,
     Iterator,
+    List,
     Mapping,
     MutableMapping,
     Sequence,
     TypeVar,
-    overload, Generic, List, Deque,
+    overload,
 )
 
-from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.util.types import AttributesAsKey, AttributeValue
 
 _T = TypeVar("_T")
@@ -74,15 +75,13 @@ class BoundedDict(MutableMapping[_KT, _VT]):
         cls, maxlen: int, mapping: Mapping[_KT, _VT]
     ) -> BoundedDict[_KT, _VT]: ...
 
-T = TypeVar('T')
-
-class BatchAccumulator(Generic[T]):
+class BatchAccumulator(Generic[_T]):
     batch_size: int
     lock: threading.Lock
-    spans: List[T]
-    batches: Deque[T]
+    items: List[_T]
+    batches: Deque[_T]
 
     def __init__(self, batch_size: int): ...
     def empty(self): ...
-    def push(self, span: T): ...
+    def push(self, span: _T): ...
     def batch(self): ...

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.pyi
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.pyi
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import collections
+import threading
 from typing import (
     Iterable,
     Iterator,
@@ -19,9 +20,10 @@ from typing import (
     MutableMapping,
     Sequence,
     TypeVar,
-    overload,
+    overload, Generic, List, Deque,
 )
 
+from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.util.types import AttributesAsKey, AttributeValue
 
 _T = TypeVar("_T")
@@ -71,3 +73,16 @@ class BoundedDict(MutableMapping[_KT, _VT]):
     def from_map(
         cls, maxlen: int, mapping: Mapping[_KT, _VT]
     ) -> BoundedDict[_KT, _VT]: ...
+
+T = TypeVar('T')
+
+class BatchAccumulator(Generic[T]):
+    batch_size: int
+    lock: threading.Lock
+    spans: List[T]
+    batches: Deque[T]
+
+    def __init__(self, batch_size: int): ...
+    def empty(self): ...
+    def push(self, span: T): ...
+    def batch(self): ...

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from opentelemetry.sdk.util import BoundedList, BatchAccumulator
+from opentelemetry.sdk.util import BatchAccumulator, BoundedList
 
 
 class TestBoundedList(unittest.TestCase):
@@ -144,7 +144,6 @@ class TestBoundedList(unittest.TestCase):
 
 
 class TestBatchAccumulator(unittest.TestCase):
-
     def test_push(self):
         acc = BatchAccumulator[int](4)
         self.assertTrue(acc.empty())

--- a/opentelemetry-sdk/tests/test_util.py
+++ b/opentelemetry-sdk/tests/test_util.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from opentelemetry.sdk.util import BoundedList
+from opentelemetry.sdk.util import BoundedList, BatchAccumulator
 
 
 class TestBoundedList(unittest.TestCase):
@@ -141,3 +141,27 @@ class TestBoundedList(unittest.TestCase):
 
         for num in range(100):
             self.assertEqual(blist[num], num)
+
+
+class TestBatchAccumulator(unittest.TestCase):
+
+    def test_push(self):
+        acc = BatchAccumulator[int](4)
+        self.assertTrue(acc.empty())
+        self.assertFalse(acc.push(1))
+        self.assertFalse(acc.push(2))
+        self.assertFalse(acc.push(3))
+        self.assertTrue(acc.push(4))
+        self.assertListEqual([1, 2, 3, 4], acc.batch())
+        self.assertEqual(0, len(acc.batch()))
+        self.assertTrue(acc.empty())
+
+    def test_batch(self):
+        acc = BatchAccumulator[int](4)
+        for i in range(10):
+            acc.push(i)
+        self.assertListEqual([0, 1, 2, 3], acc.batch())
+        self.assertListEqual([4, 5, 6, 7], acc.batch())
+        self.assertListEqual([8, 9], acc.batch())
+        self.assertListEqual([], acc.batch())
+        self.assertTrue(acc.empty())

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -183,7 +183,7 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
         )
 
         self.assertEqual(batch_span_processor.max_queue_size, 10)
-        self.assertEqual(batch_span_processor.schedule_delay_millis, 2)
+        self.assertEqual(batch_span_processor.max_export_interval, 2)
         self.assertEqual(batch_span_processor.max_export_batch_size, 3)
         self.assertEqual(batch_span_processor.export_timeout_millis, 4)
 
@@ -194,7 +194,7 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
         )
 
         self.assertEqual(batch_span_processor.max_queue_size, 2048)
-        self.assertEqual(batch_span_processor.schedule_delay_millis, 5000)
+        self.assertEqual(batch_span_processor.max_export_interval, 5000)
         self.assertEqual(batch_span_processor.max_export_batch_size, 512)
         self.assertEqual(batch_span_processor.export_timeout_millis, 30000)
 
@@ -216,7 +216,7 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
         logger.disabled = False
 
         self.assertEqual(batch_span_processor.max_queue_size, 2048)
-        self.assertEqual(batch_span_processor.schedule_delay_millis, 5000)
+        self.assertEqual(batch_span_processor.max_export_interval, 5000)
         self.assertEqual(batch_span_processor.max_export_batch_size, 512)
         self.assertEqual(batch_span_processor.export_timeout_millis, 30000)
 
@@ -287,6 +287,7 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
 
         self.assertTrue(span_processor.force_flush())
 
+    @unittest.skip('skipping long running test')
     def test_flush_from_multiple_threads(self):
         num_threads = 50
         num_spans = 10

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -183,7 +183,7 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
         )
 
         self.assertEqual(batch_span_processor.max_queue_size, 10)
-        self.assertEqual(batch_span_processor.max_export_interval, 2)
+        self.assertEqual(batch_span_processor.schedule_delay_millis, 2)
         self.assertEqual(batch_span_processor.max_export_batch_size, 3)
         self.assertEqual(batch_span_processor.export_timeout_millis, 4)
 
@@ -194,7 +194,7 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
         )
 
         self.assertEqual(batch_span_processor.max_queue_size, 2048)
-        self.assertEqual(batch_span_processor.max_export_interval, 5000)
+        self.assertEqual(batch_span_processor.schedule_delay_millis, 5000)
         self.assertEqual(batch_span_processor.max_export_batch_size, 512)
         self.assertEqual(batch_span_processor.export_timeout_millis, 30000)
 
@@ -216,7 +216,7 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
         logger.disabled = False
 
         self.assertEqual(batch_span_processor.max_queue_size, 2048)
-        self.assertEqual(batch_span_processor.max_export_interval, 5000)
+        self.assertEqual(batch_span_processor.schedule_delay_millis, 5000)
         self.assertEqual(batch_span_processor.max_export_batch_size, 512)
         self.assertEqual(batch_span_processor.export_timeout_millis, 30000)
 
@@ -287,7 +287,6 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
 
         self.assertTrue(span_processor.force_flush())
 
-    @unittest.skip('skipping long running test')
     def test_flush_from_multiple_threads(self):
         num_threads = 50
         num_spans = 10
@@ -323,10 +322,11 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
             destination=spans_names_list, export_timeout_millis=500
         )
         span_processor = export.BatchSpanProcessor(my_exporter)
+        span_processor._stop_worker()
 
         _create_start_and_end_span("foo", span_processor)
 
-        # check that the timeout is not meet
+        # check that the timeout is not met
         with self.assertLogs(level=WARNING):
             self.assertFalse(span_processor.force_flush(100))
         span_processor.shutdown()

--- a/opentelemetry-sdk/tests/trace/export/test_integration.py
+++ b/opentelemetry-sdk/tests/trace/export/test_integration.py
@@ -1,0 +1,178 @@
+import threading
+import time
+import unittest
+from concurrent import futures
+from os import environ
+
+import grpc
+
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.proto.collector.logs.v1 import logs_service_pb2, logs_service_pb2_grpc
+from opentelemetry.proto.collector.metrics.v1 import metrics_service_pb2, metrics_service_pb2_grpc
+from opentelemetry.proto.collector.trace.v1 import trace_service_pb2, trace_service_pb2_grpc
+from opentelemetry.sdk.trace import ReadableSpan, _Span
+from opentelemetry.sdk.trace import SpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import SpanContext, TraceFlags
+
+
+@unittest.skipUnless(environ.get('RUN_LONG_TESTS', '').lower() == 'true', 'Skipping, RUN_LONG_TESTS not set')
+class TestBSPIntegration(unittest.TestCase):
+    """
+    These are longer-running tests (total ~1 minute) that start up a local python grpc server and send spans to
+    it, comparing the number of received spans against how many were sent.
+    """
+
+    def test_full_speed(self):
+        self.run_bsp_test(
+            num_threads=128,
+            max_interval_sec=4,
+            num_spans_per_firehose=1000,
+            firehose_sleep_sec=0,
+        )
+
+    def test_slower(self):
+        self.run_bsp_test(
+            num_threads=128,
+            max_interval_sec=4,
+            num_spans_per_firehose=1000,
+            firehose_sleep_sec=0.01,
+        )
+
+    def test_slow_enough_to_engage_timer(self):
+        self.run_bsp_test(
+            num_threads=1,
+            max_interval_sec=4,
+            num_spans_per_firehose=10,
+            firehose_sleep_sec=1,
+        )
+
+    def run_bsp_test(self, num_threads, max_interval_sec, num_spans_per_firehose, firehose_sleep_sec):
+        server = OTLPServer()
+        server.start()
+
+        bsp = BatchSpanProcessor(OTLPSpanExporter(), schedule_delay_millis=max_interval_sec * 1e3)
+
+        firehose = SpanFirehose(bsp, num_spans=num_spans_per_firehose, sleep_sec=firehose_sleep_sec)
+
+        threads = []
+        for _ in range(num_threads):
+            thread = threading.Thread(target=firehose.run)
+            thread.start()
+            threads.append(thread)
+
+        for thread in threads:
+            thread.join()
+
+        time.sleep(max_interval_sec * 2)
+
+        num_span_received = server.get_num_spans_received()
+        self.assertEqual(num_spans_per_firehose * num_threads, num_span_received)
+        server.stop()
+
+
+class SpanFirehose:
+
+    def __init__(self, sp: SpanProcessor, num_spans: int, sleep_sec: float):
+        self._sp = sp
+        self._num_spans = num_spans
+        self._sleep_sec = sleep_sec
+
+    def run(self) -> float:
+        start = time.time()
+        span = mk_span('test-span')
+        for i in range(self._num_spans):
+            time.sleep(self._sleep_sec)
+            self._sp.on_end(span)
+        return time.time() - start
+
+
+class OTLPServer:
+
+    def __init__(self):
+        self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+
+        self.trace_servicer = TraceServiceServicer()
+        trace_service_pb2_grpc.add_TraceServiceServicer_to_server(self.trace_servicer, self.server)
+
+        metrics_servicer = MetricsServiceServicer()
+        metrics_service_pb2_grpc.add_MetricsServiceServicer_to_server(metrics_servicer, self.server)
+
+        logs_servicer = LogsServiceServicer()
+        logs_service_pb2_grpc.add_LogsServiceServicer_to_server(logs_servicer, self.server)
+
+        self.server.add_insecure_port('0.0.0.0:4317')
+
+    def start(self):
+        self.server.start()
+
+    def stop(self):
+        self.server.stop(0)
+
+    def get_num_spans_received(self):
+        return self.trace_servicer.get_num_spans()
+
+
+class LogsServiceServicer(logs_service_pb2_grpc.LogsServiceServicer):
+
+    def __init__(self):
+        self.requests_received = []
+
+    def Export(self, request, context):
+        self.requests_received.append(request)
+        return logs_service_pb2.ExportLogsServiceResponse()
+
+
+class TraceServiceServicer(trace_service_pb2_grpc.TraceServiceServicer):
+
+    def __init__(self):
+        self.requests_received = []
+
+    def Export(self, request, context):
+        self.requests_received.append(request)
+        return trace_service_pb2.ExportTraceServiceResponse()
+
+    def get_num_spans(self):
+        out = 0
+        for req in self.requests_received:
+            for rs in req.resource_spans:
+                for ss in rs.scope_spans:
+                    out += len(ss.spans)
+        return out
+
+
+class MetricsServiceServicer(metrics_service_pb2_grpc.MetricsServiceServicer):
+
+    def __init__(self):
+        self.requests_received = []
+
+    def Export(self, request, context):
+        self.requests_received.append(request)
+        return metrics_service_pb2.ExportMetricsServiceResponse()
+
+
+def mk_readable_span():
+    ctx = SpanContext(0, 0, False)
+    return ReadableSpan(context=ctx, attributes={})
+
+
+def mk_spans(n):
+    span = mk_span('foo')
+    out = []
+    for _ in range(n):
+        out.append(span)
+    return out
+
+
+def create_start_and_end_span(name, span_processor):
+    span = _Span(name, mk_ctx(), span_processor=span_processor)
+    span.start()
+    span.end()
+
+
+def mk_span(name='foo'):
+    return _Span(name=name, context=mk_ctx())
+
+
+def mk_ctx():
+    return SpanContext(1, 2, False, trace_flags=TraceFlags(TraceFlags.SAMPLED))


### PR DESCRIPTION
# Description

This is a draft PR to gather additional feedback. It takes some of the feedback received when [this proposed direction](https://github.com/open-telemetry/opentelemetry-python/pull/3465) was presented to the SIG, where it was suggested that the BatchSpanProcessor be migrated incrementally. Therefore this PR doesn't reflect the target end state of the BSP but a step towards getting there; for example some of the logic proposed in this change (e.g. the atomic flags) is expected to be replaced by a  [Timer](https://github.com/open-telemetry/opentelemetry-python/pull/3465/files#diff-a2b9f69e2880dc0988069fac93565195fdf33a10c6f53f21f5fa05cda3afba25R31) in a later PR.

This change proposes replacing some of the queueing, batching, and flushing logic in the BatchSpanProcessor with a BatchAccumulator.

Fixes # (issue)

None yet. (We'll probably want to add a new issue to capture BSP refactoring)

## Type of change

This change proposes a refactor of the BSP.

# How Has This Been Tested?

Tested manually and added new integration (slower running, end-to-end) tests.