### PR TITLE
Rename test objects to avoid pytest warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Stable and experimental attributes and metrics are defined under
   `opentelemetry.semconv._incubating` import path.
   ([#3586](https://github.com/open-telemetry/opentelemetry-python/pull/3586))
+- Rename test objects to avoid pytest warnings
+  ([#3823] (https://github.com/open-telemetry/opentelemetry-python/pull/3823))
 
 ## Version 1.24.0/0.45b0 (2024-03-28)
 

--- a/opentelemetry-api/tests/logs/test_proxy.py
+++ b/opentelemetry-api/tests/logs/test_proxy.py
@@ -28,10 +28,10 @@ class TestProvider(_logs.NoOpLoggerProvider):
         version: typing.Optional[str] = None,
         schema_url: typing.Optional[str] = None,
     ) -> _logs.Logger:
-        return TestLogger(name)
+        return LoggerTest(name)
 
 
-class TestLogger(_logs.NoOpLogger):
+class LoggerTest(_logs.NoOpLogger):
     def emit(self, record: _logs.LogRecord) -> None:
         pass
 
@@ -54,9 +54,9 @@ class TestProxy(LoggingGlobalsTest, unittest.TestCase):
 
         # logger provider now returns real instance
         self.assertIsInstance(
-            _logs.get_logger_provider().get_logger("fresh"), TestLogger
+            _logs.get_logger_provider().get_logger("fresh"), LoggerTest
         )
 
         # references to the old provider still work but return real logger now
         real_logger = provider.get_logger("proxy-test")
-        self.assertIsInstance(real_logger, TestLogger)
+        self.assertIsInstance(real_logger, LoggerTest)

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -7,7 +7,7 @@ from opentelemetry.test.globals_test import TraceGlobalsTest
 from opentelemetry.trace.status import Status, StatusCode
 
 
-class TestSpan(trace.NonRecordingSpan):
+class SpanTest(trace.NonRecordingSpan):
     has_ended = False
     recorded_exception = None
     recorded_status = Status(status_code=StatusCode.UNSET)
@@ -110,7 +110,7 @@ class TestUseTracer(unittest.TestCase):
 
     def test_use_span_end_on_exit(self):
 
-        test_span = TestSpan(trace.INVALID_SPAN_CONTEXT)
+        test_span = SpanTest(trace.INVALID_SPAN_CONTEXT)
 
         with trace.use_span(test_span):
             pass
@@ -124,7 +124,7 @@ class TestUseTracer(unittest.TestCase):
         class TestUseSpanException(Exception):
             pass
 
-        test_span = TestSpan(trace.INVALID_SPAN_CONTEXT)
+        test_span = SpanTest(trace.INVALID_SPAN_CONTEXT)
         exception = TestUseSpanException("test exception")
         with self.assertRaises(TestUseSpanException):
             with trace.use_span(test_span):
@@ -136,7 +136,7 @@ class TestUseTracer(unittest.TestCase):
         class TestUseSpanException(Exception):
             pass
 
-        test_span = TestSpan(trace.INVALID_SPAN_CONTEXT)
+        test_span = SpanTest(trace.INVALID_SPAN_CONTEXT)
         with self.assertRaises(TestUseSpanException):
             with trace.use_span(test_span):
                 raise TestUseSpanException("test error")

--- a/opentelemetry-api/tests/trace/test_proxy.py
+++ b/opentelemetry-api/tests/trace/test_proxy.py
@@ -38,7 +38,7 @@ class TestProvider(trace.NoOpTracerProvider):
 
 class TestTracer(trace.NoOpTracer):
     def start_span(self, *args, **kwargs):
-        return TestSpan(INVALID_SPAN_CONTEXT)
+        return SpanTest(INVALID_SPAN_CONTEXT)
 
     @_agnosticcontextmanager  # pylint: disable=protected-access
     def start_as_current_span(self, *args, **kwargs):  # type: ignore
@@ -46,7 +46,7 @@ class TestTracer(trace.NoOpTracer):
             yield span
 
 
-class TestSpan(NonRecordingSpan):
+class SpanTest(NonRecordingSpan):
     pass
 
 
@@ -82,7 +82,7 @@ class TestProxy(TraceGlobalsTest, unittest.TestCase):
         # reference to old proxy tracer now delegates to a real tracer and
         # creates real spans
         with tracer.start_span("") as span:
-            self.assertIsInstance(span, TestSpan)
+            self.assertIsInstance(span, SpanTest)
 
     def test_late_config(self):
         # get a tracer and instrument a function as we would at the
@@ -100,4 +100,4 @@ class TestProxy(TraceGlobalsTest, unittest.TestCase):
         # configure tracing provider
         trace.set_tracer_provider(TestProvider())
         # call function again, we should now be getting a TestSpan
-        self.assertIsInstance(my_function(), TestSpan)
+        self.assertIsInstance(my_function(), SpanTest)


### PR DESCRIPTION
This PR removes unneccesary warnings

Fixes: #3779

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
