### PR TITLE
Fix: Add missing Resource SchemaURL in otlp exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add missing Resource SchemaURL in OTLP exporters
+  ([#3652](https://github.com/open-telemetry/opentelemetry-python/pull/3652))
 - Fix loglevel warning text
   ([#3566](https://github.com/open-telemetry/opentelemetry-python/pull/3566))
 - Prometheus Exporter string representation for target_info labels

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
@@ -77,6 +77,7 @@ def _encode_resource_logs(batch: Sequence[LogData]) -> List[ResourceLogs]:
             ResourceLogs(
                 resource=_encode_resource(sdk_resource),
                 scope_logs=scope_logs,
+                schema_url=sdk_resource.schema_url,
             )
         )
 

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/metrics_encoder/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/metrics_encoder/__init__.py
@@ -312,6 +312,7 @@ def encode_metrics(data: MetricsData) -> ExportMetricsServiceRequest:
                     attributes=_encode_attributes(sdk_resource.attributes)
                 ),
                 scope_metrics=scope_data.values(),
+                schema_url=sdk_resource.schema_url,
             )
         )
     resource_metrics = resource_data

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/trace_encoder/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/trace_encoder/__init__.py
@@ -97,6 +97,7 @@ def _encode_resource_spans(
             PB2ResourceSpans(
                 resource=_encode_resource(sdk_resource),
                 scope_spans=scope_spans,
+                schema_url=sdk_resource.schema_url,
             )
         )
 

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
@@ -75,7 +75,10 @@ class TestOTLPLogEncoder(unittest.TestCase):
                 severity_text="WARN",
                 severity_number=SeverityNumber.WARN,
                 body="Do not go gentle into that good night. Rage, rage against the dying of the light",
-                resource=SDKResource({"first_resource": "value"}),
+                resource=SDKResource(
+                    {"first_resource": "value"},
+                    "resource_schema_url",
+                ),
                 attributes={"a": 1, "b": "c"},
             ),
             instrumentation_scope=InstrumentationScope(
@@ -124,7 +127,10 @@ class TestOTLPLogEncoder(unittest.TestCase):
                 severity_text="INFO",
                 severity_number=SeverityNumber.INFO,
                 body="Love is the one thing that transcends time and space",
-                resource=SDKResource({"first_resource": "value"}),
+                resource=SDKResource(
+                    {"first_resource": "value"},
+                    "resource_schema_url",
+                ),
                 attributes={"filename": "model.py", "func_name": "run_method"},
             ),
             instrumentation_scope=InstrumentationScope(
@@ -206,6 +212,7 @@ class TestOTLPLogEncoder(unittest.TestCase):
                             ],
                         ),
                     ],
+                    schema_url="resource_schema_url",
                 ),
                 PB2ResourceLogs(
                     resource=PB2Resource(

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_metrics_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_metrics_encoder.py
@@ -99,6 +99,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
         expected = ExportMetricsServiceRequest(
             resource_metrics=[
                 pb2.ResourceMetrics(
+                    schema_url="resource_schema_url",
                     resource=OTLPResource(
                         attributes=[
                             KeyValue(key="a", value=AnyValue(int_value=1)),
@@ -178,6 +179,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
         expected = ExportMetricsServiceRequest(
             resource_metrics=[
                 pb2.ResourceMetrics(
+                    schema_url="resource_schema_url",
                     resource=OTLPResource(
                         attributes=[
                             KeyValue(key="a", value=AnyValue(int_value=1)),
@@ -257,6 +259,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
         expected = ExportMetricsServiceRequest(
             resource_metrics=[
                 pb2.ResourceMetrics(
+                    schema_url="resource_schema_url",
                     resource=OTLPResource(
                         attributes=[
                             KeyValue(key="a", value=AnyValue(int_value=1)),
@@ -333,6 +336,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
         expected = ExportMetricsServiceRequest(
             resource_metrics=[
                 pb2.ResourceMetrics(
+                    schema_url="resource_schema_url",
                     resource=OTLPResource(
                         attributes=[
                             KeyValue(key="a", value=AnyValue(int_value=1)),
@@ -409,6 +413,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
         expected = ExportMetricsServiceRequest(
             resource_metrics=[
                 pb2.ResourceMetrics(
+                    schema_url="resource_schema_url",
                     resource=OTLPResource(
                         attributes=[
                             KeyValue(key="a", value=AnyValue(int_value=1)),
@@ -511,6 +516,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
         expected = ExportMetricsServiceRequest(
             resource_metrics=[
                 pb2.ResourceMetrics(
+                    schema_url="resource_schema_url",
                     resource=OTLPResource(
                         attributes=[
                             KeyValue(key="a", value=AnyValue(int_value=1)),
@@ -739,6 +745,7 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
         expected = ExportMetricsServiceRequest(
             resource_metrics=[
                 pb2.ResourceMetrics(
+                    schema_url="resource_schema_url",
                     resource=OTLPResource(
                         attributes=[
                             KeyValue(key="a", value=AnyValue(int_value=1)),

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_trace_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_trace_encoder.py
@@ -111,7 +111,7 @@ class TestOTLPTraceEncoder(unittest.TestCase):
             links=(
                 SDKLink(context=other_context, attributes={"key_bool": True}),
             ),
-            resource=SDKResource({}),
+            resource=SDKResource({}, "resource_schema_url"),
         )
         span1.start(start_time=start_times[0])
         span1.set_attribute("key_bool", False)
@@ -143,7 +143,7 @@ class TestOTLPTraceEncoder(unittest.TestCase):
             name="test-span-4",
             context=other_context,
             parent=None,
-            resource=SDKResource({}),
+            resource=SDKResource({}, "resource_schema_url"),
             instrumentation_scope=SDKInstrumentationScope(
                 name="name", version="version"
             ),
@@ -163,6 +163,7 @@ class TestOTLPTraceEncoder(unittest.TestCase):
         pb2_service_request = PB2ExportTraceServiceRequest(
             resource_spans=[
                 PB2ResourceSpans(
+                    schema_url="resource_schema_url",
                     resource=PB2Resource(),
                     scope_spans=[
                         PB2ScopeSpans(


### PR DESCRIPTION
# Description

Schema URL was missed in Resources when using OTLP exporters
The specified issue says only about the logs, but in fact it was missed in the traces and in the metrics
Fixes #3553 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Check specified issue for example

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added (actually not added, but updated)
- [ ] Documentation has been updated
