### PR TITLE
Fix shellcheck --severity=warning issues

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,13 +8,13 @@ set -ev
 # Get the latest versions of packaging tools
 python3 -m pip install --upgrade pip build setuptools wheel
 
-BASEDIR=$(dirname $(readlink -f $(dirname $0)))
+BASEDIR=$(dirname "$(readlink -f "$(dirname $0)")")
 DISTDIR=dist
 
 (
   cd $BASEDIR
   mkdir -p $DISTDIR
-  rm -rf $DISTDIR/*
+  rm -rf ${DISTDIR:?}/*
 
  for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-proto/ opentelemetry-semantic-conventions/ exporter/*/ shim/opentelemetry-opentracing-shim/ propagator/*/ tests/opentelemetry-test-utils/; do
    (

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -22,9 +22,6 @@ function cov {
     fi
 }
 
-PYTHON_VERSION=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
-PYTHON_VERSION_INFO=(${PYTHON_VERSION//./ })
-
 coverage erase
 
 cov opentelemetry-api


### PR DESCRIPTION
# Description
Run `shellcheck --severity=warning` on all build scripts.  Fix a quoting issue, remove some dead code, and safely ensure that the build can't ever accidentally wipe the file system.

If desired, I could add a PR for enabling a shellcheck CI step similar to https://github.com/open-telemetry/opentelemetry-lambda/pull/396

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
(Yes, and Contrib also has additional shellcheck errors/warnings in non-shared scripts)

- [x] Yes. - Link to PR:  [contrib shellcheck warnings](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2354)
- [ ] No.

