### PR TITLE
Remove 'backoff' dependency and use a function instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3645](https://github.com/open-telemetry/opentelemetry-python/pull/3645))
 - Add Proxy classes for logging
   ([#3575](https://github.com/open-telemetry/opentelemetry-python/pull/3575))
+- Remove dependency on 'backoff' library
+  ([#3679](https://github.com/open-telemetry/opentelemetry-python/pull/3679))
 
 ## Version 1.22.0/0.43b0 (2023-12-15)
 

--- a/exporter/opentelemetry-exporter-otlp-proto-common/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-proto == 1.23.0.dev",
-  "backoff >= 1.10.0, < 3.0.0; python_version>='3.8'",
 ]
 
 [project.optional-dependencies]

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -16,7 +16,16 @@
 import logging
 from collections.abc import Sequence
 from itertools import count
-from typing import Any, Mapping, Optional, List, Callable, TypeVar, Dict, Iterator
+from typing import (
+    Any,
+    Mapping,
+    Optional,
+    List,
+    Callable,
+    TypeVar,
+    Dict,
+    Iterator,
+)
 
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.proto.common.v1.common_pb2 import (
@@ -159,10 +168,8 @@ def _create_exp_backoff_generator(max_value: int = 0) -> Iterator[int]:
     8
     10
 
-    Note: this functionality used to be handled by the 'backoff' package but the dependency
-    was replaced by the implementation below.
+    Note: this functionality used to be handled by the 'backoff' package.
     """
     for i in count(0):
-        out = 2 ** i
+        out = 2**i
         yield min(out, max_value) if max_value else out
-

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -15,9 +15,8 @@
 
 import logging
 from collections.abc import Sequence
-from typing import Any, Mapping, Optional, List, Callable, TypeVar, Dict
-
-import backoff
+from itertools import count
+from typing import Any, Mapping, Optional, List, Callable, TypeVar, Dict, Iterator
 
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.proto.common.v1.common_pb2 import (
@@ -36,7 +35,6 @@ from opentelemetry.proto.common.v1.common_pb2 import (
 )
 from opentelemetry.sdk.trace import Resource
 from opentelemetry.util.types import Attributes
-
 
 _logger = logging.getLogger(__name__)
 
@@ -113,7 +111,6 @@ def _get_resource_data(
     resource_class: Callable[..., _TypingResourceT],
     name: str,
 ) -> List[_TypingResourceT]:
-
     resource_data = []
 
     for (
@@ -134,14 +131,38 @@ def _get_resource_data(
     return resource_data
 
 
-# Work around API change between backoff 1.x and 2.x. Since 2.0.0 the backoff
-# wait generator API requires a first .send(None) before reading the backoff
-# values from the generator.
-_is_backoff_v2 = next(backoff.expo()) is None
+def _create_exp_backoff_generator(max_value: int = 0) -> Iterator[int]:
+    """
+    Generates an infinite sequence of exponential backoff values. The sequence starts
+    from 1 (2^0) and doubles each time (2^1, 2^2, 2^3, ...). If a max_value is specified
+    and non-zero, the generated values will not exceed this maximum, capping at max_value
+    instead of growing indefinitely.
 
+    Parameters:
+    - max_value (int, optional): The maximum value to yield. If 0 or not provided, the
+      sequence grows without bound.
 
-def _create_exp_backoff_generator(*args, **kwargs):
-    gen = backoff.expo(*args, **kwargs)
-    if _is_backoff_v2:
-        gen.send(None)
-    return gen
+    Returns:
+    Iterator[int]: An iterator that yields the exponential backoff values, either uncapped or
+    capped at max_value.
+
+    Example:
+    ```
+    gen = _create_exp_backoff_generator(max_value=10)
+    for _ in range(5):
+        print(next(gen))
+    ```
+    This will print:
+    1
+    2
+    4
+    8
+    10
+
+    Note: this functionality used to be handled by the 'backoff' package but the dependency
+    was replaced by the implementation below.
+    """
+    for i in count(0):
+        out = 2 ** i
+        yield min(out, max_value) if max_value else out
+

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_backoff.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_backoff.py
@@ -1,10 +1,11 @@
 import unittest
 
-from opentelemetry.exporter.otlp.proto.common._internal import _create_exp_backoff_generator
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    _create_exp_backoff_generator,
+)
 
 
 class TestBackoffGenerator(unittest.TestCase):
-
     def test_exp_backoff_generator(self):
         generator = _create_exp_backoff_generator()
         self.assertEqual(next(generator), 1)
@@ -29,4 +30,3 @@ class TestBackoffGenerator(unittest.TestCase):
         self.assertEqual(next(generator), 4)
         self.assertEqual(next(generator), 8)
         self.assertEqual(next(generator), 11)
-

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_backoff.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_backoff.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from unittest import TestCase
+
 from opentelemetry.exporter.otlp.proto.common._internal import (
     _create_exp_backoff_generator,
 )

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_backoff.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_backoff.py
@@ -1,0 +1,32 @@
+import unittest
+
+from opentelemetry.exporter.otlp.proto.common._internal import _create_exp_backoff_generator
+
+
+class TestBackoffGenerator(unittest.TestCase):
+
+    def test_exp_backoff_generator(self):
+        generator = _create_exp_backoff_generator()
+        self.assertEqual(next(generator), 1)
+        self.assertEqual(next(generator), 2)
+        self.assertEqual(next(generator), 4)
+        self.assertEqual(next(generator), 8)
+        self.assertEqual(next(generator), 16)
+
+    def test_exp_backoff_generator_with_max(self):
+        generator = _create_exp_backoff_generator(max_value=4)
+        self.assertEqual(next(generator), 1)
+        self.assertEqual(next(generator), 2)
+        self.assertEqual(next(generator), 4)
+        self.assertEqual(next(generator), 4)
+        self.assertEqual(next(generator), 4)
+
+    def test_exp_backoff_generator_with_odd_max(self):
+        # use a max_value that's not in the set
+        generator = _create_exp_backoff_generator(max_value=11)
+        self.assertEqual(next(generator), 1)
+        self.assertEqual(next(generator), 2)
+        self.assertEqual(next(generator), 4)
+        self.assertEqual(next(generator), 8)
+        self.assertEqual(next(generator), 11)
+

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_backoff.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_backoff.py
@@ -1,11 +1,24 @@
-import unittest
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+from unittest import TestCase
 from opentelemetry.exporter.otlp.proto.common._internal import (
     _create_exp_backoff_generator,
 )
 
 
-class TestBackoffGenerator(unittest.TestCase):
+class TestBackoffGenerator(TestCase):
     def test_exp_backoff_generator(self):
         generator = _create_exp_backoff_generator()
         self.assertEqual(next(generator), 1)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 ]
 dependencies = [
   "Deprecated >= 1.2.6",
-  "backoff >= 1.8.0, < 3.0.0",
   "googleapis-common-protos ~= 1.52",
   "grpcio >= 1.0.0, < 2.0.0",
   "opentelemetry-api ~= 1.15",

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -28,7 +28,6 @@ from grpc import ChannelCredentials, Compression, StatusCode, server
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.exporter.otlp.proto.common._internal import (
     _encode_key_value,
-    _is_backoff_v2,
 )
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
     OTLPSpanExporter,
@@ -459,23 +458,6 @@ class TestOTLPSpanExporter(TestCase):
             exporter._headers,
             (("user-agent", "OTel-OTLP-Exporter-Python/" + __version__),),
         )
-
-    @patch("opentelemetry.exporter.otlp.proto.common._internal.backoff")
-    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
-    def test_handles_backoff_v2_api(self, mock_sleep, mock_backoff):
-        # In backoff ~= 2.0.0 the first value yielded from expo is None.
-        def generate_delays(*args, **kwargs):
-            if _is_backoff_v2:
-                yield None
-            yield 1
-
-        mock_backoff.expo.configure_mock(**{"side_effect": generate_delays})
-
-        add_TraceServiceServicer_to_server(
-            TraceServiceServicerUNAVAILABLE(), self.server
-        )
-        self.exporter.export([self.span])
-        mock_sleep.assert_called_once_with(1)
 
     @patch(
         "opentelemetry.exporter.otlp.proto.grpc.exporter._create_exp_backoff_generator"

--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 ]
 dependencies = [
   "Deprecated >= 1.2.6",
-  "backoff >= 1.10.0, < 3.0.0",
   "googleapis-common-protos ~= 1.52",
   "opentelemetry-api ~= 1.15",
   "opentelemetry-proto == 1.23.0.dev",

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
@@ -15,7 +15,7 @@
 from logging import WARNING
 from os import environ
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, patch, call
+from unittest.mock import MagicMock, Mock, call, patch
 
 from requests import Session
 from requests.models import Response
@@ -313,7 +313,9 @@ class TestOTLPMetricExporter(TestCase):
         metrics_data = self.metrics["sum_int"]
 
         exporter.export(metrics_data)
-        mock_sleep.assert_has_calls([call(1), call(2), call(4), call(8), call(16), call(32)])
+        mock_sleep.assert_has_calls(
+            [call(1), call(2), call(4), call(8), call(16), call(32)]
+        )
 
     def test_aggregation_temporality(self):
 

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
@@ -15,13 +15,12 @@
 from logging import WARNING
 from os import environ
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch, call
 
 from requests import Session
 from requests.models import Response
 from responses import POST, activate, add
 
-from opentelemetry.exporter.otlp.proto.common._internal import _is_backoff_v2
 from opentelemetry.exporter.otlp.proto.common.metrics_encoder import (
     encode_metrics,
 )
@@ -298,17 +297,8 @@ class TestOTLPMetricExporter(TestCase):
         )
 
     @activate
-    @patch("opentelemetry.exporter.otlp.proto.common._internal.backoff")
     @patch("opentelemetry.exporter.otlp.proto.http.metric_exporter.sleep")
-    def test_handles_backoff_v2_api(self, mock_sleep, mock_backoff):
-        # In backoff ~= 2.0.0 the first value yielded from expo is None.
-        def generate_delays(*args, **kwargs):
-            if _is_backoff_v2:
-                yield None
-            yield 1
-
-        mock_backoff.expo.configure_mock(**{"side_effect": generate_delays})
-
+    def test_exponential_backoff(self, mock_sleep):
         # return a retryable error
         add(
             POST,
@@ -323,7 +313,7 @@ class TestOTLPMetricExporter(TestCase):
         metrics_data = self.metrics["sum_int"]
 
         exporter.export(metrics_data)
-        mock_sleep.assert_called_once_with(1)
+        mock_sleep.assert_has_calls([call(1), call(2), call(4), call(8), call(16), call(32)])
 
     def test_aggregation_temporality(self):
 

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
@@ -16,7 +16,7 @@
 
 import unittest
 from typing import List
-from unittest.mock import MagicMock, Mock, patch, call
+from unittest.mock import MagicMock, Mock, call, patch
 
 import requests
 import responses
@@ -182,7 +182,9 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         logs = self._get_sdk_log_data()
 
         exporter.export(logs)
-        mock_sleep.assert_has_calls([call(1), call(2), call(4), call(8), call(16), call(32)])
+        mock_sleep.assert_has_calls(
+            [call(1), call(2), call(4), call(8), call(16), call(32)]
+        )
 
     @staticmethod
     def _get_sdk_log_data() -> List[LogData]:

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
@@ -16,13 +16,12 @@
 
 import unittest
 from typing import List
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch, call
 
 import requests
 import responses
 
 from opentelemetry._logs import SeverityNumber
-from opentelemetry.exporter.otlp.proto.common._internal import _is_backoff_v2
 from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http._log_exporter import (
     DEFAULT_COMPRESSION,
@@ -169,17 +168,8 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         self.assertIsInstance(exporter._session, requests.Session)
 
     @responses.activate
-    @patch("opentelemetry.exporter.otlp.proto.common._internal.backoff")
     @patch("opentelemetry.exporter.otlp.proto.http._log_exporter.sleep")
-    def test_handles_backoff_v2_api(self, mock_sleep, mock_backoff):
-        # In backoff ~= 2.0.0 the first value yielded from expo is None.
-        def generate_delays(*args, **kwargs):
-            if _is_backoff_v2:
-                yield None
-            yield 1
-
-        mock_backoff.expo.configure_mock(**{"side_effect": generate_delays})
-
+    def test_exponential_backoff(self, mock_sleep):
         # return a retryable error
         responses.add(
             responses.POST,
@@ -192,7 +182,7 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         logs = self._get_sdk_log_data()
 
         exporter.export(logs)
-        mock_sleep.assert_called_once_with(1)
+        mock_sleep.assert_has_calls([call(1), call(2), call(4), call(8), call(16), call(32)])
 
     @staticmethod
     def _get_sdk_log_data() -> List[LogData]:

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
@@ -14,12 +14,11 @@
 
 import unittest
 from collections import OrderedDict
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch, call
 
 import requests
 import responses
 
-from opentelemetry.exporter.otlp.proto.common._internal import _is_backoff_v2
 from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     DEFAULT_COMPRESSION,
@@ -205,17 +204,8 @@ class TestOTLPSpanExporter(unittest.TestCase):
 
     # pylint: disable=no-self-use
     @responses.activate
-    @patch("opentelemetry.exporter.otlp.proto.common._internal.backoff")
     @patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.sleep")
-    def test_handles_backoff_v2_api(self, mock_sleep, mock_backoff):
-        # In backoff ~= 2.0.0 the first value yielded from expo is None.
-        def generate_delays(*args, **kwargs):
-            if _is_backoff_v2:
-                yield None
-            yield 1
-
-        mock_backoff.expo.configure_mock(**{"side_effect": generate_delays})
-
+    def test_exponential_backoff(self, mock_sleep):
         # return a retryable error
         responses.add(
             responses.POST,
@@ -239,7 +229,7 @@ class TestOTLPSpanExporter(unittest.TestCase):
         )
 
         exporter.export([span])
-        mock_sleep.assert_called_once_with(1)
+        mock_sleep.assert_has_calls([call(1), call(2), call(4), call(8), call(16), call(32)])
 
     @patch.object(OTLPSpanExporter, "_export", return_value=Mock(ok=True))
     def test_2xx_status_code(self, mock_otlp_metric_exporter):

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
@@ -14,7 +14,7 @@
 
 import unittest
 from collections import OrderedDict
-from unittest.mock import MagicMock, Mock, patch, call
+from unittest.mock import MagicMock, Mock, call, patch
 
 import requests
 import responses
@@ -229,7 +229,9 @@ class TestOTLPSpanExporter(unittest.TestCase):
         )
 
         exporter.export([span])
-        mock_sleep.assert_has_calls([call(1), call(2), call(4), call(8), call(16), call(32)])
+        mock_sleep.assert_has_calls(
+            [call(1), call(2), call(4), call(8), call(16), call(32)]
+        )
 
     @patch.object(OTLPSpanExporter, "_export", return_value=Mock(ok=True))
     def test_2xx_status_code(self, mock_otlp_metric_exporter):


### PR DESCRIPTION
# Description

The backoff dependency doesn't appear to have been needed as used, and it has caused at least one reported dependency conflict for an OTel Python user/developer. This change removes the dependency and replaces it with a function.

Fixes #3680
