### PR TITLE
Fix python 3.12 deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix python 3.12 deprecation warning
+  ([#3751](https://github.com/open-telemetry/opentelemetry-python/pull/3751))
+
 ## Version 1.23.0/0.44b0 (2024-02-23)
 
 - Use Attribute rather than boundattribute in logrecord

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -23,7 +23,9 @@ from deprecated import deprecated
 
 def ns_to_iso_str(nanoseconds):
     """Get an ISO 8601 string from time_ns value."""
-    ts = datetime.datetime.utcfromtimestamp(nanoseconds / 1e9)
+    ts = datetime.datetime.fromtimestamp(
+        nanoseconds / 1e9, tz=datetime.timezone.utc
+    )
     return ts.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 


### PR DESCRIPTION

# Description

utcfromtimestamp is deprecated replace
with fromtimestamp with explict UTC timezone

See https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This is a simple bug fix to an existing line that is already tested

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added  N/A
- [ ] Documentation has been updated N/A
