### PR TITLE
Fix: Don't pass ns for ms in timeout during metrics collection

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
@@ -102,16 +102,16 @@ class SynchronousMeasurementConsumer(MeasurementConsumer):
             callback_options = CallbackOptions()
             deadline_ns = time_ns() + timeout_millis * 10**6
 
-            default_timeout_millis = 10000 * 10**6
+            default_timeout_ns = 10_000 * 10**6
 
             for async_instrument in self._async_instruments:
 
-                remaining_time = deadline_ns - time_ns()
+                remaining_time_ns = deadline_ns - time_ns()
 
-                if remaining_time < default_timeout_millis:
+                if remaining_time_ns < default_timeout_ns:
 
                     callback_options = CallbackOptions(
-                        timeout_millis=remaining_time
+                        timeout_millis=remaining_time_ns / 10**6
                     )
 
                 measurements = async_instrument.callback(callback_options)

--- a/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
+++ b/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
@@ -180,5 +180,5 @@ class TestSynchronousMeasurementConsumer(TestCase):
 
         self.assertLess(
             callback_options_time_call,
-            10000 * 10**6,
+            10000,
         )


### PR DESCRIPTION
# Description

When nearing the collection deadline, the remaining time should be accurately passed is timeout to the callbacks.
Once the deadline is closer than 10s, the remaining time in nanoseconds is passed to timeout_millis, which is expected to be in milliseconds, thus giving a timeout that is 10e6 times too large.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

CI?

# Does This PR Require a Contrib Repo Change?

No. (As far as I can tell.)

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
