### PR TITLE
Create a `tracer.decorate` decorator that work with async functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add `Tracer.decorate` to allow decorating a function with a span
+  ([#3595](https://github.com/open-telemetry/opentelemetry-python/pull/3595))
+
 ## Version 1.22.0/0.43b0 (2023-12-15)
 
 - Prometheus exporter sanitize info metric ([#3572](https://github.com/open-telemetry/opentelemetry-python/pull/3572))

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -288,7 +288,7 @@ class Tracer(ABC):
 
     def decorate(
         self,
-        name: str = None,
+        name: str | None = None,
         context: Optional[Context] = None,
         kind: SpanKind = SpanKind.INTERNAL,
         attributes: types.Attributes = None,
@@ -297,7 +297,6 @@ class Tracer(ABC):
         record_exception: bool = True,
         set_status_on_exception: bool = True,
         end_on_exit: bool = True,
-        span_arg_name: str | None = "span",
     ) -> Callable[[Callable[P, R]], Callable[P, R]]:
         """Decorate the function with a span.
 
@@ -328,9 +327,6 @@ class Tracer(ABC):
                 this mechanism if it was previously set manually.
             end_on_exit: Whether to end the span automatically when leaving the
                 context manager.
-            span_arg_name: Lookup for this span in the function's kwargs to pass
-                the span to the function. If None, the span will not be passed
-                to the function.
         """
 
         def __decorator(func: Callable[P, R]) -> Callable[P, R]:
@@ -349,12 +345,7 @@ class Tracer(ABC):
                         record_exception=record_exception,
                         set_status_on_exception=set_status_on_exception,
                         end_on_exit=end_on_exit,
-                    ) as span:
-                        if (
-                            span_arg_name in func.__annotations__
-                            and span_arg_name not in kwargs
-                        ):
-                            kwargs[span_arg_name] = span
+                    ):
                         return await func(*args, **kwargs)
 
             else:
@@ -371,12 +362,7 @@ class Tracer(ABC):
                         record_exception=record_exception,
                         set_status_on_exception=set_status_on_exception,
                         end_on_exit=end_on_exit,
-                    ) as span:
-                        if (
-                            span_arg_name in func.__annotations__
-                            and span_arg_name not in kwargs
-                        ):
-                            kwargs[span_arg_name] = span
+                    ):
                         return func(*args, **kwargs)
 
             return __decorated

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -76,6 +76,7 @@ either implicit or explicit context propagation consistently throughout.
 
 import os
 import typing
+import inspect
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from enum import Enum
@@ -334,7 +335,7 @@ class Tracer(ABC):
 
         def __decorator(func: Callable[P, R]) -> Callable[P, R]:
             _span_name = name or func.__name__
-            if bool(func.__code__.co_flags & 0x80):
+            if inspect.iscoroutinefunction(func):
 
                 @wraps(func)
                 async def __decorated(*args, **kwargs):

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -287,7 +287,7 @@ class Tracer(ABC):
 
     def decorate(
         self,
-        name: str,
+        name: str = None,
         context: Optional[Context] = None,
         kind: SpanKind = SpanKind.INTERNAL,
         attributes: types.Attributes = None,


### PR DESCRIPTION
# Description

As we discussed in #3270, we want to be able to decorate functions with a span.

Currently it's not raising any exceptions, but async functions always reports a near zero span duration due to the result not beeing awaited.

But as context managers can be sync OR async but not both ([@contextlib.asynccontextmanager](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager)), I've added a small method `Tracer.decorate` that do this job.

I'm still not sure about the function name ... Any ideas are welcome :)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Not yet tested, here is my two tests idea :

- [x] Test a sync function decorator.
- [x] Test an async function decorator.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`

I dont think so, I'm in the "this functionality MAY be offered additionally as a separate operation" of [Span creation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span-creation).

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated - nothing to change
