### PR TITLE
Support for Jaeger Remote Sampling addition to contrib repo

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -1246,6 +1246,8 @@ class TracerProvider(trace_api.TracerProvider):
     def shutdown(self):
         """Shut down the span processors added to the tracer provider."""
         self._active_span_processor.shutdown()
+        if self.sampler is not None:
+            self.sampler.close()
         if self._atexit_handler is not None:
             atexit.unregister(self._atexit_handler)
             self._atexit_handler = None

--- a/opentelemetry-sdk/tests/trace/test_sampling.py
+++ b/opentelemetry-sdk/tests/trace/test_sampling.py
@@ -220,7 +220,7 @@ class TestSampler(unittest.TestCase):
             attributes={"sampled.expect": "true"},
         )
         self.assertTrue(sampled_result.decision.is_sampled())
-        self.assertEqual(sampled_result.attributes, {"sampled.expect": "true"})
+        self.assertEqual(sampled_result.attributes, {"sampler.type": "traceidratio", "sampler.param": 0.5, "sampled.expect": "true"})
         self.assertIsNone(sampled_result.trace_state)
 
         not_sampled_result = sampler.should_sample(
@@ -231,7 +231,7 @@ class TestSampler(unittest.TestCase):
             attributes={"sampled.expect": "false"},
         )
         self.assertFalse(not_sampled_result.decision.is_sampled())
-        self.assertEqual(not_sampled_result.attributes, {})
+        self.assertEqual(not_sampled_result.attributes, {"sampler.type": "traceidratio", "sampler.param": 0.5})
         self.assertIsNone(sampled_result.trace_state)
 
     def test_probability_sampler_zero(self):
@@ -537,3 +537,17 @@ class TestSampler(unittest.TestCase):
             context_api.detach(token)
 
         self.exec_parent_based(implicit_parent_context)
+
+    def test_sampler_equality(self):
+        const1 = sampling.StaticSampler(True)
+        const2 = sampling.StaticSampler(True)
+        const3 = sampling.StaticSampler(False)
+        self.assertEqual(const1, const2)
+        self.assertNotEqual(const1, const3)
+        
+        prob1 = sampling.TraceIdRatioBased(rate=0.01)
+        prob2 = sampling.TraceIdRatioBased(rate=0.01)
+        prob3 = sampling.TraceIdRatioBased(rate=0.02)
+        self.assertEqual(prob1, prob2)
+        self.assertNotEqual(prob1, prob3)
+        self.assertNotEqual(const1, prob1)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -50,6 +50,7 @@ from opentelemetry.sdk.trace.sampling import (
     Decision,
     ParentBased,
     StaticSampler,
+    Sampler,
 )
 from opentelemetry.sdk.util import BoundedDict, ns_to_iso_str
 from opentelemetry.sdk.util.instrumentation import InstrumentationInfo
@@ -83,7 +84,8 @@ class TestTracer(unittest.TestCase):
         self.assertIsInstance(tracer, trace_api.Tracer)
 
     def test_shutdown(self):
-        tracer_provider = trace.TracerProvider()
+        mock_sampler = Mock(spec=Sampler)
+        tracer_provider = trace.TracerProvider(sampler=mock_sampler)
 
         mock_processor1 = mock.Mock(spec=trace.SpanProcessor)
         tracer_provider.add_span_processor(mock_processor1)
@@ -95,6 +97,8 @@ class TestTracer(unittest.TestCase):
 
         self.assertEqual(mock_processor1.shutdown.call_count, 1)
         self.assertEqual(mock_processor2.shutdown.call_count, 1)
+
+        self.assertEqual(mock_sampler.close.call_count, 1)
 
         shutdown_python_code = """
 import atexit


### PR DESCRIPTION
# Description

I'm attempting to port the jaeger remote sampling support from the jaeger-client-python project. 

Per @srikanthccv 's feedback [here](https://github.com/open-telemetry/opentelemetry-python/pull/3827#issuecomment-2031971650), it really makes more sense for the bulk of the port to go into the contrib repo. However there are elements of the core sampler code that need to change to accommodate these contrib samplers.

I'm opening this in draft mode to seek initial feedback+guidance. There's a series of TODO's that raise questions about approach.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests, in test_sampling.py

# Does This PR Require a Contrib Repo Change?

It doesn't require one, but there will be a companion PR that depends on this change.

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
