### PR TITLE
Remove references to `Log` and `Event` in `LoggerProvider` doc string

### DIFF
--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -14,8 +14,7 @@
 """
 The OpenTelemetry logging API describes the classes used to generate logs and events.
 
-The :class:`.LoggerProvider` provides users access to the :class:`.Logger` which in
-turn is used to create :class:`.Event` and :class:`.Log` objects.
+The :class:`.LoggerProvider` provides users access to the :class:`.Logger`.
 
 This module provides abstract (i.e. unimplemented) classes required for
 logging, and a concrete no-op implementation :class:`.NoOpLogger` that allows applications


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-python/issues/3556