### PR TITLE
opentelemetry-api: allow importlib-metadata up to 8.0

### DIFF
--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "Deprecated >= 1.2.6",
     # FIXME This should be able to be removed after 3.12 is released if there is a reliable API
     # in importlib.metadata.
-    "importlib-metadata >= 6.0, <= 7.2.1",
+    "importlib-metadata >= 6.0, <= 8.0.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
# Description

Allow importlib-metadata 8.0.0 too

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with the following patch applied:

```
diff --git a/opentelemetry-api/test-requirements.txt b/opentelemetry-api/test-requirements.txt
index 3c84695a..b7f263c8 100644
--- a/opentelemetry-api/test-requirements.txt
+++ b/opentelemetry-api/test-requirements.txt
@@ -1,7 +1,7 @@
 asgiref==3.7.2
 Deprecated==1.2.14
 flaky==3.7.0
-importlib-metadata==6.11.0
+importlib-metadata==8.0.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.5.0
```

- [x] `tox -e py310-test-opentelemetry-api`

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
