### PR TITLE
Fix public symbol checker flaky case

### DIFF
--- a/scripts/public_symbols_checker.py
+++ b/scripts/public_symbols_checker.py
@@ -122,6 +122,7 @@ def remove_common_symbols():
         if not removed_symbols[file_path]:
             del removed_symbols[file_path]
 
+
 # If a symbol is added and removed in the same commit, we consider it as not
 # added or removed.
 remove_common_symbols()

--- a/scripts/public_symbols_checker.py
+++ b/scripts/public_symbols_checker.py
@@ -122,12 +122,11 @@ def remove_common_symbols():
         if not removed_symbols[file_path]:
             del removed_symbols[file_path]
 
+# If a symbol is added and removed in the same commit, we consider it as not
+# added or removed.
+remove_common_symbols()
 
 if added_symbols or removed_symbols:
-
-    # If a symbol is added and removed in the same commit, we consider it
-    # as not added or removed.
-    remove_common_symbols()
     print("The code in this branch adds the following public symbols:")
     print()
     for file_path_, symbols_ in added_symbols.items():


### PR DESCRIPTION
If a PR has only symbols that were removed then re-added (e.g. moving to a different part of the same file), the checker complains with an empty message. This fixes the script to not fail in that case.

Tested on https://github.com/open-telemetry/opentelemetry-python/pull/3822