### PR TITLE
Add otlp exporters missing documentation

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -9,8 +9,13 @@ sphinx-jekyll-builder==0.3.0
 ./opentelemetry-api
 ./opentelemetry-semantic-conventions
 ./opentelemetry-sdk
+./opentelemetry-proto
 ./shim/opentelemetry-opencensus-shim
 ./shim/opentelemetry-opentracing-shim
+./exporter/opentelemetry-exporter-otlp-proto-common 
+./exporter/opentelemetry-exporter-otlp-proto-http 
+./exporter/opentelemetry-exporter-otlp-proto-grpc 
+./exporter/opentelemetry-exporter-otlp
 
 # Required by instrumentation and exporter packages
 grpcio~=1.27

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -12,10 +12,9 @@ sphinx-jekyll-builder==0.3.0
 ./opentelemetry-proto
 ./shim/opentelemetry-opencensus-shim
 ./shim/opentelemetry-opentracing-shim
-./exporter/opentelemetry-exporter-otlp-proto-common 
-./exporter/opentelemetry-exporter-otlp-proto-http 
-./exporter/opentelemetry-exporter-otlp-proto-grpc 
-./exporter/opentelemetry-exporter-otlp
+./exporter/opentelemetry-exporter-otlp-proto-common
+./exporter/opentelemetry-exporter-otlp-proto-http
+./exporter/opentelemetry-exporter-otlp-proto-grpc
 
 # Required by instrumentation and exporter packages
 grpcio~=1.27

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,6 +132,12 @@ nitpick_ignore = [
         "py:class",
         "opentelemetry.proto.collector.metrics.v1.metrics_service_pb2.ExportMetricsServiceRequest",
     ),
+    ("py:class", "opentelemetry.sdk._logs._internal.export.LogExporter"),
+    ("py:class", "opentelemetry.sdk._logs._internal.export.LogExportResult"),
+    (
+        "py:class",
+        "opentelemetry.proto.collector.logs.v1.logs_service_pb2.ExportLogsServiceRequest",
+    ),
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,23 @@ nitpick_ignore = [
         "py:class",
         "opentelemetry.trace._LinkBase",
     ),
+    (
+        "py:class",
+        "opentelemetry.exporter.otlp.proto.grpc.exporter.OTLPExporterMixin",
+    ),
+    (
+        "py:class",
+        "opentelemetry.proto.collector.trace.v1.trace_service_pb2.ExportTraceServiceRequest",
+    ),
+    (
+        "py:class",
+        "opentelemetry.exporter.otlp.proto.common._internal.metrics_encoder.OTLPMetricExporterMixin",
+    ),
+    ("py:class", "opentelemetry.proto.resource.v1.resource_pb2.Resource"),
+    (
+        "py:class",
+        "opentelemetry.proto.collector.metrics.v1.metrics_service_pb2.ExportMetricsServiceRequest",
+    ),
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/exporter/otlp/otlp.rst
+++ b/docs/exporter/otlp/otlp.rst
@@ -14,14 +14,10 @@ opentelemetry.exporter.otlp.proto.http
     :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.http.trace_exporter
-    :members:
-    :undoc-members:
-    :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.http.metric_exporter
-    :members:
-    :undoc-members:
-    :show-inheritance:
+
+.. automodule:: opentelemetry.exporter.otlp.proto.http._log_exporter
 
 opentelemetry.exporter.otlp.proto.grpc
 ---------------------------------------
@@ -32,11 +28,7 @@ opentelemetry.exporter.otlp.proto.grpc
     :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc.trace_exporter
-    :members:
-    :undoc-members:
-    :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc.metric_exporter
-    :members:
-    :undoc-members:
-    :show-inheritance:
+
+.. automodule:: opentelemetry.exporter.otlp.proto.grpc._log_exporter

--- a/docs/exporter/otlp/otlp.rst
+++ b/docs/exporter/otlp/otlp.rst
@@ -1,12 +1,42 @@
 OpenTelemetry OTLP Exporters
 ============================
-
 .. automodule:: opentelemetry.exporter.otlp
     :members:
     :undoc-members:
     :show-inheritance:
 
+opentelemetry.exporter.otlp.proto.http
+---------------------------------------
+
+.. automodule:: opentelemetry.exporter.otlp.proto.http
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: opentelemetry.exporter.otlp.proto.http.trace_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: opentelemetry.exporter.otlp.proto.http.metric_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+opentelemetry.exporter.otlp.proto.grpc
+---------------------------------------
+
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: opentelemetry.exporter.otlp.proto.grpc.trace_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: opentelemetry.exporter.otlp.proto.grpc.metric_exporter
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
# Description

I noticed we don't have the full [documentation](https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html#) of OTLP exporters at this moment. This is a simple improvement for that. I grouped them in the same rst file. 