### PR TITLE
Pin codespell version to fix builds

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -206,7 +206,7 @@ commands =
 basepython: python3
 recreate = True
 deps =
-  codespell
+  codespell==2.2.6
 
 commands =
   codespell


### PR DESCRIPTION
Builds are [failing](https://github.com/open-telemetry/opentelemetry-python/actions/runs/9216287713/job/25356256218?pr=3923) due to new version of [codespell](https://pypi.org/project/codespell/2.3.0/)

