### PR TITLE
Bump certifi and zipp

### DIFF
--- a/docs/getting_started/tests/requirements.txt
+++ b/docs/getting_started/tests/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.7.2
 attrs==23.1.0
-certifi==2023.7.22
+certifi==2024.7.4
 charset-normalizer==2.0.12
 click==8.1.7
 Deprecated==1.2.14

--- a/docs/getting_started/tests/requirements.txt
+++ b/docs/getting_started/tests/requirements.txt
@@ -21,7 +21,7 @@ typing_extensions==4.8.0
 urllib3==1.26.19
 Werkzeug==3.0.3
 wrapt==1.15.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-semantic-conventions
 -e opentelemetry-api
 -e opentelemetry-sdk

--- a/exporter/opentelemetry-exporter-opencensus/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-opencensus/test-requirements.txt
@@ -12,7 +12,7 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e tests/opentelemetry-test-utils

--- a/exporter/opentelemetry-exporter-otlp-proto-common/test-requirements-0.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/test-requirements-0.txt
@@ -10,7 +10,7 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions

--- a/exporter/opentelemetry-exporter-otlp-proto-common/test-requirements-1.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/test-requirements-1.txt
@@ -10,7 +10,7 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements-0.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements-0.txt
@@ -13,7 +13,7 @@ pytest-benchmark==4.0.0
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e tests/opentelemetry-test-utils
 -e exporter/opentelemetry-exporter-otlp-proto-common

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements-1.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements-1.txt
@@ -13,7 +13,7 @@ pytest-benchmark==4.0.0
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e tests/opentelemetry-test-utils
 -e exporter/opentelemetry-exporter-otlp-proto-common

--- a/exporter/opentelemetry-exporter-otlp-proto-http/test-requirements-0.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/test-requirements-0.txt
@@ -1,5 +1,5 @@
 asgiref==3.7.2
-certifi==2024.2.2
+certifi==2024.7.4
 charset-normalizer==3.3.2
 Deprecated==1.2.14
 googleapis-common-protos==1.62.0

--- a/exporter/opentelemetry-exporter-otlp-proto-http/test-requirements-0.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/test-requirements-0.txt
@@ -18,7 +18,7 @@ tomli==2.0.1
 typing_extensions==4.10.0
 urllib3==2.2.2
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e tests/opentelemetry-test-utils
 -e exporter/opentelemetry-exporter-otlp-proto-common

--- a/exporter/opentelemetry-exporter-otlp-proto-http/test-requirements-1.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/test-requirements-1.txt
@@ -1,5 +1,5 @@
 asgiref==3.7.2
-certifi==2024.2.2
+certifi==2024.7.4
 charset-normalizer==3.3.2
 Deprecated==1.2.14
 googleapis-common-protos==1.62.0

--- a/exporter/opentelemetry-exporter-otlp-proto-http/test-requirements-1.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/test-requirements-1.txt
@@ -18,7 +18,7 @@ tomli==2.0.1
 typing_extensions==4.10.0
 urllib3==2.2.2
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e tests/opentelemetry-test-utils
 -e exporter/opentelemetry-exporter-otlp-proto-common

--- a/exporter/opentelemetry-exporter-otlp/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-otlp/test-requirements.txt
@@ -9,7 +9,7 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e tests/opentelemetry-test-utils
 -e exporter/opentelemetry-exporter-otlp-proto-common

--- a/exporter/opentelemetry-exporter-prometheus/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-prometheus/test-requirements.txt
@@ -10,7 +10,7 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e tests/opentelemetry-test-utils

--- a/exporter/opentelemetry-exporter-zipkin-json/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-zipkin-json/test-requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.7.2
-certifi==2024.2.2
+certifi==2024.7.4
 charset-normalizer==3.3.2
 Deprecated==1.2.14
 idna==3.7

--- a/exporter/opentelemetry-exporter-zipkin-json/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-zipkin-json/test-requirements.txt
@@ -14,7 +14,7 @@ tomli==2.0.1
 typing_extensions==4.10.0
 urllib3==2.2.2
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/test-requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.7.2
-certifi==2024.2.2
+certifi==2024.7.4
 charset-normalizer==3.3.2
 Deprecated==1.2.14
 idna==3.7

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/test-requirements.txt
@@ -15,7 +15,7 @@ tomli==2.0.1
 typing_extensions==4.10.0
 urllib3==2.2.2
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e exporter/opentelemetry-exporter-zipkin-json
 -e opentelemetry-sdk

--- a/exporter/opentelemetry-exporter-zipkin/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-zipkin/test-requirements.txt
@@ -9,7 +9,7 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e exporter/opentelemetry-exporter-zipkin-json
 -e exporter/opentelemetry-exporter-zipkin-proto-http

--- a/opentelemetry-api/test-requirements.txt
+++ b/opentelemetry-api/test-requirements.txt
@@ -9,7 +9,7 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions
 -e tests/opentelemetry-test-utils

--- a/opentelemetry-proto/test-requirements-0.txt
+++ b/opentelemetry-proto/test-requirements-0.txt
@@ -10,5 +10,5 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-proto

--- a/opentelemetry-proto/test-requirements-1.txt
+++ b/opentelemetry-proto/test-requirements-1.txt
@@ -10,5 +10,5 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-proto

--- a/opentelemetry-sdk/test-requirements.txt
+++ b/opentelemetry-sdk/test-requirements.txt
@@ -11,7 +11,7 @@ pytest-benchmark==4.0.0
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e tests/opentelemetry-test-utils
 -e opentelemetry-api
 -e opentelemetry-semantic-conventions

--- a/opentelemetry-semantic-conventions/test-requirements.txt
+++ b/opentelemetry-semantic-conventions/test-requirements.txt
@@ -9,6 +9,6 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-semantic-conventions

--- a/propagator/opentelemetry-propagator-b3/test-requirements.txt
+++ b/propagator/opentelemetry-propagator-b3/test-requirements.txt
@@ -10,7 +10,7 @@ pytest-benchmark==4.0.0
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions

--- a/propagator/opentelemetry-propagator-jaeger/test-requirements.txt
+++ b/propagator/opentelemetry-propagator-jaeger/test-requirements.txt
@@ -9,7 +9,7 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions

--- a/shim/opentelemetry-opencensus-shim/test-requirements.txt
+++ b/shim/opentelemetry-opencensus-shim/test-requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.7.2
 cachetools==5.3.3
-certifi==2024.2.2
+certifi==2024.7.4
 charset-normalizer==3.3.2
 Deprecated==1.2.14
 google-api-core==2.17.1

--- a/shim/opentelemetry-opencensus-shim/test-requirements.txt
+++ b/shim/opentelemetry-opencensus-shim/test-requirements.txt
@@ -27,7 +27,7 @@ tomli==2.0.1
 typing_extensions==4.10.0
 urllib3==2.2.2
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e tests/opentelemetry-test-utils

--- a/shim/opentelemetry-opentracing-shim/test-requirements.txt
+++ b/shim/opentelemetry-opentracing-shim/test-requirements.txt
@@ -10,7 +10,7 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e tests/opentelemetry-test-utils

--- a/tests/opentelemetry-test-utils/test-requirements.txt
+++ b/tests/opentelemetry-test-utils/test-requirements.txt
@@ -9,7 +9,7 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.17.0
+zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions


### PR DESCRIPTION
# Description

Bump zipp and certifi to latest to resolve dependabot security warnings.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
