### PR TITLE
Allow importlib_metadata < 8

### DIFF
--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "Deprecated >= 1.2.6",
     # FIXME This should be able to be removed after 3.12 is released if there is a reliable API
     # in importlib.metadata.
-    "importlib-metadata >= 6.0, <= 7.0",
+    "importlib-metadata >= 6.0, < 8",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
# Description

importlib_metadata 7.1 is out. If you don't plan to update the configuration for every minor release, it might make sense to allow all versions 7.x.y. importlib_metadata is pretty stable so I'd not be afraid of any breaking changes.