### PR TITLE
Auto instrumentation parameters

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 # skipping auto generated folders
 skip = ./.tox,./.mypy_cache,./docs/_build,./target,*/LICENSE,./venv,.git,./opentelemetry-semantic-conventions
-ignore-words-list = ans,assertIn,ue,ot,hist,ro,
+ignore-words-list = ans,ue,ot,hist,ro

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 # skipping auto generated folders
 skip = ./.tox,./.mypy_cache,./docs/_build,./target,*/LICENSE,./venv,.git,./opentelemetry-semantic-conventions
-ignore-words-list = ans,ue,ot,hist,ro
+ignore-words-list = ans,assertIn,ue,ot,hist,ro,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - unit annotations (enclosed in curly braces like `{requests}`) are stripped away
   - units with slash are converted e.g. `m/s` -> `meters_per_second`.
   - The exporter's API is not changed
-- Add parameters for Distros and configurators to configure autoinstrumentation
+- Add parameters for Distros and configurators to configure autoinstrumentation in addition to existing environment variables.
   ([#3864] (https://github.com/open-telemetry/opentelemetry-python/pull/3864))
 
 ## Version 1.24.0/0.45b0 (2024-03-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - unit annotations (enclosed in curly braces like `{requests}`) are stripped away
   - units with slash are converted e.g. `m/s` -> `meters_per_second`.
   - The exporter's API is not changed
+- Add parameters for Distros and configurators to configure autoinstrumentation
+  ([#3864] (https://github.com/open-telemetry/opentelemetry-python/pull/3864))
 
 ## Version 1.24.0/0.45b0 (2024-03-28)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -360,55 +360,41 @@ def _import_id_generator(id_generator_name: str) -> IdGenerator:
 def _initialize_components(
         auto_instrumentation_version: Optional[str] = None,
         # Could be trace_exporters or span_exporters
-        # Could be full span processors
-        span_exporter_names: Optional[list[str]] = None,
-        metric_exporter_names: Optional[list[str]] = None,
-        log_exporter_names: Optional[list[str]] = None,
-        # Could be sampler obj
-        # sampler_name: Optional[str] = None,
+        span_exporter_names: Optional[List[str]] = None,
+        metric_exporter_names: Optional[List[str]] = None,
+        log_exporter_names: Optional[List[str]] = None,
         sampler: Optional[Sampler] = None,
-        # Could be attribute dict or Resource object
-        # resource_attributes: Optional[Attributes] = None,
-        resource: Optional[Resource] = None,
+        resource_attributes: Optional[Attributes] = None,
+        id_generator: IdGenerator = None,
         logging_enabled: Optional[bool] = None,
     ):
-    # Could come before or after
+    if span_exporter_names is None:
+        span_exporter_names = list()
+    if metric_exporter_names is None:
+        metric_exporter_names = list()
+    if log_exporter_names is None:
+        log_exporter_names = list()
     span_exporters, metric_exporters, log_exporters = _import_exporters(
         span_exporter_names + _get_exporter_names("traces"),
         metric_exporter_names + _get_exporter_names("metrics"),
         log_exporter_names + _get_exporter_names("logs"),
     )
-    # If using sampler name instead of sampler obj
-    # if sampler_name is None:
-    #     sampler_name = _get_sampler()
-    # sampler = _import_sampler(sampler_name)
-    # If using sampler obj instead of name. This means user would have to specify the rate on their own
     if sampler is None:
         sampler_name = _get_sampler()
         sampler = _import_sampler(sampler_name)
-    if id_generator_name is None:
+    if id_generator is None:
         id_generator_name = _get_id_generator()
-    id_generator = _import_id_generator(id_generator_name)
-    # if env var OTEL_RESOURCE_ATTRIBUTES is given, it will read the service_name
-    # from the env variable else defaults to "unknown_service"
-    # If using attributes dict instead of resource object
-    # if resource_attributes is None:
-    #     resource_attributes = {}
-    # # populate version if using auto-instrumentation
-    # if auto_instrumentation_version:
-    #     resource_attributes[
-    #         ResourceAttributes.TELEMETRY_AUTO_VERSION
-    #     ] = auto_instrumentation_version
-    # resource = Resource.create(resource_attributes)
-    # If using resource object instead of attributes dict
-    if resource is None:
-        resource = Resource.create()
+        id_generator = _import_id_generator(id_generator_name)
+    if resource_attributes is None:
+        resource_attributes = {}
     # populate version if using auto-instrumentation
     if auto_instrumentation_version:
-        resource.attributes()[
+        resource_attributes[
             ResourceAttributes.TELEMETRY_AUTO_VERSION
         ] = auto_instrumentation_version
-    resource = Resource.create(resource)
+    # if env var OTEL_RESOURCE_ATTRIBUTES is given, it will read the service_name
+    # from the env variable else defaults to "unknown_service"
+    resource = Resource.create(resource_attributes)
 
     _init_tracing(
         exporters=span_exporters,
@@ -467,5 +453,4 @@ class _OTelSDKConfigurator(_BaseConfigurator):
     """
 
     def _configure(self, **kwargs):
-        # _initialize_components(kwargs.get("auto_instrumentation_version"))
         _initialize_components(**kwargs)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -368,8 +368,8 @@ def _initialize_components(
         sampler_name: Optional[str] = None,
         # sampler: Optional[Sampler] = None,
         # Could be attribute dict or Resource object
-        resource_attributes: Optional[Attributes] = None,
-        # resource: Optional[Resource] = None,
+        # resource_attributes: Optional[Attributes] = None,
+        resource: Optional[Resource] = None,
         logging_enabled: Optional[bool] = None,
     ):
     # Could come before or after
@@ -391,23 +391,23 @@ def _initialize_components(
     # if env var OTEL_RESOURCE_ATTRIBUTES is given, it will read the service_name
     # from the env variable else defaults to "unknown_service"
     # If using attributes dict instead of resource object
-    if resource_attributes is None:
-        resource_attributes = {}
-    # populate version if using auto-instrumentation
-    if auto_instrumentation_version:
-        resource_attributes[
-            ResourceAttributes.TELEMETRY_AUTO_VERSION
-        ] = auto_instrumentation_version
-    resource = Resource.create(resource_attributes)
-    # If using resource object instead of attributes dict
-    # if resource is None:
-    #     resource = Resource.create()
+    # if resource_attributes is None:
+    #     resource_attributes = {}
     # # populate version if using auto-instrumentation
     # if auto_instrumentation_version:
-    #     resource.attributes()[
+    #     resource_attributes[
     #         ResourceAttributes.TELEMETRY_AUTO_VERSION
     #     ] = auto_instrumentation_version
-    # resource = Resource.create(resource)
+    # resource = Resource.create(resource_attributes)
+    # If using resource object instead of attributes dict
+    if resource is None:
+        resource = Resource.create()
+    # populate version if using auto-instrumentation
+    if auto_instrumentation_version:
+        resource.attributes()[
+            ResourceAttributes.TELEMETRY_AUTO_VERSION
+        ] = auto_instrumentation_version
+    resource = Resource.create(resource)
 
     _init_tracing(
         exporters=span_exporters,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -50,10 +50,7 @@ from opentelemetry.sdk.metrics.export import (
     MetricReader,
     PeriodicExportingMetricReader,
 )
-from opentelemetry.sdk.resources import (
-    Attributes,
-    Resource
-)
+from opentelemetry.sdk.resources import Attributes, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
 from opentelemetry.sdk.trace.id_generator import IdGenerator
@@ -358,15 +355,15 @@ def _import_id_generator(id_generator_name: str) -> IdGenerator:
 
 
 def _initialize_components(
-        auto_instrumentation_version: Optional[str] = None,
-        span_exporter_names: Optional[List[str]] = None,
-        metric_exporter_names: Optional[List[str]] = None,
-        log_exporter_names: Optional[List[str]] = None,
-        sampler: Optional[Sampler] = None,
-        resource_attributes: Optional[Attributes] = None,
-        id_generator: IdGenerator = None,
-        logging_enabled: Optional[bool] = None,
-    ):
+    auto_instrumentation_version: Optional[str] = None,
+    span_exporter_names: Optional[List[str]] = None,
+    metric_exporter_names: Optional[List[str]] = None,
+    log_exporter_names: Optional[List[str]] = None,
+    sampler: Optional[Sampler] = None,
+    resource_attributes: Optional[Attributes] = None,
+    id_generator: IdGenerator = None,
+    logging_enabled: Optional[bool] = None,
+):
     if span_exporter_names is None:
         span_exporter_names = list()
     if metric_exporter_names is None:
@@ -388,9 +385,9 @@ def _initialize_components(
         resource_attributes = {}
     # populate version if using auto-instrumentation
     if auto_instrumentation_version:
-        resource_attributes[
-            ResourceAttributes.TELEMETRY_AUTO_VERSION
-        ] = auto_instrumentation_version
+        resource_attributes[ResourceAttributes.TELEMETRY_AUTO_VERSION] = (
+            auto_instrumentation_version
+        )
     # if env var OTEL_RESOURCE_ATTRIBUTES is given, it will read the service_name
     # from the env variable else defaults to "unknown_service"
     resource = Resource.create(resource_attributes)
@@ -404,9 +401,14 @@ def _initialize_components(
     _init_metrics(metric_exporters, resource)
     # This could also be paramaterized
     if logging_enabled is None:
-        logging_enabled = os.getenv(
-            _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, "false"
-        ).strip().lower() == "true"
+        logging_enabled = (
+            os.getenv(
+                _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, "false"
+            )
+            .strip()
+            .lower()
+            == "true"
+        )
     # Could be string or bool
     if logging_enabled:
         _init_logging(log_exporters, resource)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -399,7 +399,6 @@ def _initialize_components(
         resource=resource,
     )
     _init_metrics(metric_exporters, resource)
-    # This could also be paramaterized
     if logging_enabled is None:
         logging_enabled = (
             os.getenv(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -50,7 +50,10 @@ from opentelemetry.sdk.metrics.export import (
     MetricReader,
     PeriodicExportingMetricReader,
 )
-from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.resources import (
+    Attributes,
+    Resource
+)
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
 from opentelemetry.sdk.trace.id_generator import IdGenerator
@@ -355,18 +358,19 @@ def _import_id_generator(id_generator_name: str) -> IdGenerator:
 
 
 def _initialize_components(
-        auto_instrumentation_version: str = None,
+        auto_instrumentation_version: Optional[str] = None,
         # Could be trace_exporters or span_exporters
         # Could be full span processors
-        span_exporter_names: str = None,
-        metric_exporter_names: str = None,
-        log_exporter_names: str = None,
+        span_exporter_names: Optional[list[str]] = None,
+        metric_exporter_names: Optional[list[str]] = None,
+        log_exporter_names: Optional[list[str]] = None,
         # Could be sampler obj
-        sampler_name: str = None,
+        sampler_name: Optional[str] = None,
+        # sampler: Optional[Sampler] = None,
         # Could be attribute dict or Resource object
-        resource_attributes: dict = None,
-        # resource: Resource = None,
-        logging_enabled: bool = None,
+        resource_attributes: Optional[Attributes] = None,
+        # resource: Optional[Resource] = None,
+        logging_enabled: Optional[bool] = None,
     ):
     # Could come before or after
     span_exporters, metric_exporters, log_exporters = _import_exporters(
@@ -398,7 +402,7 @@ def _initialize_components(
     # If using resource object instead of attributes dict
     # if resource is None:
     #     resource = Resource.create()
-    # populate version if using auto-instrumentation
+    # # populate version if using auto-instrumentation
     # if auto_instrumentation_version:
     #     resource.attributes()[
     #         ResourceAttributes.TELEMETRY_AUTO_VERSION

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -365,11 +365,11 @@ def _initialize_components(
     logging_enabled: Optional[bool] = None,
 ):
     if span_exporter_names is None:
-        span_exporter_names = list()
+        span_exporter_names = []
     if metric_exporter_names is None:
-        metric_exporter_names = list()
+        metric_exporter_names = []
     if log_exporter_names is None:
-        log_exporter_names = list()
+        log_exporter_names = []
     span_exporters, metric_exporters, log_exporters = _import_exporters(
         span_exporter_names + _get_exporter_names("traces"),
         metric_exporter_names + _get_exporter_names("metrics"),

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -356,7 +356,7 @@ def _import_id_generator(id_generator_name: str) -> IdGenerator:
 
 def _initialize_components(
     auto_instrumentation_version: Optional[str] = None,
-    span_exporter_names: Optional[List[str]] = None,
+    trace_exporter_names: Optional[List[str]] = None,
     metric_exporter_names: Optional[List[str]] = None,
     log_exporter_names: Optional[List[str]] = None,
     sampler: Optional[Sampler] = None,
@@ -364,14 +364,14 @@ def _initialize_components(
     id_generator: IdGenerator = None,
     logging_enabled: Optional[bool] = None,
 ):
-    if span_exporter_names is None:
-        span_exporter_names = []
+    if trace_exporter_names is None:
+        trace_exporter_names = []
     if metric_exporter_names is None:
         metric_exporter_names = []
     if log_exporter_names is None:
         log_exporter_names = []
     span_exporters, metric_exporters, log_exporters = _import_exporters(
-        span_exporter_names + _get_exporter_names("traces"),
+        trace_exporter_names + _get_exporter_names("traces"),
         metric_exporter_names + _get_exporter_names("metrics"),
         log_exporter_names + _get_exporter_names("logs"),
     )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -365,8 +365,8 @@ def _initialize_components(
         metric_exporter_names: Optional[list[str]] = None,
         log_exporter_names: Optional[list[str]] = None,
         # Could be sampler obj
-        sampler_name: Optional[str] = None,
-        # sampler: Optional[Sampler] = None,
+        # sampler_name: Optional[str] = None,
+        sampler: Optional[Sampler] = None,
         # Could be attribute dict or Resource object
         # resource_attributes: Optional[Attributes] = None,
         resource: Optional[Resource] = None,
@@ -378,13 +378,14 @@ def _initialize_components(
         metric_exporter_names + _get_exporter_names("metrics"),
         log_exporter_names + _get_exporter_names("logs"),
     )
-    if sampler_name is None:
-        sampler_name = _get_sampler()
-    sampler = _import_sampler(sampler_name)
-    # If using sampler obj instead of name
-    # if sampler is None:
+    # If using sampler name instead of sampler obj
+    # if sampler_name is None:
     #     sampler_name = _get_sampler()
-    #     sampler = _import_sampler(sampler_name)
+    # sampler = _import_sampler(sampler_name)
+    # If using sampler obj instead of name. This means user would have to specify the rate on their own
+    if sampler is None:
+        sampler_name = _get_sampler()
+        sampler = _import_sampler(sampler_name)
     if id_generator_name is None:
         id_generator_name = _get_id_generator()
     id_generator = _import_id_generator(id_generator_name)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -359,7 +359,6 @@ def _import_id_generator(id_generator_name: str) -> IdGenerator:
 
 def _initialize_components(
         auto_instrumentation_version: Optional[str] = None,
-        # Could be trace_exporters or span_exporters
         span_exporter_names: Optional[List[str]] = None,
         metric_exporter_names: Optional[List[str]] = None,
         log_exporter_names: Optional[List[str]] = None,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -408,7 +408,6 @@ def _initialize_components(
             .lower()
             == "true"
         )
-    # Could be string or bool
     if logging_enabled:
         _init_logging(log_exporters, resource)
 

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -735,7 +735,7 @@ class TestLoggingInit(TestCase):
         resource_mock.create.return_value = "TEST_RESOURCE"
         kwargs = {
             "auto_instrumentation_version": "auto-version",
-            "span_exporter_names": ["custom_span_exporter"],
+            "trace_exporter_names": ["custom_span_exporter"],
             "metric_exporter_names": ["custom_metric_exporter"],
             "log_exporter_names": ["custom_log_exporter"],
             "sampler": "TEST_SAMPLER",

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -912,26 +912,20 @@ class TestImportConfigComponents(TestCase):
             "Requested component 'a' not found in entry point 'name'",
         )
 
-class CustomConfigurator(_OTelSDKConfigurator):
-    def _configure(self, **kwargs):
-        kwargs["sampler"] = "TEST_SAMPLER"
-        super.configure(**kwargs)
-
-class TestOTelSDKConfigurator(TestCase):
-    @patch("opentelemetry.sdk._configuration._initialize_components")
-    def test_configure(self, mock_init_comp):
-        configurator = _OTelSDKConfigurator()
-        configurator.configure(auto_instrumentation_version="TEST_VERSION")
-        mock_init_comp.assert_called_with(auto_instrumentation_version="TEST_VERSION")
+class TestConfigurator(TestCase):
+    class CustomConfigurator(_OTelSDKConfigurator):
+        def _configure(self, **kwargs):
+            kwargs["sampler"] = "TEST_SAMPLER"
+            super()._configure(**kwargs)
 
     @patch("opentelemetry.sdk._configuration._initialize_components")
     def test_custom_configurator(self, mock_init_comp):
-        configurator = CustomConfigurator()
-        configurator.configure(auto_instrumentation_version="TEST_VERSION")
+        custom_configurator = TestConfigurator.CustomConfigurator()
+        custom_configurator._configure(auto_instrumentation_version="TEST_VERSION2")
         kwargs = {
-            "auto_instrumentation_version": "TEST_VERSION",
+            "auto_instrumentation_version": "TEST_VERSION2",
             "sampler": "TEST_SAMPLER",
         }
-        mock_init_comp.assert_called_with(**kwargs)
+        mock_init_comp.assert_called_once_with(**kwargs)
 
 

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -18,7 +18,7 @@ from logging import WARNING, getLogger
 from os import environ
 from typing import Dict, Iterable, Optional, Sequence
 from unittest import TestCase
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import Mock, patch
 
 from pytest import raises
 

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -715,9 +715,18 @@ class TestLoggingInit(TestCase):
     @patch("opentelemetry.sdk._configuration._init_logging")
     @patch("opentelemetry.sdk._configuration._init_metrics")
     def test_initialize_components_kwargs(
-        self, metrics_mock, logging_mock, tracing_mock, exporter_names_mock, import_exporters_mock, resource_mock
+        self,
+        metrics_mock,
+        logging_mock,
+        tracing_mock,
+        exporter_names_mock,
+        import_exporters_mock,
+        resource_mock,
     ):
-        exporter_names_mock.return_value = ["env_var_exporter_1", "env_var_exporter_2"]
+        exporter_names_mock.return_value = [
+            "env_var_exporter_1",
+            "env_var_exporter_2",
+        ]
         import_exporters_mock.return_value = (
             "TEST_SPAN_EXPORTERS_DICT",
             "TEST_METRICS_EXPORTERS_DICT",
@@ -740,9 +749,21 @@ class TestLoggingInit(TestCase):
         _initialize_components(**kwargs)
 
         import_exporters_mock.assert_called_once_with(
-            ["custom_span_exporter", "env_var_exporter_1", "env_var_exporter_2"],
-            ["custom_metric_exporter", "env_var_exporter_1", "env_var_exporter_2"],
-            ["custom_log_exporter", "env_var_exporter_1", "env_var_exporter_2"]
+            [
+                "custom_span_exporter",
+                "env_var_exporter_1",
+                "env_var_exporter_2",
+            ],
+            [
+                "custom_metric_exporter",
+                "env_var_exporter_1",
+                "env_var_exporter_2",
+            ],
+            [
+                "custom_log_exporter",
+                "env_var_exporter_1",
+                "env_var_exporter_2",
+            ],
         )
         resource_mock.create.assert_called_once_with(
             {


### PR DESCRIPTION
# Description

Currently, the only way for custom Configurators to configure is through setting or defaulting environment variables. While it makes sense for customers to configure autoinstrumentation with env vars, there is no reason Configurators should not be able to directly configure start up (exporters, samplers...etc). Exposing autoinstrumentation configuration of otel via env var defaults is invasive, confusing, and easy for users to mess up. For instance, even a blank env var or a left-over setting from previous run could interfere with a distro starting up.

In this approach, configurators can pass kwargs to _initialize_components to easily configure autoinstrumentation which currently _only_ considers env vars.

# Precedence of params over env vars

Params would be preferred over (or merged with) env vars. This follows the approach towards env vars elsewhere in OTel Python. And doing so would be necessary for custom distros to guarantee certain behavior.

In this approach, exporters given by params would be ADDED to those from env vars. Resource attributes would be merged with those from env vars and resource detectors. Since there's only 1 sampler, param would take precedence. Same for logging_enabled.