### PR TITLE
Handle HTTP 2XX responses as successful in OTLP exporters

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -185,7 +185,12 @@ class OTLPExporterMixin(
 
         if parsed_url.netloc:
             self._endpoint = parsed_url.netloc
-
+            if parsed_url.path:
+                logger.warning(
+                    f"Endpoint set to {self._endpoint}, which differs from the "
+                    f"provided endpoint {endpoint}. If you're trying to configure "
+                    f"an HTTP endpoint, please ensure you're using the correct exporter."
+                )
         self._headers = headers or environ.get(OTEL_EXPORTER_OTLP_HEADERS)
         if isinstance(self._headers, str):
             temp_headers = parse_env_headers(self._headers)

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -146,7 +146,7 @@ class OTLPLogExporter(LogExporter):
 
             resp = self._export(serialized_data)
             # pylint: disable=no-else-return
-            if resp.status_code in (200, 202):
+            if resp.ok:
                 return LogExportResult.SUCCESS
             elif self._retryable(resp):
                 _logger.warning(

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
@@ -178,7 +178,7 @@ class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
 
             resp = self._export(serialized_data.SerializeToString())
             # pylint: disable=no-else-return
-            if resp.status_code in (200, 202):
+            if resp.ok:
                 return MetricExportResult.SUCCESS
             elif self._retryable(resp):
                 _logger.warning(

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -144,7 +144,7 @@ class OTLPSpanExporter(SpanExporter):
 
             resp = self._export(serialized_data)
             # pylint: disable=no-else-return
-            if resp.status_code in (200, 202):
+            if resp.ok:
                 return SpanExportResult.SUCCESS
             elif self._retryable(resp):
                 _logger.warning(


### PR DESCRIPTION
# Description

This change modifies the OTLP exporters to treat HTTP 204 responses as successful. Previously, these were logged as errors and returned an error code, even though a 204 status code indicates a successful request. This change prevents unnecessary pollution of the logs.

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/3621

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this change locally by using the modified code and verified that it works as expected. Specifically, I sent logs to the Grafana OTLP endpoint and confirmed that a 204 status code no longer results in an error message or error code.

[x] Test A: Sent logs to Grafana OTLP endpoint and confirmed correct behavior

# Does This PR Require a Contrib Repo Change?

- [ X] No.

# Checklist:

- [ X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
