### PR TITLE
Meaningful message when span name is not a string

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -377,6 +377,10 @@ class ReadableSpan:
         end_time: Optional[int] = None,
         instrumentation_scope: Optional[InstrumentationScope] = None,
     ) -> None:
+        if not isinstance(name, str):
+            stack_trace = ''.join(traceback.format_stack())
+            logger.warning(f"span name must be a string.\n Stack trace: {stack_trace}")
+            name = str(name)
         self._name = name
         self._context = context
         self._kind = kind


### PR DESCRIPTION
# Description

When the span name is not a string, the error message is confusing. Logs a warning message "span name must be a string" with the stack trace to help identify where the issue is. Converts the span name to a string and continues execution.

Fixes #3918 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the code given in the issue to reproduce the issue.

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
