### PR TITLE
Update ReadableSpan.__init__ to accept a Mapping for attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Allow plain dicts as arguments to `attributes` in `ReadableSpan.__init__`
+  ([#3606](https://github.com/open-telemetry/opentelemetry-python/pull/3606))
+
 ## Version 1.22.0/0.43b0 (2023-12-15)
 
 - Prometheus exporter sanitize info metric ([#3572](https://github.com/open-telemetry/opentelemetry-python/pull/3572))

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -377,7 +377,7 @@ class ReadableSpan:
         self._parent = parent
         self._start_time = start_time
         self._end_time = end_time
-        self._attributes = attributes
+        self._attributes = BoundedAttributes(attributes=attributes)
         self._events = events
         self._links = links
         if resource is None:

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -26,6 +26,7 @@ from unittest import mock
 from unittest.mock import Mock, patch
 
 from opentelemetry import trace as trace_api
+from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.context import Context
 from opentelemetry.sdk import resources, trace
 from opentelemetry.sdk.environment_variables import (
@@ -625,6 +626,10 @@ class TestReadableSpan(unittest.TestCase):
         ]
         span = trace.ReadableSpan("test", events=events)
         self.assertEqual(span.events, tuple(events))
+
+    def test_attributes(self):
+        span = trace.ReadableSpan("test", attributes={'x': 'y'})
+        self.assertIsInstance(span.attributes, BoundedAttributes)
 
 
 class TestSpan(unittest.TestCase):


### PR DESCRIPTION
I'm not sure if I should add this as a test but here's how I discovered the issue:

```python
from opentelemetry import trace
from opentelemetry.sdk.resources import Resource
from opentelemetry.sdk.trace import ReadableSpan
from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans


encode_spans(
    [
        ReadableSpan(
            name='test_span',
            context=trace.SpanContext(
                trace_id=1,
                span_id=1,
                is_remote=False,
            ),
            parent=None,
            resource=Resource(
                attributes={
                    'service.name': 'test_service',
                },
            ),
            attributes={'x': 'y'},
            start_time=1_000_000_000,
            end_time=2_000_000_000,
        )

    ]
)
```

```
Traceback (most recent call last):
  File "/Users/adriangarciabadaracco/GitHub/pydantic-data-platform/test.py", line 6, in <module>
    encode_spans(
  File "/Users/adriangarciabadaracco/GitHub/pydantic-data-platform/.venv/lib/python3.11/site-packages/opentelemetry/exporter/otlp/proto/common/_internal/trace_encoder/__init__.py", line 58, in encode_spans
    resource_spans=_encode_resource_spans(sdk_spans)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/adriangarciabadaracco/GitHub/pydantic-data-platform/.venv/lib/python3.11/site-packages/opentelemetry/exporter/otlp/proto/common/_internal/trace_encoder/__init__.py", line 81, in _encode_resource_spans
    pb2_span = _encode_span(sdk_span)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/adriangarciabadaracco/GitHub/pydantic-data-platform/.venv/lib/python3.11/site-packages/opentelemetry/exporter/otlp/proto/common/_internal/trace_encoder/__init__.py", line 121, in _encode_span
    dropped_attributes_count=sdk_span.dropped_attributes,
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/adriangarciabadaracco/GitHub/pydantic-data-platform/.venv/lib/python3.11/site-packages/opentelemetry/sdk/trace/__init__.py", line 390, in dropped_attributes
    return self._attributes.dropped
           ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'dropped
```

It seems like `encode_spans` is making assumptions about `ReadableSpan` that are not true.
One option would be to update `encode_spans` but given that there is no test for this and they usually will be `BoundedAttributes` I think updating `ReadableSpan` makes more sense.