### PR TITLE
Use python baseline version for pylint checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -44,6 +44,9 @@ suggestion-mode=yes
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
+# Run python dependant checks considering the baseline version
+py-version=3.8
+
 
 [MESSAGES CONTROL]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,7 +266,7 @@ automatically load as options for the `opentelemetry-instrument` command.
 
 ## Updating supported Python version
 
-### Bumping the python baseline
+### Bumping the Python baseline
 
 When updating the minimum supported Python version remember to:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,11 +273,11 @@ When updating the minimum supported Python version remember to:
 - Remove the version in `pyproject.toml` trove classifiers
 - Remove the version from `tox.ini`
 - Search for `sys.version_info` usage and remove code for unsupported versions
-- Bump `py-version` in `.pylintrc` for Python version dependant checks
+- Bump `py-version` in `.pylintrc` for Python version dependent checks
 
 ### Adding support for a new Python release
 
-When adding support for a new Python relase remember to:
+When adding support for a new Python release remember to:
 
 - Add the version in `tox.ini`
 - Add the version in `pyproject.toml` trove classifiers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,7 +264,7 @@ automatically load as options for the `opentelemetry-instrument` command.
   extension](http://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy)
   extension in [Sphinx](http://www.sphinx-doc.org/en/master/index.html).
 
-## Updating supported Python version
+## Updating supported Python versions
 
 ### Bumping the Python baseline
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,3 +263,24 @@ automatically load as options for the `opentelemetry-instrument` command.
   as specified with the [napoleon
   extension](http://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy)
   extension in [Sphinx](http://www.sphinx-doc.org/en/master/index.html).
+
+## Updating supported Python version
+
+### Bumping the python baseline
+
+When updating the minimum supported Python version remember to:
+
+- Remove the version in `pyproject.toml` trove classifiers
+- Remove the version from `tox.ini`
+- Search for `sys.version_info` usage and remove code for unsupported versions
+- Bump `py-version` in `.pylintrc` for Python version dependant checks
+
+### Adding support for a new Python release
+
+When adding support for a new Python relase remember to:
+
+- Add the version in `tox.ini`
+- Add the version in `pyproject.toml` trove classifiers
+- Update github workflows accordingly; lint and benchmarks use the latest supported version
+- Update `.pre-commit-config.yaml`
+- Update tox examples in the documentation


### PR DESCRIPTION
# Description

We need to use the baseline Python version for version dependent pylint checks otherwise it may warn about things that will break older python versions.

While at it add some notes on changing supported python versions.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
