### PR TITLE
Fix flush exception thrown when LoggerProvider not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix flush error when no LoggerProvider configured for LoggingHandler
+  ([#3608](https://github.com/open-telemetry/opentelemetry-python/pull/3608))
 - Fix `OTLPMetricExporter` ignores `preferred_aggregation` property
   ([#3603](https://github.com/open-telemetry/opentelemetry-python/pull/3603))
 - Logs: set `observed_timestamp` field

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -553,9 +553,10 @@ class LoggingHandler(logging.Handler):
 
     def flush(self) -> None:
         """
-        Flushes the logging output.
+        Flushes the logging output. Skip flushing if logger is NoOp.
         """
-        self._logger_provider.force_flush()
+        if not isinstance(self._logger, NoOpLogger):
+            self._logger_provider.force_flush()
 
 
 class Logger(APILogger):

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -84,7 +84,7 @@ class TestLoggingHandler(unittest.TestCase):
         no_op_logger_provider = NoOpLoggerProvider()
         no_op_logger_provider.force_flush = Mock()
 
-        logger = get_logger(logger_provider=NoOpLoggerProvider())
+        logger = get_logger(logger_provider=no_op_logger_provider)
 
         with self.assertLogs(level=logging.WARNING):
             logger.warning("Warning message")

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -79,6 +79,12 @@ class TestLoggingHandler(unittest.TestCase):
             logger.warning("Warning message")
         handler_mock._translate.assert_not_called()
 
+    def test_log_flush_noop(self):
+        emitter_provider_mock = Mock(spec=NoOpLoggerProvider)
+        logger = get_logger(logger_provider=emitter_provider_mock)
+        with self.assertLogs(level=logging.WARNING):
+            logger.warning("Warning message")
+
     def test_log_record_no_span_context(self):
         emitter_provider_mock = Mock(spec=LoggerProvider)
         emitter_mock = APIGetLogger(

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -80,10 +80,17 @@ class TestLoggingHandler(unittest.TestCase):
         handler_mock._translate.assert_not_called()
 
     def test_log_flush_noop(self):
-        emitter_provider_mock = Mock(spec=NoOpLoggerProvider)
-        logger = get_logger(logger_provider=emitter_provider_mock)
+
+        no_op_logger_provider = NoOpLoggerProvider()
+        no_op_logger_provider.force_flush = Mock()
+
+        logger = get_logger(logger_provider=NoOpLoggerProvider())
+
         with self.assertLogs(level=logging.WARNING):
             logger.warning("Warning message")
+
+        logger.handlers[0].flush()
+        no_op_logger_provider.force_flush.assert_not_called()
 
     def test_log_record_no_span_context(self):
         emitter_provider_mock = Mock(spec=LoggerProvider)


### PR DESCRIPTION
# Description

I found #3423 fixing a similar issue and reused most of the idea. I preferred to write a test using the proper spec `NoOpLoggerProvider` instead of using the generic `LogProvider` and mocking the `force_flush` method.

I checked for other uses of `logger_provider` but didn't find any.

Fixes #3602 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit test

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated

Happy new year! 🎉 🎆 🍰 