### PR TITLE
Remove thread lock by loading RuntimeContext explicitly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Remove thread lock by loading RuntimeContext explicitly.
+  ([#3763](https://github.com/open-telemetry/opentelemetry-python/pull/3763))
 - Update proto version to v1.2.0
   ([#3844](https://github.com/open-telemetry/opentelemetry-python/pull/3844))
 - Add to_json method to ExponentialHistogram

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -41,14 +41,18 @@ def _load_runtime_context() -> typing.Optional[_RuntimeContext]:
         OTEL_PYTHON_CONTEXT, default_context
     )  # type: str
 
-    return next(  # type: ignore
-        iter(  # type: ignore
-            entry_points(  # type: ignore
-                group="opentelemetry_context",
-                name=configured_context,
+    try:
+        return next(  # type: ignore
+            iter(  # type: ignore
+                entry_points(  # type: ignore
+                    group="opentelemetry_context",
+                    name=configured_context,
+                )
             )
-        )
-    ).load()()
+        ).load()()
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Failed to load context: %s", configured_context)
+        return None
 
 
 _RUNTIME_CONTEXT = _load_runtime_context()

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -25,55 +25,38 @@ from opentelemetry.environment_variables import OTEL_PYTHON_CONTEXT
 from opentelemetry.util._importlib_metadata import entry_points
 
 logger = logging.getLogger(__name__)
-_RUNTIME_CONTEXT = None  # type: typing.Optional[_RuntimeContext]
-_RUNTIME_CONTEXT_LOCK = threading.Lock()
 
-_F = typing.TypeVar("_F", bound=typing.Callable[..., typing.Any])
-
-
-def _load_runtime_context(func: _F) -> _F:
-    """A decorator used to initialize the global RuntimeContext
+def _load_runtime_context() -> typing.Optional[_RuntimeContext]:
+    """Initialize the RuntimeContext
 
     Returns:
-        A wrapper of the decorated method.
+        An instance of RuntimeContext.
     """
 
-    @wraps(func)  # type: ignore[misc]
-    def wrapper(
-        *args: typing.Tuple[typing.Any, typing.Any],
-        **kwargs: typing.Dict[typing.Any, typing.Any],
-    ) -> typing.Optional[typing.Any]:
-        global _RUNTIME_CONTEXT  # pylint: disable=global-statement
+    # FIXME use a better implementation of a configuration manager
+    # to avoid having to get configuration values straight from
+    # environment variables
+    default_context = "contextvars_context"
 
-        with _RUNTIME_CONTEXT_LOCK:
-            if _RUNTIME_CONTEXT is None:
-                # FIXME use a better implementation of a configuration manager
-                # to avoid having to get configuration values straight from
-                # environment variables
-                default_context = "contextvars_context"
+    configured_context = environ.get(
+        OTEL_PYTHON_CONTEXT, default_context
+    )  # type: str
 
-                configured_context = environ.get(
-                    OTEL_PYTHON_CONTEXT, default_context
-                )  # type: str
-                try:
+    try:
+        return next(  # type: ignore
+            iter(  # type: ignore
+                entry_points(  # type: ignore
+                    group="opentelemetry_context",
+                    name=configured_context,
+                )
+            )
+        ).load()()
+    except Exception:  # pylint: disable=broad-except
+        logger.exception(
+            "Failed to load context: %s", configured_context
+        )
 
-                    _RUNTIME_CONTEXT = next(  # type: ignore
-                        iter(  # type: ignore
-                            entry_points(  # type: ignore
-                                group="opentelemetry_context",
-                                name=configured_context,
-                            )
-                        )
-                    ).load()()
-
-                except Exception:  # pylint: disable=broad-except
-                    logger.exception(
-                        "Failed to load context: %s", configured_context
-                    )
-        return func(*args, **kwargs)  # type: ignore[misc]
-
-    return typing.cast(_F, wrapper)  # type: ignore[misc]
-
+_RUNTIME_CONTEXT = _load_runtime_context()
 
 def create_key(keyname: str) -> str:
     """To allow cross-cutting concern to control access to their local state,
@@ -125,7 +108,6 @@ def set_value(
     return Context(new_values)
 
 
-@_load_runtime_context  # type: ignore
 def get_current() -> Context:
     """To access the context associated with program execution,
     the Context API provides a function which takes no arguments
@@ -137,7 +119,6 @@ def get_current() -> Context:
     return _RUNTIME_CONTEXT.get_current()  # type:ignore
 
 
-@_load_runtime_context  # type: ignore
 def attach(context: Context) -> object:
     """Associates a Context with the caller's current execution unit. Returns
     a token that can be used to restore the previous Context.
@@ -151,7 +132,6 @@ def attach(context: Context) -> object:
     return _RUNTIME_CONTEXT.attach(context)  # type:ignore
 
 
-@_load_runtime_context  # type: ignore
 def detach(token: object) -> None:
     """Resets the Context associated with the caller's current execution unit
     to the value it had before attaching a specified Context.

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -60,7 +60,7 @@ def _load_runtime_context() -> typing.Optional[_RuntimeContext]:
             iter(  # type: ignore
                 entry_points(  # type: ignore
                     group="opentelemetry_context",
-                    name=OTEL_PYTHON_CONTEXT,
+                    name=default_context,
                 )
             )
         ).load()()

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import logging
-import threading
 import typing
-from functools import wraps
 from os import environ
 from uuid import uuid4
 
@@ -25,6 +23,7 @@ from opentelemetry.environment_variables import OTEL_PYTHON_CONTEXT
 from opentelemetry.util._importlib_metadata import entry_points
 
 logger = logging.getLogger(__name__)
+
 
 def _load_runtime_context() -> typing.Optional[_RuntimeContext]:
     """Initialize the RuntimeContext
@@ -51,7 +50,9 @@ def _load_runtime_context() -> typing.Optional[_RuntimeContext]:
         )
     ).load()()
 
+
 _RUNTIME_CONTEXT = _load_runtime_context()
+
 
 def create_key(keyname: str) -> str:
     """To allow cross-cutting concern to control access to their local state,

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -54,7 +54,7 @@ def _load_runtime_context() -> typing.Optional[_RuntimeContext]:
         logger.exception(
             "Failed to load context: %s, fallback to %s",
             configured_context,
-            OTEL_PYTHON_CONTEXT,
+            default_context,
         )
         return next(  # type: ignore
             iter(  # type: ignore

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -51,8 +51,19 @@ def _load_runtime_context() -> typing.Optional[_RuntimeContext]:
             )
         ).load()()
     except Exception:  # pylint: disable=broad-except
-        logger.exception("Failed to load context: %s", configured_context)
-        return None
+        logger.exception(
+            "Failed to load context: %s, fallback to %s",
+            configured_context,
+            OTEL_PYTHON_CONTEXT,
+        )
+        return next(  # type: ignore
+            iter(  # type: ignore
+                entry_points(  # type: ignore
+                    group="opentelemetry_context",
+                    name=OTEL_PYTHON_CONTEXT,
+                )
+            )
+        ).load()()
 
 
 _RUNTIME_CONTEXT = _load_runtime_context()

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -42,19 +42,14 @@ def _load_runtime_context() -> typing.Optional[_RuntimeContext]:
         OTEL_PYTHON_CONTEXT, default_context
     )  # type: str
 
-    try:
-        return next(  # type: ignore
-            iter(  # type: ignore
-                entry_points(  # type: ignore
-                    group="opentelemetry_context",
-                    name=configured_context,
-                )
+    return next(  # type: ignore
+        iter(  # type: ignore
+            entry_points(  # type: ignore
+                group="opentelemetry_context",
+                name=configured_context,
             )
-        ).load()()
-    except Exception:  # pylint: disable=broad-except
-        logger.exception(
-            "Failed to load context: %s", configured_context
         )
+    ).load()()
 
 _RUNTIME_CONTEXT = _load_runtime_context()
 

--- a/opentelemetry-api/src/opentelemetry/context/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/context/__init__.py
@@ -25,7 +25,7 @@ from opentelemetry.util._importlib_metadata import entry_points
 logger = logging.getLogger(__name__)
 
 
-def _load_runtime_context() -> typing.Optional[_RuntimeContext]:
+def _load_runtime_context() -> _RuntimeContext:
     """Initialize the RuntimeContext
 
     Returns:
@@ -127,7 +127,7 @@ def get_current() -> Context:
     Returns:
         The current `Context` object.
     """
-    return _RUNTIME_CONTEXT.get_current()  # type:ignore
+    return _RUNTIME_CONTEXT.get_current()
 
 
 def attach(context: Context) -> object:
@@ -140,7 +140,7 @@ def attach(context: Context) -> object:
     Returns:
         A token that can be used with `detach` to reset the context.
     """
-    return _RUNTIME_CONTEXT.attach(context)  # type:ignore
+    return _RUNTIME_CONTEXT.attach(context)
 
 
 def detach(token: object) -> None:
@@ -151,7 +151,7 @@ def detach(token: object) -> None:
         token: The Token that was returned by a previous call to attach a Context.
     """
     try:
-        _RUNTIME_CONTEXT.detach(token)  # type: ignore
+        _RUNTIME_CONTEXT.detach(token)
     except Exception:  # pylint: disable=broad-except
         logger.exception("Failed to detach context")
 

--- a/opentelemetry-api/tests/context/test_context.py
+++ b/opentelemetry-api/tests/context/test_context.py
@@ -85,11 +85,11 @@ class TestInitContext(unittest.TestCase):
         self.assertIsInstance(ctx, ContextVarsRuntimeContext)
 
     @patch.dict("os.environ", {OTEL_PYTHON_CONTEXT: "contextvars_context"})
-    def test_load_runtime_context(self):
+    def test_load_runtime_context(self):  # type: ignore[misc]
         ctx = context._load_runtime_context()  # pylint: disable=W0212
         self.assertIsInstance(ctx, ContextVarsRuntimeContext)
 
     @patch.dict("os.environ", {OTEL_PYTHON_CONTEXT: "foo"})
-    def test_load_runtime_context_fallback(self):
+    def test_load_runtime_context_fallback(self):  # type: ignore[misc]
         ctx = context._load_runtime_context()  # pylint: disable=W0212
         self.assertIsInstance(ctx, ContextVarsRuntimeContext)

--- a/opentelemetry-api/tests/context/test_context.py
+++ b/opentelemetry-api/tests/context/test_context.py
@@ -88,3 +88,8 @@ class TestInitContext(unittest.TestCase):
     def test_load_runtime_context(self):
         ctx = context._load_runtime_context()  # pylint: disable=W0212
         self.assertIsInstance(ctx, ContextVarsRuntimeContext)
+
+    @patch.dict("os.environ", {OTEL_PYTHON_CONTEXT: "foo"})
+    def test_load_runtime_context_fallback(self):
+        ctx = context._load_runtime_context()  # pylint: disable=W0212
+        self.assertIsInstance(ctx, ContextVarsRuntimeContext)

--- a/opentelemetry-api/tests/context/test_context.py
+++ b/opentelemetry-api/tests/context/test_context.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import unittest
+from os import environ
 
 from opentelemetry import context
 from opentelemetry.context.context import Context
+from opentelemetry.context.contextvars_context import ContextVarsRuntimeContext
+from opentelemetry.environment_variables import OTEL_PYTHON_CONTEXT
 
 
 def _do_work() -> str:
@@ -75,16 +78,13 @@ class TestContext(unittest.TestCase):
         context.detach(token)
         self.assertEqual("yyy", context.get_value("a"))
 
+
 class TestInitContext(unittest.TestCase):
     def test_load_runtime_context(self):
-        from os import environ
-        from opentelemetry.environment_variables import OTEL_PYTHON_CONTEXT
-        from opentelemetry.context.contextvars_context import ContextVarsRuntimeContext
-
         environ[OTEL_PYTHON_CONTEXT] = "contextvars_context"
-        ctx = context._load_runtime_context()
+        ctx = context._load_runtime_context()  # pylint: disable=W0212
         self.assertIsInstance(ctx, ContextVarsRuntimeContext)
 
         environ.pop(OTEL_PYTHON_CONTEXT)
-        ctx = context._load_runtime_context()
+        ctx = context._load_runtime_context()  # pylint: disable=W0212
         self.assertIsInstance(ctx, ContextVarsRuntimeContext)

--- a/opentelemetry-api/tests/context/test_context.py
+++ b/opentelemetry-api/tests/context/test_context.py
@@ -74,3 +74,17 @@ class TestContext(unittest.TestCase):
 
         context.detach(token)
         self.assertEqual("yyy", context.get_value("a"))
+
+class TestInitContext(unittest.TestCase):
+    def test_load_runtime_context(self):
+        from os import environ
+        from opentelemetry.environment_variables import OTEL_PYTHON_CONTEXT
+        from opentelemetry.context.contextvars_context import ContextVarsRuntimeContext
+
+        environ[OTEL_PYTHON_CONTEXT] = "contextvars_context"
+        ctx = context._load_runtime_context()
+        self.assertIsInstance(ctx, ContextVarsRuntimeContext)
+
+        environ.pop(OTEL_PYTHON_CONTEXT)
+        ctx = context._load_runtime_context()
+        self.assertIsInstance(ctx, ContextVarsRuntimeContext)

--- a/opentelemetry-api/tests/context/test_context.py
+++ b/opentelemetry-api/tests/context/test_context.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from os import environ
+from unittest.mock import patch
 
 from opentelemetry import context
 from opentelemetry.context.context import Context
@@ -80,11 +80,11 @@ class TestContext(unittest.TestCase):
 
 
 class TestInitContext(unittest.TestCase):
-    def test_load_runtime_context(self):
-        environ[OTEL_PYTHON_CONTEXT] = "contextvars_context"
+    def test_load_runtime_context_default(self):
         ctx = context._load_runtime_context()  # pylint: disable=W0212
         self.assertIsInstance(ctx, ContextVarsRuntimeContext)
 
-        environ.pop(OTEL_PYTHON_CONTEXT)
+    @patch.dict("os.environ", {OTEL_PYTHON_CONTEXT: "contextvars_context"})
+    def test_load_runtime_context(self):
         ctx = context._load_runtime_context()  # pylint: disable=W0212
         self.assertIsInstance(ctx, ContextVarsRuntimeContext)


### PR DESCRIPTION
Fixes #3663, #3381

The old `_load_runtime_context` is an function wrapper, which acquires lock and check value of `_RUNTIME_CONTEXT` every time the wrapped function (`get_current`/`attach`/`deatch`) called. Since it should be initialized after the first `_load_runtime_context` call, there's no need to check repeatedly.

The solution is, initialize it on module import, which should be exactly once and thread safe, and use it directly without redundant check afterwards.
