### PR TITLE
Semconv: use constants instead of literal  in metric helpers

### DIFF
--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/container_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/container_metrics.py
@@ -29,7 +29,7 @@ Note: Total CPU time consumed by the specific container on all available CPU cor
 def create_container_cpu_time(meter: Meter) -> Counter:
     """Total CPU time consumed"""
     return meter.create_counter(
-        name="container.cpu.time",
+        name=CONTAINER_CPU_TIME,
         description="Total CPU time consumed",
         unit="s",
     )
@@ -47,7 +47,7 @@ Note: The total number of bytes read/written successfully (aggregated from all d
 def create_container_disk_io(meter: Meter) -> Counter:
     """Disk bytes for the container"""
     return meter.create_counter(
-        name="container.disk.io",
+        name=CONTAINER_DISK_IO,
         description="Disk bytes for the container.",
         unit="By",
     )
@@ -65,7 +65,7 @@ Note: Memory usage of the container.
 def create_container_memory_usage(meter: Meter) -> Counter:
     """Memory usage of the container"""
     return meter.create_counter(
-        name="container.memory.usage",
+        name=CONTAINER_MEMORY_USAGE,
         description="Memory usage of the container.",
         unit="By",
     )
@@ -83,7 +83,7 @@ Note: The number of bytes sent/received on all network interfaces by the contain
 def create_container_network_io(meter: Meter) -> Counter:
     """Network bytes for the container"""
     return meter.create_counter(
-        name="container.network.io",
+        name=CONTAINER_NETWORK_IO,
         description="Network bytes for the container.",
         unit="By",
     )

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/db_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/db_metrics.py
@@ -28,7 +28,7 @@ Unit: ms
 def create_db_client_connections_create_time(meter: Meter) -> Histogram:
     """The time it took to create a new connection"""
     return meter.create_histogram(
-        name="db.client.connections.create_time",
+        name=DB_CLIENT_CONNECTIONS_CREATE_TIME,
         description="The time it took to create a new connection",
         unit="ms",
     )
@@ -45,7 +45,7 @@ Unit: {connection}
 def create_db_client_connections_idle_max(meter: Meter) -> UpDownCounter:
     """The maximum number of idle open connections allowed"""
     return meter.create_up_down_counter(
-        name="db.client.connections.idle.max",
+        name=DB_CLIENT_CONNECTIONS_IDLE_MAX,
         description="The maximum number of idle open connections allowed",
         unit="{connection}",
     )
@@ -62,7 +62,7 @@ Unit: {connection}
 def create_db_client_connections_idle_min(meter: Meter) -> UpDownCounter:
     """The minimum number of idle open connections allowed"""
     return meter.create_up_down_counter(
-        name="db.client.connections.idle.min",
+        name=DB_CLIENT_CONNECTIONS_IDLE_MIN,
         description="The minimum number of idle open connections allowed",
         unit="{connection}",
     )
@@ -79,7 +79,7 @@ Unit: {connection}
 def create_db_client_connections_max(meter: Meter) -> UpDownCounter:
     """The maximum number of open connections allowed"""
     return meter.create_up_down_counter(
-        name="db.client.connections.max",
+        name=DB_CLIENT_CONNECTIONS_MAX,
         description="The maximum number of open connections allowed",
         unit="{connection}",
     )
@@ -100,7 +100,7 @@ def create_db_client_connections_pending_requests(
 ) -> UpDownCounter:
     """The number of pending requests for an open connection, cumulative for the entire pool"""
     return meter.create_up_down_counter(
-        name="db.client.connections.pending_requests",
+        name=DB_CLIENT_CONNECTIONS_PENDING_REQUESTS,
         description="The number of pending requests for an open connection, cumulative for the entire pool",
         unit="{request}",
     )
@@ -117,7 +117,7 @@ Unit: {timeout}
 def create_db_client_connections_timeouts(meter: Meter) -> Counter:
     """The number of connection timeouts that have occurred trying to obtain a connection from the pool"""
     return meter.create_counter(
-        name="db.client.connections.timeouts",
+        name=DB_CLIENT_CONNECTIONS_TIMEOUTS,
         description="The number of connection timeouts that have occurred trying to obtain a connection from the pool",
         unit="{timeout}",
     )
@@ -134,7 +134,7 @@ Unit: {connection}
 def create_db_client_connections_usage(meter: Meter) -> UpDownCounter:
     """The number of connections that are currently in state described by the `state` attribute"""
     return meter.create_up_down_counter(
-        name="db.client.connections.usage",
+        name=DB_CLIENT_CONNECTIONS_USAGE,
         description="The number of connections that are currently in state described by the `state` attribute",
         unit="{connection}",
     )
@@ -151,7 +151,7 @@ Unit: ms
 def create_db_client_connections_use_time(meter: Meter) -> Histogram:
     """The time between borrowing a connection and returning it to the pool"""
     return meter.create_histogram(
-        name="db.client.connections.use_time",
+        name=DB_CLIENT_CONNECTIONS_USE_TIME,
         description="The time between borrowing a connection and returning it to the pool",
         unit="ms",
     )
@@ -168,7 +168,7 @@ Unit: ms
 def create_db_client_connections_wait_time(meter: Meter) -> Histogram:
     """The time it took to obtain an open connection from the pool"""
     return meter.create_histogram(
-        name="db.client.connections.wait_time",
+        name=DB_CLIENT_CONNECTIONS_WAIT_TIME,
         description="The time it took to obtain an open connection from the pool",
         unit="ms",
     )

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/dns_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/dns_metrics.py
@@ -28,7 +28,7 @@ Unit: s
 def create_dns_lookup_duration(meter: Meter) -> Histogram:
     """Measures the time taken to perform a DNS lookup"""
     return meter.create_histogram(
-        name="dns.lookup.duration",
+        name=DNS_LOOKUP_DURATION,
         description="Measures the time taken to perform a DNS lookup.",
         unit="s",
     )

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/faas_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/faas_metrics.py
@@ -28,7 +28,7 @@ Unit: {coldstart}
 def create_faas_coldstarts(meter: Meter) -> Counter:
     """Number of invocation cold starts"""
     return meter.create_counter(
-        name="faas.coldstarts",
+        name=FAAS_COLDSTARTS,
         description="Number of invocation cold starts",
         unit="{coldstart}",
     )
@@ -45,7 +45,7 @@ Unit: s
 def create_faas_cpu_usage(meter: Meter) -> Histogram:
     """Distribution of CPU usage per invocation"""
     return meter.create_histogram(
-        name="faas.cpu_usage",
+        name=FAAS_CPU_USAGE,
         description="Distribution of CPU usage per invocation",
         unit="s",
     )
@@ -62,7 +62,7 @@ Unit: {error}
 def create_faas_errors(meter: Meter) -> Counter:
     """Number of invocation errors"""
     return meter.create_counter(
-        name="faas.errors",
+        name=FAAS_ERRORS,
         description="Number of invocation errors",
         unit="{error}",
     )
@@ -79,7 +79,7 @@ Unit: s
 def create_faas_init_duration(meter: Meter) -> Histogram:
     """Measures the duration of the function's initialization, such as a cold start"""
     return meter.create_histogram(
-        name="faas.init_duration",
+        name=FAAS_INIT_DURATION,
         description="Measures the duration of the function's initialization, such as a cold start",
         unit="s",
     )
@@ -96,7 +96,7 @@ Unit: {invocation}
 def create_faas_invocations(meter: Meter) -> Counter:
     """Number of successful invocations"""
     return meter.create_counter(
-        name="faas.invocations",
+        name=FAAS_INVOCATIONS,
         description="Number of successful invocations",
         unit="{invocation}",
     )
@@ -113,7 +113,7 @@ Unit: s
 def create_faas_invoke_duration(meter: Meter) -> Histogram:
     """Measures the duration of the function's logic execution"""
     return meter.create_histogram(
-        name="faas.invoke_duration",
+        name=FAAS_INVOKE_DURATION,
         description="Measures the duration of the function's logic execution",
         unit="s",
     )
@@ -130,7 +130,7 @@ Unit: By
 def create_faas_mem_usage(meter: Meter) -> Histogram:
     """Distribution of max memory usage per invocation"""
     return meter.create_histogram(
-        name="faas.mem_usage",
+        name=FAAS_MEM_USAGE,
         description="Distribution of max memory usage per invocation",
         unit="By",
     )
@@ -147,7 +147,7 @@ Unit: By
 def create_faas_net_io(meter: Meter) -> Histogram:
     """Distribution of net I/O usage per invocation"""
     return meter.create_histogram(
-        name="faas.net_io",
+        name=FAAS_NET_IO,
         description="Distribution of net I/O usage per invocation",
         unit="By",
     )
@@ -164,7 +164,7 @@ Unit: {timeout}
 def create_faas_timeouts(meter: Meter) -> Counter:
     """Number of invocation timeouts"""
     return meter.create_counter(
-        name="faas.timeouts",
+        name=FAAS_TIMEOUTS,
         description="Number of invocation timeouts",
         unit="{timeout}",
     )

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/http_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/http_metrics.py
@@ -28,7 +28,7 @@ Unit: {request}
 def create_http_client_active_requests(meter: Meter) -> UpDownCounter:
     """Number of active HTTP requests"""
     return meter.create_up_down_counter(
-        name="http.client.active_requests",
+        name=HTTP_CLIENT_ACTIVE_REQUESTS,
         description="Number of active HTTP requests.",
         unit="{request}",
     )
@@ -45,7 +45,7 @@ Unit: s
 def create_http_client_connection_duration(meter: Meter) -> Histogram:
     """The duration of the successfully established outbound HTTP connections"""
     return meter.create_histogram(
-        name="http.client.connection.duration",
+        name=HTTP_CLIENT_CONNECTION_DURATION,
         description="The duration of the successfully established outbound HTTP connections.",
         unit="s",
     )
@@ -62,7 +62,7 @@ Unit: {connection}
 def create_http_client_open_connections(meter: Meter) -> UpDownCounter:
     """Number of outbound HTTP connections that are currently active or idle on the client"""
     return meter.create_up_down_counter(
-        name="http.client.open_connections",
+        name=HTTP_CLIENT_OPEN_CONNECTIONS,
         description="Number of outbound HTTP connections that are currently active or idle on the client.",
         unit="{connection}",
     )
@@ -80,7 +80,7 @@ Note: The size of the request payload body in bytes. This is the number of bytes
 def create_http_client_request_body_size(meter: Meter) -> Histogram:
     """Size of HTTP client request bodies"""
     return meter.create_histogram(
-        name="http.client.request.body.size",
+        name=HTTP_CLIENT_REQUEST_BODY_SIZE,
         description="Size of HTTP client request bodies.",
         unit="By",
     )
@@ -95,7 +95,7 @@ Deprecated in favor of stable :py:const:`opentelemetry.semconv.metrics.http_metr
 def create_http_client_request_duration(meter: Meter) -> Histogram:
     """Duration of HTTP client requests"""
     return meter.create_histogram(
-        name="http.client.request.duration",
+        name=HTTP_CLIENT_REQUEST_DURATION,
         description="Duration of HTTP client requests.",
         unit="s",
     )
@@ -113,7 +113,7 @@ Note: The size of the response payload body in bytes. This is the number of byte
 def create_http_client_response_body_size(meter: Meter) -> Histogram:
     """Size of HTTP client response bodies"""
     return meter.create_histogram(
-        name="http.client.response.body.size",
+        name=HTTP_CLIENT_RESPONSE_BODY_SIZE,
         description="Size of HTTP client response bodies.",
         unit="By",
     )
@@ -130,7 +130,7 @@ Unit: {request}
 def create_http_server_active_requests(meter: Meter) -> UpDownCounter:
     """Number of active HTTP server requests"""
     return meter.create_up_down_counter(
-        name="http.server.active_requests",
+        name=HTTP_SERVER_ACTIVE_REQUESTS,
         description="Number of active HTTP server requests.",
         unit="{request}",
     )
@@ -148,7 +148,7 @@ Note: The size of the request payload body in bytes. This is the number of bytes
 def create_http_server_request_body_size(meter: Meter) -> Histogram:
     """Size of HTTP server request bodies"""
     return meter.create_histogram(
-        name="http.server.request.body.size",
+        name=HTTP_SERVER_REQUEST_BODY_SIZE,
         description="Size of HTTP server request bodies.",
         unit="By",
     )
@@ -163,7 +163,7 @@ Deprecated in favor of stable :py:const:`opentelemetry.semconv.metrics.http_metr
 def create_http_server_request_duration(meter: Meter) -> Histogram:
     """Duration of HTTP server requests"""
     return meter.create_histogram(
-        name="http.server.request.duration",
+        name=HTTP_SERVER_REQUEST_DURATION,
         description="Duration of HTTP server requests.",
         unit="s",
     )
@@ -181,7 +181,7 @@ Note: The size of the response payload body in bytes. This is the number of byte
 def create_http_server_response_body_size(meter: Meter) -> Histogram:
     """Size of HTTP server response bodies"""
     return meter.create_histogram(
-        name="http.server.response.body.size",
+        name=HTTP_SERVER_RESPONSE_BODY_SIZE,
         description="Size of HTTP server response bodies.",
         unit="By",
     )

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/messaging_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/messaging_metrics.py
@@ -28,7 +28,7 @@ Unit: s
 def create_messaging_process_duration(meter: Meter) -> Histogram:
     """Measures the duration of process operation"""
     return meter.create_histogram(
-        name="messaging.process.duration",
+        name=MESSAGING_PROCESS_DURATION,
         description="Measures the duration of process operation.",
         unit="s",
     )
@@ -45,7 +45,7 @@ Unit: {message}
 def create_messaging_process_messages(meter: Meter) -> Counter:
     """Measures the number of processed messages"""
     return meter.create_counter(
-        name="messaging.process.messages",
+        name=MESSAGING_PROCESS_MESSAGES,
         description="Measures the number of processed messages.",
         unit="{message}",
     )
@@ -62,7 +62,7 @@ Unit: s
 def create_messaging_publish_duration(meter: Meter) -> Histogram:
     """Measures the duration of publish operation"""
     return meter.create_histogram(
-        name="messaging.publish.duration",
+        name=MESSAGING_PUBLISH_DURATION,
         description="Measures the duration of publish operation.",
         unit="s",
     )
@@ -79,7 +79,7 @@ Unit: {message}
 def create_messaging_publish_messages(meter: Meter) -> Counter:
     """Measures the number of published messages"""
     return meter.create_counter(
-        name="messaging.publish.messages",
+        name=MESSAGING_PUBLISH_MESSAGES,
         description="Measures the number of published messages.",
         unit="{message}",
     )
@@ -96,7 +96,7 @@ Unit: s
 def create_messaging_receive_duration(meter: Meter) -> Histogram:
     """Measures the duration of receive operation"""
     return meter.create_histogram(
-        name="messaging.receive.duration",
+        name=MESSAGING_RECEIVE_DURATION,
         description="Measures the duration of receive operation.",
         unit="s",
     )
@@ -113,7 +113,7 @@ Unit: {message}
 def create_messaging_receive_messages(meter: Meter) -> Counter:
     """Measures the number of received messages"""
     return meter.create_counter(
-        name="messaging.receive.messages",
+        name=MESSAGING_RECEIVE_MESSAGES,
         description="Measures the number of received messages.",
         unit="{message}",
     )

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/process_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/process_metrics.py
@@ -38,6 +38,7 @@ CallbackT = Union[
     Generator[Iterable[Observation], CallbackOptions, None],
 ]
 
+
 PROCESS_CONTEXT_SWITCHES: Final = "process.context_switches"
 """
 Number of times the process has been context switched
@@ -49,7 +50,7 @@ Unit: {count}
 def create_process_context_switches(meter: Meter) -> Counter:
     """Number of times the process has been context switched"""
     return meter.create_counter(
-        name="process.context_switches",
+        name=PROCESS_CONTEXT_SWITCHES,
         description="Number of times the process has been context switched.",
         unit="{count}",
     )
@@ -66,7 +67,7 @@ Unit: s
 def create_process_cpu_time(meter: Meter) -> Counter:
     """Total CPU seconds broken down by different states"""
     return meter.create_counter(
-        name="process.cpu.time",
+        name=PROCESS_CPU_TIME,
         description="Total CPU seconds broken down by different states.",
         unit="s",
     )
@@ -85,7 +86,7 @@ def create_process_cpu_utilization(
 ) -> ObservableGauge:
     """Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process"""
     return meter.create_observable_gauge(
-        name="process.cpu.utilization",
+        name=PROCESS_CPU_UTILIZATION,
         callbacks=callbacks,
         description="Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process.",
         unit="1",
@@ -103,7 +104,7 @@ Unit: By
 def create_process_disk_io(meter: Meter) -> Counter:
     """Disk bytes transferred"""
     return meter.create_counter(
-        name="process.disk.io",
+        name=PROCESS_DISK_IO,
         description="Disk bytes transferred.",
         unit="By",
     )
@@ -120,7 +121,7 @@ Unit: By
 def create_process_memory_usage(meter: Meter) -> UpDownCounter:
     """The amount of physical memory in use"""
     return meter.create_up_down_counter(
-        name="process.memory.usage",
+        name=PROCESS_MEMORY_USAGE,
         description="The amount of physical memory in use.",
         unit="By",
     )
@@ -137,7 +138,7 @@ Unit: By
 def create_process_memory_virtual(meter: Meter) -> UpDownCounter:
     """The amount of committed virtual memory"""
     return meter.create_up_down_counter(
-        name="process.memory.virtual",
+        name=PROCESS_MEMORY_VIRTUAL,
         description="The amount of committed virtual memory.",
         unit="By",
     )
@@ -154,7 +155,7 @@ Unit: By
 def create_process_network_io(meter: Meter) -> Counter:
     """Network bytes transferred"""
     return meter.create_counter(
-        name="process.network.io",
+        name=PROCESS_NETWORK_IO,
         description="Network bytes transferred.",
         unit="By",
     )
@@ -173,7 +174,7 @@ Unit: {count}
 def create_process_open_file_descriptor_count(meter: Meter) -> UpDownCounter:
     """Number of file descriptors in use by the process"""
     return meter.create_up_down_counter(
-        name="process.open_file_descriptor.count",
+        name=PROCESS_OPEN_FILE_DESCRIPTOR_COUNT,
         description="Number of file descriptors in use by the process.",
         unit="{count}",
     )
@@ -190,7 +191,7 @@ Unit: {fault}
 def create_process_paging_faults(meter: Meter) -> Counter:
     """Number of page faults the process has made"""
     return meter.create_counter(
-        name="process.paging.faults",
+        name=PROCESS_PAGING_FAULTS,
         description="Number of page faults the process has made.",
         unit="{fault}",
     )
@@ -207,7 +208,7 @@ Unit: {thread}
 def create_process_thread_count(meter: Meter) -> UpDownCounter:
     """Process threads count"""
     return meter.create_up_down_counter(
-        name="process.thread.count",
+        name=PROCESS_THREAD_COUNT,
         description="Process threads count.",
         unit="{thread}",
     )

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/rpc_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/rpc_metrics.py
@@ -32,7 +32,7 @@ Note: While streaming RPCs may record this metric as start-of-batch
 def create_rpc_client_duration(meter: Meter) -> Histogram:
     """Measures the duration of outbound RPC"""
     return meter.create_histogram(
-        name="rpc.client.duration",
+        name=RPC_CLIENT_DURATION,
         description="Measures the duration of outbound RPC.",
         unit="ms",
     )
@@ -50,7 +50,7 @@ Note: **Streaming**: Recorded per message in a streaming batch.
 def create_rpc_client_request_size(meter: Meter) -> Histogram:
     """Measures the size of RPC request messages (uncompressed)"""
     return meter.create_histogram(
-        name="rpc.client.request.size",
+        name=RPC_CLIENT_REQUEST_SIZE,
         description="Measures the size of RPC request messages (uncompressed).",
         unit="By",
     )
@@ -70,7 +70,7 @@ Note: Should be 1 for all non-streaming RPCs.
 def create_rpc_client_requests_per_rpc(meter: Meter) -> Histogram:
     """Measures the number of messages received per RPC"""
     return meter.create_histogram(
-        name="rpc.client.requests_per_rpc",
+        name=RPC_CLIENT_REQUESTS_PER_RPC,
         description="Measures the number of messages received per RPC.",
         unit="{count}",
     )
@@ -88,7 +88,7 @@ Note: **Streaming**: Recorded per response in a streaming batch.
 def create_rpc_client_response_size(meter: Meter) -> Histogram:
     """Measures the size of RPC response messages (uncompressed)"""
     return meter.create_histogram(
-        name="rpc.client.response.size",
+        name=RPC_CLIENT_RESPONSE_SIZE,
         description="Measures the size of RPC response messages (uncompressed).",
         unit="By",
     )
@@ -108,7 +108,7 @@ Note: Should be 1 for all non-streaming RPCs.
 def create_rpc_client_responses_per_rpc(meter: Meter) -> Histogram:
     """Measures the number of messages sent per RPC"""
     return meter.create_histogram(
-        name="rpc.client.responses_per_rpc",
+        name=RPC_CLIENT_RESPONSES_PER_RPC,
         description="Measures the number of messages sent per RPC.",
         unit="{count}",
     )
@@ -129,7 +129,7 @@ Note: While streaming RPCs may record this metric as start-of-batch
 def create_rpc_server_duration(meter: Meter) -> Histogram:
     """Measures the duration of inbound RPC"""
     return meter.create_histogram(
-        name="rpc.server.duration",
+        name=RPC_SERVER_DURATION,
         description="Measures the duration of inbound RPC.",
         unit="ms",
     )
@@ -147,7 +147,7 @@ Note: **Streaming**: Recorded per message in a streaming batch.
 def create_rpc_server_request_size(meter: Meter) -> Histogram:
     """Measures the size of RPC request messages (uncompressed)"""
     return meter.create_histogram(
-        name="rpc.server.request.size",
+        name=RPC_SERVER_REQUEST_SIZE,
         description="Measures the size of RPC request messages (uncompressed).",
         unit="By",
     )
@@ -167,7 +167,7 @@ Note: Should be 1 for all non-streaming RPCs.
 def create_rpc_server_requests_per_rpc(meter: Meter) -> Histogram:
     """Measures the number of messages received per RPC"""
     return meter.create_histogram(
-        name="rpc.server.requests_per_rpc",
+        name=RPC_SERVER_REQUESTS_PER_RPC,
         description="Measures the number of messages received per RPC.",
         unit="{count}",
     )
@@ -185,7 +185,7 @@ Note: **Streaming**: Recorded per response in a streaming batch.
 def create_rpc_server_response_size(meter: Meter) -> Histogram:
     """Measures the size of RPC response messages (uncompressed)"""
     return meter.create_histogram(
-        name="rpc.server.response.size",
+        name=RPC_SERVER_RESPONSE_SIZE,
         description="Measures the size of RPC response messages (uncompressed).",
         unit="By",
     )
@@ -205,7 +205,7 @@ Note: Should be 1 for all non-streaming RPCs.
 def create_rpc_server_responses_per_rpc(meter: Meter) -> Histogram:
     """Measures the number of messages sent per RPC"""
     return meter.create_histogram(
-        name="rpc.server.responses_per_rpc",
+        name=RPC_SERVER_RESPONSES_PER_RPC,
         description="Measures the number of messages sent per RPC.",
         unit="{count}",
     )

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/system_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/system_metrics.py
@@ -38,6 +38,7 @@ CallbackT = Union[
     Generator[Iterable[Observation], CallbackOptions, None],
 ]
 
+
 SYSTEM_CPU_FREQUENCY: Final = "system.cpu.frequency"
 """
 Reports the current frequency of the CPU in Hz
@@ -51,7 +52,7 @@ def create_system_cpu_frequency(
 ) -> ObservableGauge:
     """Reports the current frequency of the CPU in Hz"""
     return meter.create_observable_gauge(
-        name="system.cpu.frequency",
+        name=SYSTEM_CPU_FREQUENCY,
         callbacks=callbacks,
         description="Reports the current frequency of the CPU in Hz",
         unit="{Hz}",
@@ -69,7 +70,7 @@ Unit: {cpu}
 def create_system_cpu_logical_count(meter: Meter) -> UpDownCounter:
     """Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking"""
     return meter.create_up_down_counter(
-        name="system.cpu.logical.count",
+        name=SYSTEM_CPU_LOGICAL_COUNT,
         description="Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking",
         unit="{cpu}",
     )
@@ -86,7 +87,7 @@ Unit: {cpu}
 def create_system_cpu_physical_count(meter: Meter) -> UpDownCounter:
     """Reports the number of actual physical processor cores on the hardware"""
     return meter.create_up_down_counter(
-        name="system.cpu.physical.count",
+        name=SYSTEM_CPU_PHYSICAL_COUNT,
         description="Reports the number of actual physical processor cores on the hardware",
         unit="{cpu}",
     )
@@ -103,7 +104,7 @@ Unit: s
 def create_system_cpu_time(meter: Meter) -> Counter:
     """Seconds each logical CPU spent on each mode"""
     return meter.create_counter(
-        name="system.cpu.time",
+        name=SYSTEM_CPU_TIME,
         description="Seconds each logical CPU spent on each mode",
         unit="s",
     )
@@ -122,7 +123,7 @@ def create_system_cpu_utilization(
 ) -> ObservableGauge:
     """Difference in system.cpu.time since the last measurement, divided by the elapsed time and number of logical CPUs"""
     return meter.create_observable_gauge(
-        name="system.cpu.utilization",
+        name=SYSTEM_CPU_UTILIZATION,
         callbacks=callbacks,
         description="Difference in system.cpu.time since the last measurement, divided by the elapsed time and number of logical CPUs",
         unit="1",
@@ -138,7 +139,7 @@ Unit: By
 
 def create_system_disk_io(meter: Meter) -> Counter:
     return meter.create_counter(
-        name="system.disk.io",
+        name=SYSTEM_DISK_IO,
         description="",
         unit="By",
     )
@@ -161,7 +162,7 @@ Note: The real elapsed time ("wall clock") used in the I/O path (time from opera
 def create_system_disk_io_time(meter: Meter) -> Counter:
     """Time disk spent activated"""
     return meter.create_counter(
-        name="system.disk.io_time",
+        name=SYSTEM_DISK_IO_TIME,
         description="Time disk spent activated",
         unit="s",
     )
@@ -176,7 +177,7 @@ Unit: {operation}
 
 def create_system_disk_merged(meter: Meter) -> Counter:
     return meter.create_counter(
-        name="system.disk.merged",
+        name=SYSTEM_DISK_MERGED,
         description="",
         unit="{operation}",
     )
@@ -197,7 +198,7 @@ Note: Because it is the sum of time each request took, parallel-issued requests 
 def create_system_disk_operation_time(meter: Meter) -> Counter:
     """Sum of the time each operation took to complete"""
     return meter.create_counter(
-        name="system.disk.operation_time",
+        name=SYSTEM_DISK_OPERATION_TIME,
         description="Sum of the time each operation took to complete",
         unit="s",
     )
@@ -212,7 +213,7 @@ Unit: {operation}
 
 def create_system_disk_operations(meter: Meter) -> Counter:
     return meter.create_counter(
-        name="system.disk.operations",
+        name=SYSTEM_DISK_OPERATIONS,
         description="",
         unit="{operation}",
     )
@@ -227,7 +228,7 @@ Unit: By
 
 def create_system_filesystem_usage(meter: Meter) -> UpDownCounter:
     return meter.create_up_down_counter(
-        name="system.filesystem.usage",
+        name=SYSTEM_FILESYSTEM_USAGE,
         description="",
         unit="By",
     )
@@ -244,7 +245,7 @@ def create_system_filesystem_utilization(
     meter: Meter, callbacks: Optional[Sequence[CallbackT]]
 ) -> ObservableGauge:
     return meter.create_observable_gauge(
-        name="system.filesystem.utilization",
+        name=SYSTEM_FILESYSTEM_UTILIZATION,
         callbacks=callbacks,
         description="",
         unit="1",
@@ -267,7 +268,7 @@ Note: This is an alternative to `system.memory.usage` metric with `state=free`.
 def create_system_linux_memory_available(meter: Meter) -> UpDownCounter:
     """An estimate of how much memory is available for starting new applications, without causing swapping"""
     return meter.create_up_down_counter(
-        name="system.linux.memory.available",
+        name=SYSTEM_LINUX_MEMORY_AVAILABLE,
         description="An estimate of how much memory is available for starting new applications, without causing swapping",
         unit="By",
     )
@@ -285,7 +286,7 @@ Note: Its value SHOULD equal the sum of `system.memory.state` over all states.
 def create_system_memory_limit(meter: Meter) -> UpDownCounter:
     """Total memory available in the system"""
     return meter.create_up_down_counter(
-        name="system.memory.limit",
+        name=SYSTEM_MEMORY_LIMIT,
         description="Total memory available in the system.",
         unit="By",
     )
@@ -304,7 +305,7 @@ Note: The sum over all `system.memory.state` values SHOULD equal the total memor
 def create_system_memory_usage(meter: Meter) -> UpDownCounter:
     """Reports memory in use by state"""
     return meter.create_up_down_counter(
-        name="system.memory.usage",
+        name=SYSTEM_MEMORY_USAGE,
         description="Reports memory in use by state.",
         unit="By",
     )
@@ -321,7 +322,7 @@ def create_system_memory_utilization(
     meter: Meter, callbacks: Optional[Sequence[CallbackT]]
 ) -> ObservableGauge:
     return meter.create_observable_gauge(
-        name="system.memory.utilization",
+        name=SYSTEM_MEMORY_UTILIZATION,
         callbacks=callbacks,
         description="",
         unit="1",
@@ -337,7 +338,7 @@ Unit: {connection}
 
 def create_system_network_connections(meter: Meter) -> UpDownCounter:
     return meter.create_up_down_counter(
-        name="system.network.connections",
+        name=SYSTEM_NETWORK_CONNECTIONS,
         description="",
         unit="{connection}",
     )
@@ -359,7 +360,7 @@ Note: Measured as:
 def create_system_network_dropped(meter: Meter) -> Counter:
     """Count of packets that are dropped or discarded even though there was no error"""
     return meter.create_counter(
-        name="system.network.dropped",
+        name=SYSTEM_NETWORK_DROPPED,
         description="Count of packets that are dropped or discarded even though there was no error",
         unit="{packet}",
     )
@@ -381,7 +382,7 @@ Note: Measured as:
 def create_system_network_errors(meter: Meter) -> Counter:
     """Count of network errors detected"""
     return meter.create_counter(
-        name="system.network.errors",
+        name=SYSTEM_NETWORK_ERRORS,
         description="Count of network errors detected",
         unit="{error}",
     )
@@ -396,7 +397,7 @@ Unit: By
 
 def create_system_network_io(meter: Meter) -> Counter:
     return meter.create_counter(
-        name="system.network.io",
+        name=SYSTEM_NETWORK_IO,
         description="",
         unit="By",
     )
@@ -411,7 +412,7 @@ Unit: {packet}
 
 def create_system_network_packets(meter: Meter) -> Counter:
     return meter.create_counter(
-        name="system.network.packets",
+        name=SYSTEM_NETWORK_PACKETS,
         description="",
         unit="{packet}",
     )
@@ -426,7 +427,7 @@ Unit: {fault}
 
 def create_system_paging_faults(meter: Meter) -> Counter:
     return meter.create_counter(
-        name="system.paging.faults",
+        name=SYSTEM_PAGING_FAULTS,
         description="",
         unit="{fault}",
     )
@@ -441,7 +442,7 @@ Unit: {operation}
 
 def create_system_paging_operations(meter: Meter) -> Counter:
     return meter.create_counter(
-        name="system.paging.operations",
+        name=SYSTEM_PAGING_OPERATIONS,
         description="",
         unit="{operation}",
     )
@@ -458,7 +459,7 @@ Unit: By
 def create_system_paging_usage(meter: Meter) -> UpDownCounter:
     """Unix swap or windows pagefile usage"""
     return meter.create_up_down_counter(
-        name="system.paging.usage",
+        name=SYSTEM_PAGING_USAGE,
         description="Unix swap or windows pagefile usage",
         unit="By",
     )
@@ -475,7 +476,7 @@ def create_system_paging_utilization(
     meter: Meter, callbacks: Optional[Sequence[CallbackT]]
 ) -> ObservableGauge:
     return meter.create_observable_gauge(
-        name="system.paging.utilization",
+        name=SYSTEM_PAGING_UTILIZATION,
         callbacks=callbacks,
         description="",
         unit="1",
@@ -493,7 +494,7 @@ Unit: {process}
 def create_system_process_count(meter: Meter) -> UpDownCounter:
     """Total number of processes in each state"""
     return meter.create_up_down_counter(
-        name="system.process.count",
+        name=SYSTEM_PROCESS_COUNT,
         description="Total number of processes in each state",
         unit="{process}",
     )
@@ -510,7 +511,7 @@ Unit: {process}
 def create_system_process_created(meter: Meter) -> Counter:
     """Total number of processes created over uptime of the host"""
     return meter.create_counter(
-        name="system.process.created",
+        name=SYSTEM_PROCESS_CREATED,
         description="Total number of processes created over uptime of the host",
         unit="{process}",
     )

--- a/scripts/semconv/templates/semantic_metrics.j2
+++ b/scripts/semconv/templates/semantic_metrics.j2
@@ -107,7 +107,8 @@ from typing import Final
 
   {%- for metric in filtered_metrics %}
 
-{{metric.metric_name | to_const_name}}: Final = "{{metric.metric_name}}"
+{% set const_name = metric.metric_name | to_const_name %}
+{{const_name}}: Final = "{{metric.metric_name}}"
 {{metric_brief(metric, metric.metric_name | to_const_name) }}
 
     {% if filter == "any" %}
@@ -122,7 +123,7 @@ def create_{{ metric_name }}(meter: Meter) -> {{to_python_instrument_type(metric
     """{{brief}}"""
         {%- endif %}
     return meter.create_{{to_python_instrument_factory(metric.instrument)}}(
-        name="{{ metric.metric_name }}",
+        name={{ const_name }},
       {%- if metric.instrument == "gauge" %}
         callbacks=callbacks,
       {%- endif %}


### PR DESCRIPTION
# Description

Tiny semconv script improvement - generates metric helpers reusing constant name instead of string literal.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
