### PR TITLE
Make `tracer.start_as_current_span()` decorator work with async functions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -166,7 +166,7 @@ notes=FIXME,
 # List of decorators that produce context managers, such as
 # contextlib.contextmanager. Add to this list to register other decorators that
 # produce valid context managers.
-contextmanager-decorators=contextlib.contextmanager
+contextmanager-decorators=contextlib.contextmanager, agnosticcontextmanager
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular

--- a/.pylintrc
+++ b/.pylintrc
@@ -166,7 +166,7 @@ notes=FIXME,
 # List of decorators that produce context managers, such as
 # contextlib.contextmanager. Add to this list to register other decorators that
 # produce valid context managers.
-contextmanager-decorators=contextlib.contextmanager, agnosticcontextmanager
+contextmanager-decorators=contextlib.contextmanager, _agnosticcontextmanager
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Make `tracer.start_as_current_span()` decorator work with async functions
+  ([#3633](https://github.com/open-telemetry/opentelemetry-python/pull/3633))
 - Fix python 3.12 deprecation warning
   ([#3751](https://github.com/open-telemetry/opentelemetry-python/pull/3751))
 - bump mypy to 0.982
@@ -46,8 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3639](https://github.com/open-telemetry/opentelemetry-python/pull/3639))
 - Upgrade markupsafe, Flask and related dependencies to dev and test
   environments ([#3609](https://github.com/open-telemetry/opentelemetry-python/pull/3609))
-- Make `tracer.start_as_current_span()` decorator work with async functions
-  ([#3633](https://github.com/open-telemetry/opentelemetry-python/pull/3633))
 - Handle HTTP 2XX responses as successful in OTLP exporters
   ([#3623](https://github.com/open-telemetry/opentelemetry-python/pull/3623))
 - Improve Resource Detector timeout messaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3639](https://github.com/open-telemetry/opentelemetry-python/pull/3639))
 - Upgrade markupsafe, Flask and related dependencies to dev and test
   environments ([#3609](https://github.com/open-telemetry/opentelemetry-python/pull/3609))
-=======
-- Fix `Tracer.start_as_current_span` to allow decorating a function with a span
+- Make `tracer.start_as_current_span()` decorator work with async functions
   ([#3633](https://github.com/open-telemetry/opentelemetry-python/pull/3633))
->>>>>>> 9baa98d7 (docs: changelog)
 - Handle HTTP 2XX responses as successful in OTLP exporters
   ([#3623](https://github.com/open-telemetry/opentelemetry-python/pull/3623))
 - Improve Resource Detector timeout messaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3639](https://github.com/open-telemetry/opentelemetry-python/pull/3639))
 - Upgrade markupsafe, Flask and related dependencies to dev and test
   environments ([#3609](https://github.com/open-telemetry/opentelemetry-python/pull/3609))
+=======
+- Fix `Tracer.start_as_current_span` to allow decorating a function with a span
+  ([#3633](https://github.com/open-telemetry/opentelemetry-python/pull/3633))
+>>>>>>> 9baa98d7 (docs: changelog)
 - Handle HTTP 2XX responses as successful in OTLP exporters
   ([#3623](https://github.com/open-telemetry/opentelemetry-python/pull/3623))
 - Improve Resource Detector timeout messaging

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -434,7 +434,7 @@ class ProxyTracer(Tracer):
     @contextmanager  # type: ignore
     def start_as_current_span(self, *args, **kwargs) -> Iterator[Span]:
         with self._tracer.start_as_current_span(*args, **kwargs) as span:  # type: ignore
-            yield span
+            yield span  # type: ignore
 
 
 class NoOpTracer(Tracer):

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -74,9 +74,6 @@ either implicit or explicit context propagation consistently throughout.
 """
 
 
-import asyncio
-import contextlib
-import functools
 import os
 import typing
 from abc import ABC, abstractmethod
@@ -114,99 +111,9 @@ from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util import types
 from opentelemetry.util._once import Once
 from opentelemetry.util._providers import _load_provider
+from opentelemetry.util._decorator import _agnosticcontextmanager
 
 logger = getLogger(__name__)
-
-
-class _AgnosticContextManager(
-    contextlib.AbstractContextManager,
-    contextlib.ContextDecorator,
-):
-    """A reimplementation of contextlib._GeneratorContextManager that supports decorating async functions.
-
-    All credit goes to the CPython team for the original implementation.
-    https://github.com/python/cpython/blob/3.12/Lib/contextlib.py
-    """
-
-    def __init__(self, func, args, kwds):
-        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L104"""
-        self.gen = func(*args, **kwds)
-        self.func, self.args, self.kwds = func, args, kwds
-        doc = getattr(func, "__doc__", None)
-        if doc is None:
-            doc = type(self).__doc__
-        self.__doc__ = doc
-
-    def _recreate_cm(self):
-        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L122C9-L122C21"""
-        return self.__class__(self.func, self.args, self.kwds)
-
-    def __enter__(self):
-        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L132"""
-        del self.args, self.kwds, self.func
-        try:
-            return next(self.gen)
-        except StopIteration:
-            raise RuntimeError("generator didn't yield") from None
-
-    def __exit__(self, typ, value, traceback):
-        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L141"""
-        if typ is None:
-            try:
-                next(self.gen)
-            except StopIteration:
-                return False
-            raise RuntimeError("generator didn't stop")
-        if value is None:
-            value = typ()
-        try:
-            self.gen.throw(typ, value, traceback)
-        except StopIteration as exc:
-            return exc is not value
-        except RuntimeError as exc:
-            if exc is value:
-                exc.__traceback__ = traceback
-                return False
-            if isinstance(value, StopIteration) and exc.__cause__ is value:
-                exc.__traceback__ = traceback
-                return False
-            raise
-        except BaseException as exc:
-            if exc is not value:
-                raise
-            exc.__traceback__ = traceback
-            return False
-        raise RuntimeError("generator didn't stop after throw()")
-
-    def __call__(self, func):
-        """Mixing contextlib.ContextDecorator.__call__ and contextlib.AsyncContextDecorator.__call__
-
-        https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L77
-        https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L93
-        """
-        if asyncio.iscoroutinefunction(func):
-
-            @functools.wraps(func)
-            async def async_wrapper(*args, **kwargs):
-                with self._recreate_cm():
-                    return await func(*args, **kwargs)
-
-            return async_wrapper
-
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            with self._recreate_cm():
-                return func(*args, **kwargs)
-
-        return wrapper
-
-
-def _agnosticcontextmanager(func):
-    @functools.wraps(func)
-    def helper(*args, **kwds):
-        return _AgnosticContextManager(func, args, kwds)
-
-    return helper
 
 
 class _LinkBase(ABC):

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -109,9 +109,9 @@ from opentelemetry.trace.span import (
 )
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util import types
+from opentelemetry.util._decorator import _agnosticcontextmanager
 from opentelemetry.util._once import Once
 from opentelemetry.util._providers import _load_provider
-from opentelemetry.util._decorator import _agnosticcontextmanager
 
 logger = getLogger(__name__)
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -77,7 +77,6 @@ either implicit or explicit context propagation consistently throughout.
 import os
 import typing
 from abc import ABC, abstractmethod
-from contextlib import contextmanager
 from enum import Enum
 from logging import getLogger
 from typing import Iterator, Optional, Sequence, cast
@@ -544,7 +543,7 @@ def get_tracer_provider() -> TracerProvider:
     return cast("TracerProvider", _TRACER_PROVIDER)
 
 
-@contextmanager
+@_agnosticcontextmanager
 def use_span(
     span: Span,
     end_on_exit: bool = False,

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -431,7 +431,7 @@ class ProxyTracer(Tracer):
     def start_span(self, *args, **kwargs) -> Span:  # type: ignore
         return self._tracer.start_span(*args, **kwargs)  # type: ignore
 
-    @contextmanager  # type: ignore
+    @_agnosticcontextmanager  # type: ignore
     def start_as_current_span(self, *args, **kwargs) -> Iterator[Span]:
         with self._tracer.start_as_current_span(*args, **kwargs) as span:  # type: ignore
             yield span

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -434,7 +434,7 @@ class ProxyTracer(Tracer):
     @contextmanager  # type: ignore
     def start_as_current_span(self, *args, **kwargs) -> Iterator[Span]:
         with self._tracer.start_as_current_span(*args, **kwargs) as span:  # type: ignore
-            yield span  # type: ignore
+            yield span
 
 
 class NoOpTracer(Tracer):

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -118,7 +118,9 @@ from opentelemetry.util._providers import _load_provider
 logger = getLogger(__name__)
 
 
-class _AgnosticContextManager(contextlib._GeneratorContextManager):
+class _AgnosticContextManager(
+    contextlib._GeneratorContextManager
+):  # pylint: disable=protected-access
     def __call__(self, func):
         if asyncio.iscoroutinefunction(func):
 
@@ -128,14 +130,13 @@ class _AgnosticContextManager(contextlib._GeneratorContextManager):
                     return await func(*args, **kwargs)
 
             return async_wrapper
-        else:
 
-            @functools.wraps(func)
-            def wrapper(*args, **kwargs):
-                with self._recreate_cm():
-                    return func(*args, **kwargs)
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with self._recreate_cm():
+                return func(*args, **kwargs)
 
-            return wrapper
+        return wrapper
 
 
 def agnosticcontextmanager(func):

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -15,7 +15,7 @@
 import asyncio
 import contextlib
 import functools
-from typing import Awaitable, Callable, Iterator, TypeVar, Union
+from typing import Awaitable, Callable, Generic, Iterator, TypeVar, Union
 
 R = TypeVar("R")  # Return type
 P = TypeVar("P")  # Generic type for all arguments
@@ -24,7 +24,7 @@ Pkwargs = TypeVar("Pkwargs")  # Generic type for arguments
 
 
 class _AgnosticContextManager(
-    contextlib._GeneratorContextManager[R]
+    contextlib._GeneratorContextManager, Generic[R]
 ):  # pylint: disable=protected-access
     """Context manager that can decorate both async and sync functions.
 

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -15,19 +15,17 @@
 import asyncio
 import contextlib
 import functools
-from typing import TYPE_CHECKING, Awaitable, Callable, Iterator, Union
+from typing import Awaitable, Callable, Iterator, TypeVar, Union
+
+R = TypeVar("R")  # Return type
+P = TypeVar("P")  # Generic type for all arguments
+Pargs = TypeVar("Pargs")  # Generic type for arguments
+Pkwargs = TypeVar("Pkwargs")  # Generic type for arguments
 
 
-if TYPE_CHECKING:
-    from typing import TypeVar
-
-    R = TypeVar("R")  # Return type
-    P = TypeVar("P")  # Generic type for all arguments
-    Pargs = TypeVar("Pargs")  # Generic type for arguments
-    Pkwargs = TypeVar("Pkwargs")  # Generic type for arguments
-
-
-class _AgnosticContextManager(contextlib._GeneratorContextManager[R]):
+class _AgnosticContextManager(
+    contextlib._GeneratorContextManager[R]
+):  # pylint: disable=protected-access
     def __call__(  # type: ignore
         self, func: Callable[..., Union[R, Awaitable[R]]]
     ) -> Callable[..., Union[R, Awaitable[R]]]:

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -36,14 +36,7 @@ class _AgnosticContextManager(
                     return await func(*args, **kwargs)  # type: ignore
 
             return async_wrapper
-        else:
-
-            @functools.wraps(func)
-            def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-                with self._recreate_cm():  # type: ignore
-                    return func(*args, **kwargs)  # type: ignore
-
-            return wrapper
+        return super().__call__(func)
 
 
 def _agnosticcontextmanager(

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -15,7 +15,7 @@
 import asyncio
 import contextlib
 import functools
-from typing import Awaitable, Callable, Generic, Iterator, TypeVar, Union
+from typing import Coroutine, Callable, Generic, Iterator, TypeVar, Union
 import typing
 
 R = TypeVar("R")  # Return type
@@ -41,8 +41,8 @@ class _AgnosticContextManager(
     """
 
     def __call__(  # type: ignore
-        self, func: Callable["P", Union[R, Awaitable[R]]]
-    ) -> Callable["P", Union[R, Awaitable[R]]]:
+        self, func: Callable["P", Union[R, Coroutine[None, None, R]]]
+    ) -> Callable["P", Union[R, Coroutine[None, None, R]]]:
         if asyncio.iscoroutinefunction(func):
 
             @functools.wraps(func)

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -76,6 +76,6 @@ def _agnosticcontextmanager(
 ) -> "Callable[P, _AgnosticContextManager[R]]":
     @functools.wraps(func)
     def helper(*args: Pargs, **kwargs: Pkwargs) -> _AgnosticContextManager[R]:
-        return _AgnosticContextManager(func, args, kwargs)  # type: ignore
+        return _AgnosticContextManager(func, args, kwargs)
 
     return helper

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -28,7 +28,7 @@ class _AgnosticContextManager(
 ):  # pylint: disable=protected-access
     """Context manager that can decorate both async and sync functions.
 
-    This is an overriden version of the contextlib._GeneratorContextManager
+    This is an overridden version of the contextlib._GeneratorContextManager
     class that will decorate async functions with an async context manager
     to end the span AFTER the entire async function coroutine finishes.
 

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -23,9 +23,10 @@ R = TypeVar("R")  # Return type
 Pargs = TypeVar("Pargs")  # Generic type for arguments
 Pkwargs = TypeVar("Pkwargs")  # Generic type for arguments
 
-if typing.TYPE_CHECKING:
-    if hasattr(typing, "ParamSpec"):
-        P = typing.ParamSpec("P")  # Generic type for all arguments
+if hasattr(typing, "ParamSpec"):
+    # only available in python 3.10+
+    # https://peps.python.org/pep-0612/
+    P = typing.ParamSpec("P")  # Generic type for all arguments
 
 
 class _AgnosticContextManager(
@@ -54,8 +55,8 @@ class _AgnosticContextManager(
 
 
 def _agnosticcontextmanager(
-    func: Callable["P", Iterator[R]]
-) -> Callable["P", _AgnosticContextManager[R]]:
+    func: "Callable[P, Iterator[R]]"
+) -> "Callable[P, _AgnosticContextManager[R]]":
     @functools.wraps(func)
     def helper(*args: Pargs, **kwargs: Pkwargs) -> _AgnosticContextManager[R]:
         return _AgnosticContextManager(func, args, kwargs)  # type: ignore

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -1,0 +1,123 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import contextlib
+import functools
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    ParamSpec,
+    TypeVar,
+    cast,
+    ParamSpecKwargs,
+    ParamSpecArgs,
+)
+
+P = ParamSpec("P")
+R = TypeVar("R")
+A = ParamSpecArgs("ARGS")
+K = ParamSpecKwargs("KWARGS")
+
+class _AgnosticContextManager(
+    contextlib.AbstractContextManager,
+    contextlib.ContextDecorator,
+):
+    """A reimplementation of contextlib._GeneratorContextManager that supports decorating async functions.
+
+    All credit goes to the CPython team for the original implementation.
+    https://github.com/python/cpython/blob/3.12/Lib/contextlib.py
+    """
+
+    def __init__(self, func: Callable[P, R], args: A, kwds: K) -> None:
+        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L104"""
+        self.gen = func(*args, **kwds)
+        self.func, self.args, self.kwds = func, args, kwds
+        doc = getattr(func, "__doc__", None)
+        if doc is None:
+            doc = type(self).__doc__
+        self.__doc__ = doc
+
+    def _recreate_cm(self) -> "_AgnosticContextManager":
+        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L122C9-L122C21"""
+        return self.__class__(self.func, self.args, self.kwds)
+
+    def __enter__(self):
+        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L132"""
+        del self.args, self.kwds, self.func
+        try:
+            return next(self.gen)
+        except StopIteration:
+            raise RuntimeError("generator didn't yield") from None
+
+    def __exit__(self, typ, value, traceback):
+        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L141"""
+        if typ is None:
+            try:
+                next(self.gen)
+            except StopIteration:
+                return False
+            raise RuntimeError("generator didn't stop")
+        if value is None:
+            value = typ()
+        try:
+            self.gen.throw(typ, value, traceback)
+        except StopIteration as exc:
+            return exc is not value
+        except RuntimeError as exc:
+            if exc is value:
+                exc.__traceback__ = traceback
+                return False
+            if isinstance(value, StopIteration) and exc.__cause__ is value:
+                exc.__traceback__ = traceback
+                return False
+            raise
+        except BaseException as exc:
+            if exc is not value:
+                raise
+            exc.__traceback__ = traceback
+            return False
+        raise RuntimeError("generator didn't stop after throw()")
+
+    def __call__(self, func):
+        """Mixing contextlib.ContextDecorator.__call__ and contextlib.AsyncContextDecorator.__call__
+
+        https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L77
+        https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L93
+        """
+        if asyncio.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                with self._recreate_cm():
+                    return await func(*args, **kwargs)
+
+            return async_wrapper
+
+        @functools.wraps(func)
+        def wrapper(*args: list[Any], **kwargs: dict[str, Any]) -> Any:
+            with self._recreate_cm():
+                return func(*args, **kwargs)
+
+        return wrapper
+
+
+def _agnosticcontextmanager(func: Callable[P, R]) -> Callable[P, R]:
+    @functools.wraps(func)
+    def helper(*args, **kwds) -> Callable[P, R]:
+        return _AgnosticContextManager(func, args, kwds)
+
+    return helper

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -20,16 +20,14 @@ from typing import TYPE_CHECKING, Awaitable, Callable, Iterator, Union
 
 if TYPE_CHECKING:
     from typing import TypeVar
+
     R = TypeVar("R")  # Return type
     P = TypeVar("P")  # Generic type for all arguments
     Pargs = TypeVar("Pargs")  # Generic type for arguments
     Pkwargs = TypeVar("Pkwargs")  # Generic type for arguments
 
 
-class _AgnosticContextManager(
-    contextlib._GeneratorContextManager[R]
-):
-
+class _AgnosticContextManager(contextlib._GeneratorContextManager[R]):
     def __call__(  # type: ignore
         self, func: Callable[..., Union[R, Awaitable[R]]]
     ) -> Callable[..., Union[R, Awaitable[R]]]:

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -42,6 +42,17 @@ class _AgnosticContextManager(
     https://github.com/open-telemetry/opentelemetry-python/pull/3633
     """
 
+    def __enter__(self) -> R:
+        """Reimplementing __enter__ to avoid the type error.
+        
+        The original __enter__ method returns Any type, but we want to return R.
+        """
+        del self.args, self.kwds, self.func
+        try:
+            return next(self.gen)
+        except StopIteration:
+            raise RuntimeError("generator didn't yield") from None
+
     def __call__(self, func: V) -> V:
         if asyncio.iscoroutinefunction(func):
 

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -26,6 +26,16 @@ Pkwargs = TypeVar("Pkwargs")  # Generic type for arguments
 class _AgnosticContextManager(
     contextlib._GeneratorContextManager[R]
 ):  # pylint: disable=protected-access
+    """Context manager that can decorate both async and sync functions.
+
+    This is an overriden version of the contextlib._GeneratorContextManager
+    class that will decorate async functions with an async context manager
+    to end the span AFTER the entire async function coroutine finishes.
+
+    Else it will report near zero spans durations for async functions.
+    https://github.com/open-telemetry/opentelemetry-python/pull/3633
+    """
+
     def __call__(  # type: ignore
         self, func: Callable[..., Union[R, Awaitable[R]]]
     ) -> Callable[..., Union[R, Awaitable[R]]]:

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -47,9 +47,9 @@ class _AgnosticContextManager(
 
         The original __enter__ method returns Any type, but we want to return R.
         """
-        del self.args, self.kwds, self.func
+        del self.args, self.kwds, self.func  # type: ignore
         try:
-            return next(self.gen)
+            return next(self.gen)  # type: ignore
         except StopIteration:
             raise RuntimeError("generator didn't yield") from None
 

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -15,109 +15,42 @@
 import asyncio
 import contextlib
 import functools
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Coroutine,
-    ParamSpec,
-    TypeVar,
-    cast,
-    ParamSpecKwargs,
-    ParamSpecArgs,
-)
+from typing import Awaitable, Callable, ParamSpec, TypeVar, Iterator
 
 P = ParamSpec("P")
 R = TypeVar("R")
-A = ParamSpecArgs("ARGS")
-K = ParamSpecKwargs("KWARGS")
+
 
 class _AgnosticContextManager(
-    contextlib.AbstractContextManager,
-    contextlib.ContextDecorator,
+    contextlib._GeneratorContextManager[R]
 ):
-    """A reimplementation of contextlib._GeneratorContextManager that supports decorating async functions.
 
-    All credit goes to the CPython team for the original implementation.
-    https://github.com/python/cpython/blob/3.12/Lib/contextlib.py
-    """
-
-    def __init__(self, func: Callable[P, R], args: A, kwds: K) -> None:
-        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L104"""
-        self.gen = func(*args, **kwds)
-        self.func, self.args, self.kwds = func, args, kwds
-        doc = getattr(func, "__doc__", None)
-        if doc is None:
-            doc = type(self).__doc__
-        self.__doc__ = doc
-
-    def _recreate_cm(self) -> "_AgnosticContextManager":
-        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L122C9-L122C21"""
-        return self.__class__(self.func, self.args, self.kwds)
-
-    def __enter__(self):
-        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L132"""
-        del self.args, self.kwds, self.func
-        try:
-            return next(self.gen)
-        except StopIteration:
-            raise RuntimeError("generator didn't yield") from None
-
-    def __exit__(self, typ, value, traceback):
-        """https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L141"""
-        if typ is None:
-            try:
-                next(self.gen)
-            except StopIteration:
-                return False
-            raise RuntimeError("generator didn't stop")
-        if value is None:
-            value = typ()
-        try:
-            self.gen.throw(typ, value, traceback)
-        except StopIteration as exc:
-            return exc is not value
-        except RuntimeError as exc:
-            if exc is value:
-                exc.__traceback__ = traceback
-                return False
-            if isinstance(value, StopIteration) and exc.__cause__ is value:
-                exc.__traceback__ = traceback
-                return False
-            raise
-        except BaseException as exc:
-            if exc is not value:
-                raise
-            exc.__traceback__ = traceback
-            return False
-        raise RuntimeError("generator didn't stop after throw()")
-
-    def __call__(self, func):
-        """Mixing contextlib.ContextDecorator.__call__ and contextlib.AsyncContextDecorator.__call__
-
-        https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L77
-        https://github.com/python/cpython/blob/3.12/Lib/contextlib.py#L93
-        """
+    def __call__(  # type: ignore
+        self, func: Callable[P, R | Awaitable[R]]
+    ) -> Callable[P, R | Awaitable[R]]:
         if asyncio.iscoroutinefunction(func):
 
             @functools.wraps(func)
-            async def async_wrapper(*args, **kwargs):
-                with self._recreate_cm():
-                    return await func(*args, **kwargs)
+            async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+                with self._recreate_cm():  # type: ignore
+                    return await func(*args, **kwargs)  # type: ignore
 
             return async_wrapper
+        else:
 
-        @functools.wraps(func)
-        def wrapper(*args: list[Any], **kwargs: dict[str, Any]) -> Any:
-            with self._recreate_cm():
-                return func(*args, **kwargs)
+            @functools.wraps(func)
+            def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+                with self._recreate_cm():  # type: ignore
+                    return func(*args, **kwargs)  # type: ignore
 
-        return wrapper
+            return wrapper
 
 
-def _agnosticcontextmanager(func: Callable[P, R]) -> Callable[P, R]:
+def _agnosticcontextmanager(
+    func: Callable[P, Iterator[R]]
+) -> Callable[P, _AgnosticContextManager[R]]:
     @functools.wraps(func)
-    def helper(*args, **kwds) -> Callable[P, R]:
-        return _AgnosticContextManager(func, args, kwds)
+    def helper(*args: P.args, **kwargs: P.kwargs) -> _AgnosticContextManager[R]:
+        return _AgnosticContextManager(func, args, kwargs)  # type: ignore
 
     return helper

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -15,8 +15,8 @@
 import asyncio
 import contextlib
 import functools
-from typing import Callable, Generic, Iterator, TypeVar
 import typing
+from typing import Callable, Generic, Iterator, TypeVar
 
 V = TypeVar("V")
 R = TypeVar("R")  # Return type
@@ -44,7 +44,7 @@ class _AgnosticContextManager(
 
     def __enter__(self) -> R:
         """Reimplementing __enter__ to avoid the type error.
-        
+
         The original __enter__ method returns Any type, but we want to return R.
         """
         del self.args, self.kwds, self.func
@@ -66,7 +66,7 @@ class _AgnosticContextManager(
 
 
 def _agnosticcontextmanager(
-    func: "Callable[P, Iterator[R]]"
+    func: "Callable[P, Iterator[R]]",
 ) -> "Callable[P, _AgnosticContextManager[R]]":
     @functools.wraps(func)
     def helper(*args: Pargs, **kwargs: Pkwargs) -> _AgnosticContextManager[R]:

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -39,6 +39,12 @@ class _AgnosticContextManager(
     to end the span AFTER the entire async function coroutine finishes.
 
     Else it will report near zero spans durations for async functions.
+
+    We are overriding the contextlib._GeneratorContextManager class as
+    reimplementing it is a lot of code to maintain and this class (even if it's
+    marked as protected) doesn't seems like to be evolving a lot.
+
+    For more information, see:
     https://github.com/open-telemetry/opentelemetry-python/pull/3633
     """
 

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -15,9 +15,10 @@
 import asyncio
 import contextlib
 import functools
-from typing import Coroutine, Callable, Generic, Iterator, TypeVar, Union
+from typing import Callable, Generic, Iterator, TypeVar
 import typing
 
+V = TypeVar("V")
 R = TypeVar("R")  # Return type
 Pargs = TypeVar("Pargs")  # Generic type for arguments
 Pkwargs = TypeVar("Pkwargs")  # Generic type for arguments
@@ -40,18 +41,16 @@ class _AgnosticContextManager(
     https://github.com/open-telemetry/opentelemetry-python/pull/3633
     """
 
-    def __call__(  # type: ignore
-        self, func: Callable["P", Union[R, Coroutine[None, None, R]]]
-    ) -> Callable["P", Union[R, Coroutine[None, None, R]]]:
+    def __call__(self, func: V) -> V:
         if asyncio.iscoroutinefunction(func):
 
-            @functools.wraps(func)
+            @functools.wraps(func)  # type: ignore
             async def async_wrapper(*args: Pargs, **kwargs: Pkwargs) -> R:
                 with self._recreate_cm():  # type: ignore
                     return await func(*args, **kwargs)  # type: ignore
 
-            return async_wrapper
-        return super().__call__(func)
+            return async_wrapper  # type: ignore
+        return super().__call__(func)  # type: ignore
 
 
 def _agnosticcontextmanager(

--- a/opentelemetry-api/tests/trace/test_proxy.py
+++ b/opentelemetry-api/tests/trace/test_proxy.py
@@ -15,7 +15,6 @@
 # pylint: disable=W0212,W0222,W0221
 import typing
 import unittest
-from contextlib import contextmanager
 
 from opentelemetry import trace
 from opentelemetry.test.globals_test import TraceGlobalsTest
@@ -40,7 +39,7 @@ class TestTracer(trace.NoOpTracer):
     def start_span(self, *args, **kwargs):
         return TestSpan(INVALID_SPAN_CONTEXT)
 
-    @contextmanager
+    @trace.agnosticcontextmanager
     def start_as_current_span(self, *args, **kwargs):  # type: ignore
         with trace.use_span(self.start_span(*args, **kwargs)) as span:  # type: ignore
             yield span

--- a/opentelemetry-api/tests/trace/test_proxy.py
+++ b/opentelemetry-api/tests/trace/test_proxy.py
@@ -23,6 +23,7 @@ from opentelemetry.trace.span import (
     NonRecordingSpan,
     Span,
 )
+from opentelemetry.util._decorator import _agnosticcontextmanager
 
 
 class TestProvider(trace.NoOpTracerProvider):
@@ -39,7 +40,7 @@ class TestTracer(trace.NoOpTracer):
     def start_span(self, *args, **kwargs):
         return TestSpan(INVALID_SPAN_CONTEXT)
 
-    @trace._agnosticcontextmanager  # pylint: disable=protected-access
+    @_agnosticcontextmanager  # pylint: disable=protected-access
     def start_as_current_span(self, *args, **kwargs):  # type: ignore
         with trace.use_span(self.start_span(*args, **kwargs)) as span:  # type: ignore
             yield span

--- a/opentelemetry-api/tests/trace/test_proxy.py
+++ b/opentelemetry-api/tests/trace/test_proxy.py
@@ -39,7 +39,7 @@ class TestTracer(trace.NoOpTracer):
     def start_span(self, *args, **kwargs):
         return TestSpan(INVALID_SPAN_CONTEXT)
 
-    @trace.agnosticcontextmanager
+    @trace._agnosticcontextmanager  # pylint: disable=protected-access
     def start_as_current_span(self, *args, **kwargs):  # type: ignore
         with trace.use_span(self.start_span(*args, **kwargs)) as span:  # type: ignore
             yield span

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -47,7 +47,7 @@ class TestTracer(TestCase):
                 return INVALID_SPAN
 
             @_agnosticcontextmanager  # pylint: disable=protected-access
-            def start_as_current_span(self, *args, **kwargs):
+            def start_as_current_span(self, *args, **kwargs):  # type: ignore
                 lst.append(1)
                 yield INVALID_SPAN
                 lst.append(9)
@@ -56,7 +56,7 @@ class TestTracer(TestCase):
 
         # test 1 : sync function
         @mock_tracer.start_as_current_span("name")
-        def function_sync():
+        def function_sync():  # type: ignore
             lst.append(5)
 
         lst = []
@@ -65,7 +65,7 @@ class TestTracer(TestCase):
 
         # test 2 : async function
         @mock_tracer.start_as_current_span("name")
-        async def function_async():
+        async def function_async():  # type: ignore
             lst.append(5)
 
         lst = []

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -56,20 +56,24 @@ class TestTracer(TestCase):
 
         # test 1 : sync function
         @mock_tracer.start_as_current_span("name")
-        def function_sync():  # type: ignore
+        def function_sync(data: str) -> int:
             lst.append(5)
+            return len(data)
 
         lst = []
-        function_sync()
+        res = function_sync("123")
+        self.assertEqual(res, 3)
         self.assertEqual(lst, [1, 5, 9])
 
         # test 2 : async function
         @mock_tracer.start_as_current_span("name")
-        async def function_async():  # type: ignore
+        async def function_async(data: str) -> int:
             lst.append(5)
+            return len(data)
 
         lst = []
-        asyncio.run(function_async())
+        res = asyncio.run(function_async("123"))
+        self.assertEqual(res, 3)
         self.assertEqual(lst, [1, 5, 9])
 
     def test_get_current_span(self):

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -14,9 +14,8 @@
 
 
 import asyncio
-import time
+import contextlib
 from unittest import TestCase
-from unittest.mock import Mock
 
 from opentelemetry.trace import (
     INVALID_SPAN,
@@ -41,62 +40,38 @@ class TestTracer(TestCase):
             self.assertIsInstance(span, Span)
 
     def test_start_as_current_span_decorator(self):
-        mock_call = Mock()
+        # using a list to track the mock call order
+        lst = []
 
         class MockTracer(Tracer):
             def start_span(self, *args, **kwargs):
                 return INVALID_SPAN
 
             @agnosticcontextmanager
-            def start_as_current_span(self, *args, **kwargs):  # type: ignore
-                mock_call()
+            def start_as_current_span(self, *args, **kwargs):
+                lst.append(1)
                 yield INVALID_SPAN
+                lst.append(9)
 
         mock_tracer = MockTracer()
 
+        # test 1 : sync function
         @mock_tracer.start_as_current_span("name")
-        def function():  # type: ignore
-            pass
+        def function_sync():
+            lst.append(5)
 
-        function()  # type: ignore
-        function()  # type: ignore
-        function()  # type: ignore
+        lst = []
+        function_sync()
+        self.assertEqual(lst, [1, 5, 9])
 
-        self.assertEqual(mock_call.call_count, 3)
-
-    def test_start_as_current_span_decorator_work_with_async(self):
-        # As explored in GH issue #3270 the start_as_current_span decorator
-        # does work with async functions but expose a near zero timing issue
-        # this test intend to reproduce the issue and validate the fix
-
-        # create a near zero time to not slow down the test but it must be
-        # greater 1.5e-6 to reproduce the issue
-        near_zero = 1e-5
-        mock_call = Mock()
-
-        class MockTracer(Tracer):
-            waited: float = 0
-
-            def start_span(self, *args, **kwargs):
-                return INVALID_SPAN
-
-            @agnosticcontextmanager
-            def start_as_current_span(self, *args, **kwargs):  # type: ignore
-                mock_call()
-                i = time.monotonic()
-                yield INVALID_SPAN
-                self.waited = time.monotonic() - i
-
-        mock_tracer = MockTracer()
-
+        # test 2 : async function
         @mock_tracer.start_as_current_span("name")
-        async def function():  # type: ignore
-            time.sleep(near_zero)
+        async def function_async():
+            lst.append(5)
 
-        asyncio.run(function())  # type: ignore
-
-        self.assertEqual(mock_call.call_count, 1)
-        self.assertTrue(mock_tracer.waited > near_zero)
+        lst = []
+        asyncio.run(function_async())
+        self.assertEqual(lst, [1, 5, 9])
 
     def test_get_current_span(self):
         with self.tracer.start_as_current_span("test") as span:

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -40,7 +40,7 @@ class TestTracer(TestCase):
 
     def test_start_as_current_span_decorator(self):
         # using a list to track the mock call order
-        lst = []
+        calls = []
 
         class MockTracer(Tracer):
             def start_span(self, *args, **kwargs):
@@ -48,33 +48,33 @@ class TestTracer(TestCase):
 
             @_agnosticcontextmanager  # pylint: disable=protected-access
             def start_as_current_span(self, *args, **kwargs):  # type: ignore
-                lst.append(1)
+                calls.append(1)
                 yield INVALID_SPAN
-                lst.append(9)
+                calls.append(9)
 
         mock_tracer = MockTracer()
 
         # test 1 : sync function
         @mock_tracer.start_as_current_span("name")
         def function_sync(data: str) -> int:
-            lst.append(5)
+            calls.append(5)
             return len(data)
 
-        lst = []
+        calls = []
         res = function_sync("123")
         self.assertEqual(res, 3)
-        self.assertEqual(lst, [1, 5, 9])
+        self.assertEqual(calls, [1, 5, 9])
 
         # test 2 : async function
         @mock_tracer.start_as_current_span("name")
         async def function_async(data: str) -> int:
-            lst.append(5)
+            calls.append(5)
             return len(data)
 
-        lst = []
+        calls = []
         res = asyncio.run(function_async("123"))
         self.assertEqual(res, 3)
-        self.assertEqual(lst, [1, 5, 9])
+        self.assertEqual(calls, [1, 5, 9])
 
     def test_get_current_span(self):
         with self.tracer.start_as_current_span("test") as span:

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-import time
 import asyncio
-from contextlib import contextmanager
+import time
 from unittest import TestCase
 from unittest.mock import Mock
 
@@ -24,6 +23,7 @@ from opentelemetry.trace import (
     NoOpTracer,
     Span,
     Tracer,
+    agnosticcontextmanager,
     get_current_span,
 )
 
@@ -47,7 +47,7 @@ class TestTracer(TestCase):
             def start_span(self, *args, **kwargs):
                 return INVALID_SPAN
 
-            @contextmanager
+            @agnosticcontextmanager
             def start_as_current_span(self, *args, **kwargs):  # type: ignore
                 mock_call()
                 yield INVALID_SPAN
@@ -80,7 +80,7 @@ class TestTracer(TestCase):
             def start_span(self, *args, **kwargs):
                 return INVALID_SPAN
 
-            @contextmanager
+            @agnosticcontextmanager
             def start_as_current_span(self, *args, **kwargs):  # type: ignore
                 mock_call()
                 i = time.monotonic()

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -14,7 +14,6 @@
 
 
 import asyncio
-import contextlib
 from unittest import TestCase
 
 from opentelemetry.trace import (
@@ -22,7 +21,7 @@ from opentelemetry.trace import (
     NoOpTracer,
     Span,
     Tracer,
-    agnosticcontextmanager,
+    _agnosticcontextmanager,
     get_current_span,
 )
 
@@ -47,7 +46,7 @@ class TestTracer(TestCase):
             def start_span(self, *args, **kwargs):
                 return INVALID_SPAN
 
-            @agnosticcontextmanager
+            @_agnosticcontextmanager  # pylint: disable=protected-access
             def start_as_current_span(self, *args, **kwargs):
                 lst.append(1)
                 yield INVALID_SPAN

--- a/opentelemetry-api/tests/trace/test_tracer.py
+++ b/opentelemetry-api/tests/trace/test_tracer.py
@@ -67,7 +67,7 @@ class TestTracer(TestCase):
     def test_start_as_current_span_decorator_work_with_async(self):
         # As explored in GH issue #3270 the start_as_current_span decorator
         # does work with async functions but expose a near zero timing issue
-        # this test entend to reproduce the issue and validate the fix
+        # this test intend to reproduce the issue and validate the fix
 
         # create a near zero time to not slow down the test but it must be
         # greater 1.5e-6 to reproduce the issue

--- a/opentelemetry-api/tests/util/test_contextmanager.py
+++ b/opentelemetry-api/tests/util/test_contextmanager.py
@@ -1,0 +1,76 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import unittest
+from typing import Callable, Iterator
+
+from opentelemetry.util._decorator import _agnosticcontextmanager
+
+
+@_agnosticcontextmanager
+def cm(*args, **kwargs) -> Iterator[int]:
+    yield 3
+
+
+@_agnosticcontextmanager
+def cm_call_when_done(f: Callable[[], None]) -> Iterator[int]:
+    yield 3
+    f()
+
+
+class TestContextManager(unittest.TestCase):
+    def test_sync_with(self):
+        with cm() as val:
+            self.assertEqual(val, 3)
+
+    def test_decorate_sync_func(self):
+        @cm()
+        def sync_func(a: str) -> str:
+            return a + a
+
+        res = sync_func("a")
+        self.assertEqual(res, "aa")
+
+    def test_decorate_async_func(self):
+        # Test that a universal context manager decorating an async function runs it's cleanup
+        # code after the entire async function coroutine finishes. This silently fails when
+        # using the normal @contextmanager decorator, which runs it's __exit__() after the
+        # un-started coroutine is returned.
+        #
+        # To see this behavior, change cm_call_when_done() to
+        # be decorated with @contextmanager.
+
+        events = []
+
+        @cm_call_when_done(lambda: events.append("cm_done"))
+        async def async_func(a: str) -> str:
+            events.append("start_async_func")
+            await asyncio.sleep(0)
+            events.append("finish_sleep")
+            return a + a
+
+        res = asyncio.run(async_func("a"))
+        self.assertEqual(res, "aa")
+        self.assertEqual(
+            events, ["start_async_func", "finish_sleep", "cm_done"]
+        )
+
+    def test_wraps_contextlib(self):
+        """It should proxy to the wrapped contextlib.contextmanager to access underlying properties"""
+        instance = cm(1, 2, a="hello")
+        self.assertEqual(instance.args, (1, 2))
+        self.assertEqual(instance.kwds, {"a": "hello"})
+        self.assertTrue(hasattr(instance, "gen"))
+        self.assertTrue(hasattr(instance, "func"))

--- a/opentelemetry-api/tests/util/test_contextmanager.py
+++ b/opentelemetry-api/tests/util/test_contextmanager.py
@@ -69,9 +69,11 @@ class TestContextManager(unittest.TestCase):
 
     def test_wraps_contextlib(self):
         """It should proxy to the wrapped contextlib.contextmanager to access underlying properties"""
+
         @_agnosticcontextmanager
-        def cm_with_args(*args, **kwargs) -> Iterator[int]: # type: ignore
+        def cm_with_args(*args, **kwargs) -> Iterator[int]:  # type: ignore
             yield 3
+
         instance = cm_with_args(1, 2, a="hello")
         self.assertEqual(instance.args, (1, 2))  # type: ignore
         self.assertEqual(instance.kwds, {"a": "hello"})  # type: ignore

--- a/opentelemetry-api/tests/util/test_contextmanager.py
+++ b/opentelemetry-api/tests/util/test_contextmanager.py
@@ -66,16 +66,3 @@ class TestContextManager(unittest.TestCase):
         self.assertEqual(
             events, ["start_async_func", "finish_sleep", "cm_done"]
         )
-
-    def test_wraps_contextlib(self):
-        """It should proxy to the wrapped contextlib.contextmanager to access underlying properties"""
-
-        @_agnosticcontextmanager
-        def cm_with_args(*args, **kwargs) -> Iterator[int]:  # type: ignore
-            yield 3
-
-        instance = cm_with_args(1, 2, a="hello")
-        self.assertEqual(instance.args, (1, 2))  # type: ignore
-        self.assertEqual(instance.kwds, {"a": "hello"})  # type: ignore
-        self.assertTrue(hasattr(instance, "gen"))
-        self.assertTrue(hasattr(instance, "func"))

--- a/opentelemetry-api/tests/util/test_contextmanager.py
+++ b/opentelemetry-api/tests/util/test_contextmanager.py
@@ -20,7 +20,7 @@ from opentelemetry.util._decorator import _agnosticcontextmanager
 
 
 @_agnosticcontextmanager
-def cm(*args, **kwargs) -> Iterator[int]:
+def cm() -> Iterator[int]:
     yield 3
 
 
@@ -69,7 +69,10 @@ class TestContextManager(unittest.TestCase):
 
     def test_wraps_contextlib(self):
         """It should proxy to the wrapped contextlib.contextmanager to access underlying properties"""
-        instance = cm(1, 2, a="hello")
+        @_agnosticcontextmanager
+        def cm_with_args(*args, **kwargs) -> Iterator[int]: # type: ignore
+            yield 3
+        instance = cm_with_args(1, 2, a="hello")
         self.assertEqual(instance.args, (1, 2))  # type: ignore
         self.assertEqual(instance.kwds, {"a": "hello"})  # type: ignore
         self.assertTrue(hasattr(instance, "gen"))

--- a/opentelemetry-api/tests/util/test_contextmanager.py
+++ b/opentelemetry-api/tests/util/test_contextmanager.py
@@ -70,7 +70,7 @@ class TestContextManager(unittest.TestCase):
     def test_wraps_contextlib(self):
         """It should proxy to the wrapped contextlib.contextmanager to access underlying properties"""
         instance = cm(1, 2, a="hello")
-        self.assertEqual(instance.args, (1, 2))
-        self.assertEqual(instance.kwds, {"a": "hello"})
+        self.assertEqual(instance.args, (1, 2))  # type: ignore
+        self.assertEqual(instance.kwds, {"a": "hello"})  # type: ignore
         self.assertTrue(hasattr(instance, "gen"))
         self.assertTrue(hasattr(instance, "func"))

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -21,7 +21,6 @@ import logging
 import threading
 import traceback
 import typing
-from contextlib import contextmanager
 from os import environ
 from time import time_ns
 from types import MappingProxyType, TracebackType
@@ -1038,7 +1037,7 @@ class Tracer(trace_api.Tracer):
         self._span_limits = span_limits
         self._instrumentation_scope = instrumentation_scope
 
-    @contextmanager
+    @trace_api.agnosticcontextmanager
     def start_as_current_span(
         self,
         name: str,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -1037,7 +1037,7 @@ class Tracer(trace_api.Tracer):
         self._span_limits = span_limits
         self._instrumentation_scope = instrumentation_scope
 
-    @trace_api.agnosticcontextmanager
+    @trace_api._agnosticcontextmanager  # pylint: disable=protected-access
     def start_as_current_span(
         self,
         name: str,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -43,6 +43,7 @@ from deprecated import deprecated
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.attributes import BoundedAttributes
+from opentelemetry.util._decorator import _agnosticcontextmanager
 from opentelemetry.sdk import util
 from opentelemetry.sdk.environment_variables import (
     OTEL_ATTRIBUTE_COUNT_LIMIT,
@@ -1037,7 +1038,7 @@ class Tracer(trace_api.Tracer):
         self._span_limits = span_limits
         self._instrumentation_scope = instrumentation_scope
 
-    @trace_api._agnosticcontextmanager  # pylint: disable=protected-access
+    @_agnosticcontextmanager  # pylint: disable=protected-access
     def start_as_current_span(
         self,
         name: str,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -43,7 +43,6 @@ from deprecated import deprecated
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.attributes import BoundedAttributes
-from opentelemetry.util._decorator import _agnosticcontextmanager
 from opentelemetry.sdk import util
 from opentelemetry.sdk.environment_variables import (
     OTEL_ATTRIBUTE_COUNT_LIMIT,
@@ -66,6 +65,7 @@ from opentelemetry.sdk.util.instrumentation import (
 from opentelemetry.trace import SpanContext
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util import types
+from opentelemetry.util._decorator import _agnosticcontextmanager
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

Fixing the `start_as_current_span` decorator that report near zero time for spans of decorated async functions.

Fixes #3270

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change : It's not a breaking change as the other libraries that implement their own `Tracer` class can still use the `contextlib` decorator (but it will still be bugged for them), as soon as they implement it, it must be working fine on their end two.
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `opentelemetry-api/tests/trace/test_tracer.py` : Created the minimal reproduction and fixed it.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated - nothing to change
