### PR TITLE
Fix collection of exponential histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix python 3.12 deprecation warning
   ([#3751](https://github.com/open-telemetry/opentelemetry-python/pull/3751))
+- Fix exponential histograms
+  ([#3798](https://github.com/open-telemetry/opentelemetry-python/pull/3798))
 - bump mypy to 0.982
   ([#3776](https://github.com/open-telemetry/opentelemetry-python/pull/3776))
 - Fix ValueError message for PeriodicExportingMetricsReader

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -869,6 +869,7 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                     min_scale,
                     collection_aggregation_temporality,
                 )
+                current_scale = min_scale
 
                 current_positive = self._previous_positive
                 current_negative = self._previous_negative

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -609,6 +609,7 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
         self._previous_scale = None
         self._previous_start_time_unix_nano = None
         self._previous_zero_count = None
+        self._previous_count = None
         self._previous_sum = None
         self._previous_max = None
         self._previous_min = None
@@ -780,6 +781,7 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                 self._previous_max = current_max
                 self._previous_min = current_min
                 self._previous_sum = current_sum
+                self._previous_count = current_count
                 self._previous_zero_count = current_zero_count
                 self._previous_positive = current_positive
                 self._previous_negative = current_negative
@@ -848,6 +850,7 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                 start_time_unix_nano = self._previous_start_time_unix_nano
                 sum_ = current_sum + self._previous_sum
                 zero_count = current_zero_count + self._previous_zero_count
+                count = current_count + self._previous_count
                 # Only update min/max on delta -> cumulative
                 max_ = max(current_max, self._previous_max)
                 min_ = min(current_min, self._previous_min)
@@ -874,6 +877,7 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                 start_time_unix_nano = self._previous_start_time_unix_nano
                 sum_ = current_sum - self._previous_sum
                 zero_count = current_zero_count
+                count = current_count
                 max_ = current_max
                 min_ = current_min
 
@@ -896,7 +900,7 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                 attributes=self._attributes,
                 start_time_unix_nano=start_time_unix_nano,
                 time_unix_nano=collection_start_nano,
-                count=current_count,
+                count=count,
                 sum=sum_,
                 scale=current_scale,
                 zero_count=zero_count,
@@ -918,8 +922,11 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
             self._previous_positive = current_positive
             self._previous_negative = current_negative
             self._previous_start_time_unix_nano = current_start_time_unix_nano
-            self._previous_sum = current_sum
-            self._previous_zero_count += current_zero_count
+            self._previous_sum = sum_
+            self._previous_count = count
+            self._previous_max = max_
+            self._previous_min = min_
+            self._previous_zero_count = zero_count
 
             return current_point
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -952,7 +952,8 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
 
         return low, high
 
-    def _get_low_high(self, buckets, scale, min_scale):
+    @staticmethod
+    def _get_low_high(buckets, scale, min_scale):
         if buckets.counts == [0]:
             return 0, -1
 
@@ -972,7 +973,8 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
 
         return change
 
-    def _downscale(self, change: int, positive, negative):
+    @staticmethod
+    def _downscale(change: int, positive, negative):
 
         if change == 0:
             return

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -37,6 +37,9 @@ from opentelemetry.metrics import (
 from opentelemetry.sdk.metrics._internal.exponential_histogram.buckets import (
     Buckets,
 )
+from opentelemetry.sdk.metrics._internal.exponential_histogram.mapping import (
+    Mapping,
+)
 from opentelemetry.sdk.metrics._internal.exponential_histogram.mapping.exponent_mapping import (
     ExponentMapping,
 )
@@ -519,6 +522,12 @@ class _ExplicitBucketHistogramAggregation(_Aggregation[HistogramPoint]):
             return None
 
 
+def _new_exponential_mapping(scale: int) -> Mapping:
+    if scale <= 0:
+        return ExponentMapping(scale)
+    return LogarithmMapping(scale)
+
+
 # pylint: disable=protected-access
 class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
     # _min_max_size and _max_max_size are the smallest and largest values
@@ -592,13 +601,14 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                 "larger than the recommended value of 20",
                 self._max_scale,
             )
-        self._mapping = LogarithmMapping(self._max_scale)
+        self._mapping = _new_exponential_mapping(self._max_scale)
 
         self._instrument_aggregation_temporality = AggregationTemporality.DELTA
         self._start_time_unix_nano = start_time_unix_nano
 
         self._previous_scale = None
         self._previous_start_time_unix_nano = None
+        self._previous_zero_count = None
         self._previous_sum = None
         self._previous_max = None
         self._previous_min = None
@@ -678,11 +688,14 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
             # 4. Rescale the mapping if needed.
             if is_rescaling_needed:
 
+                scale_change = self._get_scale_change(low, high)
                 self._downscale(
-                    self._get_scale_change(low, high),
+                    scale_change,
                     self._positive,
                     self._negative,
                 )
+                new_scale = self._mapping.scale - scale_change
+                self._mapping = _new_exponential_mapping(new_scale)
 
                 index = self._mapping.map_to_index(value)
 
@@ -756,28 +769,6 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
             self._min = inf
             self._max = -inf
 
-            current_point = ExponentialHistogramDataPoint(
-                attributes=self._attributes,
-                start_time_unix_nano=current_start_time_unix_nano,
-                time_unix_nano=collection_start_nano,
-                count=current_count,
-                sum=current_sum,
-                scale=current_scale,
-                zero_count=current_zero_count,
-                positive=BucketsPoint(
-                    offset=current_positive.offset,
-                    bucket_counts=current_positive.counts,
-                ),
-                negative=BucketsPoint(
-                    offset=current_negative.offset,
-                    bucket_counts=current_negative.counts,
-                ),
-                # FIXME: Find the right value for flags
-                flags=0,
-                min=current_min,
-                max=current_max,
-            )
-
             if self._previous_scale is None or (
                 self._instrument_aggregation_temporality
                 is collection_aggregation_temporality
@@ -789,18 +780,47 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                 self._previous_max = current_max
                 self._previous_min = current_min
                 self._previous_sum = current_sum
+                self._previous_zero_count = current_zero_count
                 self._previous_positive = current_positive
                 self._previous_negative = current_negative
+
+                current_point = ExponentialHistogramDataPoint(
+                    attributes=self._attributes,
+                    start_time_unix_nano=current_start_time_unix_nano,
+                    time_unix_nano=collection_start_nano,
+                    count=current_count,
+                    sum=current_sum,
+                    scale=current_scale,
+                    zero_count=current_zero_count,
+                    positive=BucketsPoint(
+                        offset=current_positive.offset,
+                        bucket_counts=current_positive.get_offset_counts(),
+                    ),
+                    negative=BucketsPoint(
+                        offset=current_negative.offset,
+                        bucket_counts=current_negative.get_offset_counts(),
+                    ),
+                    # FIXME: Find the right value for flags
+                    flags=0,
+                    min=current_min,
+                    max=current_max,
+                )
 
                 return current_point
 
             min_scale = min(self._previous_scale, current_scale)
 
             low_positive, high_positive = self._get_low_high_previous_current(
-                self._previous_positive, current_positive, min_scale
+                self._previous_positive,
+                current_positive,
+                current_scale,
+                min_scale,
             )
             low_negative, high_negative = self._get_low_high_previous_current(
-                self._previous_negative, current_negative, min_scale
+                self._previous_negative,
+                current_negative,
+                current_scale,
+                min_scale,
             )
 
             min_scale = min(
@@ -814,10 +834,11 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
             # but the histogram) has a count larger than zero, if not, scale
             # (the histogram scale) would be zero. See exponential.go 191
             self._downscale(
-                self._mapping.scale - min_scale,
+                self._previous_scale - min_scale,
                 self._previous_positive,
                 self._previous_negative,
             )
+            self._previous_scale = min_scale
 
             if (
                 collection_aggregation_temporality
@@ -826,6 +847,7 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
 
                 start_time_unix_nano = self._previous_start_time_unix_nano
                 sum_ = current_sum + self._previous_sum
+                zero_count = current_zero_count + self._previous_zero_count
                 # Only update min/max on delta -> cumulative
                 max_ = max(current_max, self._previous_max)
                 min_ = min(current_min, self._previous_min)
@@ -845,9 +867,13 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                     collection_aggregation_temporality,
                 )
 
+                current_positive = self._previous_positive
+                current_negative = self._previous_negative
+
             else:
                 start_time_unix_nano = self._previous_start_time_unix_nano
                 sum_ = current_sum - self._previous_sum
+                zero_count = current_zero_count
                 max_ = current_max
                 min_ = current_min
 
@@ -873,14 +899,14 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                 count=current_count,
                 sum=sum_,
                 scale=current_scale,
-                zero_count=current_zero_count,
+                zero_count=zero_count,
                 positive=BucketsPoint(
                     offset=current_positive.offset,
-                    bucket_counts=current_positive.counts,
+                    bucket_counts=current_positive.get_offset_counts(),
                 ),
                 negative=BucketsPoint(
                     offset=current_negative.offset,
-                    bucket_counts=current_negative.counts,
+                    bucket_counts=current_negative.get_offset_counts(),
                 ),
                 # FIXME: Find the right value for flags
                 flags=0,
@@ -893,18 +919,23 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
             self._previous_negative = current_negative
             self._previous_start_time_unix_nano = current_start_time_unix_nano
             self._previous_sum = current_sum
+            self._previous_zero_count += current_zero_count
 
             return current_point
 
     def _get_low_high_previous_current(
-        self, previous_point_buckets, current_point_buckets, min_scale
+        self,
+        previous_point_buckets,
+        current_point_buckets,
+        current_scale,
+        min_scale,
     ):
 
         (previous_point_low, previous_point_high) = self._get_low_high(
-            previous_point_buckets, min_scale
+            previous_point_buckets, self._previous_scale, min_scale
         )
         (current_point_low, current_point_high) = self._get_low_high(
-            current_point_buckets, min_scale
+            current_point_buckets, current_scale, min_scale
         )
 
         if current_point_low > current_point_high:
@@ -921,11 +952,11 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
 
         return low, high
 
-    def _get_low_high(self, buckets, min_scale):
+    def _get_low_high(self, buckets, scale, min_scale):
         if buckets.counts == [0]:
             return 0, -1
 
-        shift = self._mapping._scale - min_scale
+        shift = scale - min_scale
 
         return buckets.index_start >> shift, buckets.index_end >> shift
 
@@ -949,22 +980,13 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
         if change < 0:
             raise Exception("Invalid change of scale")
 
-        new_scale = self._mapping.scale - change
-
         positive.downscale(change)
         negative.downscale(change)
 
-        if new_scale <= 0:
-            mapping = ExponentMapping(new_scale)
-        else:
-            mapping = LogarithmMapping(new_scale)
-
-        self._mapping = mapping
-
     def _merge(
         self,
-        previous_buckets,
-        current_buckets,
+        previous_buckets: Buckets,
+        current_buckets: Buckets,
         current_scale,
         min_scale,
         aggregation_temporality,
@@ -983,9 +1005,11 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
             # would not happen because self._previous_point is only assigned to
             # an ExponentialHistogramDataPoint object if self._count != 0.
 
-            index = (
-                current_buckets.offset + current_bucket_index
-            ) >> current_change
+            current_index = current_buckets.index_base + current_bucket_index
+            if current_index > current_buckets.index_end:
+                current_index -= len(current_buckets.counts)
+
+            index = current_index >> current_change
 
             if index < previous_buckets.index_start:
                 span = previous_buckets.index_end - index
@@ -999,7 +1023,7 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                 previous_buckets.index_start = index
 
             if index > previous_buckets.index_end:
-                span = index - previous_buckets.index_end
+                span = index - previous_buckets.index_start
 
                 if span >= self._max_size:
                     raise Exception("Incorrect merge scale")

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exponential_histogram/buckets.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exponential_histogram/buckets.py
@@ -73,6 +73,10 @@ class Buckets:
     def counts(self):
         return self._counts
 
+    def get_offset_counts(self):
+        bias = self.__index_base - self.__index_start
+        return self._counts[-bias:] + self._counts[:-bias]
+
     def grow(self, needed: int, max_size: int) -> None:
 
         size = len(self._counts)
@@ -129,7 +133,6 @@ class Buckets:
         bias = self.__index_base - self.__index_start
 
         if bias != 0:
-
             self.__index_base = self.__index_start
 
             # [0, 1, 2, 3, 4] Original backing array

--- a/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
+++ b/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random as insecure_random
 from itertools import permutations
 from logging import WARNING
 from math import ldexp
 from sys import float_info
 from types import MethodType
 from unittest.mock import Mock, patch
-import random as insecure_random
 
 from opentelemetry.sdk.metrics._internal.aggregation import (
     AggregationTemporality,
@@ -38,11 +38,11 @@ from opentelemetry.sdk.metrics._internal.exponential_histogram.mapping.logarithm
     LogarithmMapping,
 )
 from opentelemetry.sdk.metrics._internal.measurement import Measurement
-from opentelemetry.sdk.metrics.view import (
-    ExponentialBucketHistogramAggregation,
-)
 from opentelemetry.sdk.metrics._internal.point import (
     ExponentialHistogramDataPoint,
+)
+from opentelemetry.sdk.metrics.view import (
+    ExponentialBucketHistogramAggregation,
 )
 from opentelemetry.test import TestCase
 

--- a/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
+++ b/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
@@ -916,7 +916,7 @@ class TestExponentialBucketHistogramAggregation(TestCase):
                 previous_count = count
                 count_counts.append([previous_count, 1])
 
-        self.assertEqual(collection_1.count, 5)
+        self.assertEqual(collection_1.count, 8)
         self.assertEqual(collection_1.sum, 16.645)
         self.assertEqual(collection_1.scale, 4)
         self.assertEqual(collection_1.zero_count, 0)
@@ -969,6 +969,11 @@ class TestExponentialBucketHistogramAggregation(TestCase):
                 ), f"index: {index}, count: {count}, lower_bound: {lower_bound}, upper_bound: {upper_bound}, matches: {matches}"
 
             assert sum(buckets) + result.zero_count == len(values)
+            assert result.sum == sum(values)
+            assert result.count == len(values)
+            assert result.min == min(values)
+            assert result.max == max(values)
+            assert result.zero_count == len([v for v in values if v == 0])
             assert scale >= 4
 
         random = insecure_random.Random("opentelemetry")

--- a/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
+++ b/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
@@ -966,7 +966,7 @@ class TestExponentialBucketHistogramAggregation(TestCase):
                         matches += 1
                 assert (
                     matches == count
-                ), f"index: {index}, count: {count}, lower_bound: {lower_bound}, upper_bound: {upper_bound}, matches: {matches}"
+                ), f"index: {index}, count: {count}, scale: {scale}, lower_bound: {lower_bound}, upper_bound: {upper_bound}, matches: {matches}"
 
             assert sum(buckets) + result.zero_count == len(values)
             assert result.sum == sum(values)
@@ -974,9 +974,9 @@ class TestExponentialBucketHistogramAggregation(TestCase):
             assert result.min == min(values)
             assert result.max == max(values)
             assert result.zero_count == len([v for v in values if v == 0])
-            assert scale >= 4
+            assert scale >= 3
 
-        random = insecure_random.Random("opentelemetry")
+        random = insecure_random.Random("opentelemetry2")
         values = []
         for i in range(2000):
             value = random.randint(0, 1000)
@@ -1026,7 +1026,8 @@ class TestExponentialBucketHistogramAggregation(TestCase):
             0,
         )
 
-        self.assertEqual(result.scale, result_1.scale)
+        self.assertEqual(result.scale, 0)
+        self.assertEqual(result_1.scale, -1)
 
     def test_merge_collect_delta(self):
         exponential_histogram_aggregation = (


### PR DESCRIPTION
# Description

Fix various small issues in exponential histogram collection discovered by a newly added test and issues mentioned below:
1. maintain `self._scale` to be consistent with current bucket's scale
2. consistently pass `scale` of the correct buckets alongside the buckets to method calls
3. maintain `min`, `max`, `sum`, `count`, `zero_count` values across collection calls
4. calculate the exponential bucket's index based on the index in the circular buffer based on the `index_base` instead of `index_start`, also take wrapping around the buffer into account
5. calculate an expected span size based on the `index_start` and new index instead of `index_end`
6. while collecting the data point, rotate the circular buffer so that `index_start` matches `index_base`

Fixes #3393
Fixes #3600
Fixes #3562 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Fixed existing test for cumulative collection
- [x] Added a new pseudo-random blackbox test for validating that collected result's buckets exactly match the expected distribution

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
