### PR TITLE
bugfix: RandomIdGenerator can generate invalid Span/Trace Ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix RandomIdGenerator can generate invalid Span/Trace Ids
+  ([#3949](https://github.com/open-telemetry/opentelemetry-python/pull/3949))
 - Add Python 3.12 to tox
   ([#3616](https://github.com/open-telemetry/opentelemetry-python/pull/3616))
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/id_generator.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/id_generator.py
@@ -15,6 +15,8 @@
 import abc
 import random
 
+from opentelemetry.trace.span import INVALID_SPAN_ID, INVALID_TRACE_ID
+
 
 class IdGenerator(abc.ABC):
     @abc.abstractmethod
@@ -46,7 +48,13 @@ class RandomIdGenerator(IdGenerator):
     """
 
     def generate_span_id(self) -> int:
-        return random.getrandbits(64)
+        span_id = random.getrandbits(64)
+        while span_id == INVALID_SPAN_ID:
+            span_id = random.getrandbits(64)
+        return span_id
 
     def generate_trace_id(self) -> int:
-        return random.getrandbits(128)
+        trace_id = random.getrandbits(128)
+        while trace_id == INVALID_TRACE_ID:
+            trace_id = random.getrandbits(128)
+        return trace_id

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/id_generator.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/id_generator.py
@@ -15,7 +15,7 @@
 import abc
 import random
 
-from opentelemetry.trace.span import INVALID_SPAN_ID, INVALID_TRACE_ID
+from opentelemetry import trace
 
 
 class IdGenerator(abc.ABC):
@@ -49,12 +49,12 @@ class RandomIdGenerator(IdGenerator):
 
     def generate_span_id(self) -> int:
         span_id = random.getrandbits(64)
-        while span_id == INVALID_SPAN_ID:
+        while span_id == trace.INVALID_SPAN_ID:
             span_id = random.getrandbits(64)
         return span_id
 
     def generate_trace_id(self) -> int:
         trace_id = random.getrandbits(128)
-        while trace_id == INVALID_TRACE_ID:
+        while trace_id == trace.INVALID_TRACE_ID:
             trace_id = random.getrandbits(128)
         return trace_id

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -62,7 +62,6 @@ from opentelemetry.trace import (
     StatusCode,
     get_tracer,
     set_tracer_provider,
-    span,
 )
 
 
@@ -2070,14 +2069,13 @@ class TestRandomIdGenerator(unittest.TestCase):
 
     @patch(
         "random.getrandbits",
-        side_effect=[span.INVALID_SPAN_ID, 0x00000000DEADBEF0],
+        side_effect=[trace_api.INVALID_SPAN_ID, 0x00000000DEADBEF0],
     )
     def test_generate_span_id_avoids_invalid(self, mock_getrandbits):
         generator = RandomIdGenerator()
         span_id = generator.generate_span_id()
 
-        self.assertNotEqual(span_id, span.INVALID_SPAN_ID)
-        self.assertGreater(span_id, span.INVALID_SPAN_ID)
+        self.assertGreater(span_id, trace_api.INVALID_SPAN_ID)
         self.assertLessEqual(span_id, self._SPAN_ID_MAX_VALUE)
         self.assertEqual(
             mock_getrandbits.call_count, 2
@@ -2086,7 +2084,7 @@ class TestRandomIdGenerator(unittest.TestCase):
     @patch(
         "random.getrandbits",
         side_effect=[
-            span.INVALID_TRACE_ID,
+            trace_api.INVALID_TRACE_ID,
             0x000000000000000000000000DEADBEEF,
         ],
     )
@@ -2094,8 +2092,7 @@ class TestRandomIdGenerator(unittest.TestCase):
         generator = RandomIdGenerator()
         trace_id = generator.generate_trace_id()
 
-        self.assertNotEqual(trace_id, span.INVALID_TRACE_ID)
-        self.assertGreater(trace_id, span.INVALID_TRACE_ID)
+        self.assertGreater(trace_id, trace_api.INVALID_TRACE_ID)
         self.assertLessEqual(trace_id, self._TRACE_ID_MAX_VALUE)
         self.assertEqual(
             mock_getrandbits.call_count, 2

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -2075,11 +2075,9 @@ class TestRandomIdGenerator(unittest.TestCase):
         generator = RandomIdGenerator()
         span_id = generator.generate_span_id()
 
-        self.assertGreater(span_id, trace_api.INVALID_SPAN_ID)
-        self.assertLessEqual(span_id, self._SPAN_ID_MAX_VALUE)
-        self.assertEqual(
-            mock_getrandbits.call_count, 2
-        )  # Ensure exactly two calls
+        self.assertNotEqual(span_id, trace_api.INVALID_SPAN_ID)
+        mock_getrandbits.assert_any_call(64)
+        self.assertEqual(mock_getrandbits.call_count, 2)
 
     @patch(
         "random.getrandbits",
@@ -2092,8 +2090,6 @@ class TestRandomIdGenerator(unittest.TestCase):
         generator = RandomIdGenerator()
         trace_id = generator.generate_trace_id()
 
-        self.assertGreater(trace_id, trace_api.INVALID_TRACE_ID)
-        self.assertLessEqual(trace_id, self._TRACE_ID_MAX_VALUE)
-        self.assertEqual(
-            mock_getrandbits.call_count, 2
-        )  # Ensure exactly two calls
+        self.assertNotEqual(trace_id, trace_api.INVALID_TRACE_ID)
+        mock_getrandbits.assert_any_call(128)
+        self.assertEqual(mock_getrandbits.call_count, 2)

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -62,6 +62,7 @@ from opentelemetry.trace import (
     StatusCode,
     get_tracer,
     set_tracer_provider,
+    span,
 )
 
 
@@ -2061,3 +2062,41 @@ class TestTracerProvider(unittest.TestCase):
         sample_patch.assert_called_once()
         self.assertIsNotNone(tracer_provider._span_limits)
         self.assertIsNotNone(tracer_provider._atexit_handler)
+
+
+class TestRandomIdGenerator(unittest.TestCase):
+    _TRACE_ID_MAX_VALUE = 2**128 - 1
+    _SPAN_ID_MAX_VALUE = 2**64 - 1
+
+    @patch(
+        "random.getrandbits",
+        side_effect=[span.INVALID_SPAN_ID, 0x00000000DEADBEF0],
+    )
+    def test_generate_span_id_avoids_invalid(self, mock_getrandbits):
+        generator = RandomIdGenerator()
+        span_id = generator.generate_span_id()
+
+        self.assertNotEqual(span_id, span.INVALID_SPAN_ID)
+        self.assertGreater(span_id, span.INVALID_SPAN_ID)
+        self.assertLessEqual(span_id, self._SPAN_ID_MAX_VALUE)
+        self.assertEqual(
+            mock_getrandbits.call_count, 2
+        )  # Ensure exactly two calls
+
+    @patch(
+        "random.getrandbits",
+        side_effect=[
+            span.INVALID_TRACE_ID,
+            0x000000000000000000000000DEADBEEF,
+        ],
+    )
+    def test_generate_trace_id_avoids_invalid(self, mock_getrandbits):
+        generator = RandomIdGenerator()
+        trace_id = generator.generate_trace_id()
+
+        self.assertNotEqual(trace_id, span.INVALID_TRACE_ID)
+        self.assertGreater(trace_id, span.INVALID_TRACE_ID)
+        self.assertLessEqual(trace_id, self._TRACE_ID_MAX_VALUE)
+        self.assertEqual(
+            mock_getrandbits.call_count, 2
+        )  # Ensure exactly two calls


### PR DESCRIPTION
# Description

This PR updates the RandomIdGenerator class to ensure that it generates valid span and trace IDs by avoiding specific invalid values.

Fixes #3921

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I wrote 2 new tests for this one, when it generate a invalid id(for example: 0), the generate function will run again.
- [x] tox -e py38-opentelemetry-sdk    

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
