### PR TITLE
Fix typo in exponential bucket aggregation resizing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix typo in exponential bucket aggregation resizing logic
+  ([#3599](https://github.com/open-telemetry/opentelemetry-python/pull/3599))
+
 ## Version 1.22.0/0.43b0 (2023-12-15)
 
-- Prometheus exporter sanitize info metric ([#3572](https://github.com/open-telemetry/opentelemetry-python/pull/3572))
+- Prometheus exporter sanitize info metric
+  ([#3572](https://github.com/open-telemetry/opentelemetry-python/pull/3572))
 - Remove Jaeger exporters
   ([#3554](https://github.com/open-telemetry/opentelemetry-python/pull/3554))
 - Log stacktrace on `UNKNOWN` status OTLP export error 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -993,7 +993,7 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                 previous_buckets.index_start = index
 
             if index > previous_buckets.index_end:
-                span = index - previous_buckets.index_end
+                span = index - previous_buckets.index_start
 
                 if span >= self._max_size:
                     raise Exception("Incorrect merge scale")


### PR DESCRIPTION
# Description

There was an error in the resizing logic of exponential buckets. I found it by comparing it to the JavaScript implementation: https://github.com/open-telemetry/opentelemetry-js/blob/f4b681d4f388ecedaecff03b7c95f460c97a8f6c/packages/sdk-metrics/src/aggregator/ExponentialHistogram.ts#L347-L359

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/3562

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I ran the code in production.


# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
