### PR TITLE
Handle HTTP 2XX responses as successful in OTLP exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Handle HTTP 2XX responses as successful in OTLP exporters
+  ([#3623](https://github.com/open-telemetry/opentelemetry-python/pull/3623))
+
 ## Version 1.22.0/0.43b0 (2023-12-15)
 
-- Prometheus exporter sanitize info metric ([#3572](https://github.com/open-telemetry/opentelemetry-python/pull/3572))
+- Prometheus exporter sanitize info metric
+  ([#3572](https://github.com/open-telemetry/opentelemetry-python/pull/3572))
 - Remove Jaeger exporters
   ([#3554](https://github.com/open-telemetry/opentelemetry-python/pull/3554))
 - Log stacktrace on `UNKNOWN` status OTLP export error 

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -146,7 +146,7 @@ class OTLPLogExporter(LogExporter):
 
             resp = self._export(serialized_data)
             # pylint: disable=no-else-return
-            if resp.status_code in (200, 202):
+            if resp.ok:
                 return LogExportResult.SUCCESS
             elif self._retryable(resp):
                 _logger.warning(

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
@@ -178,7 +178,7 @@ class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
 
             resp = self._export(serialized_data.SerializeToString())
             # pylint: disable=no-else-return
-            if resp.status_code in (200, 202):
+            if resp.ok:
                 return MetricExportResult.SUCCESS
             elif self._retryable(resp):
                 _logger.warning(

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -144,7 +144,7 @@ class OTLPSpanExporter(SpanExporter):
 
             resp = self._export(serialized_data)
             # pylint: disable=no-else-return
-            if resp.status_code in (200, 202):
+            if resp.ok:
                 return SpanExportResult.SUCCESS
             elif self._retryable(resp):
                 _logger.warning(

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
@@ -478,7 +478,7 @@ class TestOTLPMetricExporter(TestCase):
             )
 
     @patch.object(OTLPMetricExporter, "_export", return_value=Mock(ok=True))
-    def test_2XX_status_code(self, mock_otlp_metric_exporter):
+    def test_2xx_status_code(self, mock_otlp_metric_exporter):
         """
         Test that any HTTP 2XX code returns a successful result
         """

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
@@ -15,7 +15,7 @@
 from logging import WARNING
 from os import environ
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, Mock, patch
 
 from requests import Session
 from requests.models import Response
@@ -476,3 +476,14 @@ class TestOTLPMetricExporter(TestCase):
                 OTLPMetricExporter()._preferred_aggregation[Histogram],
                 ExplicitBucketHistogramAggregation,
             )
+
+    @patch.object(OTLPMetricExporter, "_export", return_value=Mock(ok=True))
+    def test_2XX_status_code(self, mock_otlp_metric_exporter):
+        """
+        Test that any HTTP 2XX code returns a successful result
+        """
+
+        self.assertEqual(
+            OTLPMetricExporter().export(MagicMock()),
+            MetricExportResult.SUCCESS,
+        )

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
@@ -265,7 +265,7 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         return [log1, log2, log3, log4]
 
     @patch.object(OTLPLogExporter, "_export", return_value=Mock(ok=True))
-    def test_2XX_status_code(self, mock_otlp_metric_exporter):
+    def test_2xx_status_code(self, mock_otlp_metric_exporter):
         """
         Test that any HTTP 2XX code returns a successful result
         """

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
@@ -16,7 +16,7 @@
 
 import unittest
 from typing import List
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import requests
 import responses
@@ -34,6 +34,7 @@ from opentelemetry.exporter.otlp.proto.http._log_exporter import (
 from opentelemetry.exporter.otlp.proto.http.version import __version__
 from opentelemetry.sdk._logs import LogData
 from opentelemetry.sdk._logs import LogRecord as SDKLogRecord
+from opentelemetry.sdk._logs.export import LogExportResult
 from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_CERTIFICATE,
     OTEL_EXPORTER_OTLP_COMPRESSION,
@@ -262,3 +263,13 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         )
 
         return [log1, log2, log3, log4]
+
+    @patch.object(OTLPLogExporter, "_export", return_value=Mock(ok=True))
+    def test_2XX_status_code(self, mock_otlp_metric_exporter):
+        """
+        Test that any HTTP 2XX code returns a successful result
+        """
+
+        self.assertEqual(
+            OTLPLogExporter().export(MagicMock()), LogExportResult.SUCCESS
+        )

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
@@ -242,7 +242,7 @@ class TestOTLPSpanExporter(unittest.TestCase):
         mock_sleep.assert_called_once_with(1)
 
     @patch.object(OTLPSpanExporter, "_export", return_value=Mock(ok=True))
-    def test_2XX_status_code(self, mock_otlp_metric_exporter):
+    def test_2xx_status_code(self, mock_otlp_metric_exporter):
         """
         Test that any HTTP 2XX code returns a successful result
         """

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
@@ -14,7 +14,7 @@
 
 import unittest
 from collections import OrderedDict
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import requests
 import responses
@@ -42,6 +42,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
 )
 from opentelemetry.sdk.trace import _Span
+from opentelemetry.sdk.trace.export import SpanExportResult
 
 OS_ENV_ENDPOINT = "os.env.base"
 OS_ENV_CERTIFICATE = "os/env/base.crt"
@@ -239,3 +240,13 @@ class TestOTLPSpanExporter(unittest.TestCase):
 
         exporter.export([span])
         mock_sleep.assert_called_once_with(1)
+
+    @patch.object(OTLPSpanExporter, "_export", return_value=Mock(ok=True))
+    def test_2XX_status_code(self, mock_otlp_metric_exporter):
+        """
+        Test that any HTTP 2XX code returns a successful result
+        """
+
+        self.assertEqual(
+            OTLPSpanExporter().export(MagicMock()), SpanExportResult.SUCCESS
+        )


### PR DESCRIPTION
# Description

This change modifies the OTLP exporters to treat HTTP 204 responses as successful. Previously, these were logged as errors and returned an error code, even though a 204 status code indicates a successful request. This change prevents unnecessary pollution of the logs.

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/3621

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this change locally by using the modified code and verified that it works as expected. Specifically, I sent logs to the Grafana OTLP endpoint and confirmed that a 204 status code no longer results in an error message or error code.

[x] Test A: Sent logs to Grafana OTLP endpoint and confirmed correct behavior

# Does This PR Require a Contrib Repo Change?

- [ X] No.

# Checklist:

- [ X] Followed the style guidelines of this project

