### PR TITLE
Improve tracing sdk type annotations

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -30,6 +30,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    MutableMapping,
     Optional,
     Sequence,
     Tuple,
@@ -745,13 +746,13 @@ class Span(trace_api.Span, ReadableSpan):
         parent: Optional[trace_api.SpanContext] = None,
         sampler: Optional[sampling.Sampler] = None,
         trace_config: None = None,  # TODO
-        resource: Resource = None,
+        resource: Optional[Resource] = None,
         attributes: types.Attributes = None,
-        events: Sequence[Event] = None,
+        events: Optional[Sequence[Event]] = None,
         links: Sequence[trace_api.Link] = (),
         kind: trace_api.SpanKind = trace_api.SpanKind.INTERNAL,
         span_processor: SpanProcessor = SpanProcessor(),
-        instrumentation_info: InstrumentationInfo = None,
+        instrumentation_info: Optional[InstrumentationInfo] = None,
         record_exception: bool = True,
         set_status_on_exception: bool = True,
         limits=_UnsetLimits,
@@ -994,7 +995,7 @@ class Span(trace_api.Span, ReadableSpan):
                 type(exception), value=exception, tb=exception.__traceback__
             )
         )
-        _attributes = {
+        _attributes: MutableMapping[str, types.AttributeValue] = {
             "exception.type": exception.__class__.__name__,
             "exception.message": str(exception),
             "exception.stacktrace": stacktrace,
@@ -1045,7 +1046,7 @@ class Tracer(trace_api.Tracer):
         context: Optional[context_api.Context] = None,
         kind: trace_api.SpanKind = trace_api.SpanKind.INTERNAL,
         attributes: types.Attributes = None,
-        links: Sequence[trace_api.Link] = (),
+        links: Optional[Sequence[trace_api.Link]] = (),
         start_time: Optional[int] = None,
         record_exception: bool = True,
         set_status_on_exception: bool = True,
@@ -1075,7 +1076,7 @@ class Tracer(trace_api.Tracer):
         context: Optional[context_api.Context] = None,
         kind: trace_api.SpanKind = trace_api.SpanKind.INTERNAL,
         attributes: types.Attributes = None,
-        links: Sequence[trace_api.Link] = (),
+        links: Optional[Sequence[trace_api.Link]] = (),
         start_time: Optional[int] = None,
         record_exception: bool = True,
         set_status_on_exception: bool = True,
@@ -1152,15 +1153,15 @@ class TracerProvider(trace_api.TracerProvider):
 
     def __init__(
         self,
-        sampler: sampling.Sampler = None,
-        resource: Resource = None,
+        sampler: Optional[sampling.Sampler] = None,
+        resource: Optional[Resource] = None,
         shutdown_on_exit: bool = True,
         active_span_processor: Union[
-            SynchronousMultiSpanProcessor, ConcurrentMultiSpanProcessor
+            SynchronousMultiSpanProcessor, ConcurrentMultiSpanProcessor, None
         ] = None,
-        id_generator: IdGenerator = None,
-        span_limits: SpanLimits = None,
-    ):
+        id_generator: Optional[IdGenerator] = None,
+        span_limits: Optional[SpanLimits] = None,
+    ) -> None:
         self._active_span_processor = (
             active_span_processor or SynchronousMultiSpanProcessor()
         )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -756,7 +756,7 @@ class Span(trace_api.Span, ReadableSpan):
         record_exception: bool = True,
         set_status_on_exception: bool = True,
         limits=_UnsetLimits,
-        instrumentation_scope: InstrumentationScope = None,
+        instrumentation_scope: Optional[InstrumentationScope] = None,
     ) -> None:
         if resource is None:
             resource = Resource.create({})

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -184,7 +184,7 @@ class SamplingResult:
         self,
         decision: Decision,
         attributes: "Attributes" = None,
-        trace_state: "TraceState" = None,
+        trace_state: Optional["TraceState"] = None,
     ) -> None:
         self.decision = decision
         if attributes is None:
@@ -201,10 +201,10 @@ class Sampler(abc.ABC):
         parent_context: Optional["Context"],
         trace_id: int,
         name: str,
-        kind: SpanKind = None,
+        kind: Optional[SpanKind] = None,
         attributes: Attributes = None,
-        links: Sequence["Link"] = None,
-        trace_state: "TraceState" = None,
+        links: Optional[Sequence["Link"]] = None,
+        trace_state: Optional["TraceState"] = None,
     ) -> "SamplingResult":
         pass
 
@@ -216,7 +216,7 @@ class Sampler(abc.ABC):
 class StaticSampler(Sampler):
     """Sampler that always returns the same decision."""
 
-    def __init__(self, decision: "Decision"):
+    def __init__(self, decision: "Decision") -> None:
         self._decision = decision
 
     def should_sample(
@@ -224,10 +224,10 @@ class StaticSampler(Sampler):
         parent_context: Optional["Context"],
         trace_id: int,
         name: str,
-        kind: SpanKind = None,
+        kind: Optional[SpanKind] = None,
         attributes: Attributes = None,
-        links: Sequence["Link"] = None,
-        trace_state: "TraceState" = None,
+        links: Optional[Sequence["Link"]] = None,
+        trace_state: Optional["TraceState"] = None,
     ) -> "SamplingResult":
         if self._decision is Decision.DROP:
             attributes = None
@@ -285,10 +285,10 @@ class TraceIdRatioBased(Sampler):
         parent_context: Optional["Context"],
         trace_id: int,
         name: str,
-        kind: SpanKind = None,
+        kind: Optional[SpanKind] = None,
         attributes: Attributes = None,
-        links: Sequence["Link"] = None,
-        trace_state: "TraceState" = None,
+        links: Optional[Sequence["Link"]] = None,
+        trace_state: Optional["TraceState"] = None,
     ) -> "SamplingResult":
         decision = Decision.DROP
         if trace_id & self.TRACE_ID_LIMIT < self.bound:
@@ -340,10 +340,10 @@ class ParentBased(Sampler):
         parent_context: Optional["Context"],
         trace_id: int,
         name: str,
-        kind: SpanKind = None,
+        kind: Optional[SpanKind] = None,
         attributes: Attributes = None,
-        links: Sequence["Link"] = None,
-        trace_state: "TraceState" = None,
+        links: Optional[Sequence["Link"]] = None,
+        trace_state: Optional["TraceState"] = None,
     ) -> "SamplingResult":
         parent_span_context = get_current_span(
             parent_context
@@ -443,7 +443,9 @@ def _get_from_env_or_default() -> Sampler:
     return _KNOWN_SAMPLERS[trace_sampler]
 
 
-def _get_parent_trace_state(parent_context) -> Optional["TraceState"]:
+def _get_parent_trace_state(
+    parent_context: Optional[Context],
+) -> Optional["TraceState"]:
     parent_span_context = get_current_span(parent_context).get_span_context()
     if parent_span_context is None or not parent_span_context.is_valid:
         return None


### PR DESCRIPTION
# Description

Mostly fixed two obvious types of problems:
* `= None` arguments not being marked as `Optional`.
* type mismatches between child and parent class methods' arguments.

no functional changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

