### PR TITLE
Pass span id to Sampler

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -1074,6 +1074,8 @@ class Tracer(trace_api.Tracer):
             trace_id = self.id_generator.generate_trace_id()
         else:
             trace_id = parent_span_context.trace_id
+        
+        span_id = self.id_generator.generate_span_id()
 
         # The sampler decides whether to create a real or no-op span at the
         # time of span creation. No-op spans do not record events, and are not
@@ -1082,7 +1084,7 @@ class Tracer(trace_api.Tracer):
         # to include information about the sampling result.
         # The sampler may also modify the parent span context's tracestate
         sampling_result = self.sampler.should_sample(
-            context, trace_id, name, kind, attributes, links
+            context, trace_id, name, kind, attributes, links, span_id=span_id,
         )
 
         trace_flags = (
@@ -1092,7 +1094,7 @@ class Tracer(trace_api.Tracer):
         )
         span_context = trace_api.SpanContext(
             trace_id,
-            self.id_generator.generate_span_id(),
+            span_id,
             is_remote=False,
             trace_flags=trace_flags,
             trace_state=sampling_result.trace_state,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -205,6 +205,7 @@ class Sampler(abc.ABC):
         attributes: Attributes = None,
         links: Sequence["Link"] = None,
         trace_state: "TraceState" = None,
+        span_id: Optional[int] = None,
     ) -> "SamplingResult":
         pass
 
@@ -228,6 +229,7 @@ class StaticSampler(Sampler):
         attributes: Attributes = None,
         links: Sequence["Link"] = None,
         trace_state: "TraceState" = None,
+        span_id: Optional[int] = None,
     ) -> "SamplingResult":
         if self._decision is Decision.DROP:
             attributes = None
@@ -289,6 +291,7 @@ class TraceIdRatioBased(Sampler):
         attributes: Attributes = None,
         links: Sequence["Link"] = None,
         trace_state: "TraceState" = None,
+        span_id: Optional[int] = None,
     ) -> "SamplingResult":
         decision = Decision.DROP
         if trace_id & self.TRACE_ID_LIMIT < self.bound:
@@ -344,6 +347,7 @@ class ParentBased(Sampler):
         attributes: Attributes = None,
         links: Sequence["Link"] = None,
         trace_state: "TraceState" = None,
+        span_id: Optional[int] = None,
     ) -> "SamplingResult":
         parent_span_context = get_current_span(
             parent_context


### PR DESCRIPTION
This proposes a path forward for https://github.com/open-telemetry/opentelemetry-specification/issues/3205.

The idea is that implementers can come up with whatever attribute based scheme they want to use to samples spans. For example:
- Log level equivalent. Put a `'myorg.log_level'` attribute in spans you want to sample and write a custom sampler that samples only above a certain level or samples a ratio of spans depending on the level.
- Sample rate at the span level. Put a `myorg.sample_rate` attribute and spans like in the test I added.

There's a lot of use cases discussed but one in particular I find very useful is:

```
for x in range(100):
    with tracer.start_as_current_span('processing chunk or whatever', attributes={'sample_rate': 0.1}):
        x = 1 + 1 - 1
        with tracer.start_as_current_span('doing subtask in chunk'):
              sleep(x)
```

If you are processing tens (millions?) or "equivalent" chunks you may want to get some idea of long each chunk is taking but you probably don't want telemetry for every single chunk.
In the example above you'd get ~ 10 `'processing chunk or whatever'` spans with their complete subtree (so 10 `'doing subtask in chunk'`).
You could also sample nested loops e.g. to get 10% of the outer loop and 1% of the inner loop.
This won't "break" traces as discussed in the linked issue because any child spans will be of a non-sampled span will also be not sampled (assuming this is wrapped in the ParentBased Sampler).