### PR TITLE
Don't exit ticker thread on collection failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3776](https://github.com/open-telemetry/opentelemetry-python/pull/3776))
 - Add support for OTEL_SDK_DISABLED environment variable
   ([#3648](https://github.com/open-telemetry/opentelemetry-python/pull/3648))
+- Don't exit ticker thread on collection failure
+  ([#3788](https://github.com/open-telemetry/opentelemetry-python/pull/3788))
 - Fix ValueError message for PeriodicExportingMetricsReader
   ([#3769](https://github.com/open-telemetry/opentelemetry-python/pull/3769))
 - Make span.record_exception more robust

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
@@ -518,6 +518,10 @@ class PeriodicExportingMetricReader(MetricReader):
                     interval_secs,
                     exc_info=True,
                 )
+            except Exception as e:  # pylint: disable=broad-except,invalid-name
+                _logger.exception(
+                    "Exception while collecting metrics %s", str(e)
+                )
         # one last collection below before shutting down completely
         self.collect(timeout_millis=self._export_interval_millis)
 


### PR DESCRIPTION
# Description

Currently, if collect raises an uncaught error, _ticker stops and service's metrics disappear.  This PR makes it more robust for the one-off-failures.  Persistent failures would also be more visible in logs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
