### PR TITLE
Improve documentation for trace.propagator.inject()

### DIFF
--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -109,8 +109,9 @@ def inject(
     """Uses the configured propagator to inject a Context into the carrier.
 
     Args:
-        carrier: An object that contains a representation of HTTP
-            headers. Should be paired with setter, which
+        carrier: An object that can carry information including 
+            the traceparent id.
+            Should be paired with setter, which
             should know how to set header values on the carrier.
         context: An optional Context to use. Defaults to current
             context if not set.


### PR DESCRIPTION
# Description

At present, the documentation suggests that HTTP Headers are the only appropriate carrier, when any object is fine including a standard dict.

This PR updates the wording to make clear it is more generic.

## Type of change

Please delete options that are not relevant.

- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

N/A - Documentation change

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Documentation has been updated
