### PR TITLE
Record links with invalid SpanContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3823] (https://github.com/open-telemetry/opentelemetry-python/pull/3823))
 - Add span flags to OTLP spans and links
   ([#3881](https://github.com/open-telemetry/opentelemetry-python/pull/3881))
-- Record links with invalid SpanContext
+- Record links with invalid SpanContext if either attributes or TraceState are not empty
   ([#3917](https://github.com/open-telemetry/opentelemetry-python/pull/3917/))
 
 ## Version 1.24.0/0.45b0 (2024-03-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3823] (https://github.com/open-telemetry/opentelemetry-python/pull/3823))
 - Add span flags to OTLP spans and links
   ([#3881](https://github.com/open-telemetry/opentelemetry-python/pull/3881))
+- Record links with invalid SpanContext
+  ([#3917](https://github.com/open-telemetry/opentelemetry-python/pull/3917/))
 
 ## Version 1.24.0/0.45b0 (2024-03-28)
 

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -127,7 +127,8 @@ class Span(abc.ABC):
 
         Adds a single `Link` with the `SpanContext` of the span to link to and,
         optionally, attributes passed as arguments. Implementations may ignore
-        calls with an invalid span context.
+        calls with an invalid span context if both attributes and TraceState
+        are empty.
 
         Note: It is preferred to add links at span creation, instead of calling
         this method later since samplers can only consider information already

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -348,10 +348,8 @@ def _check_span_ended(func):
 
 
 def _is_valid_link(context: SpanContext, attributes: types.Attributes) -> bool:
-    return (
-        context.is_valid or (attributes or context.trace_state)
-        if context
-        else False
+    return bool(
+        context and (context.is_valid or (attributes or context.trace_state))
     )
 
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -347,6 +347,14 @@ def _check_span_ended(func):
     return wrapper
 
 
+def _is_valid_link(context: SpanContext, attributes: types.Attributes) -> bool:
+    return (
+        context.is_valid or (attributes or context.trace_state)
+        if context
+        else False
+    )
+
+
 class ReadableSpan:
     """Provides read-only access to span attributes.
 
@@ -868,11 +876,7 @@ class Span(trace_api.Span, ReadableSpan):
         attributes: types.Attributes = None,
     ) -> None:
 
-        if (
-            context is None
-            or not context.is_valid
-            and not (attributes or context.trace_state)
-        ):
+        if not _is_valid_link(context, attributes):
             return
 
         attributes = BoundedAttributes(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -867,7 +867,12 @@ class Span(trace_api.Span, ReadableSpan):
         context: SpanContext,
         attributes: types.Attributes = None,
     ) -> None:
-        if context is None or not context.is_valid:
+
+        if (
+            context is None
+            or not context.is_valid
+            and not (attributes or context.trace_state)
+        ):
             return
 
         attributes = BoundedAttributes(

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -944,6 +944,35 @@ class TestSpan(unittest.TestCase):
 
             self.assertEqual(len(root.links), 0)
 
+    def test_add_link_with_invalid_span_context_record(self):
+        invalid_context = trace_api.INVALID_SPAN_CONTEXT
+
+        with self.tracer.start_as_current_span("root") as root:
+            root.add_link(invalid_context, {"name": "neighbor"})
+            self.assertEqual(len(root.links), 1)
+            self.assertEqual(root.links[0].attributes, {"name": "neighbor"})
+
+        invalid_context = trace.SpanContext(
+            trace_api.INVALID_TRACE_ID,
+            trace_api.INVALID_SPAN_ID,
+            is_remote=False,
+            trace_state="a=b",
+        )
+
+        with self.tracer.start_as_current_span("root") as root:
+            root.add_link(invalid_context)
+            self.assertEqual(len(root.links), 1)
+            self.assertEqual(root.links[0].context.trace_state, "a=b")
+
+        with self.tracer.start_as_current_span("root") as root:
+            root.add_link(invalid_context)
+            root.add_link(invalid_context, {"name": "neighbor"})
+            self.assertEqual(len(root.links), 2)
+
+        with self.tracer.start_as_current_span("root") as root:
+            root.add_link(None)
+            self.assertEqual(len(root.links), 0)
+
     def test_update_name(self):
         with self.tracer.start_as_current_span("root") as root:
             # name

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -941,10 +941,10 @@ class TestSpan(unittest.TestCase):
 
         with self.tracer.start_as_current_span("root") as root:
             root.add_link(other_context)
-
+            root.add_link(None)
             self.assertEqual(len(root.links), 0)
 
-    def test_add_link_with_invalid_span_context_record(self):
+    def test_add_link_with_invalid_span_context_with_attributes(self):
         invalid_context = trace_api.INVALID_SPAN_CONTEXT
 
         with self.tracer.start_as_current_span("root") as root:
@@ -952,6 +952,7 @@ class TestSpan(unittest.TestCase):
             self.assertEqual(len(root.links), 1)
             self.assertEqual(root.links[0].attributes, {"name": "neighbor"})
 
+    def test_add_link_with_invalid_span_context_with_tracestate(self):
         invalid_context = trace.SpanContext(
             trace_api.INVALID_TRACE_ID,
             trace_api.INVALID_SPAN_ID,
@@ -963,15 +964,6 @@ class TestSpan(unittest.TestCase):
             root.add_link(invalid_context)
             self.assertEqual(len(root.links), 1)
             self.assertEqual(root.links[0].context.trace_state, "a=b")
-
-        with self.tracer.start_as_current_span("root") as root:
-            root.add_link(invalid_context)
-            root.add_link(invalid_context, {"name": "neighbor"})
-            self.assertEqual(len(root.links), 2)
-
-        with self.tracer.start_as_current_span("root") as root:
-            root.add_link(None)
-            self.assertEqual(len(root.links), 0)
 
     def test_update_name(self):
         with self.tracer.start_as_current_span("root") as root:

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -957,13 +957,13 @@ class TestSpan(unittest.TestCase):
             trace_api.INVALID_TRACE_ID,
             trace_api.INVALID_SPAN_ID,
             is_remote=False,
-            trace_state="a=b",
+            trace_state="foo=bar",
         )
 
         with self.tracer.start_as_current_span("root") as root:
             root.add_link(invalid_context)
             self.assertEqual(len(root.links), 1)
-            self.assertEqual(root.links[0].context.trace_state, "a=b")
+            self.assertEqual(root.links[0].context.trace_state, "foo=bar")
 
     def test_update_name(self):
         with self.tracer.start_as_current_span("root") as root:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

>Implementations SHOULD record links containing SpanContext with empty TraceId or SpanId (all zeros) as long as either the attribute set or TraceState is non-empty.`

Fixes #3914

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] `tox -e py311-opentelemetry-sdk`

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
