### PR TITLE
Fix class BoundedAttributes to have RLock rather than Lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix class BoundedAttributes to have RLock rather than Lock
+  ([#3859](https://github.com/open-telemetry/opentelemetry-python/pull/3859))
 - Update proto version to v1.2.0
   ([#3844](https://github.com/open-telemetry/opentelemetry-python/pull/3844))
 - Add to_json method to ExponentialHistogram

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -150,7 +150,7 @@ class BoundedAttributes(MutableMapping):
         self.max_value_len = max_value_len
         # OrderedDict is not used until the maxlen is reached for efficiency.
         self._dict = {}  # type: dict | OrderedDict
-        self._lock = threading.Lock()  # type: threading.Lock
+        self._lock = threading.RLock()  # type: threading.RLock
         if attributes:
             for key, value in attributes.items():
                 self[key] = value

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -182,7 +182,7 @@ class TestBoundedAttributes(unittest.TestCase):
             bdict["should-not-work"] = "dict immutable"
 
     def test_locking(self):
-        """Supporting test case for a commit titled: Fix class BoundedAttributes to have RLock rather than Lock
+        """Supporting test case for a commit titled: Fix class BoundedAttributes to have RLock rather than Lock. See #3858.
         The change was introduced because __iter__ of the class BoundedAttributes holds lock, and we observed some deadlock symptoms
         in the codebase. This test case is to verify that the fix works as expected.
         """

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -181,10 +181,11 @@ class TestBoundedAttributes(unittest.TestCase):
         with self.assertRaises(TypeError):
             bdict["should-not-work"] = "dict immutable"
 
-    # Supporting test case for a commit titled: Fix class BoundedAttributes to have RLock rather than Lock
-    # The change was introduced because __iter__ of the class BoundedAttributes holds lock, and we observed some deadlock symptoms
-    # in the codebase. This test case is to verify that the fix works as expected.
     def test_locking(self):
+        """Supporting test case for a commit titled: Fix class BoundedAttributes to have RLock rather than Lock
+        The change was introduced because __iter__ of the class BoundedAttributes holds lock, and we observed some deadlock symptoms
+        in the codebase. This test case is to verify that the fix works as expected.
+        """
         bdict = BoundedAttributes(immutable=False)
         for num in range(100):
             bdict[str(num)] = num

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -187,23 +187,10 @@ class TestBoundedAttributes(unittest.TestCase):
         in the codebase. This test case is to verify that the fix works as expected.
         """
         bdict = BoundedAttributes(immutable=False)
-        for num in range(100):
-            bdict[str(num)] = num
 
-        def iter_and_set():
-            for key in bdict:
-                bdict[key] = 2 * bdict[key]
-
-        import threading
-
-        t1 = threading.Thread(target=iter_and_set)
-        t2 = threading.Thread(target=iter_and_set)
-
-        t1.start()
-        t2.start()
-
-        t1.join()
-        t2.join()
+        with bdict._lock:
+            for num in range(100):
+                bdict[str(num)] = num
 
         for num in range(100):
-            self.assertEqual(bdict[str(num)], 4 * num)
+            self.assertEqual(bdict[str(num)], num)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The change fixes the class BoundedAttributes to have RLock rather than Lock.
Fixes #3858 (issue).
Motivation of this PR is that a deadlock symptom was observed while using the Opentelemetry _logs API.
No additional dependencies are required for this change.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

It seems that a dedicated test case is required.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
