### PR TITLE
Use set -e to catch errors in all scripts

### DIFF
--- a/scripts/generate_website_docs.sh
+++ b/scripts/generate_website_docs.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 # this script generates the documentation required for
 # opentelemetry.io
 

--- a/scripts/semconv/generate.sh
+++ b/scripts/semconv/generate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"


### PR DESCRIPTION
# Description

A couple of build scripts were not setting `-e` to detect errors in commands (the other scripts already were).


# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- Scripts in `scripts/` that were copied over to the Contrib repo have changed

No, but the same problem is present in non-copied-over contrib scripts, for which I will file a separate PR.

- [ ] Yes. - Link to PR: 
- [x] No.
