### PR TITLE
[WIP] Configurable max export delay value for OTLPExporterMixin

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -151,6 +151,7 @@ class OTLPExporterMixin(
         timeout: Backend request timeout in seconds
         compression: gRPC compression method to use
     """
+    _MAX_EXPORT_DELAY_VALUE = 64
 
     def __init__(
         self,
@@ -249,12 +250,12 @@ class OTLPExporterMixin(
         #     data.__class__.__name__,
         #     delay,
         # )
-        max_value = 64
+
         # expo returns a generator that yields delay values which grow
         # exponentially. Once delay is greater than max_value, the yielded
         # value will remain constant.
-        for delay in _create_exp_backoff_generator(max_value=max_value):
-            if delay == max_value or self._shutdown:
+        for delay in _create_exp_backoff_generator(max_value=self._MAX_EXPORT_DELAY_VALUE):
+            if delay == self._MAX_EXPORT_DELAY_VALUE or self._shutdown:
                 return self._result.FAILURE
 
             with self._export_lock:


### PR DESCRIPTION
# Description

Change related with https://github.com/open-telemetry/opentelemetry-python/pull/1842.

Default OTLPExporterMixin approach to retry exporting with hardcoded time range causes issues when using it in specific kinds of short lasting processes.

I moved hardcoded value to make it configurable.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

OTLPExporterMixin tests pass after change. 


# Does This PR Require a Contrib Repo Change?

- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Documentation has been updated
