### PR TITLE
Tweak sdk tests so they run faster

### DIFF
--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -33,6 +33,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_BSP_MAX_QUEUE_SIZE,
     OTEL_BSP_SCHEDULE_DELAY,
 )
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import export
 from opentelemetry.sdk.trace.export import logger
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
@@ -151,7 +152,7 @@ class TestSimpleSpanProcessor(unittest.TestCase):
         self.assertListEqual([], spans_names_list)
 
 
-def _create_start_and_end_span(name, span_processor):
+def _create_start_and_end_span(name, span_processor, resource):
     span = trace._Span(
         name,
         trace_api.SpanContext(
@@ -161,6 +162,7 @@ def _create_start_and_end_span(name, span_processor):
             trace_flags=trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
         ),
         span_processor=span_processor,
+        resource=resource,
     )
     span.start()
     span.end()
@@ -245,8 +247,9 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
 
         span_names = ["xxx", "bar", "foo"]
 
+        resource = Resource.create({})
         for name in span_names:
-            _create_start_and_end_span(name, span_processor)
+            _create_start_and_end_span(name, span_processor, resource)
 
         span_processor.shutdown()
         self.assertTrue(my_exporter.is_shutdown)
@@ -264,15 +267,16 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
         span_names0 = ["xxx", "bar", "foo"]
         span_names1 = ["yyy", "baz", "fox"]
 
+        resource = Resource.create({})
         for name in span_names0:
-            _create_start_and_end_span(name, span_processor)
+            _create_start_and_end_span(name, span_processor, resource)
 
         self.assertTrue(span_processor.force_flush())
         self.assertListEqual(span_names0, spans_names_list)
 
         # create some more spans to check that span processor still works
         for name in span_names1:
-            _create_start_and_end_span(name, span_processor)
+            _create_start_and_end_span(name, span_processor, resource)
 
         self.assertTrue(span_processor.force_flush())
         self.assertListEqual(span_names0 + span_names1, spans_names_list)
@@ -298,10 +302,12 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
             my_exporter, max_queue_size=512, max_export_batch_size=128
         )
 
+        resource = Resource.create({})
+
         def create_spans_and_flush(tno: int):
             for span_idx in range(num_spans):
                 _create_start_and_end_span(
-                    f"Span {tno}-{span_idx}", span_processor
+                    f"Span {tno}-{span_idx}", span_processor, resource
                 )
             self.assertTrue(span_processor.force_flush())
 
@@ -323,7 +329,8 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
         )
         span_processor = export.BatchSpanProcessor(my_exporter)
 
-        _create_start_and_end_span("foo", span_processor)
+        resource = Resource.create({})
+        _create_start_and_end_span("foo", span_processor, resource)
 
         # check that the timeout is not meet
         with self.assertLogs(level=WARNING):
@@ -341,8 +348,9 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
             my_exporter, max_queue_size=512, max_export_batch_size=128
         )
 
+        resource = Resource.create({})
         for _ in range(512):
-            _create_start_and_end_span("foo", span_processor)
+            _create_start_and_end_span("foo", span_processor, resource)
 
         time.sleep(1)
         self.assertTrue(span_processor.force_flush())
@@ -363,9 +371,10 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
             schedule_delay_millis=100,
         )
 
+        resource = Resource.create({})
         for _ in range(4):
             for _ in range(256):
-                _create_start_and_end_span("foo", span_processor)
+                _create_start_and_end_span("foo", span_processor, resource)
 
             time.sleep(0.1)  # give some time for the exporter to upload spans
 
@@ -467,7 +476,8 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
         )
 
         # create single span
-        _create_start_and_end_span("foo", span_processor)
+        resource = Resource.create({})
+        _create_start_and_end_span("foo", span_processor, resource)
 
         self.assertTrue(export_event.wait(2))
         export_time = time.time()
@@ -497,7 +507,8 @@ class TestBatchSpanProcessor(ConcurrencyTestBase):
         )
 
         with mock.patch.object(span_processor.condition, "wait") as mock_wait:
-            _create_start_and_end_span("foo", span_processor)
+            resource = Resource.create({})
+            _create_start_and_end_span("foo", span_processor, resource)
             self.assertTrue(export_event.wait(2))
 
             # give some time for exporter to loop


### PR DESCRIPTION
The test utility `_create_start_and_end_span()` creates a new Resource each time it creates a span. This is quite slow because Resource.create() iterates through entry points every time it's called. This change requires that a Resource be passed in to `_create_start_and_end_span` instead.

Tests that take > 1 second:

BEFORE:

145.20s call     opentelemetry-sdk/tests/trace/export/test_export.py::TestBatchSpanProcessor::test_flush_from_multiple_threads
4.68s call     opentelemetry-sdk/tests/trace/export/test_export.py::TestBatchSpanProcessor::test_batch_span_processor_many_spans
3.12s call     opentelemetry-sdk/tests/trace/export/test_export.py::TestBatchSpanProcessor::test_batch_span_processor_lossless
2.02s call     opentelemetry-sdk/tests/metrics/test_metrics.py::TestDuplicateInstrumentAggregateData::test_duplicate_instrument_aggregate_data
2.01s call     opentelemetry-sdk/tests/metrics/test_measurement_consumer.py::TestSynchronousMeasurementConsumer::test_collect_deadline
1.79s call     opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py::TestExponentialBucketHistogramAggregation::test_ascending_sequence
1.72s call     opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py::TestMetricReaderStorage::test_race_concurrent_measurements
1.49s call     opentelemetry-sdk/tests/trace/export/test_export.py::TestBatchSpanProcessor::test_batch_span_processor_fork
1.13s call     opentelemetry-sdk/tests/logs/test_export.py::TestBatchLogRecordProcessor::test_batch_log_record_processor_fork
1.10s call     opentelemetry-sdk/tests/performance/benchmarks/metrics/test_benchmark_metrics.py::test_counter_add[0-delta]
1.02s call     opentelemetry-sdk/tests/metrics/integration_test/test_time_align.py::TestTimeAlign::test_time_align_cumulative
1.00s call     opentelemetry-sdk/tests/metrics/test_measurement_consumer.py::TestSynchronousMeasurementConsumer::test_collect_timeout

AFTER:

2.01s call     opentelemetry-sdk/tests/metrics/test_measurement_consumer.py::TestSynchronousMeasurementConsumer::test_collect_deadline
1.73s call     opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py::TestExponentialBucketHistogramAggregation::test_ascending_sequence
1.37s call     opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py::TestMetricReaderStorage::test_race_concurrent_measurements
1.36s call     opentelemetry-sdk/tests/trace/export/test_export.py::TestBatchSpanProcessor::test_batch_span_processor_fork
1.10s call     opentelemetry-sdk/tests/logs/test_export.py::TestBatchLogRecordProcessor::test_batch_log_record_processor_fork
1.09s call     opentelemetry-sdk/tests/performance/benchmarks/metrics/test_benchmark_metrics.py::test_counter_add[0-delta]
1.03s call     opentelemetry-sdk/tests/trace/export/test_export.py::TestBatchSpanProcessor::test_batch_span_processor_lossless
1.01s call     opentelemetry-sdk/tests/metrics/integration_test/test_time_align.py::TestTimeAlign::test_time_align_cumulative
1.00s call     opentelemetry-sdk/tests/metrics/test_measurement_consumer.py::TestSynchronousMeasurementConsumer::test_collect_timeout
