### PR TITLE
[feat]: Add OTLP HTTP/JSON traces exporter

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-json/LICENSE
+++ b/exporter/opentelemetry-exporter-otlp-json/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/exporter/opentelemetry-exporter-otlp-json/README.rst
+++ b/exporter/opentelemetry-exporter-otlp-json/README.rst
@@ -1,0 +1,25 @@
+OpenTelemetry OTLP JSON Exporter
+==================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-exporter-otlp-json.svg
+   :target: https://pypi.org/project/opentelemetry-exporter-otlp-json/
+
+This library allows to export data to the OpenTelemetry Collector using the OpenTelemetry Protocol using JSON over HTTP.
+
+Installation
+------------
+
+::
+
+     pip install opentelemetry-exporter-otlp-json
+
+
+References
+----------
+
+* `OpenTelemetry Collector Exporter <https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html>`_
+* `OpenTelemetry Collector <https://github.com/open-telemetry/opentelemetry-collector/>`_
+* `OpenTelemetry <https://opentelemetry.io/>`_
+* `OpenTelemetry Protocol Specification <https://github.com/open-telemetry/oteps/blob/main/text/0035-opentelemetry-protocol.md>`_

--- a/exporter/opentelemetry-exporter-otlp-json/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-json/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opentelemetry-exporter-otlp-json"
+dynamic = ["version"]
+description = "OTLP Exporter over HTTP JSON"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.7"
+authors = [
+  { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
+]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Typing :: Typed",
+]
+dependencies = [
+  "opentelemetry-api ~= 1.3",
+  "opentelemetry-sdk ~= 1.11",
+  "requests ~= 2.7",
+]
+
+[project.optional-dependencies]
+test = []
+
+[project.entry-points.opentelemetry_traces_exporter]
+otlp_json = "opentelemetry.exporter.otlp.json.traces_exporter:OTLPSpanExporter"
+
+[project.urls]
+Homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-json"
+
+[tool.hatch.version]
+path = "src/opentelemetry/exporter/otlp/json/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/src",
+  "/tests",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]

--- a/exporter/opentelemetry-exporter-otlp-json/src/opentelemetry/exporter/otlp/json/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-json/src/opentelemetry/exporter/otlp/json/__init__.py
@@ -1,0 +1,88 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+This library allows to export tracing data to an OTLP collector.
+
+Usage
+-----
+
+The **OTLP Span Exporter** allows to export `OpenTelemetry`_ traces to the
+`OTLP`_ collector.
+
+You can configure the exporter with the following environment variables:
+
+- :envvar:`OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`
+- :envvar:`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`
+- :envvar:`OTEL_EXPORTER_OTLP_TRACES_HEADERS`
+- :envvar:`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+- :envvar:`OTEL_EXPORTER_OTLP_TRACES_COMPRESSION`
+- :envvar:`OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE`
+- :envvar:`OTEL_EXPORTER_OTLP_TIMEOUT`
+- :envvar:`OTEL_EXPORTER_OTLP_PROTOCOL`
+- :envvar:`OTEL_EXPORTER_OTLP_HEADERS`
+- :envvar:`OTEL_EXPORTER_OTLP_ENDPOINT`
+- :envvar:`OTEL_EXPORTER_OTLP_COMPRESSION`
+- :envvar:`OTEL_EXPORTER_OTLP_CERTIFICATE`
+
+.. _OTLP: https://github.com/open-telemetry/opentelemetry-collector/
+.. _OpenTelemetry: https://github.com/open-telemetry/opentelemetry-python/
+
+.. code:: python
+
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.json.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    # Resource can be required for some backends, e.g. Jaeger
+    # If resource aren't set - traces wouldn't appear in Jaeger
+    resource = Resource(attributes={
+        "service.name": "service"
+    })
+
+    trace.set_tracer_provider(TracerProvider(resource=resource))
+    tracer = trace.get_tracer(__name__)
+
+    otlp_exporter = OTLPSpanExporter()
+
+    span_processor = BatchSpanProcessor(otlp_exporter)
+
+    trace.get_tracer_provider().add_span_processor(span_processor)
+
+    with tracer.start_as_current_span("foo"):
+        print("Hello world!")
+
+API
+---
+"""
+import enum
+
+from .version import __version__
+
+DEFAULT_ENDPOINT = "http://localhost:9411/api/v2/spans"
+
+
+_OTLP_HTTP_HEADERS = {
+    "Content-Type": "application/json",
+    "User-Agent": "OTel-OTLP-Exporter-Python/" + __version__,
+}
+
+
+class Compression(enum.Enum):
+    NoCompression = "none"
+    Deflate = "deflate"
+    Gzip = "gzip"

--- a/exporter/opentelemetry-exporter-otlp-json/src/opentelemetry/exporter/otlp/json/traces_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-json/src/opentelemetry/exporter/otlp/json/traces_exporter/__init__.py
@@ -1,0 +1,207 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gzip
+import logging
+import zlib
+from io import BytesIO
+from collections import defaultdict
+from os import environ
+from typing import Dict, Optional, Sequence
+import json
+
+import requests
+
+from opentelemetry.sdk.environment_variables import (
+    OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
+    OTEL_EXPORTER_OTLP_TRACES_HEADERS,
+    OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
+    OTEL_EXPORTER_OTLP_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_COMPRESSION,
+    OTEL_EXPORTER_OTLP_ENDPOINT,
+    OTEL_EXPORTER_OTLP_HEADERS,
+    OTEL_EXPORTER_OTLP_TIMEOUT,
+)
+from opentelemetry.sdk.resources import SERVICE_NAME
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.exporter.otlp.json import (
+    _OTLP_HTTP_HEADERS,
+    DEFAULT_ENDPOINT,
+    Compression,
+)
+from opentelemetry.util.re import parse_env_headers
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_COMPRESSION = Compression.NoCompression
+DEFAULT_ENDPOINT = "http://localhost:4318/"
+DEFAULT_TRACES_EXPORT_PATH = "v1/traces"
+DEFAULT_TIMEOUT = 10  # in seconds
+REQUESTS_SUCCESS_STATUS_CODES = (200, 202)
+
+logger = logging.getLogger(__name__)
+
+
+class OTLPSpanExporter(SpanExporter):
+    def __init__(
+        self,
+        endpoint: Optional[str] = None,
+        certificate_file: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[int] = None,
+        compression: Optional[Compression] = None,
+        session: Optional[requests.Session] = None,
+    ):
+        self._endpoint = endpoint or environ.get(
+            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
+            _append_trace_path(
+                environ.get(OTEL_EXPORTER_OTLP_ENDPOINT, DEFAULT_ENDPOINT)
+            ),
+        )
+        self._certificate_file = certificate_file or environ.get(
+            OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
+            environ.get(OTEL_EXPORTER_OTLP_CERTIFICATE, True),
+        )
+        headers_string = environ.get(
+            OTEL_EXPORTER_OTLP_TRACES_HEADERS,
+            environ.get(OTEL_EXPORTER_OTLP_HEADERS, ""),
+        )
+        self._headers = headers or parse_env_headers(headers_string)
+        self._timeout = timeout or int(
+            environ.get(
+                OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
+                environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, DEFAULT_TIMEOUT),
+            )
+        )
+        self._compression = compression or _compression_from_env()
+        self._session = session or requests.Session()
+        self._session.headers.update(self._headers)
+        self._session.headers.update(_OTLP_HTTP_HEADERS)
+        if self._compression is not Compression.NoCompression:
+            self._session.headers.update(
+                {"Content-Encoding": self._compression.value}
+            )
+        self._shutdown = False
+
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        # After the call to Shutdown subsequent calls to Export are
+        # not allowed and should return a Failure result
+        if self._shutdown:
+            logger.warning("Exporter already shutdown, ignoring batch")
+            return SpanExportResult.FAILURE
+        
+        serialized_data = self._serialize_spans(spans)
+        resp = self._export(serialized_data)
+
+        #TODO: add retry logic / backoff - see otlp-proto-http for example
+        if resp.ok:
+            return SpanExportResult.SUCCESS
+        
+        _logger.error(
+            "Failed to export batch code: %s, reason: %s",
+            resp.status_code,
+            resp.text,
+        )
+        return SpanExportResult.FAILURE
+
+
+    def shutdown(self) -> None:
+        if self._shutdown:
+            logger.warning("Exporter already shutdown, ignoring call")
+            return
+        self.session.close()
+        self._shutdown = True
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Nothing is buffered in this exporter, so this method does nothing."""
+        return True
+    
+    def _export(self, serialized_data: str):
+        data = serialized_data
+        if self._compression == Compression.Gzip:
+            gzip_data = BytesIO()
+            with gzip.GzipFile(fileobj=gzip_data, mode="w") as gzip_stream:
+                gzip_stream.write(serialized_data)
+            data = gzip_data.getvalue()
+        elif self._compression == Compression.Deflate:
+            data = zlib.compress(bytes(serialized_data))
+
+        return self._session.post(
+            url=self._endpoint,
+            data=data,
+            verify=self._certificate_file,
+            timeout=self._timeout,
+        )
+
+    def _serialize_spans(self, sdk_spans: Sequence[ReadableSpan]) -> str:
+        # We need to inspect the spans and group + structure them as:
+        #
+        #   Resource
+        #     Instrumentation Scope
+        #       Spans
+        #
+        # First loop organizes the SDK spans in this structure.
+        #
+        # Second loop encodes the data into JSON format.
+        #
+
+        sdk_resource_spans = defaultdict(lambda: defaultdict(list))
+        for sdk_span in sdk_spans:
+            sdk_resource = sdk_span.resource
+            sdk_instrumentation = sdk_span.instrumentation_scope
+            sdk_resource_spans[sdk_resource][sdk_instrumentation].append(sdk_span)
+
+        resource_spans = []
+        for sdk_resource, sdk_instrumentations in sdk_resource_spans.items():
+            scope_spans = []
+            for sdk_instrumentation, sdk_spans in sdk_instrumentations.items():
+                scope_spans.append(
+                    {
+                        "scope": json.loads(sdk_instrumentation[0].to_json()),
+                        "spans": [json.loads(sdk_span.to_json()) for sdk_span in sdk_spans],
+                    }
+                )
+            resource_spans.append(
+                {
+                    "resource": json.loads(sdk_resource.to_json()),
+                    "scope_spans": scope_spans,
+                }
+            )
+
+        data = {
+            "resource_spans": resource_spans
+        }
+        return json.dumps(data)
+
+
+def _compression_from_env() -> Compression:
+    compression = (
+        environ.get(
+            OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
+            environ.get(OTEL_EXPORTER_OTLP_COMPRESSION, "none"),
+        )
+        .lower()
+        .strip()
+    )
+    return Compression(compression)
+
+
+def _append_trace_path(endpoint: str) -> str:
+    if endpoint.endswith("/"):
+        return endpoint + DEFAULT_TRACES_EXPORT_PATH
+    return endpoint + f"/{DEFAULT_TRACES_EXPORT_PATH}"

--- a/exporter/opentelemetry-exporter-otlp-json/src/opentelemetry/exporter/otlp/json/version.py
+++ b/exporter/opentelemetry-exporter-otlp-json/src/opentelemetry/exporter/otlp/json/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "1.23.0.dev"

--- a/exporter/opentelemetry-exporter-otlp-json/tests/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-json/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/exporter/opentelemetry-exporter-otlp-json/tests/test_otlp_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-json/tests/test_otlp_exporter.py
@@ -1,0 +1,83 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import json
+
+from opentelemetry import trace
+from opentelemetry.trace import TraceFlags
+from opentelemetry.exporter.otlp.json import DEFAULT_ENDPOINT
+from opentelemetry.exporter.otlp.json.traces_exporter import OTLPSpanExporter
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider, ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExportResult
+
+TEST_SERVICE_NAME = "test_service"
+
+
+class MockResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+        self.text = status_code
+
+
+class TestOTLPSpanExporter(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        trace.set_tracer_provider(
+            TracerProvider(
+                resource=Resource({SERVICE_NAME: TEST_SERVICE_NAME})
+            )
+        )
+
+    
+    def test_serialize(self):
+        test_resource = Resource.create({SERVICE_NAME: TEST_SERVICE_NAME})
+        test_scope = InstrumentationScope(
+            name="name", version="version",
+        ),
+        trace_id = 0x6E0C63257DE34C926F9EFCD03927272E
+        spans = [
+            ReadableSpan(
+                name="test-span-1",
+                context=trace.SpanContext(
+                    trace_id,
+                    0x34BF92DEEFC58C92,
+                    is_remote=False,
+                    trace_flags=TraceFlags(TraceFlags.SAMPLED),
+                ),
+                resource=test_resource,
+                instrumentation_scope=test_scope,
+            )
+        ]
+        exporter = OTLPSpanExporter()
+        encoded_data = exporter._serialize_spans(spans)
+        print(encoded_data)
+
+        expected_output = json.dumps({
+            "resource_spans": [
+                {
+                    "resource": json.loads(spans[0].resource.to_json()),
+                    "scope_spans": [
+                        {
+                            "scope": json.loads(spans[0].instrumentation_scope[0].to_json()),
+                            "spans": [json.loads(spans[0].to_json())],
+                        }
+                    ],
+                }
+            ]
+        })
+        print(expected_output)
+        self.assertEqual(encoded_data, expected_output)

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,9 @@ envlist =
     py3{8,9,10,11}-proto{3,4}-opentelemetry-exporter-otlp-proto-grpc
     ; intentionally excluded from pypy3
 
+    py3{7,8,9,10,11}-opentelemetry-exporter-otlp-json
+    pypy3-opentelemetry-exporter-otlp-json
+
     py3{8,9,10,11}-proto{3,4}-opentelemetry-exporter-otlp-proto-http
     pypy3-opentelemetry-proto{3,4}-exporter-otlp-proto-http
 
@@ -108,6 +111,7 @@ changedir =
   exporter-otlp-combined: exporter/opentelemetry-exporter-otlp/tests
   exporter-otlp-proto-grpc: exporter/opentelemetry-exporter-otlp-proto-grpc/tests
   exporter-otlp-proto-http: exporter/opentelemetry-exporter-otlp-proto-http/tests
+  exporter-otlp-json: exporter/opentelemetry-exporter-otlp-json/tests
   exporter-prometheus: exporter/opentelemetry-exporter-prometheus/tests
   exporter-zipkin-combined: exporter/opentelemetry-exporter-zipkin/tests
   exporter-zipkin-proto-http: exporter/opentelemetry-exporter-zipkin-proto-http/tests
@@ -151,6 +155,8 @@ commands_pre =
   exporter-otlp-proto-http: pip install {toxinidir}/opentelemetry-proto
   exporter-otlp-proto-http: pip install {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-common
   exporter-otlp-proto-http: pip install {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-http[test]
+
+  exporter-otlp-json: pip install {toxinidir}/exporter/opentelemetry-exporter-otlp-json
 
   opentracing-shim: pip install {toxinidir}/opentelemetry-sdk
   opentracing-shim: pip install {toxinidir}/shim/opentelemetry-opentracing-shim
@@ -221,6 +227,7 @@ commands_pre =
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-common[test]
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-grpc[test]
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-http[test]
+  python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-otlp-json[test]
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-otlp[test]
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-prometheus[test]
   python -m pip install -e {toxinidir}/exporter/opentelemetry-exporter-zipkin-json[test]


### PR DESCRIPTION
# Description

Adds a OTLP HTTP/JSON exporter. Currently only exports trace data, but can be expanded to add metrics and logs too.

Fixes #1003 

NOTE: I've created as a draft to gather feedback and will add more tests. Also needs lint rules applied too.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Add simple Unit Test to verify JSON output, want to add more

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
