### PR TITLE
Allow broad exceptions in pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -76,6 +76,7 @@ disable=missing-docstring,
       unused-argument, # temp-pylint-upgrade
       redefined-builtin,
       cyclic-import,
+      broad-exception-raised,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -480,10 +481,3 @@ max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2
-
-
-[EXCEPTIONS]
-
-# Exceptions that will emit a warning when being caught. Defaults to
-# "Exception".
-overgeneral-exceptions=Exception


### PR DESCRIPTION
Fixes #3671

If I just change `Exception` in `.pylintrc` to `builtins.Exception` I get these errors:

```
************* Module tests.error_handler.test_error_handler                                                                                                                                     
opentelemetry-sdk/tests/error_handler/test_error_handler.py:33:16: W0719: Raising too general exception: Exception (broad-exception-raised)                
************* Module opentelemetry.sdk.metrics._internal.aggregation
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py:950:12: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py:994:20: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py:1005:20: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py:1121:8: W0719: Raising too general exception: Exception (broad-exception-raised)
************* Module opentelemetry.sdk.metrics._internal
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py:409:20: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py:450:12: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py:475:20: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py:500:12: W0719: Raising too general exception: Exception (broad-exception-raised)
************* Module opentelemetry.sdk.metrics._internal.instrument
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py:57:12: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py:60:12: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py:88:12: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py:91:12: W0719: Raising too general exception: Exception (broad-exception-raised)
************* Module opentelemetry.sdk.metrics._internal.view
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/view.py:106:12: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/view.py:117:12: W0719: Raising too general exception: Exception (broad-exception-raised)
************* Module opentelemetry.sdk.metrics._internal.exponential_histogram.mapping
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exponential_histogram/mapping/__init__.py:43:12: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exponential_histogram/mapping/__init__.py:46:12: W0719: Raising too general exception: Exception (broad-exception-raised)
************* Module opentelemetry.sdk.metrics._internal.export
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py:241:20: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py:272:20: W0719: Raising too general exception: Exception (broad-exception-raised)
opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py:312:20: W0719: Raising too general exception: Exception (broad-exception-raised)
************* Module tests.test_shim
shim/opentelemetry-opentracing-shim/tests/test_shim.py:499:16: W0719: Raising too general exception: Exception (broad-exception-raised)
```

What I think is happening here is that we have always had the wrong value (`Exception`) in `.pylintrc`. When I changed it to `builtins.Exception` that wrong value gets fixed and `pylint` then considers any `Exception` being raised as an error.

So far we have been freely raising `Exception`s all over the place. I think we have been ok with that so what I am doing here is just to ignore that error.