### PR TITLE
docs(examples/logs): include batch processor in pipeline

### DIFF
--- a/docs/examples/logs/README.rst
+++ b/docs/examples/logs/README.rst
@@ -26,6 +26,7 @@ Start the Collector locally to see data being exported. Write the following file
         pipelines:
             logs:
                 receivers: [otlp]
+                processors: [batch]
                 exporters: [logging]
   
 Then start the Docker container:

--- a/docs/examples/logs/otel-collector-config.yaml
+++ b/docs/examples/logs/otel-collector-config.yaml
@@ -14,4 +14,5 @@ service:
     pipelines:
         logs:
             receivers: [otlp]
+            processors: [batch]
             exporters: [logging]


### PR DESCRIPTION
# Description

The example for auto-instrumentation of logs with the OTel Collector specifies a `batch` processor in the config:

https://github.com/open-telemetry/opentelemetry-python/blob/ac3c189ad40b3e482eda3cbfedd2d03312a20d4d/docs/examples/logs/otel-collector-config.yaml#L10-L11

However the batch processor is not included in the logs pipeline:

https://github.com/open-telemetry/opentelemetry-python/blob/ac3c189ad40b3e482eda3cbfedd2d03312a20d4d/docs/examples/logs/otel-collector-config.yaml#L15-L17

This PR adds the batch processor to the pipeline (assuming it should be there, otherwise I would suggest L10-L11 to be removed 😊).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran the [Docker container](https://github.com/open-telemetry/opentelemetry-python/blob/ac3c189ad40b3e482eda3cbfedd2d03312a20d4d/docs/examples/logs/README.rst?plain=1#L35-L38) and [Python example](https://github.com/open-telemetry/opentelemetry-python/blob/ac3c189ad40b3e482eda3cbfedd2d03312a20d4d/docs/examples/logs/README.rst?plain=1#L42) as per README instructions

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
