### PR TITLE
Add stack trace on `StatusCode.UNKNOWN` export error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Log stacktrace on `UNKNOWN` status OTLP export error 
+  ([#3536](https://github.com/open-telemetry/opentelemetry-python/pull/3536))
 - Fix OTLPExporterMixin shutdown timeout period
   ([#3524](https://github.com/open-telemetry/opentelemetry-python/pull/3524))
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -308,6 +308,7 @@ class OTLPExporterMixin(
                             self._exporting,
                             self._endpoint,
                             error.code(),
+                            exc_info=error.code() == StatusCode.UNKNOWN,
                         )
 
                     if error.code() == StatusCode.OK:

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
@@ -453,8 +453,8 @@ class TestOTLPMetricExporter(TestCase):
         "opentelemetry.exporter.otlp.proto.grpc.exporter._create_exp_backoff_generator"
     )
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
-    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.logger")
-    def test_unknown_logs(self, mock_sleep, mock_expo, mock_logger):
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.logger.error")
+    def test_unknown_logs(self, mock_logger_error, mock_sleep, mock_expo):
 
         mock_expo.configure_mock(**{"return_value": [1]})
 
@@ -465,11 +465,11 @@ class TestOTLPMetricExporter(TestCase):
             self.exporter.export(self.metrics["sum_int"]),
             MetricExportResult.FAILURE,
         )
-        mock_sleep.assert_called_with(1)
-        mock_logger.error.assert_called_with(
+        mock_sleep.assert_not_called()
+        mock_logger_error.assert_called_with(
             "Failed to export %s to %s, error code: %s",
             "metrics",
-            "TODO",
+            "localhost:4317",
             StatusCode.UNKNOWN,
             exc_info=True,
         )

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
@@ -112,6 +112,14 @@ class MetricsServiceServicerUNAVAILABLE(MetricsServiceServicer):
         return ExportMetricsServiceResponse()
 
 
+class MetricsServiceServicerUNKNOWN(MetricsServiceServicer):
+    # pylint: disable=invalid-name,unused-argument,no-self-use
+    def Export(self, request, context):
+        context.set_code(StatusCode.UNKNOWN)
+
+        return ExportMetricsServiceResponse()
+
+
 class MetricsServiceServicerSUCCESS(MetricsServiceServicer):
     # pylint: disable=invalid-name,unused-argument,no-self-use
     def Export(self, request, context):
@@ -440,6 +448,31 @@ class TestOTLPMetricExporter(TestCase):
             MetricExportResult.FAILURE,
         )
         mock_sleep.assert_called_with(4)
+
+    @patch(
+        "opentelemetry.exporter.otlp.proto.grpc.exporter._create_exp_backoff_generator"
+    )
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.logger")
+    def test_unknown_logs(self, mock_sleep, mock_expo, mock_logger):
+
+        mock_expo.configure_mock(**{"return_value": [1]})
+
+        add_MetricsServiceServicer_to_server(
+            MetricsServiceServicerUNKNOWN(), self.server
+        )
+        self.assertEqual(
+            self.exporter.export(self.metrics["sum_int"]),
+            MetricExportResult.FAILURE,
+        )
+        mock_sleep.assert_called_with(1)
+        mock_logger.error.assert_called_with(
+            "Failed to export %s to %s, error code: %s",
+            "metrics",
+            "TODO",
+            StatusCode.UNKNOWN,
+            exc_info=True,
+        )
 
     def test_success(self):
         add_MetricsServiceServicer_to_server(


### PR DESCRIPTION
# Description

A deployment I ran over the weekend is logging the following message hundreds of times per minute:

> "Failed to export metrics to otlp.eu01.nr-data.net, error code: StatusCode.UNKNOWN"

For this status code - 'Unknown' - it would be nice to have the full error logged, as the message above is very hard to debug.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've added a unit test, `test_unknown_logs`, but haven't been able to run it, because I'm struggling a bit with how to set up this project for development. 

If this patchset seems useful to include, I'm happy to invest some time to get the test sorted properly. I asked in the slack channel for some help with how people normally set up the project for development. 

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
