### PR TITLE
Use right test value for default timeout in OTLP exporter mixin

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
@@ -195,11 +195,21 @@ class TestOTLPExporterMixin(TestCase):
         try:
             # pylint: disable=protected-access
             self.assertTrue(otlp_mock_exporter._export_lock.locked())
-            # delay is 1 second while the default shutdown timeout is 30_000 milliseconds
+            # delay is 1 second while the default shutdown timeout is 30_000
+            # milliseconds
             start_time = time_ns()
             otlp_mock_exporter.shutdown()
             now = time_ns()
-            self.assertGreaterEqual(now, (start_time + 30 / 1000))
+
+            actual_delta = now - start_time
+            minumum_expected_delta = int(30e9)
+
+            self.assertGreaterEqual(
+                actual_delta,
+                minumum_expected_delta,
+                "Default shutdown timeout was less than the expected 30000ms, "
+                f"it was {actual_delta * 1e-6}ms"
+            )
             # pylint: disable=protected-access
             self.assertTrue(otlp_mock_exporter._shutdown)
             # pylint: disable=protected-access


### PR DESCRIPTION
Fixes #4057

This PR is expected to fail, I think we have an underlying issue. This PR and its corresponding issue are just here to point to the fact that we have a test case to fix.