### PR TITLE
fix: timeout period when acquiring grpc exporter lock on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix OTLPExporterMixin shutdown timeout period
+  ([#3524](https://github.com/open-telemetry/opentelemetry-python/pull/3524))
+
 ## Version 1.21.0/0.42b0 (2023-11-01)
 
 - Fix `SumAggregation`

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -322,7 +322,7 @@ class OTLPExporterMixin(
             logger.warning("Exporter already shutdown, ignoring call")
             return
         # wait for the last export if any
-        self._export_lock.acquire(timeout=timeout_millis)
+        self._export_lock.acquire(timeout=timeout_millis / 1e3)
         self._shutdown = True
         self._export_lock.release()
 


### PR DESCRIPTION
# Description

[`Lock.acquire`](https://docs.python.org/3/library/threading.html#threading.Lock.acquire) with timeout takes a seconds parameter not milliseconds. Currently if the exporting is not successful the acquire takes much longer than the intended timeout.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

