### PR TITLE
Prometheus Exporter string representation for target_info labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Prometheus Exporter string representation for target_info labels ([#3659](https://github.com/open-telemetry/opentelemetry-python/pull/3659))
 - Include key in attribute sequence warning
   ([#3639](https://github.com/open-telemetry/opentelemetry-python/pull/3639))
 - Upgrade markupsafe, Flask and related dependencies to dev and test

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
@@ -380,7 +380,8 @@ class _CustomCollector:
         """Create an Info Metric Family with list of attributes"""
         # sanitize the attribute names according to Prometheus rule
         attributes = {
-            self._sanitize(key): value for key, value in attributes.items()
+            self._sanitize(key): self._check_value(value)
+            for key, value in attributes.items()
         }
         info = InfoMetricFamily(name, description, labels=attributes)
         info.add_metric(labels=list(attributes.keys()), value=attributes)

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -358,17 +358,18 @@ class TestPrometheusMetricReader(TestCase):
         counter.add(1)
         result = list(metric_reader._collector.collect())
 
-        for prometheus_metric in result[:0]:
-            self.assertEqual(type(prometheus_metric), InfoMetricFamily)
-            self.assertEqual(prometheus_metric.name, "target")
-            self.assertEqual(
-                prometheus_metric.documentation, "Target metadata"
-            )
-            self.assertTrue(len(prometheus_metric.samples) == 1)
-            self.assertEqual(prometheus_metric.samples[0].value, 1)
-            self.assertTrue(len(prometheus_metric.samples[0].labels) == 2)
-            self.assertEqual(prometheus_metric.samples[0].labels["os"], "Unix")
-            self.assertEqual(prometheus_metric.samples[0].labels["histo"], "1")
+        self.assertEqual(len(result), 2)
+
+        prometheus_metric = result[0]
+
+        self.assertEqual(type(prometheus_metric), InfoMetricFamily)
+        self.assertEqual(prometheus_metric.name, "target")
+        self.assertEqual(prometheus_metric.documentation, "Target metadata")
+        self.assertTrue(len(prometheus_metric.samples) == 1)
+        self.assertEqual(prometheus_metric.samples[0].value, 1)
+        self.assertTrue(len(prometheus_metric.samples[0].labels) == 2)
+        self.assertEqual(prometheus_metric.samples[0].labels["os"], "Unix")
+        self.assertEqual(prometheus_metric.samples[0].labels["histo"], 1)
 
     def test_target_info_disabled(self):
         metric_reader = PrometheusMetricReader(disable_target_info=True)

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -351,7 +351,7 @@ class TestPrometheusMetricReader(TestCase):
         metric_reader = PrometheusMetricReader()
         provider = MeterProvider(
             metric_readers=[metric_reader],
-            resource=Resource({"os": "Unix", "histo": 1}),
+            resource=Resource({"os": "Unix", "version": "1.2.3"}),
         )
         meter = provider.get_meter("getting-started", "0.1.2")
         counter = meter.create_counter("counter")
@@ -369,13 +369,15 @@ class TestPrometheusMetricReader(TestCase):
         self.assertEqual(prometheus_metric.samples[0].value, 1)
         self.assertTrue(len(prometheus_metric.samples[0].labels) == 2)
         self.assertEqual(prometheus_metric.samples[0].labels["os"], "Unix")
-        self.assertEqual(prometheus_metric.samples[0].labels["histo"], 1)
+        self.assertEqual(
+            prometheus_metric.samples[0].labels["version"], "1.2.3"
+        )
 
     def test_target_info_disabled(self):
         metric_reader = PrometheusMetricReader(disable_target_info=True)
         provider = MeterProvider(
             metric_readers=[metric_reader],
-            resource=Resource({"os": "Unix", "histo": 1}),
+            resource=Resource({"os": "Unix", "version": "1.2.3"}),
         )
         meter = provider.get_meter("getting-started", "0.1.2")
         counter = meter.create_counter("counter")
@@ -389,7 +391,7 @@ class TestPrometheusMetricReader(TestCase):
                 prometheus_metric.documentation, "Target metadata"
             )
             self.assertNotIn("os", prometheus_metric.samples[0].labels)
-            self.assertNotIn("histo", prometheus_metric.samples[0].labels)
+            self.assertNotIn("version", prometheus_metric.samples[0].labels)
 
     def test_target_info_sanitize(self):
         metric_reader = PrometheusMetricReader()
@@ -399,6 +401,8 @@ class TestPrometheusMetricReader(TestCase):
                 {
                     "system.os": "Unix",
                     "system.name": "Prometheus Target Sanitize",
+                    "histo": 1,
+                    "ratio": 0.1,
                 }
             ),
         )
@@ -412,7 +416,7 @@ class TestPrometheusMetricReader(TestCase):
         self.assertEqual(prometheus_metric.documentation, "Target metadata")
         self.assertTrue(len(prometheus_metric.samples) == 1)
         self.assertEqual(prometheus_metric.samples[0].value, 1)
-        self.assertTrue(len(prometheus_metric.samples[0].labels) == 2)
+        self.assertTrue(len(prometheus_metric.samples[0].labels) == 4)
         self.assertTrue("system_os" in prometheus_metric.samples[0].labels)
         self.assertEqual(
             prometheus_metric.samples[0].labels["system_os"], "Unix"
@@ -421,4 +425,14 @@ class TestPrometheusMetricReader(TestCase):
         self.assertEqual(
             prometheus_metric.samples[0].labels["system_name"],
             "Prometheus Target Sanitize",
+        )
+        self.assertTrue("histo" in prometheus_metric.samples[0].labels)
+        self.assertEqual(
+            prometheus_metric.samples[0].labels["histo"],
+            "1",
+        )
+        self.assertTrue("ratio" in prometheus_metric.samples[0].labels)
+        self.assertEqual(
+            prometheus_metric.samples[0].labels["ratio"],
+            "0.1",
         )


### PR DESCRIPTION
# Description

Fixes #3676

Labels of the `target_info` metric must be exported in a string representation.


Furthermore the `test_target_info_enabled_by_default` contained some dead code due to a wrong list slicing.
`python_list[:0]` returns always an empty list.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the unit tests.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
