### PR TITLE
Validate links at span creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3973](https://github.com/open-telemetry/opentelemetry-python/pull/3966))
 - Update semantic conventions to version 1.26.0.
   ([#3964](https://github.com/open-telemetry/opentelemetry-python/pull/3964))
-  - Use semconv exception attributes for record exceptions in spans
+- Use semconv exception attributes for record exceptions in spans
   ([#3979](https://github.com/open-telemetry/opentelemetry-python/pull/3979))
+- Validate links at span creation
+  ([#3991](https://github.com/open-telemetry/opentelemetry-python/pull/3991))
 
 ## Version 1.25.0/0.46b0 (2024-05-30)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -819,13 +819,18 @@ class Span(trace_api.Span, ReadableSpan):
         if links is None:
             self._links = self._new_links()
         else:
+            valid_links = []
             for link in links:
-                link._attributes = BoundedAttributes(
-                    self._limits.max_link_attributes,
-                    link.attributes,
-                    max_value_len=self._limits.max_attribute_length,
-                )
-            self._links = BoundedList.from_seq(self._limits.max_links, links)
+                if _is_valid_link(link.context, link.attributes):
+                    link._attributes = BoundedAttributes(
+                        self._limits.max_link_attributes,
+                        link.attributes,
+                        max_value_len=self._limits.max_attribute_length,
+                    )
+                    valid_links.append(link)
+            self._links = BoundedList.from_seq(
+                self._limits.max_links, valid_links
+            )
 
     def __repr__(self):
         return f'{type(self).__name__}(name="{self._name}", context={self._context})'

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -830,9 +830,7 @@ class Span(trace_api.Span, ReadableSpan):
 
         valid_links = []
         for link in links:
-            if isinstance(link, trace_api.Link) and _is_valid_link(
-                link.context, link.attributes
-            ):
+            if link and _is_valid_link(link.context, link.attributes):
                 # pylint: disable=protected-access
                 link._attributes = BoundedAttributes(
                     self._limits.max_link_attributes,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -824,7 +824,7 @@ class Span(trace_api.Span, ReadableSpan):
     def _new_events(self):
         return BoundedList(self._limits.max_events)
 
-    def _new_links(self, links: Optional[Sequence[trace_api.Link]]):
+    def _new_links(self, links: Sequence[trace_api.Link]):
         if not links:
             return BoundedList(self._limits.max_links)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -828,18 +828,23 @@ class Span(trace_api.Span, ReadableSpan):
         if not links:
             return BoundedList(self._limits.max_links)
 
-        valid_links = []
-        for link in links:
-            if _is_valid_link(link.context, link.attributes):
-                # pylint: disable=protected-access
-                link._attributes = BoundedAttributes(
-                    self._limits.max_link_attributes,
-                    link.attributes,
-                    max_value_len=self._limits.max_attribute_length,
-                )
-                valid_links.append(link)
+        links = list(
+            filter(
+                lambda link: link
+                and _is_valid_link(link.context, link.attributes),
+                links,
+            )
+        )
 
-        return BoundedList.from_seq(self._limits.max_links, valid_links)
+        for link in links:
+            # pylint: disable=protected-access
+            link._attributes = BoundedAttributes(
+                self._limits.max_link_attributes,
+                link.attributes,
+                max_value_len=self._limits.max_attribute_length,
+            )
+
+        return BoundedList.from_seq(self._limits.max_links, links)
 
     def get_span_context(self):
         return self._context

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -954,6 +954,11 @@ class TestSpan(unittest.TestCase):
             root.add_link(None)
             self.assertEqual(len(root.links), 0)
 
+        with self.tracer.start_as_current_span(
+            "root", links=[trace_api.Link(other_context)]
+        ) as root:
+            self.assertEqual(len(root.links), 0)
+
     def test_add_link_with_invalid_span_context_with_attributes(self):
         invalid_context = trace_api.INVALID_SPAN_CONTEXT
 
@@ -961,6 +966,12 @@ class TestSpan(unittest.TestCase):
             root.add_link(invalid_context, {"name": "neighbor"})
             self.assertEqual(len(root.links), 1)
             self.assertEqual(root.links[0].attributes, {"name": "neighbor"})
+
+        with self.tracer.start_as_current_span(
+            "root",
+            links=[trace_api.Link(invalid_context, {"name": "neighbor"})],
+        ) as root:
+            self.assertEqual(len(root.links), 1)
 
     def test_add_link_with_invalid_span_context_with_tracestate(self):
         invalid_context = trace.SpanContext(
@@ -974,6 +985,11 @@ class TestSpan(unittest.TestCase):
             root.add_link(invalid_context)
             self.assertEqual(len(root.links), 1)
             self.assertEqual(root.links[0].context.trace_state, "foo=bar")
+
+        with self.tracer.start_as_current_span(
+            "root", links=[trace_api.Link(invalid_context)]
+        ) as root:
+            self.assertEqual(len(root.links), 1)
 
     def test_update_name(self):
         with self.tracer.start_as_current_span("root") as root:

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -955,7 +955,7 @@ class TestSpan(unittest.TestCase):
             self.assertEqual(len(root.links), 0)
 
         with self.tracer.start_as_current_span(
-            "root", links=[trace_api.Link(other_context)]
+            "root", links=[trace_api.Link(other_context), None]
         ) as root:
             self.assertEqual(len(root.links), 0)
 
@@ -963,13 +963,17 @@ class TestSpan(unittest.TestCase):
         invalid_context = trace_api.INVALID_SPAN_CONTEXT
 
         with self.tracer.start_as_current_span("root") as root:
+            root.add_link(invalid_context)
             root.add_link(invalid_context, {"name": "neighbor"})
             self.assertEqual(len(root.links), 1)
             self.assertEqual(root.links[0].attributes, {"name": "neighbor"})
 
         with self.tracer.start_as_current_span(
             "root",
-            links=[trace_api.Link(invalid_context, {"name": "neighbor"})],
+            links=[
+                trace_api.Link(invalid_context, {"name": "neighbor"}),
+                trace_api.Link(invalid_context),
+            ],
         ) as root:
             self.assertEqual(len(root.links), 1)
 
@@ -983,11 +987,16 @@ class TestSpan(unittest.TestCase):
 
         with self.tracer.start_as_current_span("root") as root:
             root.add_link(invalid_context)
+            root.add_link(trace_api.INVALID_SPAN_CONTEXT)
             self.assertEqual(len(root.links), 1)
             self.assertEqual(root.links[0].context.trace_state, "foo=bar")
 
         with self.tracer.start_as_current_span(
-            "root", links=[trace_api.Link(invalid_context)]
+            "root",
+            links=[
+                trace_api.Link(invalid_context),
+                trace_api.Link(trace_api.INVALID_SPAN_CONTEXT),
+            ],
         ) as root:
             self.assertEqual(len(root.links), 1)
 


### PR DESCRIPTION
# Description
Implementing validation of links during span creation as per spec, we shouldn't record invalid links (i.e., links with invalid span context with empty attributes and tracestate)
Fixes #3990

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] `tox -e`

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
