### PR TITLE
Otlp http exporter client cert

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -83,7 +83,7 @@ class OTLPLogExporter(LogExporter):
             OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE,
             environ.get(OTEL_EXPORTER_OTLP_CERTIFICATE, True),
         )
-        self._client_certificate_file = certificate_file
+        self._client_certificate_file = client_certificate_file
         headers_string = environ.get(
             OTEL_EXPORTER_OTLP_LOGS_HEADERS,
             environ.get(OTEL_EXPORTER_OTLP_HEADERS, ""),

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -67,6 +67,7 @@ class OTLPLogExporter(LogExporter):
         self,
         endpoint: Optional[str] = None,
         certificate_file: Optional[str] = None,
+        client_certificate_file: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
         timeout: Optional[int] = None,
         compression: Optional[Compression] = None,
@@ -82,6 +83,7 @@ class OTLPLogExporter(LogExporter):
             OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE,
             environ.get(OTEL_EXPORTER_OTLP_CERTIFICATE, True),
         )
+        self._client_certificate_file = certificate_file
         headers_string = environ.get(
             OTEL_EXPORTER_OTLP_LOGS_HEADERS,
             environ.get(OTEL_EXPORTER_OTLP_HEADERS, ""),
@@ -118,6 +120,7 @@ class OTLPLogExporter(LogExporter):
             data=data,
             verify=self._certificate_file,
             timeout=self._timeout,
+            cert=self._client_certificate_file,
         )
 
     @staticmethod


### PR DESCRIPTION
# Description

Allow to pass a client certificate to the OTLPLogExporter
In our environment, the server needs to authenticate the client, in this PR, it simply forward the client certificate to the requests.post()

Did not hookup with environment variables yet, open the discussion here and we can add later
https://github.com/open-telemetry/opentelemetry-python/discussions/3882#discussion-6565784

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This test requires the server setup to authenticate the client certificate

- [X] Test A
1. Start the otel server to set required client certificate true
2. Create a client to pass the client certificate, 
```
    exporter = OTLPLogExporter(
                endpoint=f"https://{endpoint}/v1/logs",
                timeout=5,
                certificate_file="/etc/pki/tls/certs/ca-bundle.crt",
                client_certificate_file="/etc/nobody.pem"
            )
```
3. Check the client certificate can be properly authenticated.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
