### PR TITLE
opentelemetry-api: allow importlib-metadata 7.2.1

### DIFF
--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "Deprecated >= 1.2.6",
     # FIXME This should be able to be removed after 3.12 is released if there is a reliable API
     # in importlib.metadata.
-    "importlib-metadata >= 6.0, <= 7.1",
+    "importlib-metadata >= 6.0, <= 7.2.1",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
# Description

Tested that `tox -e py310-test-opentelemetry-api` works fine with:

```
--- a/opentelemetry-api/test-requirements.txt
+++ b/opentelemetry-api/test-requirements.txt
@@ -1,7 +1,7 @@
 asgiref==3.7.2
 Deprecated==1.2.14
 flaky==3.7.0
-importlib-metadata==6.11.0
+importlib-metadata==7.2.1
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.5.0
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
