### PR TITLE
Update build.sh so opentelemetry-opencensus-shim gets published

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ DISTDIR=dist
   mkdir -p $DISTDIR
   rm -rf ${DISTDIR:?}/*
 
- for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-proto/ opentelemetry-semantic-conventions/ exporter/*/ shim/opentelemetry-opentracing-shim/ propagator/*/ tests/opentelemetry-test-utils/; do
+ for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-proto/ opentelemetry-semantic-conventions/ exporter/*/ shim/*/ propagator/*/ tests/opentelemetry-test-utils/; do
    (
      echo "building $d"
      cd "$d"


### PR DESCRIPTION
# Description

"Reverts" https://github.com/open-telemetry/opentelemetry-python/pull/3227 so that the opentelemetry-opencensus-shim package gets published. This package was name-squatted on PyPI but we got it back and own it.

Part of #3203 

## Type of change

Please delete options that are not relevant.

# How Has This Been Tested?

Manually tested the glob pattern with
```sh
for d in opentelemetry-api/ opentelemetry-sdk/ opentelemetry-proto/ opentelemetry-semantic-conventions/ exporter/*/ shim/*/ propagator/*/ tests/opentelemetry-test-utils/; do echo $d; done | grep opentelemetry-opencensus-shim
shim/opentelemetry-opencensus-shim/
```

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
