### PR TITLE
Use semconv exception attributes for record exceptions in spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - enable mypy and fix detected issues
   - allow to drop specific attributes in preparation for Semantic Conventions v1.26.0
   ([#3964](https://github.com/open-telemetry/opentelemetry-python/pull/3964))
+  - Use semconv exception attributes for record exceptions in spans
+  ([#3979](https://github.com/open-telemetry/opentelemetry-python/pull/3979))
 
 ## Version 1.25.0/0.46b0 (2024-05-30)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -64,6 +64,12 @@ from opentelemetry.sdk.util.instrumentation import (
     InstrumentationInfo,
     InstrumentationScope,
 )
+from opentelemetry.semconv.attributes.exception_attributes import (
+    EXCEPTION_ESCAPED,
+    EXCEPTION_MESSAGE,
+    EXCEPTION_STACKTRACE,
+    EXCEPTION_TYPE,
+)
 from opentelemetry.trace import NoOpTracer, SpanContext
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util import types
@@ -1016,10 +1022,10 @@ class Span(trace_api.Span, ReadableSpan):
             else qualname
         )
         _attributes: MutableMapping[str, types.AttributeValue] = {
-            "exception.type": exception_type,
-            "exception.message": str(exception),
-            "exception.stacktrace": stacktrace,
-            "exception.escaped": str(escaped),
+            EXCEPTION_TYPE: exception_type,
+            EXCEPTION_MESSAGE: str(exception),
+            EXCEPTION_STACKTRACE: stacktrace,
+            EXCEPTION_ESCAPED: str(escaped),
         }
         if attributes:
             _attributes.update(attributes)


### PR DESCRIPTION
# Description

Ensure we are using the attributes defined in `opentelemetry.semconv.attributes.exception_attributes` instead of plain string

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
