### PR TITLE
Remove useless shebang lines

### DIFF
--- a/docs/examples/opencensus-exporter-tracer/collector.py
+++ b/docs/examples/opencensus-exporter-tracer/collector.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/w3c_tracecontext_validation_server.py
+++ b/tests/w3c_tracecontext_validation_server.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
# Description

This commit simply removes two useless shebang (`#!`) lines.

These files do not have the executable bit set in their filesystem permissions, so the shebang lines are not useful.

Fixes #3643.

This approach was requested in https://github.com/open-telemetry/opentelemetry-python/issues/3643#issuecomment-1910713652.

## Type of change

Please delete options that are not relevant.

**none of the listed types**

# How Has This Been Tested?

**tested by inspection only**

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated **not needed**
- [ ] Unit tests have been added **not applicable**
- [ ] Documentation has been updated ** not needed**
