### PR TITLE
Fix license field in pyproject.toml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3769](https://github.com/open-telemetry/opentelemetry-python/pull/3769))
 - Make span.record_exception more robust
   ([#3778](https://github.com/open-telemetry/opentelemetry-python/pull/3778))
+- Fix license field in pyproject.toml files
+  ([#3803](https://github.com/open-telemetry/opentelemetry-python/pull/3803))
 
 ## Version 1.23.0/0.44b0 (2024-02-23)
 

--- a/docs/examples/error_handler/error_handler_0/pyproject.toml
+++ b/docs/examples/error_handler/error_handler_0/pyproject.toml
@@ -7,7 +7,7 @@ name = "error-handler-0"
 dynamic = ["version"]
 description = "This is just an error handler example package"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/docs/examples/error_handler/error_handler_1/pyproject.toml
+++ b/docs/examples/error_handler/error_handler_1/pyproject.toml
@@ -7,7 +7,7 @@ name = "error-handler-1"
 dynamic = ["version"]
 description = "This is just an error handler example package"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/exporter/opentelemetry-exporter-opencensus/pyproject.toml
+++ b/exporter/opentelemetry-exporter-opencensus/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-exporter-opencensus"
 dynamic = ["version"]
 description = "OpenCensus Exporter"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/exporter/opentelemetry-exporter-otlp-proto-common/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-exporter-otlp-proto-common"
 dynamic = ["version"]
 description = "OpenTelemetry Protobuf encoding"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-exporter-otlp-proto-grpc"
 dynamic = ["version"]
 description = "OpenTelemetry Collector Protobuf over gRPC Exporter"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-exporter-otlp-proto-http"
 dynamic = ["version"]
 description = "OpenTelemetry Collector Protobuf over HTTP Exporter"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/exporter/opentelemetry-exporter-otlp/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-exporter-otlp"
 dynamic = ["version"]
 description = "OpenTelemetry Collector Exporters"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/exporter/opentelemetry-exporter-prometheus/pyproject.toml
+++ b/exporter/opentelemetry-exporter-prometheus/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-exporter-prometheus"
 dynamic = ["version"]
 description = "Prometheus Metric Exporter for OpenTelemetry"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/exporter/opentelemetry-exporter-zipkin-json/pyproject.toml
+++ b/exporter/opentelemetry-exporter-zipkin-json/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-exporter-zipkin-json"
 dynamic = ["version"]
 description = "Zipkin Span JSON Exporter for OpenTelemetry"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-exporter-zipkin-proto-http"
 dynamic = ["version"]
 description = "Zipkin Span Protobuf Exporter for OpenTelemetry"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/exporter/opentelemetry-exporter-zipkin/pyproject.toml
+++ b/exporter/opentelemetry-exporter-zipkin/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-exporter-zipkin"
 dynamic = ["version"]
 description = "Zipkin Span Exporters for OpenTelemetry"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "opentelemetry-api"
 description = "OpenTelemetry Python API"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
     { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/opentelemetry-proto/pyproject.toml
+++ b/opentelemetry-proto/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-proto"
 dynamic = ["version"]
 description = "OpenTelemetry Python Proto"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/opentelemetry-sdk/pyproject.toml
+++ b/opentelemetry-sdk/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-sdk"
 dynamic = ["version"]
 description = "OpenTelemetry Python SDK"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/opentelemetry-semantic-conventions/pyproject.toml
+++ b/opentelemetry-semantic-conventions/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-semantic-conventions"
 dynamic = ["version"]
 description = "OpenTelemetry Semantic Conventions"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/propagator/opentelemetry-propagator-b3/pyproject.toml
+++ b/propagator/opentelemetry-propagator-b3/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-propagator-b3"
 dynamic = ["version"]
 description = "OpenTelemetry B3 Propagator"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/propagator/opentelemetry-propagator-jaeger/pyproject.toml
+++ b/propagator/opentelemetry-propagator-jaeger/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-propagator-jaeger"
 dynamic = ["version"]
 description = "OpenTelemetry Jaeger Propagator"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/shim/opentelemetry-opencensus-shim/pyproject.toml
+++ b/shim/opentelemetry-opencensus-shim/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-opencensus-shim"
 dynamic = ["version"]
 description = "OpenCensus Shim for OpenTelemetry"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/shim/opentelemetry-opentracing-shim/pyproject.toml
+++ b/shim/opentelemetry-opentracing-shim/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-opentracing-shim"
 dynamic = ["version"]
 description = "OpenTracing Shim for OpenTelemetry"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },

--- a/tests/opentelemetry-test-utils/pyproject.toml
+++ b/tests/opentelemetry-test-utils/pyproject.toml
@@ -7,7 +7,7 @@ name = "opentelemetry-test-utils"
 dynamic = ["version"]
 description = "Test utilities for OpenTelemetry unit tests"
 readme = "README.rst"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 authors = [
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },


### PR DESCRIPTION
# Description

Change license field in pyproject.toml files to what's expected according to the docs:
```diff
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
```

Fixes #3802

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

CI

# Does This PR Require a Contrib Repo Change?

Perhaps, I haven't checked if contrib also has the same issue.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
