### PR TITLE
fix: align process command arguments to spec defintion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4009](https://github.com/open-telemetry/opentelemetry-python/pull/4009))
 - Fix `start_time_unix_nano` for delta collection for sum aggregation
   ([#4011](https://github.com/open-telemetry/opentelemetry-python/pull/4011))
-- Update opentracing and opencesus docs examples to not use JaegerExporter
-  ([#4023](https://github.com/open-telemetry/opentelemetry-python/pull/4023))
 - Do not execute Flask Tests in debug mode
   ([#3956](https://github.com/open-telemetry/opentelemetry-python/pull/3956))
 - When encountering an error encoding metric attributes in the OTLP exporter, log the key that had an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4009](https://github.com/open-telemetry/opentelemetry-python/pull/4009))
 - Fix `start_time_unix_nano` for delta collection for sum aggregation
   ([#4011](https://github.com/open-telemetry/opentelemetry-python/pull/4011))
+- Update opentracing and opencesus docs examples to not use JaegerExporter
+  ([#4023](https://github.com/open-telemetry/opentelemetry-python/pull/4023))
 - Do not execute Flask Tests in debug mode
   ([#3956](https://github.com/open-telemetry/opentelemetry-python/pull/3956))
 - When encountering an error encoding metric attributes in the OTLP exporter, log the key that had an error.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -348,7 +348,7 @@ class ProcessResourceDetector(ResourceDetector):
         _process_executable_path = os.path.dirname(_process_executable_name)
         _process_command = sys.argv[0]
         _process_command_line = " ".join(sys.argv)
-        _process_command_args = sys.argv[1:]
+        _process_command_args = sys.argv
         resource_info = {
             PROCESS_RUNTIME_DESCRIPTION: sys.version,
             PROCESS_RUNTIME_NAME: sys.implementation.name,

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -608,7 +608,7 @@ class TestOTELResourceDetector(unittest.TestCase):
         )
         self.assertEqual(
             aggregated_resource.attributes[PROCESS_COMMAND_ARGS],
-            tuple(sys.argv[1:]),
+            tuple(sys.argv),
         )
 
     def test_resource_detector_entry_points_default(self):


### PR DESCRIPTION
# Description

According to the [process attributes](https://opentelemetry.io/docs/specs/semconv/attributes-registry/process/#process-attributes) within the spec of semconv `process.command_args`  should be "All the command arguments (including the command/executable itself)".
In the current implementation, it is handling all command arguments **without**  the command itself.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [X] Unit tests have been added - has adjusted
- [ ] Documentation has been updated

