### PR TITLE
Don’t pin an exact version of responses for testing

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-  "responses >= 0.22.0",
+  "responses >= 0.22.0, < 0.25",
 ]
 
 [project.entry-points.opentelemetry_traces_exporter]

--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-  "responses == 0.22.0",
+  "responses >= 0.22.0",
 ]
 
 [project.entry-points.opentelemetry_traces_exporter]


### PR DESCRIPTION
# Description

In the test dependencies for opentelemetry-exporter-otlp-proto-http, allow `responses >= 0.22.0` rather than `responses == 0.22.0`.

These tests use responses in a very straightforward way, and it’s unlikely that they will be affected by any future breaking changes; meanwhile, allowing newer versions helps with compatibility with newer Python interpreter versions and makes distribution packagers’ lives easier.

Fixes # (issue)

## Type of change

**none of the listed types**

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



I tested this in a virtual environment as follows:

```
gh repo clone open-telemetry/opentelemetry-python
cd opentelemetry-python
python3.11 -m venv _e
. _e/bin/activate
cd opentelemetry-proto
pip install .
cd ../opentelemetry-api
pip install .
cd ../opentelemetry-semantic-conventions
pip install .
cd ../opentelemetry-sdk
pip install .
cd ../tests/opentelemetry-test-utils
pip install .
cd ../../exporter/opentelemetry-exporter-otlp-proto-common
pip install .
cd ../opentelemetry-exporter-otlp-proto-http
pip install -e '.[test]'
pip install pytest
python -m pytest
```

All tests passed.

```
============================== 26 passed in 0.17s ==============================
```

The version of `responses` installed in the virtual environment was 0.24.1, which wouldn’t have been permitted before this PR.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated **This doesn’t seem like it deserves a changelog entry. Let me know if I need to add one.**
- [ ] Unit tests have been added **N/A, covered by existing tests**
- [ ] Documentation has been updated **N/A**
