### PR TITLE
Avoid using OrderedDict as possible

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -15,7 +15,6 @@
 import os
 import threading
 import time
-from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from logging import WARNING
 from unittest import TestCase
@@ -153,12 +152,12 @@ class TestOTLPSpanExporter(TestCase):
             "a",
             context=Mock(
                 **{
-                    "trace_state": OrderedDict([("a", "b"), ("c", "d")]),
+                    "trace_state": {"a": "b", "c": "d"},
                     "span_id": 10217189687419569865,
                     "trace_id": 67545097771067222548457157018666467027,
                 }
             ),
-            resource=SDKResource(OrderedDict([("a", 1), ("b", False)])),
+            resource=SDKResource({"a": 1, "b": False}),
             parent=Mock(**{"span_id": 12345}),
             attributes=BoundedAttributes(attributes={"a": 1, "b": True}),
             events=[event_mock],
@@ -183,12 +182,12 @@ class TestOTLPSpanExporter(TestCase):
             "b",
             context=Mock(
                 **{
-                    "trace_state": OrderedDict([("a", "b"), ("c", "d")]),
+                    "trace_state": {"a": "b", "c": "d"},
                     "span_id": 10217189687419569865,
                     "trace_id": 67545097771067222548457157018666467027,
                 }
             ),
-            resource=SDKResource(OrderedDict([("a", 2), ("b", False)])),
+            resource=SDKResource({"a": 2, "b": False}),
             parent=Mock(**{"span_id": 12345}),
             instrumentation_scope=InstrumentationScope(
                 name="name", version="version"
@@ -199,12 +198,12 @@ class TestOTLPSpanExporter(TestCase):
             "c",
             context=Mock(
                 **{
-                    "trace_state": OrderedDict([("a", "b"), ("c", "d")]),
+                    "trace_state": {"a": "b", "c": "d"},
                     "span_id": 10217189687419569865,
                     "trace_id": 67545097771067222548457157018666467027,
                 }
             ),
-            resource=SDKResource(OrderedDict([("a", 1), ("b", False)])),
+            resource=SDKResource({"a": 1, "b": False}),
             parent=Mock(**{"span_id": 12345}),
             instrumentation_scope=InstrumentationScope(
                 name="name2", version="version2"
@@ -964,7 +963,7 @@ def _create_span_with_status(status: SDKStatus):
         "a",
         context=Mock(
             **{
-                "trace_state": OrderedDict([("a", "b"), ("c", "d")]),
+                "trace_state": {"a": "b", "c": "d"},
                 "span_id": 10217189687419569865,
                 "trace_id": 67545097771067222548457157018666467027,
             }

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from collections import OrderedDict
 from unittest.mock import MagicMock, Mock, call, patch
 
 import requests
@@ -221,7 +220,7 @@ class TestOTLPSpanExporter(unittest.TestCase):
             "abc",
             context=Mock(
                 **{
-                    "trace_state": OrderedDict([("a", "b"), ("c", "d")]),
+                    "trace_state": {"a": "b", "c": "d"},
                     "span_id": 10217189687419569865,
                     "trace_id": 67545097771067222548457157018666467027,
                 }

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -148,7 +148,8 @@ class BoundedAttributes(MutableMapping):
         self.maxlen = maxlen
         self.dropped = 0
         self.max_value_len = max_value_len
-        self._dict = OrderedDict()  # type: OrderedDict
+        # OrderedDict is not used until the maxlen is reached for efficiency.
+        self._dict = {}  # type: dict | OrderedDict
         self._lock = threading.Lock()  # type: threading.Lock
         if attributes:
             for key, value in attributes.items():
@@ -178,6 +179,8 @@ class BoundedAttributes(MutableMapping):
                 elif (
                     self.maxlen is not None and len(self._dict) == self.maxlen
                 ):
+                    if not isinstance(self._dict, OrderedDict):
+                        self._dict = OrderedDict(self._dict)
                     self._dict.popitem(last=False)
                     self.dropped += 1
 

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -3,7 +3,6 @@ import logging
 import re
 import types as python_types
 import typing
-from collections import OrderedDict
 
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util import types
@@ -218,7 +217,7 @@ class TraceState(typing.Mapping[str, str]):
             typing.Sequence[typing.Tuple[str, str]]
         ] = None,
     ) -> None:
-        self._dict = OrderedDict()  # type: OrderedDict[str, str]
+        self._dict = {}  # type: dict[str, str]
         if entries is None:
             return
         if len(entries) > _TRACECONTEXT_MAXIMUM_TRACESTATE_KEYS:
@@ -310,9 +309,8 @@ class TraceState(typing.Mapping[str, str]):
             )
             return self
         prev_state = self._dict.copy()
-        prev_state[key] = value
-        prev_state.move_to_end(key, last=False)
-        new_state = list(prev_state.items())
+        prev_state.pop(key, None)
+        new_state = [(key, value), *prev_state.items()]
         return TraceState(new_state)
 
     def delete(self, key: str) -> "TraceState":
@@ -362,7 +360,7 @@ class TraceState(typing.Mapping[str, str]):
             If the number of keys is beyond the maximum, all values
             will be discarded and an empty tracestate will be returned.
         """
-        pairs = OrderedDict()  # type: OrderedDict[str, str]
+        pairs = {}  # type: dict[str, str]
         for header in header_list:
             members: typing.List[str] = re.split(_delimiter_pattern, header)
             for member in members:

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -14,7 +14,6 @@
 
 # type: ignore
 
-import collections
 import unittest
 from typing import MutableSequence
 
@@ -90,14 +89,12 @@ class TestAttributes(unittest.TestCase):
 
 
 class TestBoundedAttributes(unittest.TestCase):
-    base = collections.OrderedDict(
-        [
-            ("name", "Firulais"),
-            ("age", 7),
-            ("weight", 13),
-            ("vaccinated", True),
-        ]
-    )
+    base = {
+        "name": "Firulais",
+        "age": 7,
+        "weight": 13,
+        "vaccinated": True,
+    }
 
     def test_negative_maxlen(self):
         with self.assertRaises(ValueError):
@@ -105,7 +102,7 @@ class TestBoundedAttributes(unittest.TestCase):
 
     def test_from_map(self):
         dic_len = len(self.base)
-        base_copy = collections.OrderedDict(self.base)
+        base_copy = self.base.copy()
         bdict = BoundedAttributes(dic_len, base_copy)
 
         self.assertEqual(len(bdict), dic_len)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -14,7 +14,7 @@
 
 import datetime
 import threading
-from collections import OrderedDict, deque
+from collections import deque
 from collections.abc import MutableMapping, Sequence
 from typing import Optional
 
@@ -107,7 +107,7 @@ class BoundedDict(MutableMapping):
                 raise ValueError
         self.maxlen = maxlen
         self.dropped = 0
-        self._dict = OrderedDict()  # type: OrderedDict
+        self._dict = {}  # type: dict
         self._lock = threading.Lock()  # type: threading.Lock
 
     def __repr__(self):
@@ -143,7 +143,7 @@ class BoundedDict(MutableMapping):
 
     @classmethod
     def from_map(cls, maxlen, mapping):
-        mapping = OrderedDict(mapping)
+        mapping = dict(mapping)
         bounded_dict = cls(maxlen)
         for key, value in mapping.items():
             bounded_dict[key] = value


### PR DESCRIPTION
# Description

Stop using OrderedDict in TraceState.
BoundedAttributes starts with dict and use OrderedDict only when reached to limit.
This makes tracing little faster and uses less memory.

Additionally, removed unnecessary use of OrderedDict in tests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py311-proto4-opentelemetry-exporter-otlp-proto-http
- [x] tox -e py311-proto4-opentelemetry-exporter-otlp-proto-grpc
- [x] tox -e py311-proto3-opentelemetry-exporter-otlp-proto-http
- [x] tox -e py311-proto3-opentelemetry-exporter-otlp-proto-grpc
- [x] tox -e py311-opentelemetry-sdk
- [x] tox -e py311-opentelemetry-api


# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
