### PR TITLE
Fix #3695: add attributes to get_meter fn and InstrumentationScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1601,4 +1601,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3778](https://github.com/open-telemetry/opentelemetry-python/pull/3778))
 - Fix license field in pyproject.toml files
   ([#3803](https://github.com/open-telemetry/opentelemetry-python/pull/3803))
+- Fix to add attributes field in get_meter and instrumentationScope
+  ([#3695](https://github.com/open-telemetry/opentelemetry-python/issues/3695))
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py
@@ -518,6 +518,7 @@ class MeterProvider(APIMeterProvider):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
+        attributes: Optional[dict] = None,
     ) -> Meter:
 
         if self._disabled:
@@ -534,7 +535,7 @@ class MeterProvider(APIMeterProvider):
             _logger.warning("Meter name cannot be None or empty.")
             return NoOpMeter(name, version=version, schema_url=schema_url)
 
-        info = InstrumentationScope(name, version, schema_url)
+        info = InstrumentationScope(name, version, schema_url, attributes)
         with self._meter_lock:
             if not self._meters.get(info):
                 # FIXME #2558 pass SDKConfig object to meter so that the meter

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/instrumentation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/instrumentation.py
@@ -82,22 +82,24 @@ class InstrumentationScope:
     properties.
     """
 
-    __slots__ = ("_name", "_version", "_schema_url")
+    __slots__ = ("_name", "_version", "_schema_url", "_attributes")
 
     def __init__(
         self,
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
+        attributes: Optional[dict] = None,
     ) -> None:
         self._name = name
         self._version = version
         if schema_url is None:
             schema_url = ""
         self._schema_url = schema_url
+        self._attributes = attributes
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({self._name}, {self._version}, {self._schema_url})"
+        return f"{type(self).__name__}({self._name}, {self._version}, {self._schema_url}, {self._attributes})"
 
     def __hash__(self) -> int:
         return hash((self._name, self._version, self._schema_url))
@@ -105,19 +107,31 @@ class InstrumentationScope:
     def __eq__(self, value: object) -> bool:
         if not isinstance(value, InstrumentationScope):
             return NotImplemented
-        return (self._name, self._version, self._schema_url) == (
+        return (
+            self._name,
+            self._version,
+            self._schema_url,
+            self._attributes,
+        ) == (
             value._name,
             value._version,
             value._schema_url,
+            value._attributes,
         )
 
     def __lt__(self, value: object) -> bool:
         if not isinstance(value, InstrumentationScope):
             return NotImplemented
-        return (self._name, self._version, self._schema_url) < (
+        return (
+            self._name,
+            self._version,
+            self._schema_url,
+            self._attributes,
+        ) < (
             value._name,
             value._version,
             value._schema_url,
+            value._attributes,
         )
 
     @property
@@ -132,12 +146,17 @@ class InstrumentationScope:
     def name(self) -> str:
         return self._name
 
+    @property
+    def attributes(self) -> Optional[dict]:
+        return self._attributes
+
     def to_json(self, indent=4) -> str:
         return dumps(
             {
                 "name": self._name,
                 "version": self._version,
                 "schema_url": self._schema_url,
+                "attributes": self._attributes,
             },
             indent=indent,
         )

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -126,11 +126,36 @@ class TestMeterProvider(ConcurrencyTestBase, TestCase):
             "name",
             version="version",
             schema_url="schema_url",
+            attributes={"key": "value"},
         )
 
         self.assertEqual(meter._instrumentation_scope.name, "name")
         self.assertEqual(meter._instrumentation_scope.version, "version")
         self.assertEqual(meter._instrumentation_scope.schema_url, "schema_url")
+        self.assertEqual(
+            meter._instrumentation_scope.attributes, {"key": "value"}
+        )
+
+    def test_get_meter_attributes(self):
+        """
+        `MeterProvider.get_meter` arguments are used to create an
+        `InstrumentationScope` object on the created `Meter`.
+        """
+
+        meter = MeterProvider().get_meter(
+            "name",
+            version="version",
+            schema_url="schema_url",
+            attributes={"key": "value", "key2": 5, "key3": "value3"},
+        )
+
+        self.assertEqual(meter._instrumentation_scope.name, "name")
+        self.assertEqual(meter._instrumentation_scope.version, "version")
+        self.assertEqual(meter._instrumentation_scope.schema_url, "schema_url")
+        self.assertEqual(
+            meter._instrumentation_scope.attributes,
+            {"key": "value", "key2": 5, "key3": "value3"},
+        )
 
     def test_get_meter_empty(self):
         """

--- a/opentelemetry-sdk/tests/metrics/test_point.py
+++ b/opentelemetry-sdk/tests/metrics/test_point.py
@@ -178,7 +178,7 @@ class TestToJson(TestCase):
             metrics=[cls.metric_0, cls.metric_1, cls.metric_2],
             schema_url="schema_url_0",
         )
-        cls.scope_metrics_0_str = f'{{"scope": {{"name": "name_0", "version": "version_0", "schema_url": "schema_url_0"}}, "metrics": [{cls.metric_0_str}, {cls.metric_1_str}, {cls.metric_2_str}], "schema_url": "schema_url_0"}}'
+        cls.scope_metrics_0_str = f'{{"scope": {{"name": "name_0", "version": "version_0", "schema_url": "schema_url_0", "attributes": null}}, "metrics": [{cls.metric_0_str}, {cls.metric_1_str}, {cls.metric_2_str}], "schema_url": "schema_url_0"}}'
 
         cls.scope_metrics_1 = ScopeMetrics(
             scope=InstrumentationScope(
@@ -189,7 +189,7 @@ class TestToJson(TestCase):
             metrics=[cls.metric_0, cls.metric_1, cls.metric_2],
             schema_url="schema_url_1",
         )
-        cls.scope_metrics_1_str = f'{{"scope": {{"name": "name_1", "version": "version_1", "schema_url": "schema_url_1"}}, "metrics": [{cls.metric_0_str}, {cls.metric_1_str}, {cls.metric_2_str}], "schema_url": "schema_url_1"}}'
+        cls.scope_metrics_1_str = f'{{"scope": {{"name": "name_1", "version": "version_1", "schema_url": "schema_url_1", "attributes": null}}, "metrics": [{cls.metric_0_str}, {cls.metric_1_str}, {cls.metric_2_str}], "schema_url": "schema_url_1"}}'
 
         cls.resource_metrics_0 = ResourceMetrics(
             resource=Resource(


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #3695 (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added unit tests for the get_meter fn call, also included the attributes where instrumentationScope is being called

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [] Yes. - Link to PR: 
- [.] No.

# Checklist:

- [.] Followed the style guidelines of this project
- [.] Changelogs have been updated
- [.] Unit tests have been added
- [.] Documentation has been updated
