### PR TITLE
Speed up OTLP proto gRPC exporter tests

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
@@ -77,7 +77,7 @@ class LogsServiceServicerUNAVAILABLEDelay(LogsServiceServicer):
                 (
                     "google.rpc.retryinfo-bin",
                     RetryInfo(
-                        retry_delay=Duration(seconds=4)
+                        retry_delay=Duration(nanos=int(1e7))
                     ).SerializeToString(),
                 ),
             )
@@ -300,7 +300,7 @@ class TestOTLPLogExporter(TestCase):
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
     def test_unavailable(self, mock_sleep, mock_expo):
 
-        mock_expo.configure_mock(**{"return_value": [1]})
+        mock_expo.configure_mock(**{"return_value": [0.01]})
 
         add_LogsServiceServicer_to_server(
             LogsServiceServicerUNAVAILABLE(), self.server
@@ -308,7 +308,7 @@ class TestOTLPLogExporter(TestCase):
         self.assertEqual(
             self.exporter.export([self.log_data_1]), LogExportResult.FAILURE
         )
-        mock_sleep.assert_called_with(1)
+        mock_sleep.assert_called_with(0.01)
 
     @patch(
         "opentelemetry.exporter.otlp.proto.grpc.exporter._create_exp_backoff_generator"
@@ -324,7 +324,7 @@ class TestOTLPLogExporter(TestCase):
         self.assertEqual(
             self.exporter.export([self.log_data_1]), LogExportResult.FAILURE
         )
-        mock_sleep.assert_called_with(4)
+        mock_sleep.assert_called_with(0.01)
 
     def test_success(self):
         add_LogsServiceServicer_to_server(

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import threading
-import time
 from logging import WARNING
+from time import time_ns
 from types import MethodType
 from typing import Sequence
 from unittest import TestCase
@@ -163,7 +163,7 @@ class TestOTLPExporterMixin(TestCase):
         def trailing_metadata(self):
             return {
                 "google.rpc.retryinfo-bin": RetryInfo(
-                    retry_delay=Duration(seconds=1)
+                    retry_delay=Duration(nanos=int(1e7))
                 ).SerializeToString()
             }
 
@@ -196,9 +196,9 @@ class TestOTLPExporterMixin(TestCase):
             # pylint: disable=protected-access
             self.assertTrue(otlp_mock_exporter._export_lock.locked())
             # delay is 1 second while the default shutdown timeout is 30_000 milliseconds
-            start_time = time.time()
+            start_time = time_ns()
             otlp_mock_exporter.shutdown()
-            now = time.time()
+            now = time_ns()
             self.assertGreaterEqual(now, (start_time + 30 / 1000))
             # pylint: disable=protected-access
             self.assertTrue(otlp_mock_exporter._shutdown)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 
 # pylint: disable=too-many-lines
 from logging import WARNING
 from os import environ
 from os.path import dirname
+from time import time_ns
 from typing import List
 from unittest import TestCase
 from unittest.mock import patch
@@ -97,7 +97,7 @@ class MetricsServiceServicerUNAVAILABLEDelay(MetricsServiceServicer):
                 (
                     "google.rpc.retryinfo-bin",
                     RetryInfo(
-                        retry_delay=Duration(seconds=4)
+                        retry_delay=Duration(nanos=int(1e7))
                     ).SerializeToString(),
                 ),
             )
@@ -423,7 +423,7 @@ class TestOTLPMetricExporter(TestCase):
     @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.sleep")
     def test_unavailable(self, mock_sleep, mock_expo):
 
-        mock_expo.configure_mock(**{"return_value": [1]})
+        mock_expo.configure_mock(**{"return_value": [0.01]})
 
         add_MetricsServiceServicer_to_server(
             MetricsServiceServicerUNAVAILABLE(), self.server
@@ -432,7 +432,7 @@ class TestOTLPMetricExporter(TestCase):
             self.exporter.export(self.metrics["sum_int"]),
             MetricExportResult.FAILURE,
         )
-        mock_sleep.assert_called_with(1)
+        mock_sleep.assert_called_with(0.01)
 
     @patch(
         "opentelemetry.exporter.otlp.proto.grpc.exporter._create_exp_backoff_generator"
@@ -449,7 +449,7 @@ class TestOTLPMetricExporter(TestCase):
             self.exporter.export(self.metrics["sum_int"]),
             MetricExportResult.FAILURE,
         )
-        mock_sleep.assert_called_with(4)
+        mock_sleep.assert_called_with(0.01)
 
     @patch(
         "opentelemetry.exporter.otlp.proto.grpc.exporter._create_exp_backoff_generator"
@@ -802,9 +802,9 @@ class TestOTLPMetricExporter(TestCase):
             # pylint: disable=protected-access
             self.assertTrue(self.exporter._export_lock.locked())
             # delay is 4 seconds while the default shutdown timeout is 30_000 milliseconds
-            start_time = time.time()
+            start_time = time_ns()
             self.exporter.shutdown()
-            now = time.time()
+            now = time_ns()
             self.assertGreaterEqual(now, (start_time + 30 / 1000))
             # pylint: disable=protected-access
             self.assertTrue(self.exporter._shutdown)


### PR DESCRIPTION
Fixes #4013

These tests had unnecessarily large delays, this PR reduces them.

For some unscientific proof this helps, I ran these tests in my laptop, with `main` it took it ~34s, with these enhancements, it took ~12s to run them.