### PR TITLE
[DO NOT MERGE] Port of jaeger remote sampler support

### DIFF
--- a/opentelemetry-sdk/pyproject.toml
+++ b/opentelemetry-sdk/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
 dependencies = [
   "opentelemetry-api == 1.24.0.dev",
   "opentelemetry-semantic-conventions == 0.45b0.dev",
+  "threadloop>=1.0.2",
+  "tornado>=6.4",
   "typing-extensions >= 3.7.4",
 ]
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -58,6 +58,7 @@ from opentelemetry.sdk.environment_variables import (
 )
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import sampling
+from opentelemetry.sdk.trace.rate_limiter import RateLimiter
 from opentelemetry.sdk.trace.id_generator import IdGenerator, RandomIdGenerator
 from opentelemetry.sdk.util import BoundedList
 from opentelemetry.sdk.util.instrumentation import (

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/local_agent_net.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/local_agent_net.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2016-2018 Uber Technologies, Inc.
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from threadloop import ThreadLoop
+import tornado
+import tornado.httpclient
+from tornado.concurrent import Future
+from tornado.httputil import url_concat
+
+DEFAULT_REPORTING_PORT = 6831
+
+class LocalAgentHTTP(object):
+
+    DEFAULT_TIMEOUT = 15
+
+    def __init__(self, host, port):
+        self.agent_http_host = host
+        self.agent_http_port = int(port)
+
+    def _request(self, path, timeout=DEFAULT_TIMEOUT, args=None):
+        http_client = tornado.httpclient.AsyncHTTPClient(
+            defaults=dict(request_timeout=timeout))
+        url = 'http://%s:%d/%s' % (self.agent_http_host, self.agent_http_port, path)
+        if args:
+            url = url_concat(url, args)
+        return http_client.fetch(url)
+
+    def request_sampling_strategy(self, service_name, timeout=DEFAULT_TIMEOUT):
+        return self._request('sampling', timeout=timeout, args={'service': service_name})
+
+    def request_throttling_credits(self,
+                                   service_name,
+                                   client_id,
+                                   operations,
+                                   timeout=DEFAULT_TIMEOUT):
+        return self._request('credits', timeout=timeout, args=[
+            ('service', service_name),
+            ('uuid', client_id),
+        ] + [('operations', op) for op in operations])
+
+
+class LocalAgentSender:
+    """
+    TODO(sconover): everything in this description about thrift is not true,
+    and UDP support has been removed.
+
+    TODO(sconover): I'm skeptical of the value of the "non-tornado" option,
+    and would advocate for stripping it out.
+
+    LocalAgentSender implements everything necessary to communicate with
+    local jaeger-agent. This class is designed to work in tornado and
+    non-tornado environments. If in torndado, pass in the ioloop, if not
+    then LocalAgentSender will create one for itself.
+
+    NOTE: LocalAgentSender derives from TBufferedTransport. This will buffer
+    up all written data until flush() is called. Flush gets called at the
+    end of the batch span submission call.
+    """
+
+    def __init__(self, host, sampling_port, reporting_port, io_loop=None, throttling_port=None):
+        # IOLoop
+        self._thread_loop = None
+        self.io_loop = io_loop or self._create_new_thread_loop()
+
+        # HTTP sampling
+        self.local_agent_http = LocalAgentHTTP(host, sampling_port)
+
+        # HTTP throttling
+        if throttling_port:
+            self.throttling_http = LocalAgentHTTP(host, throttling_port)
+
+    def _create_new_thread_loop(self):
+        """
+        Create a daemonized thread that will run Tornado IOLoop.
+        :return: the IOLoop backed by the new thread.
+        """
+        self._thread_loop = ThreadLoop()
+        if not self._thread_loop.is_ready():
+            self._thread_loop.start()
+        return self._thread_loop._io_loop
+
+    def readFrame(self):
+        """Empty read frame that is never ready"""
+        return Future()
+
+    # Pass-through for HTTP sampling strategies request.
+    def request_sampling_strategy(self, *args, **kwargs):
+        return self.local_agent_http.request_sampling_strategy(*args, **kwargs)
+
+    # Pass-through for HTTP throttling credit request.
+    def request_throttling_credits(self, *args, **kwargs):
+        return self.throttling_http.request_throttling_credits(*args, **kwargs)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/rate_limiter.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/rate_limiter.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2017 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import time
+
+
+class RateLimiter(object):
+    """
+    RateLimiter is based on leaky bucket algorithm, formulated in terms
+    of a credits balance that is replenished every time check_credit()
+    method is called (tick) by the amount proportional to the time
+    elapsed since the last tick, up to the max_balance. A call
+    to check_credit() takes a cost of an item we want to pay with the
+    balance. If the balance exceeds the cost of the item, the item is
+    "purchased" and the balance reduced, indicated by returned value of
+    true. Otherwise the balance is unchanged and return false.
+
+    This can be used to limit a rate of messages emitted by a service
+    by instantiating the Rate Limiter with the max number of messages a
+    service is allowed to emit per second, and calling check_credit(1.0)
+    for each message to determine if the message is within the rate limit.
+
+    It can also be used to limit the rate of traffic in bytes, by setting
+    credits_per_second to desired throughput as bytes/second, and calling
+    check_credit() with the actual message size.
+    """
+
+    def __init__(self, credits_per_second, max_balance):
+        self.credits_per_second = credits_per_second
+        self.max_balance = max_balance
+        self.balance = self.max_balance * random.random()
+        self.last_tick = self.timestamp()
+
+    @staticmethod
+    def timestamp():
+        return time.time()
+
+    def update(self, credits_per_second, max_balance):
+        self._update_balance()
+        self.credits_per_second = credits_per_second
+        # The new balance should be proportional to the old balance.
+        self.balance = max_balance * self.balance / self.max_balance
+        self.max_balance = max_balance
+
+    def check_credit(self, item_cost):
+        self._update_balance()
+        if self.balance >= item_cost:
+            self.balance -= item_cost
+            return True
+        return False
+
+    def _update_balance(self):
+        current_time = self.timestamp()
+        elapsed_time = current_time - self.last_tick
+        self.last_tick = current_time
+        self.balance += elapsed_time * self.credits_per_second
+        if self.balance > self.max_balance:
+            self.balance = self.max_balance

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py
@@ -1,4 +1,5 @@
 # Copyright The OpenTelemetry Authors
+# Copyright (c) 2016 Uber Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -130,13 +131,22 @@ be an empty string. For example:
 
 In order to configure you application with a custom sampler's entry point, set the ``OTEL_TRACES_SAMPLER`` environment variable to the key name of the entry point. For example, to configured the
 above sampler, set ``OTEL_TRACES_SAMPLER=custom_sampler_name`` and ``OTEL_TRACES_SAMPLER_ARG=0.5``.
+
+
+TODO(sconover): Need good explanation here if/when the overall approach 
+(porting of python jaeger remote sampler code) meets with approval
 """
 import abc
+import asyncio
 import enum
+import json
 import os
+import random
+import threading
 from logging import getLogger
+from tornado.ioloop import PeriodicCallback
 from types import MappingProxyType
-from typing import Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 # pylint: disable=unused-import
 from opentelemetry.context import Context
@@ -148,8 +158,44 @@ from opentelemetry.trace import Link, SpanKind, get_current_span
 from opentelemetry.trace.span import TraceState
 from opentelemetry.util.types import Attributes
 
+from opentelemetry.sdk.trace import rate_limiter
+
 _logger = getLogger(__name__)
 
+# TODO(sconover): not sure what to do w/ these constants + associated attrs, 
+# the don't seem like a "fit" in this codebase. However these are central to the workings
+# of the ported tests.
+SAMPLER_TYPE_TAG_KEY = 'sampler.type'
+SAMPLER_PARAM_TAG_KEY = 'sampler.param'
+
+SAMPLER_TYPE_RATE_LIMITING = 'ratelimiting'
+SAMPLER_TYPE_LOWER_BOUND = 'lowerbound'
+SAMPLER_TYPE_TRACE_ID_RATIO = 'traceidratio'
+SAMPLER_TYPE_PARENT_BASED_TRACE_ID_RATIO = 'parentbased_traceidratio'
+SAMPLER_TYPE_GUARANTEED_THROUGHPUT = 'guaranteedthroughput'
+SAMPLER_TYPE_ADAPTIVE = 'adaptive'
+SAMPLER_TYPE_REMOTE_CONTROLLED = 'remotecontrolled'
+
+# How often remotely controlled sampler polls for sampling strategy
+DEFAULT_SAMPLING_INTERVAL = 60
+
+
+DEFAULT_SAMPLING_PROBABILITY = 0.001
+DEFAULT_LOWER_BOUND = 1.0 / (10.0 * 60.0)  # sample once every 10 minutes
+DEFAULT_MAX_OPERATIONS = 2000
+
+STRATEGIES_STR = 'perOperationStrategies'
+OPERATION_STR = 'operation'
+DEFAULT_LOWER_BOUND_STR = 'defaultLowerBoundTracesPerSecond'
+PROBABILISTIC_SAMPLING_STR = 'probabilisticSampling'
+SAMPLING_RATE_STR = 'samplingRate'
+DEFAULT_SAMPLING_PROBABILITY_STR = 'defaultSamplingProbability'
+OPERATION_SAMPLING_STR = 'operationSampling'
+MAX_TRACES_PER_SECOND_STR = 'maxTracesPerSecond'
+RATE_LIMITING_SAMPLING_STR = 'rateLimitingSampling'
+STRATEGY_TYPE_STR = 'strategyType'
+PROBABILISTIC_SAMPLING_STRATEGY = 'PROBABILISTIC'
+RATE_LIMITING_SAMPLING_STRATEGY = 'RATE_LIMITING'
 
 class Decision(enum.Enum):
     # IsRecording() == false, span will not be recorded and all events and attributes will be dropped.
@@ -212,6 +258,20 @@ class Sampler(abc.ABC):
     def get_description(self) -> str:
         pass
 
+    # TODO(sconover) added close to all samplers, because of cleanup needed
+    # for RemoteControlledSampler
+    # Q: Where should sampler.close() be called? I believe it might be 
+    # TracerProvider#shutdown (but not entirely sure)
+    def close(self) -> None:
+        pass
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+        )
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
 
 class StaticSampler(Sampler):
     """Sampler that always returns the same decision."""
@@ -263,6 +323,10 @@ class TraceIdRatioBased(Sampler):
             raise ValueError("Probability must be in range [0.0, 1.0].")
         self._rate = rate
         self._bound = self.get_bound_for_rate(self._rate)
+        self._attributes = {
+            SAMPLER_TYPE_TAG_KEY: SAMPLER_TYPE_TRACE_ID_RATIO,
+            SAMPLER_PARAM_TAG_KEY: rate
+        }
 
     # For compatibility with 64 bit trace IDs, the sampler checks the 64
     # low-order bits of the trace ID to decide whether to sample a given trace.
@@ -295,6 +359,13 @@ class TraceIdRatioBased(Sampler):
             decision = Decision.RECORD_AND_SAMPLE
         if decision is Decision.DROP:
             attributes = None
+        
+        # TODO(sconover): the jaeger tests really really want this probabilistic sampler to indicate
+        # key elements of internal state via attributes
+        if attributes == None:
+            attributes = {}
+        attributes = {**self._attributes, **attributes}
+        
         return SamplingResult(
             decision,
             attributes,
@@ -304,6 +375,8 @@ class TraceIdRatioBased(Sampler):
     def get_description(self) -> str:
         return f"TraceIdRatioBased{{{self._rate}}}"
 
+    def __str__(self) -> str:
+        return self.get_description()
 
 class ParentBased(Sampler):
     """
@@ -413,14 +486,470 @@ class _ParentBasedAlwaysOn(ParentBased):
     def __init__(self, _):
         super().__init__(ALWAYS_ON)
 
+class RateLimitingSampler(Sampler):
+    """
+    Samples at most max_traces_per_second. The distribution of sampled
+    traces follows burstiness of the service, i.e. a service with uniformly
+    distributed requests will have those requests sampled uniformly as well,
+    but if requests are bursty, especially sub-second, then a number of
+    sequential requests can be sampled each second.
+    """
+
+    def __init__(self, max_traces_per_second: float = 10) -> None:
+        self.rate_limiter: rate_limiter.RateLimiter = None  # type:ignore  # value is set below
+        self._init(max_traces_per_second)
+
+    def _init(self, max_traces_per_second: float):
+        assert max_traces_per_second >= 0, \
+            'max_traces_per_second must not be negative'
+        self._attributes = {
+            SAMPLER_TYPE_TAG_KEY: SAMPLER_TYPE_RATE_LIMITING,
+            SAMPLER_PARAM_TAG_KEY: max_traces_per_second,
+        }
+        self.traces_per_second = max_traces_per_second
+        max_balance = max(self.traces_per_second, 1.0)
+        if not self.rate_limiter:
+            self.rate_limiter = rate_limiter.RateLimiter(
+                credits_per_second=self.traces_per_second,
+                max_balance=max_balance
+            )
+        else:
+            self.rate_limiter.update(max_traces_per_second, max_balance)
+
+    def should_sample(
+        self,
+        parent_context: Optional["Context"],
+        trace_id: int,
+        name: str,
+        kind: Optional[SpanKind] = None,
+        attributes: Attributes = None,
+        links: Optional[Sequence["Link"]] = None,
+        trace_state: Optional["TraceState"] = None,
+    ) -> "SamplingResult":
+        decision = Decision.DROP
+        if self.rate_limiter.check_credit(1.0):
+            decision = Decision.RECORD_AND_SAMPLE
+        
+        # TODO(sconover): what's the idea w/ override attributes (passed in above)?
+        # should these be merged with self._attributes?
+
+        return SamplingResult(
+            decision,
+            self._attributes,
+            _get_parent_trace_state(parent_context),
+        )
+
+    def __eq__(self, other) -> bool:
+        """The last_tick and balance fields can be different"""
+        if not isinstance(other, self.__class__):
+            return False
+        d1 = dict(self.rate_limiter.__dict__)
+        d2 = dict(other.rate_limiter.__dict__)
+        d1['balance'] = d2['balance']
+        d1['last_tick'] = d2['last_tick']
+        return d1 == d2
+
+    def update(self, max_traces_per_second: float) -> bool:
+        if self.traces_per_second == max_traces_per_second:
+            return False
+        self._init(max_traces_per_second)
+        return True
+    
+    def get_description(self) -> str:
+        return f'RateLimitingSampler{{{self.traces_per_second}}}'
+
+    def __str__(self) -> str:
+        return self.get_description()
+
+class GuaranteedThroughputProbabilisticSampler(Sampler):
+    """
+    A sampler that leverages both TraceIdRatioBased sampler and RateLimitingSampler.
+    The RateLimitingSampler is used as a guaranteed lower bound sampler such
+    that every operation is sampled at least once in a time interval defined by
+    the lower_bound. ie a lower_bound of 1.0 / (60 * 10) will sample an
+    operation at least once every 10 minutes.
+
+    The TraceIdRatioBased sampler is given higher priority when attributes are emitted,
+    ie. if is_sampled() for both samplers return true, the attributes for
+    TraceIdRatioBased sampler will be used.
+    """
+    def __init__(self, operation: str, lower_bound: float, rate: float) -> None:
+        self._attributes = {
+            SAMPLER_TYPE_TAG_KEY: SAMPLER_TYPE_LOWER_BOUND,
+            SAMPLER_PARAM_TAG_KEY: rate,
+        }
+        self.probabilistic_sampler = TraceIdRatioBased(rate)
+        self.lower_bound_sampler = RateLimitingSampler(lower_bound)
+        self.operation = operation
+        self.rate = rate
+        self.lower_bound = lower_bound
+
+    def should_sample(
+        self,
+        parent_context: Optional["Context"],
+        trace_id: int,
+        name: str,
+        kind: Optional[SpanKind] = None,
+        attributes: Attributes = None,
+        links: Optional[Sequence["Link"]] = None,
+        trace_state: Optional["TraceState"] = None,
+    ) -> "SamplingResult":
+        
+        # TODO(sconover): what's the idea w/ override attributes (passed in above)?
+        # should these be merged with self._attributes?
+
+        sample_result = \
+            self.probabilistic_sampler.should_sample(parent_context, trace_id, name, kind, attributes, links, trace_state)
+        if sample_result.decision.is_sampled():
+            self.lower_bound_sampler.should_sample(parent_context, trace_id, name, kind, attributes, links, trace_state)
+            return SamplingResult(
+                Decision.RECORD_AND_SAMPLE,
+                # TODO(sconover) re-evaluate all of these sampler attrs from jaeger...
+                # how useful are they? can we delete them (and accompanying test assertions)?
+                {
+                    SAMPLER_TYPE_TAG_KEY: SAMPLER_TYPE_TRACE_ID_RATIO,
+                    SAMPLER_PARAM_TAG_KEY: self.probabilistic_sampler.rate,
+                },
+                _get_parent_trace_state(parent_context),
+            )
+        sample_result = self.lower_bound_sampler.should_sample(parent_context, trace_id, name, kind, attributes, links, trace_state)
+        return SamplingResult(
+            sample_result.decision,
+            self._attributes,
+            _get_parent_trace_state(parent_context),
+        )
+
+    def update(self, lower_bound: int, rate: float) -> None:
+        # (NB) This function should only be called while holding a Write lock.
+        if self.rate != rate:
+            self.probabilistic_sampler = TraceIdRatioBased(rate)
+            self.rate = rate
+            self._attributes = {
+                SAMPLER_TYPE_TAG_KEY: SAMPLER_TYPE_LOWER_BOUND,
+                SAMPLER_PARAM_TAG_KEY: rate,
+            }
+        if self.lower_bound != lower_bound:
+            self.lower_bound_sampler.update(lower_bound)
+            self.lower_bound = lower_bound
+
+    def get_description(self) -> str:
+        return f'GuaranteedThroughputProbabilisticSampler{{{self.operation}, {self.rate}, {self.lower_bound}}}'
+
+    def __str__(self) -> str:
+        return self.get_description()
+
+class AdaptiveSampler(Sampler):
+    """
+    A sampler that leverages both TraceIdRatioBased sampler and RateLimitingSampler
+    via the GuaranteedThroughputProbabilisticSampler. This sampler keeps track
+    of all operations and delegates calls the the respective
+    GuaranteedThroughputProbabilisticSampler.
+    """
+    def __init__(self, strategies: Dict[str, Any], max_operations: int) -> None:
+        samplers = {}
+        for strategy in strategies.get(STRATEGIES_STR, []):
+            operation = strategy.get(OPERATION_STR)
+            sampler = GuaranteedThroughputProbabilisticSampler(
+                operation,
+                strategies.get(DEFAULT_LOWER_BOUND_STR, DEFAULT_LOWER_BOUND),
+                get_sampling_probability(strategy)
+            )
+            samplers[operation] = sampler
+
+        self.samplers = samplers
+        self.default_sampler = \
+            TraceIdRatioBased(strategies.get(DEFAULT_SAMPLING_PROBABILITY_STR,
+                                             DEFAULT_SAMPLING_PROBABILITY))
+        self.default_sampling_probability = \
+            strategies.get(DEFAULT_SAMPLING_PROBABILITY_STR, DEFAULT_SAMPLING_PROBABILITY)
+        self.lower_bound = strategies.get(DEFAULT_LOWER_BOUND_STR, DEFAULT_LOWER_BOUND)
+        self.max_operations = max_operations
+
+    def should_sample(
+        self,
+        parent_context: Optional["Context"],
+        trace_id: int,
+        name: str,
+        kind: Optional[SpanKind] = None,
+        attributes: Attributes = None,
+        links: Optional[Sequence["Link"]] = None,
+        trace_state: Optional["TraceState"] = None,
+    ) -> "SamplingResult":        
+        sampler = self.samplers.get(name)
+        if not sampler:
+            if len(self.samplers) >= self.max_operations:
+                return self.default_sampler.should_sample(parent_context, trace_id, name, kind, attributes, links, trace_state)
+            sampler = GuaranteedThroughputProbabilisticSampler(
+                name,
+                self.lower_bound,
+                self.default_sampling_probability
+            )
+            self.samplers[name] = sampler
+            return sampler.should_sample(parent_context, trace_id, name, kind, attributes, links, trace_state)
+        return sampler.should_sample(parent_context, trace_id, name, kind, attributes, links, trace_state)
+
+    def update(self, strategies: Dict[str, Any]) -> None:
+        # (NB) This function should only be called while holding a Write lock.
+        for strategy in strategies.get(STRATEGIES_STR, []):
+            operation = strategy.get(OPERATION_STR)
+            lower_bound = strategies.get(DEFAULT_LOWER_BOUND_STR, DEFAULT_LOWER_BOUND)
+            sampling_rate = get_sampling_probability(strategy)
+            sampler = self.samplers.get(operation)
+            if not sampler:
+                sampler = GuaranteedThroughputProbabilisticSampler(
+                    operation,
+                    lower_bound,
+                    sampling_rate
+                )
+                self.samplers[operation] = sampler
+            else:
+                sampler.update(lower_bound, sampling_rate)
+        self.lower_bound = strategies.get(DEFAULT_LOWER_BOUND_STR, DEFAULT_LOWER_BOUND)
+        if self.default_sampling_probability != strategies.get(DEFAULT_SAMPLING_PROBABILITY_STR,
+                                                               DEFAULT_SAMPLING_PROBABILITY):
+            self.default_sampling_probability = \
+                strategies.get(DEFAULT_SAMPLING_PROBABILITY_STR, DEFAULT_SAMPLING_PROBABILITY)
+            self.default_sampler = \
+                TraceIdRatioBased(self.default_sampling_probability)
+
+    def close(self) -> None:
+        for _, sampler in self.samplers.items():
+            sampler.close()
+
+    def get_description(self) -> str:
+        return f'AdaptiveSampler{{{self.default_sampling_probability}, {self.lower_bound}, {self.max_operations}}}'
+
+    def __str__(self) -> str:
+        return self.get_description()
+
+class RemoteControlledSampler(Sampler):
+    """Periodically loads the sampling strategy from a remote server."""
+    def __init__(self, channel: Any, service_name: str, **kwargs: Any) -> None:
+        """
+        :param channel: channel for communicating with jaeger-agent-compatible source
+        :param service_name: name of this application
+        :param kwargs: optional parameters
+            - init_sampler: initial value of the sampler,
+                else TraceIdRatioBased(0.001)
+            - sampling_refresh_interval: interval in seconds for polling
+              for new strategy
+            - logger: Logger instance
+            # TODO(sconover) there's a general question about what to do about metrics...
+            # - metrics: metrics facade, used to emit metrics on errors.
+            #     This parameter has been deprecated, please use
+            #     metrics_factory instead.
+            # - metrics_factory: used to generate metrics for errors
+            - error_reporter: ErrorReporter instance
+            - max_operations: maximum number of unique operations the
+              AdaptiveSampler will keep track of
+        :param init:
+        :return:
+        """
+        self._channel = channel
+        self.service_name = service_name
+        self.logger = kwargs.get('logger', _logger)
+        self.sampler = kwargs.get('init_sampler')
+        self.sampling_refresh_interval = \
+            kwargs.get('sampling_refresh_interval') or DEFAULT_SAMPLING_INTERVAL
+        # TODO(sconover) there's a general question about what to do about metrics...
+        # self.metrics_factory = kwargs.get('metrics_factory') \
+        #     or LegacyMetricsFactory(kwargs.get('metrics') or Metrics())
+        # self.metrics = SamplerMetrics(self.metrics_factory)
+        self.error_reporter = kwargs.get('error_reporter')
+        # TODO(sconover) what should we do about making/using a real error reporter?
+        #or \
+        #   ErrorReporter(Metrics())
+        self.max_operations = kwargs.get('max_operations') or \
+            DEFAULT_MAX_OPERATIONS
+
+        if not self.sampler:
+            self.sampler = TraceIdRatioBased(DEFAULT_SAMPLING_PROBABILITY)
+        else:
+            self.sampler.should_sample(None, 0, "span name").decision.is_sampled() # assert we got valid sampler API
+
+        self.lock = threading.Lock()
+        self.running = True
+        self.periodic = None
+
+        self.io_loop = channel.io_loop
+        if not self.io_loop:
+            self.logger.error(
+                'Cannot acquire IOLoop, sampler will not be updated')
+        else:
+            # according to IOLoop docs, it's not safe to use timeout methods
+            # unless already running in the loop, so we use `add_callback`
+            self.io_loop.add_callback(self._init_polling)
+
+    def should_sample(
+        self,
+        *args,
+    ) -> "SamplingResult":
+        with self.lock:
+            assert self.sampler  # needed for mypy
+            return self.sampler.should_sample(*args)
+        
+    def _init_polling(self):
+        """
+        Bootstrap polling for sampling strategy.
+
+        To avoid spiky traffic from the samplers, we use a random delay
+        before the first poll.
+        """
+        with self.lock:
+            if not self.running:
+                return
+            r = random.Random()
+            delay = r.random() * self.sampling_refresh_interval
+            self.io_loop.call_later(delay=delay,
+                                    callback=self._delayed_polling)
+            self.logger.info(
+                'Delaying sampling strategy polling by %d sec', delay)
+
+    def _delayed_polling(self):
+        periodic = self._create_periodic_callback()
+        self._poll_sampling_manager()  # Initialize sampler now
+        with self.lock:
+            if not self.running:
+                return
+            self.periodic = periodic
+            periodic.start()  # start the periodic cycle
+            self.logger.info(
+                'Tracing sampler started with sampling refresh '
+                'interval %d sec', self.sampling_refresh_interval)
+
+    def _create_periodic_callback(self):
+        return PeriodicCallback(
+            callback=self._poll_sampling_manager,
+            # convert interval to milliseconds
+            callback_time=self.sampling_refresh_interval * 1000)
+
+    def _sampling_request_callback(self, future):
+        exception = future.exception()
+        if exception:
+            # TODO(sconover) there's a general question about what to do about metrics...
+            # self.metrics.sampler_query_failure(1)
+            self.error_reporter.error(
+                'Fail to get sampling strategy from jaeger-agent: %s',
+                exception)
+            return
+
+        response = future.result()
+
+        # TODO(sconover) should we eliminate all pre-py3.5-ish code?
+        # In Python 3.5 response.body is of type bytes and json.loads() does only support str
+        # See: https://github.com/jaegertracing/jaeger-client-python/issues/180
+        if hasattr(response.body, 'decode') and callable(response.body.decode):
+            response_body = response.body.decode('utf-8')
+        else:
+            response_body = response.body
+
+        try:
+            sampling_strategies_response = json.loads(response_body)
+            # TODO(sconover) there's a general question about what to do about metrics...
+            # self.metrics.sampler_retrieved(1)
+        except Exception as e:
+            # TODO(sconover) there's a general question about what to do about metrics...
+            # self.metrics.sampler_query_failure(1)
+            self.error_reporter.error(
+                'Fail to parse sampling strategy '
+                'from jaeger-agent: %s [%s]', e, response_body)
+            return
+
+        self._update_sampler(sampling_strategies_response)
+        self.logger.debug('Tracing sampler set to %s', self.sampler)
+
+    def _update_sampler(self, response):
+        with self.lock:
+            try:
+                if response.get(OPERATION_SAMPLING_STR):
+                    self._update_adaptive_sampler(response.get(OPERATION_SAMPLING_STR))
+                else:
+                    self._update_rate_limiting_or_probabilistic_sampler(response)
+            except Exception as e:
+                # TODO(sconover) there's a general question about what to do about metrics...
+                # self.metrics.sampler_update_failure(1)
+                self.error_reporter.error(
+                    'Fail to update sampler'
+                    'from jaeger-agent: %s [%s]', e, response)
+    
+    def _update_adaptive_sampler(self, per_operation_strategies):
+        if isinstance(self.sampler, AdaptiveSampler):
+            self.sampler.update(per_operation_strategies)
+        else:
+            self.sampler = AdaptiveSampler(per_operation_strategies, self.max_operations)
+        # TODO(sconover) there's a general question about what to do about metrics...
+        # self.metrics.sampler_updated(1)
+
+    def _update_rate_limiting_or_probabilistic_sampler(self, response):
+        s_type = response.get(STRATEGY_TYPE_STR)
+        new_sampler = self.sampler
+        if s_type == PROBABILISTIC_SAMPLING_STRATEGY:
+            sampling_rate = get_sampling_probability(response)
+            new_sampler = TraceIdRatioBased(rate=sampling_rate)
+        elif s_type == RATE_LIMITING_SAMPLING_STRATEGY:
+            mtps = get_rate_limit(response)
+            if mtps < 0 or mtps >= 500:
+                raise ValueError(
+                    'Rate limiting parameter not in [0, 500) range: %s' % mtps)
+            if isinstance(self.sampler, RateLimitingSampler):
+                if self.sampler.update(max_traces_per_second=mtps):
+                    pass
+                    # TODO(sconover) there's a general question about what to do about metrics...
+                    # self.metrics.sampler_updated(1)
+            else:
+                new_sampler = RateLimitingSampler(max_traces_per_second=mtps)
+        else:
+            raise ValueError('Unsupported sampling strategy type: %s' % s_type)
+
+        if self.sampler != new_sampler:
+            self.sampler = new_sampler
+            # TODO(sconover) there's a general question about what to do about metrics...
+            # self.metrics.sampler_updated(1)
+
+    def _poll_sampling_manager(self):
+        self.logger.debug('Requesting tracing sampler refresh')
+        fut = self._channel.request_sampling_strategy(self.service_name)
+        fut.add_done_callback(self._sampling_request_callback)
+
+    def close(self) -> None:
+        with self.lock:
+            self.running = False
+            if self.periodic:
+                self.periodic.stop()
+
+    def get_description(self) -> str:
+        return f'RateLimitingSampler{{{self.traces_per_second}}}'
+
+    def __str__(self) -> str:
+        return self.get_description()
+    
+def get_sampling_probability(strategy: Optional[Dict[str, Any]] = None) -> float:
+    if not strategy:
+        return DEFAULT_SAMPLING_PROBABILITY
+    probability_strategy = strategy.get(PROBABILISTIC_SAMPLING_STR)
+    if not probability_strategy:
+        return DEFAULT_SAMPLING_PROBABILITY
+    return probability_strategy.get(SAMPLING_RATE_STR, DEFAULT_SAMPLING_PROBABILITY)
+
+def get_rate_limit(strategy: Optional[Dict[str, Any]] = None) -> float:
+    if not strategy:
+        return DEFAULT_LOWER_BOUND
+    rate_limit_strategy = strategy.get(RATE_LIMITING_SAMPLING_STR)
+    if not rate_limit_strategy:
+        return DEFAULT_LOWER_BOUND
+    return rate_limit_strategy.get(MAX_TRACES_PER_SECOND_STR, DEFAULT_LOWER_BOUND)
 
 _KNOWN_SAMPLERS = {
     "always_on": ALWAYS_ON,
     "always_off": ALWAYS_OFF,
     "parentbased_always_on": DEFAULT_ON,
     "parentbased_always_off": DEFAULT_OFF,
-    "traceidratio": TraceIdRatioBased,
-    "parentbased_traceidratio": ParentBasedTraceIdRatio,
+    SAMPLER_TYPE_TRACE_ID_RATIO: TraceIdRatioBased,
+    SAMPLER_TYPE_PARENT_BASED_TRACE_ID_RATIO: ParentBasedTraceIdRatio,
+    SAMPLER_TYPE_RATE_LIMITING: RateLimitingSampler,
+    SAMPLER_TYPE_GUARANTEED_THROUGHPUT: GuaranteedThroughputProbabilisticSampler,
+    SAMPLER_TYPE_ADAPTIVE: AdaptiveSampler,
+    SAMPLER_TYPE_REMOTE_CONTROLLED: RemoteControlledSampler,
 }
 
 

--- a/opentelemetry-sdk/test-requirements.txt
+++ b/opentelemetry-sdk/test-requirements.txt
@@ -4,12 +4,14 @@ Deprecated==1.2.14
 flaky==3.7.0
 importlib-metadata==6.11.0
 iniconfig==2.0.0
+mock==5.1.0
 packaging==23.2
 pluggy==1.4.0
 py==1.11.0
 py-cpuinfo==9.0.0
 pytest==7.1.3
 pytest-benchmark==4.0.0
+pytest-tornado==0.8.1
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0

--- a/opentelemetry-sdk/tests/context/test_asyncio.py
+++ b/opentelemetry-sdk/tests/context/test_asyncio.py
@@ -35,7 +35,7 @@ _SPAN_NAMES = [
 
 def stop_loop_when(loop, cond_func, timeout=5.0):
     """Registers a periodic callback that stops the loop when cond_func() == True.
-    Compatible with both Tornado and asyncio.
+    Compatible with both  and asyncio.
     """
     if cond_func() or timeout <= 0.0:
         loop.stop()

--- a/opentelemetry-sdk/tests/trace/test_local_agent_net.py
+++ b/opentelemetry-sdk/tests/trace/test_local_agent_net.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2016 Uber Technologies, Inc.
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import tornado.web
+from urllib.parse import urlparse
+from opentelemetry.sdk.trace import local_agent_net
+
+test_strategy = """
+    {
+        "strategyType":0,
+        "probabilisticSampling":
+        {
+            "samplingRate":0.002
+        }
+    }
+"""
+
+test_credits = """
+    {
+        \"balances\": [
+            {
+                \"operation\": \"test-operation\",
+                \"balance\": 2.0
+            }
+        ]
+    }
+"""
+
+test_client_id = 12345678
+
+
+class AgentHandler(tornado.web.RequestHandler):
+    def get(self):
+        self.write(test_strategy)
+
+
+class CreditHandler(tornado.web.RequestHandler):
+    def get(self):
+        self.write(test_credits)
+
+
+application = tornado.web.Application([
+    (r'/sampling', AgentHandler),
+    (r'/credits', CreditHandler),
+])
+
+
+@pytest.fixture
+def app():
+    return application
+
+
+@pytest.mark.gen_test
+def test_request_sampling_strategy(http_client, base_url):
+    o = urlparse(base_url)
+    sender = local_agent_net.LocalAgentSender(
+        host='localhost',
+        sampling_port=o.port,
+        reporting_port=local_agent_net.DEFAULT_REPORTING_PORT
+    )
+    response = yield sender.request_sampling_strategy(service_name='svc', timeout=15)
+    assert response.body == test_strategy.encode('utf-8')
+
+
+@pytest.mark.gen_test
+def test_request_throttling_credits(http_client, base_url):
+    o = urlparse(base_url)
+    sender = local_agent_net.LocalAgentSender(
+        host='localhost',
+        sampling_port=o.port,
+        reporting_port=local_agent_net.DEFAULT_REPORTING_PORT,
+        throttling_port=o.port,
+    )
+    response = yield sender.request_throttling_credits(
+        service_name='svc',
+        client_id=test_client_id,
+        operations=['test-operation'],
+        timeout=15)
+    assert response.body == test_credits.encode('utf-8')

--- a/opentelemetry-sdk/tests/trace/test_rate_limiter.py
+++ b/opentelemetry-sdk/tests/trace/test_rate_limiter.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2017 Uber Technologies, Inc.
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import time
+import mock
+
+from opentelemetry.sdk.trace import RateLimiter
+
+class TestRateLimiter(unittest.TestCase):
+    def test_rate_limiting_sampler(self):
+        rate_limiter = RateLimiter(2, 2)
+        self.assertLessEqual(rate_limiter.balance, 2.0)
+        rate_limiter.balance = 2.0
+        # stop time by overwriting timestamp() function to always return
+        # the same time
+        ts = time.time()
+        rate_limiter.last_tick = ts
+        with mock.patch('opentelemetry.sdk.trace.rate_limiter.RateLimiter.timestamp') \
+                as mock_time:
+            mock_time.side_effect = lambda: ts  # always return same time
+            self.assertEqual(rate_limiter.timestamp(), ts)
+            self.assertTrue(rate_limiter.check_credit(1), 'initial balance allows first item')
+            self.assertTrue(rate_limiter.check_credit(1), 'initial balance allows second item')
+            self.assertFalse(rate_limiter.check_credit(1), 'initial balance exhausted')
+
+            # move time 250ms forward, not enough credits to pay for one sample
+            mock_time.side_effect = lambda: ts + 0.25
+            self.assertFalse(rate_limiter.check_credit(1), 'not enough time passed for full item')
+
+            # move time 500ms forward, now enough credits to pay for one sample
+            mock_time.side_effect = lambda: ts + 0.5
+            self.assertTrue(rate_limiter.check_credit(1), 'enough time for new item')
+            self.assertFalse(rate_limiter.check_credit(1), 'no more balance')
+
+            # move time 5s forward, enough to accumulate credits for 10 samples,
+            # but it should still be capped at 2
+            rate_limiter.last_tick = ts  # reset the timer
+            mock_time.side_effect = lambda: ts + 5
+            self.assertTrue(rate_limiter.check_credit(1), 'enough time for new item')
+            self.assertTrue(rate_limiter.check_credit(1), 'enough time for second new item')
+            for i in range(0, 8):
+                self.assertFalse(rate_limiter.check_credit(1), 'but no further, since time is stopped')
+
+        # Test with rate limit of greater than 1 second
+        rate_limiter = RateLimiter(0.1, 1.0)
+        self.assertLessEqual(rate_limiter.balance, 1.0)
+        rate_limiter.balance = 1.0
+        ts = time.time()
+        rate_limiter.last_tick = ts
+        with mock.patch('opentelemetry.sdk.trace.rate_limiter.RateLimiter.timestamp') \
+                as mock_time:
+            mock_time.side_effect = lambda: ts  # always return same time
+            self.assertEqual(rate_limiter.timestamp(), ts)
+            self.assertTrue(rate_limiter.check_credit(1), 'initial balance allows first item')
+            self.assertFalse(rate_limiter.check_credit(1), 'initial balance exhausted')
+
+            # move time 11s forward, enough credits to pay for one sample
+            mock_time.side_effect = lambda: ts + 11
+            self.assertTrue(rate_limiter.check_credit(1))
+
+        # Test update
+        rate_limiter = RateLimiter(3.0, 3.0)
+        self.assertLessEqual(rate_limiter.balance, 3.0)
+        rate_limiter.balance = 3.0
+        ts = time.time()
+        rate_limiter.last_tick = ts
+        with mock.patch('opentelemetry.sdk.trace.rate_limiter.RateLimiter.timestamp') \
+                as mock_time:
+            mock_time.side_effect = lambda: ts  # always return same time
+            self.assertEqual(rate_limiter.timestamp(), ts)
+            self.assertTrue(rate_limiter.check_credit(1))
+            rate_limiter.update(2.0, 2.0)
+            self.assertEqual(rate_limiter.balance, 4.0 / 3.0)

--- a/opentelemetry-sdk/tests/trace/test_sampling.py
+++ b/opentelemetry-sdk/tests/trace/test_sampling.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 import contextlib
+import math
+import mock
 import sys
+import time
 import typing
 import unittest
 
@@ -24,6 +27,7 @@ from opentelemetry.sdk.trace import sampling
 TO_DEFAULT = trace.TraceFlags(trace.TraceFlags.DEFAULT)
 TO_SAMPLED = trace.TraceFlags(trace.TraceFlags.SAMPLED)
 
+MAX_INT = 1 << 63
 
 class TestDecision(unittest.TestCase):
     def test_is_recording(self):
@@ -220,7 +224,7 @@ class TestSampler(unittest.TestCase):
             attributes={"sampled.expect": "true"},
         )
         self.assertTrue(sampled_result.decision.is_sampled())
-        self.assertEqual(sampled_result.attributes, {"sampled.expect": "true"})
+        self.assertEqual(sampled_result.attributes, {"sampler.type": "traceidratio", "sampler.param": 0.5, "sampled.expect": "true"})
         self.assertIsNone(sampled_result.trace_state)
 
         not_sampled_result = sampler.should_sample(
@@ -231,7 +235,7 @@ class TestSampler(unittest.TestCase):
             attributes={"sampled.expect": "false"},
         )
         self.assertFalse(not_sampled_result.decision.is_sampled())
-        self.assertEqual(not_sampled_result.attributes, {})
+        self.assertEqual(not_sampled_result.attributes, {"sampler.type": "traceidratio", "sampler.param": 0.5})
         self.assertIsNone(sampled_result.trace_state)
 
     def test_probability_sampler_zero(self):
@@ -537,3 +541,624 @@ class TestSampler(unittest.TestCase):
             context_api.detach(token)
 
         self.exec_parent_based(implicit_parent_context)
+
+    def test_adaptive_sampler(self):
+        strategies = {
+            'defaultSamplingProbability': 0.51,
+            'defaultLowerBoundTracesPerSecond': 3,
+            'perOperationStrategies':
+            [
+                {
+                    'operation': 'op',
+                    'probabilisticSampling': {
+                        'samplingRate': 0.5
+                    }
+                }
+            ]
+        }
+        sampler = sampling.AdaptiveSampler(strategies, 2)
+        sample_result = sampler.should_sample(None, MAX_INT - 10, "op")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'traceidratio', 'sampler.param': 0.5})
+
+        # This operation is seen for the first time by the sampler
+        sample_result = sampler.should_sample(None, MAX_INT - 10, "new_op")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'traceidratio', 'sampler.param': 0.51})
+
+        ts = time.time()
+        with mock.patch('opentelemetry.sdk.trace.rate_limiter.RateLimiter.timestamp') \
+                as mock_time:
+
+            # Move time forward by a second to guarantee the rate limiter has enough credits
+            mock_time.side_effect = lambda: ts + 1
+
+            sample_result = sampler.should_sample(None, int(MAX_INT + (MAX_INT / 4)), "new_op")
+            self.assertTrue(sample_result.decision.is_sampled())
+            self.assertEqual(sample_result.attributes, {'sampler.type': 'lowerbound', 'sampler.param': 0.51})
+
+        # This operation is seen for the first time by the sampler but surpasses
+        # max_operations of 2. The default probabilistic sampler will be used
+        sample_result = sampler.should_sample(None, MAX_INT - 10, "new_op_2")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'traceidratio', 'sampler.param': 0.51})
+
+        sample_result = sampler.should_sample(None, int(MAX_INT + (MAX_INT / 4)), "new_op_2")
+        self.assertFalse(sample_result.decision.is_sampled())
+        self.assertEqual(sampler.get_description(), 'AdaptiveSampler{0.51, 3, 2}')
+
+        # Update the strategies
+        strategies = {
+            'defaultSamplingProbability': 0.52,
+            'defaultLowerBoundTracesPerSecond': 4,
+            'perOperationStrategies':
+            [
+                {
+                    'operation': 'op',
+                    'probabilisticSampling': {
+                        'samplingRate': 0.52
+                    }
+                },
+                {
+                    'operation': 'new_op_3',
+                    'probabilisticSampling': {
+                        'samplingRate': 0.53
+                    }
+                }
+            ]
+        }
+        sampler.update(strategies)
+
+        # The probability for op has been updated
+        sample_result = sampler.should_sample(None, MAX_INT - 10, "op")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'traceidratio', 'sampler.param': 0.52})
+
+        # A new operation has been added
+        sample_result = sampler.should_sample(None, MAX_INT - 10, "new_op_3")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'traceidratio', 'sampler.param': 0.53})
+        self.assertEqual(sampler.get_description(), 'AdaptiveSampler{0.52, 4, 2}')
+
+    def test_adaptive_sampler_default_values(self):
+        adaptive_sampler = sampling.AdaptiveSampler({}, 2)
+        self.assertEqual(adaptive_sampler.get_description(), \
+            'AdaptiveSampler{0.001, 0.0016666666666666668, 2}', 'sampler should use default values')
+
+        sample_result = adaptive_sampler.should_sample(None, 0, "op")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'traceidratio', 'sampler.param': 0.001})
+        self.assertEqual(adaptive_sampler.samplers['op'].get_description(), \
+            'GuaranteedThroughputProbabilisticSampler{op, 0.001, 0.0016666666666666668}')
+
+        adaptive_sampler.update(strategies={
+            'defaultLowerBoundTracesPerSecond': 4,
+            'perOperationStrategies':
+                [
+                    {
+                        'operation': 'new_op',
+                        'probabilisticSampling': {
+                            'samplingRate': 0.002
+                        }
+                    }
+                ]
+        })
+        self.assertEqual(adaptive_sampler.get_description(), 'AdaptiveSampler{0.001, 4, 2}')
+
+        sample_result = adaptive_sampler.should_sample(None, 0, "new_op")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'traceidratio', 'sampler.param': 0.002})
+        self.assertEqual(adaptive_sampler.samplers['new_op'].get_description(), \
+            'GuaranteedThroughputProbabilisticSampler{new_op, 0.002, 4}')
+
+        sample_result = adaptive_sampler.should_sample(None, 0, "op")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'traceidratio', 'sampler.param': 0.001})
+        # TODO ruh roh, the lowerbound isn't changed
+        #  if the operation isn't included in perOperationStrategies
+        self.assertEqual(adaptive_sampler.samplers['op'].get_description(), \
+            'GuaranteedThroughputProbabilisticSampler{op, 0.001, 0.0016666666666666668}')
+
+    def test_rate_limiting_sampler(self):
+        sampler = sampling.RateLimitingSampler(2)
+        sampler.rate_limiter.balance = 2.0
+        # stop time by overwriting timestamp() function to always return
+        # the same time
+        ts = time.time()
+        sampler.rate_limiter.last_tick = ts
+        with mock.patch('opentelemetry.sdk.trace.rate_limiter.RateLimiter.timestamp') \
+                as mock_time:
+            mock_time.side_effect = lambda: ts  # always return same time
+        
+            self.assertEqual(sampler.rate_limiter.timestamp(), ts)
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertTrue(sampled, 'initial balance allows first item')
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertTrue(sampled, 'initial balance allows second item')
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertFalse(sampled, 'initial balance exhausted')
+
+            # move time 250ms forward, not enough credits to pay for one sample
+            mock_time.side_effect = lambda: ts + 0.25
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertFalse(sampled, 'not enough time passed for full item')
+
+            # move time 500ms forward, now enough credits to pay for one sample
+            mock_time.side_effect = lambda: ts + 0.5
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertTrue(sampled, 'enough time for new item')
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertFalse(sampled, 'no more balance')
+
+            # move time 5s forward, enough to accumulate credits for 10 samples,
+            # but it should still be capped at 2
+            sampler.last_tick = ts  # reset the timer
+            mock_time.side_effect = lambda: ts + 5
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertTrue(sampled, 'enough time for new item')
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertTrue(sampled, 'enough time for second new item')
+            for i in range(0, 8):
+                sample_result = sampler.should_sample(None, 0, "span name")
+                self.assertFalse(sample_result.decision.is_sampled(), 'but no further, since time is stopped')
+                self.assertEqual(sample_result.attributes, {'sampler.type': 'ratelimiting', 'sampler.param': 2})
+        self.assertEqual(sampler.get_description(), 'RateLimitingSampler{2}')
+
+        # Test with rate limit of greater than 1 second
+        sampler = sampling.RateLimitingSampler(0.1)
+        sampler.rate_limiter.balance = 1.0
+        ts = time.time()
+        sampler.rate_limiter.last_tick = ts
+        with mock.patch('opentelemetry.sdk.trace.rate_limiter.RateLimiter.timestamp') \
+                as mock_time:
+            mock_time.side_effect = lambda: ts  # always return same time
+            self.assertEqual(sampler.rate_limiter.timestamp(), ts)
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertTrue(sampled, 'initial balance allows first item')
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertFalse(sampled, 'initial balance exhausted')
+
+            # move time 11s forward, enough credits to pay for one sample
+            mock_time.side_effect = lambda: ts + 11
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertTrue(sampled)
+        self.assertEqual(sampler.get_description(), 'RateLimitingSampler{0.1}')
+
+        # Test update
+        sampler = sampling.RateLimitingSampler(3.0)
+        sampler.rate_limiter.balance = 3.0
+        ts = time.time()
+        sampler.rate_limiter.last_tick = ts
+        with mock.patch('opentelemetry.sdk.trace.rate_limiter.RateLimiter.timestamp') \
+                as mock_time:
+            mock_time.side_effect = lambda: ts  # always return same time
+            self.assertEqual(sampler.rate_limiter.timestamp(), ts)
+            sampled = sampler.should_sample(None, 0, "span name").decision.is_sampled()
+            self.assertTrue(sampled)
+            self.assertEqual(sampler.rate_limiter.balance, 2.0)
+            self.assertEqual(sampler.get_description(), 'RateLimitingSampler{3.0}')
+
+            sampler.update(3.0)
+            self.assertEqual(sampler.get_description(), \
+                'RateLimitingSampler{3.0}', 'should short cirtcuit if rate is the same')
+
+            sampler.update(2.0)
+            self.assertEqual(sampler.rate_limiter.balance, 4.0 / 3.0)
+            self.assertEqual(sampler.get_description(), 'RateLimitingSampler{2.0}')
+
+    def test_guaranteed_throughput_probabilistic_sampler(self):
+        sampler = sampling.GuaranteedThroughputProbabilisticSampler('op', 2, 0.5)
+        sampler.lower_bound_sampler.rate_limiter.balance = 2.0
+        sample_result = sampler.should_sample(None, MAX_INT - 10, "span name")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'traceidratio', 'sampler.param': 0.5})
+        sample_result = sampler.should_sample(None, MAX_INT + 10, "span name")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'lowerbound', 'sampler.param': 0.5})
+        sample_result = sampler.should_sample(None, MAX_INT + 10, "span name")
+        self.assertFalse(sample_result.decision.is_sampled())
+        self.assertEqual(sampler.get_description(), 'GuaranteedThroughputProbabilisticSampler{op, 0.5, 2}')
+
+        sampler.update(3, 0.51)
+        sampler.lower_bound_sampler.rate_limiter.balance = 3.0
+        sample_result = sampler.should_sample(None, MAX_INT - 10, "span name")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'traceidratio', 'sampler.param': 0.51})
+        sample_result = sampler.should_sample(None, int(MAX_INT + (MAX_INT / 4)), "span name")
+        self.assertTrue(sample_result.decision.is_sampled())
+        self.assertEqual(sample_result.attributes, {'sampler.type': 'lowerbound', 'sampler.param': 0.51})
+
+        self.assertEqual(sampler.get_description(), 'GuaranteedThroughputProbabilisticSampler{op, 0.51, 3}')
+
+    def test_sampler_equality(self):
+        const1 = sampling.StaticSampler(True)
+        const2 = sampling.StaticSampler(True)
+        const3 = sampling.StaticSampler(False)
+        self.assertEqual(const1, const2)
+        self.assertNotEqual(const1, const3)
+
+        prob1 = sampling.TraceIdRatioBased(rate=0.01)
+        prob2 = sampling.TraceIdRatioBased(rate=0.01)
+        prob3 = sampling.TraceIdRatioBased(rate=0.02)
+        self.assertEqual(prob1, prob2)
+        self.assertNotEqual(prob1, prob3)
+        self.assertNotEqual(const1, prob1)
+
+        rate1 = sampling.RateLimitingSampler(max_traces_per_second=0.01)
+        rate2 = sampling.RateLimitingSampler(max_traces_per_second=0.01)
+        rate3 = sampling.RateLimitingSampler(max_traces_per_second=0.02)
+        self.assertEqual(rate1, rate2)
+        self.assertNotEqual(rate1, rate3)
+        self.assertNotEqual(rate1, const1)
+        self.assertNotEqual(rate1, prob1)
+
+    def test_remotely_controlled_sampler(self):
+        sampler = sampling.RemoteControlledSampler(
+            channel=mock.MagicMock(),
+            service_name='x'
+        )
+        sample_result = sampler.should_sample(None, 1, "span name")
+        self.assertTrue(sample_result.decision.is_sampled())
+        
+        # TODO: don't want to mess with TraceIdRatioBased attributes - what do we do about this assertion?
+        # self.assertEqual(sample_result.attributes, {'sampler.type': 'traceidratio', 'sampler.param': sampling.DEFAULT_SAMPLING_PROBABILITY}
+
+        init_sampler = mock.MagicMock()
+        init_sampler.should_sample = mock.MagicMock()
+        channel = mock.MagicMock()
+        channel.io_loop = None
+        sampler = sampling.RemoteControlledSampler(
+            channel=channel,
+            service_name='x',
+            init_sampler=init_sampler,
+            logger=mock.MagicMock(),
+        )
+        self.assertEqual(init_sampler.should_sample.call_count, 1)
+
+        sampler.should_sample(None, 1, "span name")
+        self.assertEqual(init_sampler.should_sample.call_count, 2)
+
+        sampler.io_loop = mock.MagicMock()
+        # noinspection PyProtectedMember
+        sampler._init_polling()
+        self.assertEqual(sampler.io_loop.call_later.call_count, 1)
+
+        sampler._create_periodic_callback = mock.MagicMock()
+        # noinspection PyProtectedMember
+        sampler._delayed_polling()
+        sampler.close()
+
+        sampler = sampling.RemoteControlledSampler(
+            channel=mock.MagicMock(),
+            service_name='x',
+        )
+
+        sampler.close()
+        self.assertFalse(sampler.running)
+        sampler._init_polling()
+        self.assertFalse(sampler.running)
+        sampler._delayed_polling()
+        self.assertFalse(sampler.running)
+
+    # noinspection PyProtectedMember
+    def test_sampling_request_callback(self):
+        channel = mock.MagicMock()
+        channel.io_loop = mock.MagicMock()
+        error_reporter = mock.MagicMock()
+        error_reporter.error = mock.MagicMock()
+        sampler = sampling.RemoteControlledSampler(
+            channel=channel,
+            service_name='x',
+            error_reporter=error_reporter,
+            max_operations=10,
+        )
+
+        return_value = mock.MagicMock()
+        return_value.exception = lambda *args: False
+
+        probabilistic_strategy = """
+        {
+            "strategyType":"PROBABILISTIC",
+            "probabilisticSampling":
+            {
+                "samplingRate":0.002
+            }
+        }
+        """
+
+        return_value.result = lambda *args: \
+            type('obj', (object,), {'body': probabilistic_strategy})()
+        sampler._sampling_request_callback(return_value)
+        self.assertEqual(sampler.sampler.get_description(), \
+            'TraceIdRatioBased{0.002}', 'sampler should have changed to probabilistic')
+        prev_sampler = sampler.sampler
+
+        sampler._sampling_request_callback(return_value)
+        self.assertTrue(prev_sampler is sampler.sampler, \
+            "strategy hasn't changed so sampler should not change")
+
+        adaptive_sampling_strategy = """
+        {
+            "strategyType":"PROBABILISTIC",
+            "operationSampling":
+            {
+                "defaultSamplingProbability":0.001,
+                "defaultLowerBoundTracesPerSecond":2,
+                "perOperationStrategies":
+                [
+                    {
+                        "operation":"op",
+                        "probabilisticSampling":{
+                            "samplingRate":0.002
+                        }
+                    }
+                ]
+            }
+        }
+        """
+        return_value.result = lambda *args: \
+            type('obj', (object,), {'body': adaptive_sampling_strategy})()
+        sampler._sampling_request_callback(return_value)
+        self.assertEqual(sampler.sampler.get_description(), 'AdaptiveSampler{0.001, 2, 10}', \
+            'sampler should have changed to adaptive')
+        prev_sampler = sampler.sampler
+
+        sampler._sampling_request_callback(return_value)
+        self.assertTrue(prev_sampler is sampler.sampler, "strategy hasn't changed so sampler should not change")
+
+        probabilistic_strategy_bytes = probabilistic_strategy.encode('utf-8')
+
+        return_value.result = lambda *args: \
+            type('obj', (object,), {'body': probabilistic_strategy_bytes})()
+        sampler._sampling_request_callback(return_value)
+        self.assertEqual(sampler.sampler.get_description(), \
+            'TraceIdRatioBased{0.002}', 'sampler should have changed to probabilistic')
+
+        adaptive_sampling_strategy_bytearray = bytearray(adaptive_sampling_strategy.encode('utf-8'))
+
+        return_value.result = lambda *args: \
+            type('obj', (object,), {'body': adaptive_sampling_strategy_bytearray})()
+        sampler._sampling_request_callback(return_value)
+        self.assertEqual(sampler.sampler.get_description(), 'AdaptiveSampler{0.001, 2, 10}', \
+            'sampler should have changed to adaptive')
+        prev_sampler = sampler.sampler
+
+        return_value.exception = lambda *args: True
+        sampler._sampling_request_callback(return_value)
+        self.assertEqual(error_reporter.error.call_count, 1)
+        self.assertTrue(prev_sampler is sampler.sampler, 'error fetching strategy should not update the sampler')
+
+        return_value.exception = lambda *args: False
+        return_value.result = lambda *args: type('obj', (object,), {'body': 'bad_json'})()
+
+        sampler._sampling_request_callback(return_value)
+        self.assertEqual(error_reporter.error.call_count, 2)
+        self.assertTrue(prev_sampler is sampler.sampler, 'error updating sampler should not update the sampler')
+
+        return_value.result = lambda *args: \
+            type('obj', (object,), {'body': None})()
+        sampler._sampling_request_callback(return_value)
+        self.assertEqual(error_reporter.error.call_count, 3)
+        self.assertTrue(prev_sampler is sampler.sampler, 'error updating sampler should not update the sampler')
+
+        return_value.result = lambda *args: \
+            type('obj', (object,), {'body': {'decode': None}})()
+        sampler._sampling_request_callback(return_value)
+        self.assertEqual(error_reporter.error.call_count, 4)
+        self.assertTrue(prev_sampler is sampler.sampler, 'error updating sampler should not update the sampler')
+
+        return_value.result = lambda *args: \
+            type('obj', (object,), {'body': probabilistic_strategy})()
+        sampler._sampling_request_callback(return_value)
+        self.assertEqual(sampler.sampler.get_description(), 'TraceIdRatioBased{0.002}', \
+            'updating sampler from adaptive to probabilistic should work')
+
+        sampler.close()
+
+    def test_update_sampler(self):
+        probabilistic_sampler = sampling.TraceIdRatioBased(0.002)
+        other_probabilistic_sampler = sampling.TraceIdRatioBased(0.003)
+        rate_limiting_sampler = sampling.RateLimitingSampler(10)
+        other_rate_limiting_sampler = sampling.RateLimitingSampler(20)
+
+        cases =    [
+            (
+                {'strategyType': 'PROBABILISTIC', 'probabilisticSampling': {'samplingRate': 0.003}},
+                probabilistic_sampler,
+                other_probabilistic_sampler,
+                0,
+                'sampler should update to new probabilistic sampler',
+                False,
+                10,
+            ),
+            (
+                {'strategyType': 'PROBABILISTIC', 'probabilisticSampling': {'samplingRate': 400}},
+                probabilistic_sampler,
+                probabilistic_sampler,
+                1,
+                'sampler should remain the same if strategy is invalid',
+                True,
+                10,
+            ),
+            (
+                {'strategyType': 'PROBABILISTIC', 'probabilisticSampling': {'samplingRate': 0.002}},
+                probabilistic_sampler,
+                probabilistic_sampler,
+                0,
+                'sampler should remain the same with the same strategy',
+                True,
+                10,
+            ),
+            (
+                {'strategyType': 'RATE_LIMITING', 'rateLimitingSampling': {'maxTracesPerSecond': 10}},
+                probabilistic_sampler,
+                rate_limiting_sampler,
+                0,
+                'sampler should update to new rate limiting sampler',
+                False,
+                10,
+            ),
+            (
+                {'strategyType': 'RATE_LIMITING', 'rateLimitingSampling': {'maxTracesPerSecond': 10}},
+                rate_limiting_sampler,
+                rate_limiting_sampler,
+                0,
+                'sampler should remain the same with the same strategy',
+                True,
+                10,
+            ),
+            (
+                {'strategyType': 'RATE_LIMITING', 'rateLimitingSampling': {'maxTracesPerSecond': -10}},
+                rate_limiting_sampler,
+                rate_limiting_sampler,
+                1,
+                'sampler should remain the same if strategy is invalid',
+                True,
+                10,
+            ),
+            (
+                {'strategyType': 'RATE_LIMITING', 'rateLimitingSampling': {'maxTracesPerSecond': 20}},
+                rate_limiting_sampler,
+                other_rate_limiting_sampler,
+                0,
+                'sampler should update to new rate limiting sampler',
+                False,
+                10,
+            ),
+            (
+                {},
+                rate_limiting_sampler,
+                rate_limiting_sampler,
+                1,
+                'sampler should remain the same if strategy is empty',
+                True,
+                10,
+            ),
+            (
+                {'strategyType': 'INVALID_TYPE'},
+                rate_limiting_sampler,
+                rate_limiting_sampler,
+                1,
+                'sampler should remain the same if strategy is invalid',
+                True,
+                10,
+            ),
+            (
+                {'strategyType': 'INVALID_TYPE'},
+                rate_limiting_sampler,
+                rate_limiting_sampler,
+                1,
+                'sampler should remain the same if strategy is invalid',
+                True,
+                None,
+            ),
+        ]
+        
+        for response, init_sampler, expected_sampler, err_count, err_msg, reference_equivalence, max_operations in cases:
+            error_reporter = mock.MagicMock()
+            error_reporter.error = mock.MagicMock()
+            remote_sampler = sampling.RemoteControlledSampler(
+                channel=mock.MagicMock(),
+                service_name='x',
+                error_reporter=error_reporter,
+                max_operations=max_operations,
+                init_sampler=init_sampler,
+            )
+
+            # noinspection PyProtectedMember
+            remote_sampler._update_sampler(response)
+            self.assertEqual(error_reporter.error.call_count, err_count)
+            if reference_equivalence:
+                self.assertTrue(remote_sampler.sampler is expected_sampler, err_msg)
+            else:
+                self.assertEqual(remote_sampler.sampler, expected_sampler, err_msg)
+
+            remote_sampler.close()
+
+    # noinspection PyProtectedMember
+    def test_update_sampler_adaptive_sampler(self):
+        error_reporter = mock.MagicMock()
+        error_reporter.error = mock.MagicMock()
+        remote_sampler = sampling.RemoteControlledSampler(
+            channel=mock.MagicMock(),
+            service_name='x',
+            error_reporter=error_reporter,
+            max_operations=10,
+        )
+
+        response = {
+            'strategyType': 'RATE_LIMITING',
+            'operationSampling':
+            {
+                'defaultSamplingProbability': 0.001,
+                'defaultLowerBoundTracesPerSecond': 2,
+                'perOperationStrategies':
+                [
+                    {
+                        'operation': 'op',
+                        'probabilisticSampling': {
+                            'samplingRate': 0.002
+                        }
+                    }
+                ]
+            }
+        }
+
+        remote_sampler._update_sampler(response)
+        self.assertEqual(remote_sampler.sampler.get_description(), 'AdaptiveSampler{0.001, 2, 10}')
+
+        new_response = {
+            'strategyType': 'RATE_LIMITING',
+            'operationSampling':
+            {
+                'defaultSamplingProbability': 0.51,
+                'defaultLowerBoundTracesPerSecond': 3,
+                'perOperationStrategies':
+                [
+                    {
+                        'operation': 'op',
+                        'probabilisticSampling': {
+                            'samplingRate': 0.002
+                        }
+                    }
+                ]
+            }
+        }
+
+        remote_sampler._update_sampler(new_response)
+        self.assertEqual(remote_sampler.sampler.get_description(), 'AdaptiveSampler{0.51, 3, 10}')
+
+        remote_sampler._update_sampler(
+            {'strategyType': 'PROBABILISTIC', 'probabilisticSampling': {'samplingRate': 0.004}})
+        self.assertEqual(remote_sampler.sampler.get_description(), 'TraceIdRatioBased{0.004}', \
+            'should not fail going from adaptive sampler to probabilistic sampler')
+
+        remote_sampler._update_sampler({'strategyType': 'RATE_LIMITING',
+                                        'operationSampling': {'defaultSamplingProbability': 0.4}})
+        self.assertEqual(remote_sampler.sampler.get_description(), 'AdaptiveSampler{0.4, 0.0016666666666666668, 10}')
+
+        remote_sampler.close()
+
+    def test_get_sampling_probability(self):
+        cases = [
+            ({'probabilisticSampling': {'samplingRate': 0.003}}, 0.003),
+            ({}, 0.001),
+            (None, 0.001),
+            ({'probabilisticSampling': {}}, 0.001),
+            ({'probabilisticSampling': None}, 0.001),
+        ]
+
+        for strategy, expected in cases:
+            self.assertEqual(expected, sampling.get_sampling_probability(strategy))
+
+    def test_get_rate_limit(self):
+        cases = [
+            ({'rateLimitingSampling': {'maxTracesPerSecond': 1}}, 1),
+            ({}, 0.0016666),
+            (None, 0.0016666),
+            ({'rateLimitingSampling': {}}, 0.0016666),
+            ({'rateLimitingSampling': None}, 0.0016666),
+        ]
+
+        for strategy, expected in cases:
+            self.assertTrue(math.fabs(expected - sampling.get_rate_limit(strategy)) < 0.0001)


### PR DESCRIPTION
- Introduce a dependency on tornado, in order to use IOLoop in RemoteControlledSampler
- Introduce a variety of new samplers, which support the jaeger remote sampling protocol

DRAFT - DO NOT MERGE

There are a variety of challenging TODO's (marked `TODO(sconover)`) and, no doubt, changes to be made based on feedback from project maintainers.

The goal of this initial set of changes is to conduct a pretty "straight" port of the corresponding code in jaeger-client-python, to get discussion going on how opentelemetry-python support for jaeger remote sampling should ultimately work.

Please see [the jaeger-client-python project](https://github.com/jaegertracing/jaeger-client-python/tree/master) and especially [sampler.py](https://github.com/jaegertracing/jaeger-client-python/blob/master/jaeger_client/sampler.py) and [test_sampler.py](https://github.com/jaegertracing/jaeger-client-python/blob/master/tests/test_sampler.py) for the source of much of this port.

New dependencies:
  - threadloop>=1.0.2
  - tornado>=6.4

I expect there's a very good chance that [opentelemetry python docs](https://opentelemetry.io/docs/languages/python) will need to be updated in advance of an ultimate merge, and would appreciate advice on what those areas might be.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ported unit tests from `jaeger-client-python`
- [x] For lack of end-to-end tests, I put together a sample flask app and, running alongside a jaeger agent, manually verified that remote configuration changes indeed sync over to the client and change the client's sampling decision behavior.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated

I'm leaving all of the above "unchecked". I've made some style changes in the direction of this project and python 3, however I'm hesitant to "compromise" the relatively straight port at this point, to make comparison/contrasting easier for initial reviewers. 

Regarding (even) unit tests: while this code is unit tested, the tests are ported, and stylistically are quite different from tests in this project - for example they make extensive use of mocks, among other differences.

Sample flask server and explanation:

```
# A jaeger agent may be started using a command like:
#
# docker run \
# -v /dev/scratch/config:/config \
# -e SAMPLING_CONFIG_TYPE=file \
# -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
# -p 5775:5775/udp \
# -p 6831:6831/udp \ 
# -p 6832:6832/udp \ 
# -p 5778:5778 \
# -p 16686:16686 \   
# -p 14268:14268 \ 
# -p 14250:14250 \ 
# -p 9411:9411 \
# jaegertracing/all-in-one:1.22 \
# --sampling.strategies-file=/config/strategies.json \
# --sampling.strategies-reload-interval=5s
#
# Where the sampling strategies config file is available locally at
# 
# /dev/scratch/config/strategies.json 
#
#
# Run this python script and make a request using:
#   curl localhost:5000/
# If the sampling decision is 'sample' then the ConsoleSpanExporter
# will print the emitted span to the console.
#
# If the agent's strategies.json files is changed to something like
#
# 
# {
#   "service_strategies": [
#     {
#       "service": "foo",
#       "type": "probabilistic",
#       "param": 0.333
#     }
#   ],
#   "default_strategy": {
#     "type": "probabilistic",
#     "param": 1
#   }
# }
#
# ...once these settings sync over via RemoteControlledSampler,
# it will take several curl invocations to see an emitted span,
# reflecting the 1-in-3 chance that a trace is created.

from opentelemetry.sdk.resources import SERVICE_NAME, Resource

from opentelemetry import trace
from opentelemetry.sdk.trace.export import ConsoleSpanExporter
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import SimpleSpanProcessor

from opentelemetry.sdk.trace.sampling import RemoteControlledSampler
from opentelemetry.sdk.trace.local_agent_net import LocalAgentSender

import threading
import tornado

main_loop = tornado.ioloop.IOLoop().current()

sampler = RemoteControlledSampler(
    channel=LocalAgentSender('localhost', 5778, 5778, io_loop=main_loop),
    service_name='foo',
    sampling_refresh_interval = 5,
)

resource = Resource(attributes={
    SERVICE_NAME: "foo"
})
traceProvider = TracerProvider(resource=resource, sampler=sampler)
traceProvider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter("foo")))
trace.set_tracer_provider(traceProvider)

from flask import (
    Flask, 
    jsonify
)

tracer = trace.get_tracer("foo")

def create_app():
    app = Flask(__name__)

    @app.route('/')
    def hello_world(): 
        with tracer.start_as_current_span("foo") as span:
                span.set_attribute("hello.value", "world")
                return jsonify({
                    "status": "success",
                    "message": "Hello World!"
                })
     
    return app

app = create_app()

if __name__ == '__main__':
    threading.Thread(target=lambda: app.run(debug=True, use_reloader=False)).start()
    main_loop.start()
```