### PR TITLE
Improve Resource Detector timeout messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Improve Resource Detector timeout messaging
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-python/pull/XXXX))
+
 ## Version 1.22.0/0.43b0 (2023-12-15)
 
 - Prometheus exporter sanitize info metric ([#3572](https://github.com/open-telemetry/opentelemetry-python/pull/3572))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Improve Resource Detector timeout messaging
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-python/pull/XXXX))
+  ([#3645](https://github.com/open-telemetry/opentelemetry-python/pull/3645))
 
 ## Version 1.22.0/0.43b0 (2023-12-15)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -392,6 +392,8 @@ def get_aggregated_resources(
                 detected_resource = future.result(timeout=timeout)
             # pylint: disable=broad-except
             except concurrent.futures._base.TimeoutError:
+                if detector.raise_on_error:
+                    raise ex
                 logger.warning(
                     "Detector %s took longer than %s seconds, skipping", detector, timeout
                 )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -394,7 +394,9 @@ def get_aggregated_resources(
                 if detector.raise_on_error:
                     raise ex
                 logger.warning(
-                    "Detector %s took longer than %s seconds, skipping", detector, timeout
+                    "Detector %s took longer than %s seconds, skipping",
+                    detector,
+                    timeout,
                 )
             # pylint: disable=broad-except
             except Exception as ex:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -390,13 +390,13 @@ def get_aggregated_resources(
             detected_resource: Resource = _EMPTY_RESOURCE
             try:
                 detected_resource = future.result(timeout=timeout)
-            # pylint: disable=broad-except
             except concurrent.futures.TimeoutError:
                 if detector.raise_on_error:
                     raise ex
                 logger.warning(
                     "Detector %s took longer than %s seconds, skipping", detector, timeout
                 )
+            # pylint: disable=broad-except
             except Exception as ex:
                 if detector.raise_on_error:
                     raise ex

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -391,11 +391,18 @@ def get_aggregated_resources(
             try:
                 detected_resource = future.result(timeout=timeout)
             # pylint: disable=broad-except
+            except concurrent.futures._base.TimeoutError:
+                logger.warning(
+                    "Detector %s took longer than %s seconds, skipping", detector, timeout
+                )
             except Exception as ex:
                 if detector.raise_on_error:
                     raise ex
                 logger.warning(
                     "Exception %s in detector %s, ignoring", ex, detector
+                )
+                print(
+                    "Exception %s in detector %s, ignoring" % (ex, detector)
                 )
             finally:
                 detectors_merged_resource = detectors_merged_resource.merge(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -401,9 +401,6 @@ def get_aggregated_resources(
                 logger.warning(
                     "Exception %s in detector %s, ignoring", ex, detector
                 )
-                print(
-                    "Exception %s in detector %s, ignoring" % (ex, detector)
-                )
             finally:
                 detectors_merged_resource = detectors_merged_resource.merge(
                     detected_resource

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -390,7 +390,7 @@ def get_aggregated_resources(
             detected_resource: Resource = _EMPTY_RESOURCE
             try:
                 detected_resource = future.result(timeout=timeout)
-            except concurrent.futures.TimeoutError:
+            except concurrent.futures.TimeoutError as ex:
                 if detector.raise_on_error:
                     raise ex
                 logger.warning(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -391,7 +391,7 @@ def get_aggregated_resources(
             try:
                 detected_resource = future.result(timeout=timeout)
             # pylint: disable=broad-except
-            except concurrent.futures._base.TimeoutError:
+            except concurrent.futures.TimeoutError:
                 if detector.raise_on_error:
                     raise ex
                 logger.warning(

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -420,7 +420,7 @@ class TestResources(unittest.TestCase):
         self.assertRaises(
             Exception, get_aggregated_resources, [resource_detector]
         )
-        
+
     @patch("opentelemetry.sdk.resources.logger")
     def test_resource_detector_timeout(self, mock_logger):
         resource_detector = Mock(spec=ResourceDetector)
@@ -432,7 +432,11 @@ class TestResources(unittest.TestCase):
                 Resource({SERVICE_NAME: "unknown_service"}, "")
             ),
         )
-        mock_logger.warning.assert_called_with("Detector %s took longer than %s seconds, skipping", resource_detector, 5)
+        mock_logger.warning.assert_called_with(
+            "Detector %s took longer than %s seconds, skipping",
+            resource_detector,
+            5,
+        )
 
     @patch.dict(
         environ,

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import concurrent.futures
 import os
 import sys
 import unittest
 import uuid
+from concurrent.futures import TimeoutError
 from logging import ERROR, WARNING
 from os import environ
 from unittest.mock import Mock, patch
@@ -415,8 +415,7 @@ class TestResources(unittest.TestCase):
 
     def test_resource_detector_raise_error(self):
         resource_detector = Mock(spec=ResourceDetector)
-        ex = Exception()
-        resource_detector.detect.side_effect = ex
+        resource_detector.detect.side_effect = Exception()
         resource_detector.raise_on_error = True
         self.assertRaises(
             Exception, get_aggregated_resources, [resource_detector]
@@ -425,7 +424,7 @@ class TestResources(unittest.TestCase):
     @patch("opentelemetry.sdk.resources.logger")
     def test_resource_detector_timeout(self, mock_logger):
         resource_detector = Mock(spec=ResourceDetector)
-        resource_detector.detect.side_effect = concurrent.futures._base.TimeoutError()
+        resource_detector.detect.side_effect = TimeoutError()
         resource_detector.raise_on_error = False
         self.assertEqual(
             get_aggregated_resources([resource_detector]),


### PR DESCRIPTION
# Description

Adds timeout catch to resource detector instead of a misleading warning with a blank exception. However, it seems concurrent.futures does not allow you to interrupt a task even after it has timed out. So, a badly written detector could still cause an application to hang.

Partially fixes #3644

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests and manually.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
