### PR TITLE
Fix prometheus metric name and unit conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3917](https://github.com/open-telemetry/opentelemetry-python/pull/3917/))
 - Add OpenTelemetry trove classifiers to PyPI packages
   ([#3913] (https://github.com/open-telemetry/opentelemetry-python/pull/3913))
+- Fix prometheus metric name and unit conversion
+  ([#3924](https://github.com/open-telemetry/opentelemetry-python/pull/3924))
+  - this is a breaking change to prometheus metric names so they comply with the
+  [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus).
+  - common unit abbreviations are converted to Prometheus conventions (`s` -> `seconds`),
+  following the [collector's implementation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c0b51136575aa7ba89326d18edb4549e7e1bbdb9/pkg/translator/prometheus/normalize_name.go#L108)
+  - repeated `_` are replaced with a single `_`
+  - UCUM annotations (enclosed in curly braces like `{requests}`) are stripped away
+  - units with slash are converted e.g. `m/s` -> `meters_per_second`.
+  - The exporter's API is not changed
 
 ## Version 1.24.0/0.45b0 (2024-03-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3924](https://github.com/open-telemetry/opentelemetry-python/pull/3924))
   - this is a breaking change to prometheus metric names so they comply with the
   [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus).
+  - you can temporarily opt-out of the unit normalization by setting the environment variable
+  `OTEL_PYTHON_EXPERIMENTAL_DISABLE_PROMETHEUS_UNIT_NORMALIZATION=true`
   - common unit abbreviations are converted to Prometheus conventions (`s` -> `seconds`),
   following the [collector's implementation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c0b51136575aa7ba89326d18edb4549e7e1bbdb9/pkg/translator/prometheus/normalize_name.go#L108)
   - repeated `_` are replaced with a single `_`
-  - UCUM annotations (enclosed in curly braces like `{requests}`) are stripped away
+  - unit annotations (enclosed in curly braces like `{requests}`) are stripped away
   - units with slash are converted e.g. `m/s` -> `meters_per_second`.
   - The exporter's API is not changed
 

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/_mapping.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/_mapping.py
@@ -1,0 +1,135 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from re import UNICODE, compile
+
+_SANITIZE_NAME_RE = compile(r"([^a-zA-Z0-9:]+)|_{2,}", UNICODE)
+# Same as name, but doesn't allow ":"
+_SANITIZE_ATTRIBUTE_KEY_RE = compile(r"([^a-zA-Z0-9]+)|_{2,}", UNICODE)
+
+# UCUM annotations are ASCII chars 33-126 enclosed in curly braces
+# https://ucum.org/ucum#para-6
+_UCUM_ANNOTATION_CURLY = compile(r"{[!-~]*}")
+
+# Remaps common UCUM and SI units to prometheus conventions. Copied from
+# https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.101.0/pkg/translator/prometheus/normalize_name.go#L19
+# See specification:
+# https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1
+_UNIT_MAPPINGS = {
+    # Time
+    "d": "days",
+    "h": "hours",
+    "min": "minutes",
+    "s": "seconds",
+    "ms": "milliseconds",
+    "us": "microseconds",
+    "ns": "nanoseconds",
+    # Bytes
+    "By": "bytes",
+    "KiBy": "kibibytes",
+    "MiBy": "mebibytes",
+    "GiBy": "gibibytes",
+    "TiBy": "tibibytes",
+    "KBy": "kilobytes",
+    "MBy": "megabytes",
+    "GBy": "gigabytes",
+    "TBy": "terabytes",
+    # SI
+    "m": "meters",
+    "V": "volts",
+    "A": "amperes",
+    "J": "joules",
+    "W": "watts",
+    "g": "grams",
+    # Misc
+    "Cel": "celsius",
+    "Hz": "hertz",
+    # TODO: this conflicts with the spec but I think it is correct. Need to open a spec issue
+    "1": "",
+    "%": "percent",
+}
+# Similar to _UNIT_MAPPINGS, but for "per" unit denominator.
+# Example: s => per second (singular)
+# Copied from https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/80317ce83ed87a2dff0c316bb939afbfaa823d5e/pkg/translator/prometheus/normalize_name.go#L58
+_PER_UNIT_MAPPINGS = {
+    "s": "second",
+    "m": "minute",
+    "h": "hour",
+    "d": "day",
+    "w": "week",
+    "mo": "month",
+    "y": "year",
+}
+
+
+def sanitize_full_name(name: str) -> str:
+    """sanitize the given metric name according to Prometheus rule, including sanitizing
+    leading digits
+
+    https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1
+    """
+    # Leading number special case
+    if name and name[0].isdigit():
+        name = "_" + name[1:]
+    return _sanitize_name(name)
+
+
+def _sanitize_name(name: str) -> str:
+    """sanitize the given metric name according to Prometheus rule, but does not handle
+    sanitizing a leading digit."""
+    return _SANITIZE_NAME_RE.sub("_", name)
+
+
+def sanitize_attribute(key: str) -> str:
+    """sanitize the given metric attribute key according to Prometheus rule.
+
+    https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#metric-attributes
+    """
+    # Leading number special case
+    if key and key[0].isdigit():
+        key = "_" + key[1:]
+    return _SANITIZE_ATTRIBUTE_KEY_RE.sub("_", key)
+
+
+def map_unit(unit: str) -> str:
+    """Maps unit to common prometheus metric names if available and sanitizes any invalid
+    characters
+
+    See:
+    - https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1
+    - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.101.0/pkg/translator/prometheus/normalize_name.go#L108
+    """
+    # remove curly brace UCUM annotations
+    unit = _UCUM_ANNOTATION_CURLY.sub("", unit)
+
+    if unit in _UNIT_MAPPINGS:
+        return _UNIT_MAPPINGS[unit]
+
+    # replace "/" with "per" units like m/s -> meters_per_second
+    ratio_unit_subparts = unit.split("/", maxsplit=1)
+    if len(ratio_unit_subparts) == 2:
+        bottom = _sanitize_name(ratio_unit_subparts[1])
+        if bottom:
+            top = _sanitize_name(ratio_unit_subparts[0])
+            top = _UNIT_MAPPINGS.get(top, top)
+            bottom = _PER_UNIT_MAPPINGS.get(bottom, bottom)
+            return f"{top}_per_{bottom}" if top else f"per_{bottom}"
+
+    return (
+        # since units end up as a metric name suffix, they must be sanitized
+        _sanitize_name(unit)
+        # strip surrounding "_" chars since it will lead to consecutive underscores in the
+        # metric name
+        .strip("_")
+    )

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/_mapping.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/_mapping.py
@@ -18,9 +18,9 @@ _SANITIZE_NAME_RE = compile(r"([^a-zA-Z0-9:]+)|_{2,}", UNICODE)
 # Same as name, but doesn't allow ":"
 _SANITIZE_ATTRIBUTE_KEY_RE = compile(r"([^a-zA-Z0-9]+)|_{2,}", UNICODE)
 
-# UCUM annotations are ASCII chars 33-126 enclosed in curly braces
-# https://ucum.org/ucum#para-6
-_UCUM_ANNOTATION_CURLY = compile(r"{[!-~]*}")
+# UCUM style annotations which are text enclosed in curly braces https://ucum.org/ucum#para-6.
+# This regex is more permissive than UCUM allows and matches any character within curly braces.
+_UNIT_ANNOTATION = compile(r"{.*}")
 
 # Remaps common UCUM and SI units to prometheus conventions. Copied from
 # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.101.0/pkg/translator/prometheus/normalize_name.go#L19
@@ -110,8 +110,8 @@ def map_unit(unit: str) -> str:
     - https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1
     - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.101.0/pkg/translator/prometheus/normalize_name.go#L108
     """
-    # remove curly brace UCUM annotations
-    unit = _UCUM_ANNOTATION_CURLY.sub("", unit)
+    # remove curly brace unit annotations
+    unit = _UNIT_ANNOTATION.sub("", unit)
 
     if unit in _UNIT_MAPPINGS:
         return _UNIT_MAPPINGS[unit]

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/_mapping.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/_mapping.py
@@ -14,9 +14,9 @@
 
 from re import UNICODE, compile
 
-_SANITIZE_NAME_RE = compile(r"([^a-zA-Z0-9:]+)|_{2,}", UNICODE)
+_SANITIZE_NAME_RE = compile(r"[^a-zA-Z0-9:]+", UNICODE)
 # Same as name, but doesn't allow ":"
-_SANITIZE_ATTRIBUTE_KEY_RE = compile(r"([^a-zA-Z0-9]+)|_{2,}", UNICODE)
+_SANITIZE_ATTRIBUTE_KEY_RE = compile(r"[^a-zA-Z0-9]+", UNICODE)
 
 # UCUM style annotations which are text enclosed in curly braces https://ucum.org/ucum#para-6.
 # This regex is more permissive than UCUM allows and matches any character within curly braces.
@@ -55,7 +55,9 @@ _UNIT_MAPPINGS = {
     # Misc
     "Cel": "celsius",
     "Hz": "hertz",
-    # TODO: this conflicts with the spec but I think it is correct. Need to open a spec issue
+    # TODO(https://github.com/open-telemetry/opentelemetry-specification/issues/4058): the
+    # specification says to normalize "1" to ratio but that may change. Update this mapping or
+    # remove TODO once a decision is made.
     "1": "",
     "%": "percent",
 }

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_mapping.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_mapping.py
@@ -1,0 +1,113 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from opentelemetry.exporter.prometheus._mapping import (
+    map_unit,
+    sanitize_attribute,
+    sanitize_full_name,
+)
+
+
+class TestMapping(TestCase):
+    def testsanitize_full_name(self):
+        self.assertEqual(
+            sanitize_full_name("valid_metric_name"), "valid_metric_name"
+        )
+        self.assertEqual(
+            sanitize_full_name("VALID_METRIC_NAME"), "VALID_METRIC_NAME"
+        )
+        self.assertEqual(
+            sanitize_full_name("_valid_metric_name"), "_valid_metric_name"
+        )
+        self.assertEqual(
+            sanitize_full_name("valid:metric_name"), "valid:metric_name"
+        )
+        self.assertEqual(
+            sanitize_full_name("valid_1_metric_name"), "valid_1_metric_name"
+        )
+        self.assertEqual(
+            sanitize_full_name("1leading_digit"), "_leading_digit"
+        )
+        self.assertEqual(
+            sanitize_full_name("1_~#consective_underscores"),
+            "_consective_underscores",
+        )
+        self.assertEqual(
+            sanitize_full_name("1!2@3#4$5%6^7&8*9(0)_-"),
+            "_2_3_4_5_6_7_8_9_0_",
+        )
+        self.assertEqual(sanitize_full_name("foo,./?;:[]{}bar"), "foo_:_bar")
+        self.assertEqual(sanitize_full_name("TestString"), "TestString")
+        self.assertEqual(sanitize_full_name("aAbBcC_12_oi"), "aAbBcC_12_oi")
+
+    def testsanitize_attribute(self):
+        self.assertEqual(
+            sanitize_attribute("valid_attr_key"), "valid_attr_key"
+        )
+        self.assertEqual(
+            sanitize_attribute("VALID_attr_key"), "VALID_attr_key"
+        )
+        self.assertEqual(
+            sanitize_attribute("_valid_attr_key"), "_valid_attr_key"
+        )
+        self.assertEqual(
+            sanitize_attribute("valid_1_attr_key"), "valid_1_attr_key"
+        )
+        self.assertEqual(
+            sanitize_attribute("sanitize:colons"), "sanitize_colons"
+        )
+        self.assertEqual(
+            sanitize_attribute("1leading_digit"), "_leading_digit"
+        )
+        self.assertEqual(
+            sanitize_attribute("1_~#consective_underscores"),
+            "_consective_underscores",
+        )
+        self.assertEqual(
+            sanitize_attribute("1!2@3#4$5%6^7&8*9(0)_-"),
+            "_2_3_4_5_6_7_8_9_0_",
+        )
+        self.assertEqual(sanitize_attribute("foo,./?;:[]{}bar"), "foo_bar")
+        self.assertEqual(sanitize_attribute("TestString"), "TestString")
+        self.assertEqual(sanitize_attribute("aAbBcC_12_oi"), "aAbBcC_12_oi")
+
+    def testmap_unit(self):
+        # select hardcoded mappings
+        self.assertEqual(map_unit("s"), "seconds")
+        self.assertEqual(map_unit("By"), "bytes")
+        self.assertEqual(map_unit("m"), "meters")
+        # should work with UCUM annotations as well
+        self.assertEqual(map_unit("g{dogfood}"), "grams")
+
+        # UCUM "default unit" aka unity and equivalent UCUM annotations should be stripped
+        self.assertEqual(map_unit("1"), "")
+        self.assertEqual(map_unit("{request}"), "")
+        self.assertEqual(map_unit("{{{;@#$}}}"), "")
+
+        # conversion of per units
+        self.assertEqual(map_unit("km/h"), "km_per_hour")
+        self.assertEqual(map_unit("m/s"), "meters_per_second")
+        self.assertEqual(map_unit("{foo}/s"), "per_second")
+        self.assertEqual(map_unit("foo/bar"), "foo_per_bar")
+        self.assertEqual(map_unit("2fer/store"), "2fer_per_store")
+
+        # should be sanitized to become part of the metric name without surrounding "_"
+        self.assertEqual(map_unit("____"), "")
+        self.assertEqual(map_unit("____"), "")
+        self.assertEqual(map_unit("1:foo#@!"), "1:foo")
+        # should not be interpreted as a per unit since there is no denominator
+        self.assertEqual(map_unit("m/"), "m")
+        self.assertEqual(map_unit("m/{bar}"), "m")

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_mapping.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_mapping.py
@@ -42,6 +42,10 @@ class TestMapping(TestCase):
             sanitize_full_name("1leading_digit"), "_leading_digit"
         )
         self.assertEqual(
+            sanitize_full_name("consective_____underscores"),
+            "consective_underscores",
+        )
+        self.assertEqual(
             sanitize_full_name("1_~#consective_underscores"),
             "_consective_underscores",
         )
@@ -84,7 +88,7 @@ class TestMapping(TestCase):
         self.assertEqual(sanitize_attribute("TestString"), "TestString")
         self.assertEqual(sanitize_attribute("aAbBcC_12_oi"), "aAbBcC_12_oi")
 
-    def testmap_unit(self):
+    def test_map_unit(self):
         # select hardcoded mappings
         self.assertEqual(map_unit("s"), "seconds")
         self.assertEqual(map_unit("By"), "bytes")
@@ -94,8 +98,10 @@ class TestMapping(TestCase):
 
         # UCUM "default unit" aka unity and equivalent UCUM annotations should be stripped
         self.assertEqual(map_unit("1"), "")
+        self.assertEqual(map_unit("{}"), "")
         self.assertEqual(map_unit("{request}"), "")
         self.assertEqual(map_unit("{{{;@#$}}}"), "")
+        self.assertEqual(map_unit("{unit with space}"), "")
 
         # conversion of per units
         self.assertEqual(map_unit("km/h"), "km_per_hour")

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_mapping.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_mapping.py
@@ -22,7 +22,7 @@ from opentelemetry.exporter.prometheus._mapping import (
 
 
 class TestMapping(TestCase):
-    def testsanitize_full_name(self):
+    def test_sanitize_full_name(self):
         self.assertEqual(
             sanitize_full_name("valid_metric_name"), "valid_metric_name"
         )
@@ -53,7 +53,7 @@ class TestMapping(TestCase):
         self.assertEqual(sanitize_full_name("TestString"), "TestString")
         self.assertEqual(sanitize_full_name("aAbBcC_12_oi"), "aAbBcC_12_oi")
 
-    def testsanitize_attribute(self):
+    def test_sanitize_attribute(self):
         self.assertEqual(
             sanitize_attribute("valid_attr_key"), "valid_attr_key"
         )

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -611,3 +611,32 @@ class TestPrometheusMetricReader(TestCase):
                 """
             ),
         )
+        # if the metric name already contains the unit, it shouldn't be added again
+        self.verify_text_format(
+            _generate_sum(
+                name="metric_name_with_myunit",
+                value=1,
+                unit="myunit",
+            ),
+            dedent(
+                """\
+                # HELP metric_name_with_myunit_total foo
+                # TYPE metric_name_with_myunit_total counter
+                metric_name_with_myunit_total{a="1",b="true"} 1.0
+                """
+            ),
+        )
+        self.verify_text_format(
+            _generate_gauge(
+                name="metric_name_percent",
+                value=1,
+                unit="%",
+            ),
+            dedent(
+                """\
+                # HELP metric_name_percent foo
+                # TYPE metric_name_percent gauge
+                metric_name_percent{a="1",b="true"} 1.0
+                """
+            ),
+        )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables.py
@@ -720,7 +720,7 @@ OTEL_PYTHON_EXPERIMENTAL_DISABLE_PROMETHEUS_UNIT_NORMALIZATION = (
 .. envvar:: OTEL_PYTHON_EXPERIMENTAL_DISABLE_PROMETHEUS_UNIT_NORMALIZATION
 
 The :envvar:`OTEL_PYTHON_EXPERIMENTAL_DISABLE_PROMETHEUS_UNIT_NORMALIZATION` environment
-variable allows you to opt-out of the unit normalization described` in the specification
+variable allows you to opt-out of the unit normalization described `in the specification
 <https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1>`_.
 
 Default: False

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables.py
@@ -710,3 +710,21 @@ Default: 9464
 This is an experimental environment variable and the name of this variable and its behavior can
 change in a non-backwards compatible way.
 """
+
+
+# TODO(#3929): remove this opt-out option
+OTEL_PYTHON_EXPERIMENTAL_DISABLE_PROMETHEUS_UNIT_NORMALIZATION = (
+    "OTEL_PYTHON_EXPERIMENTAL_DISABLE_PROMETHEUS_UNIT_NORMALIZATION"
+)
+"""
+.. envvar:: OTEL_PYTHON_EXPERIMENTAL_DISABLE_PROMETHEUS_UNIT_NORMALIZATION
+
+The :envvar:`OTEL_PYTHON_EXPERIMENTAL_DISABLE_PROMETHEUS_UNIT_NORMALIZATION` environment
+variable allows you to opt-out of the unit normalization described` in the specification
+<https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1>`_.
+
+Default: False
+
+This is an temporary environment variable that provides backward compatibility but will be
+removed in the future https://github.com/open-telemetry/opentelemetry-python/issues/3929.
+"""

--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/metrictestutil.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/metrictestutil.py
@@ -13,14 +13,19 @@
 # limitations under the License.
 
 
+from typing import Optional
+
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
     Gauge,
+    Histogram,
+    HistogramDataPoint,
     Metric,
     NumberDataPoint,
     Sum,
 )
+from opentelemetry.util.types import Attributes
 
 
 def _generate_metric(
@@ -95,6 +100,37 @@ def _generate_unsupported_metric(
     return _generate_metric(
         name,
         None,
+        description=description,
+        unit=unit,
+    )
+
+
+def _generate_histogram(
+    name: str,
+    attributes: Attributes = None,
+    description: Optional[str] = None,
+    unit: Optional[str] = None,
+) -> Metric:
+    if attributes is None:
+        attributes = BoundedAttributes(attributes={"a": 1, "b": True})
+    return _generate_metric(
+        name,
+        Histogram(
+            data_points=[
+                HistogramDataPoint(
+                    attributes=attributes,
+                    start_time_unix_nano=1641946016139533244,
+                    time_unix_nano=1641946016139533244,
+                    count=6,
+                    sum=579.0,
+                    bucket_counts=[1, 3, 2],
+                    explicit_bounds=[123.0, 456.0],
+                    min=1,
+                    max=457,
+                )
+            ],
+            aggregation_temporality=AggregationTemporality.CUMULATIVE,
+        ),
         description=description,
         unit=unit,
     )


### PR DESCRIPTION
> [!IMPORTANT]  
> This is a breaking change. This PR changes the output prometheus metric names, but the API is not changed.

# Description

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/2938

Updates the prometheus exporter name conversion to match the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus) by implementing a few fixes:
- this is a breaking change to prometheus metric names so they comply with the
[specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus).
- you can temporarily opt-out of the unit normalization by setting the environment variable
`OTEL_PYTHON_EXPERIMENTAL_DISABLE_PROMETHEUS_UNIT_NORMALIZATION=true`
- common unit abbreviations are converted to Prometheus conventions (`s` -> `seconds`),
following the [collector's implementation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c0b51136575aa7ba89326d18edb4549e7e1bbdb9/pkg/translator/prometheus/normalize_name.go#L108)
- consecutive `_` are replaced with a single `_`
- unit annotations (enclosed in curly braces like `{requests}`) are stripped away
- units with slash are converted e.g. `m/s` -> `meters_per_second`.
- The exporter's API is not changed

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

I added a ton of test cases. Many were copied from the collector's [test cases](https://github.com/open-telemetry/opentelemetry-go/blob/aecd31529684966b0ed67e023444ec785de8f905/exporters/prometheus/exporter_test.go). I also added tests for semconv metrics so we can be sure what they will look like.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
