### PR TITLE
Prometheus exporter sanitize info metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Prometheus exporter sanitize info metric ([#3572](https://github.com/open-telemetry/opentelemetry-python/pull/3572))
 - Remove Jaeger exporters
   ([#3554](https://github.com/open-telemetry/opentelemetry-python/pull/3554))
 - Log stacktrace on `UNKNOWN` status OTLP export error 

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
@@ -378,6 +378,8 @@ class _CustomCollector:
         self, name: str, description: str, attributes: Dict[str, str]
     ) -> InfoMetricFamily:
         """Create an Info Metric Family with list of attributes"""
+        # sanitize the attribute names according to Prometheus rule
+        attributes = {self._sanitize(key): value for key, value in attributes.items()}
         info = InfoMetricFamily(name, description, labels=attributes)
         info.add_metric(labels=list(attributes.keys()), value=attributes)
         return info

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
@@ -379,7 +379,9 @@ class _CustomCollector:
     ) -> InfoMetricFamily:
         """Create an Info Metric Family with list of attributes"""
         # sanitize the attribute names according to Prometheus rule
-        attributes = {self._sanitize(key): value for key, value in attributes.items()}
+        attributes = {
+            self._sanitize(key): value for key, value in attributes.items()
+        }
         info = InfoMetricFamily(name, description, labels=attributes)
         info.add_metric(labels=list(attributes.keys()), value=attributes)
         return info

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -394,7 +394,12 @@ class TestPrometheusMetricReader(TestCase):
         metric_reader = PrometheusMetricReader()
         provider = MeterProvider(
             metric_readers=[metric_reader],
-            resource=Resource({"system.os": "Unix", "system.name": "Prometheus Target Sanitize"}),
+            resource=Resource(
+                {
+                    "system.os": "Unix",
+                    "system.name": "Prometheus Target Sanitize",
+                }
+            ),
         )
         meter = provider.get_meter("getting-started", "0.1.2")
         counter = meter.create_counter("counter")
@@ -403,13 +408,16 @@ class TestPrometheusMetricReader(TestCase):
 
         self.assertEqual(type(prometheus_metric), InfoMetricFamily)
         self.assertEqual(prometheus_metric.name, "target")
-        self.assertEqual(
-            prometheus_metric.documentation, "Target metadata"
-        )
+        self.assertEqual(prometheus_metric.documentation, "Target metadata")
         self.assertTrue(len(prometheus_metric.samples) == 1)
         self.assertEqual(prometheus_metric.samples[0].value, 1)
         self.assertTrue(len(prometheus_metric.samples[0].labels) == 2)
         self.assertTrue("system_os" in prometheus_metric.samples[0].labels)
-        self.assertEqual(prometheus_metric.samples[0].labels["system_os"], "Unix")
+        self.assertEqual(
+            prometheus_metric.samples[0].labels["system_os"], "Unix"
+        )
         self.assertTrue("system_name" in prometheus_metric.samples[0].labels)
-        self.assertEqual(prometheus_metric.samples[0].labels["system_name"], "Prometheus Target Sanitize")
+        self.assertEqual(
+            prometheus_metric.samples[0].labels["system_name"],
+            "Prometheus Target Sanitize",
+        )

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -389,3 +389,27 @@ class TestPrometheusMetricReader(TestCase):
             )
             self.assertNotIn("os", prometheus_metric.samples[0].labels)
             self.assertNotIn("histo", prometheus_metric.samples[0].labels)
+
+    def test_target_info_sanitize(self):
+        metric_reader = PrometheusMetricReader()
+        provider = MeterProvider(
+            metric_readers=[metric_reader],
+            resource=Resource({"system.os": "Unix", "system.name": "Prometheus Target Sanitize"}),
+        )
+        meter = provider.get_meter("getting-started", "0.1.2")
+        counter = meter.create_counter("counter")
+        counter.add(1)
+        prometheus_metric = list(metric_reader._collector.collect())[0]
+
+        self.assertEqual(type(prometheus_metric), InfoMetricFamily)
+        self.assertEqual(prometheus_metric.name, "target")
+        self.assertEqual(
+            prometheus_metric.documentation, "Target metadata"
+        )
+        self.assertTrue(len(prometheus_metric.samples) == 1)
+        self.assertEqual(prometheus_metric.samples[0].value, 1)
+        self.assertTrue(len(prometheus_metric.samples[0].labels) == 2)
+        self.assertTrue("system_os" in prometheus_metric.samples[0].labels)
+        self.assertEqual(prometheus_metric.samples[0].labels["system_os"], "Unix")
+        self.assertTrue("system_name" in prometheus_metric.samples[0].labels)
+        self.assertEqual(prometheus_metric.samples[0].labels["system_name"], "Prometheus Target Sanitize")


### PR DESCRIPTION
# Description

The Prometheus Exporter did not sanitize the info metric.
This might prevent successful scraping from Prometheus when having, for example, dots in an attribute.

Fixes #3571 and #3563

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

- [x] Unit test `test_target_info_sanitize` which checks if a character like a dot `.` in an attribute name is translated to an underscore `_`.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
