### PR TITLE
fix benchmark sdk ci empty output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -206,7 +206,7 @@ commands =
   lint-opentelemetry-sdk: isort --diff --check-only --settings-path {toxinidir}/.isort.cfg {toxinidir}/opentelemetry-sdk
   lint-opentelemetry-sdk: flake8 --config {toxinidir}/.flake8 {toxinidir}/opentelemetry-sdk
   lint-opentelemetry-sdk: pylint {toxinidir}/opentelemetry-sdk
-  benchmark-opentelemetry-sdk: pytest {toxinidir}/opentelemetry-sdk/benchmarks {posargs} --benchmark-json=sdk-benchmark.json
+  benchmark-opentelemetry-sdk: pytest {toxinidir}/opentelemetry-sdk/benchmarks --benchmark-json={toxinidir}/opentelemetry-sdk/sdk-benchmark.json {posargs}
 
   test-opentelemetry-proto: pytest {toxinidir}/opentelemetry-proto/tests {posargs}
   lint-opentelemetry-proto: black --diff --check --config {toxinidir}/pyproject.toml {toxinidir}/opentelemetry-proto
@@ -261,7 +261,7 @@ commands =
   lint-opentelemetry-exporter-otlp-proto-grpc: isort --diff --check-only --settings-path {toxinidir}/.isort.cfg {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-grpc
   lint-opentelemetry-exporter-otlp-proto-grpc: flake8 --config {toxinidir}/.flake8 {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-grpc
   lint-opentelemetry-exporter-otlp-proto-grpc: sh -c "cd exporter && pylint --rcfile ../.pylintrc {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-grpc"
-  benchmark-opentelemetry-exporter-otlp-proto-grpc: pytest {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-grpc/benchmarks {posargs} --benchmark-json=exporter-otlp-proto-grpc-benchmark.json
+  benchmark-opentelemetry-exporter-otlp-proto-grpc: pytest {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-grpc/benchmarks --benchmark-json=exporter-otlp-proto-grpc-benchmark.json {posargs}
 
   test-opentelemetry-exporter-otlp-proto-http: pytest {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-http/tests {posargs}
   lint-opentelemetry-exporter-otlp-proto-http: black --diff --check --config {toxinidir}/pyproject.toml {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-http
@@ -298,7 +298,7 @@ commands =
   lint-opentelemetry-propagator-b3: isort --diff --check-only --settings-path {toxinidir}/.isort.cfg {toxinidir}/propagator/opentelemetry-propagator-b3
   lint-opentelemetry-propagator-b3: flake8 --config {toxinidir}/.flake8 {toxinidir}/propagator/opentelemetry-propagator-b3
   lint-opentelemetry-propagator-b3: sh -c "cd propagator && pylint --rcfile ../.pylintrc {toxinidir}/propagator/opentelemetry-propagator-b3"
-  benchmark-opentelemetry-propagator-b3: pytest {toxinidir}/propagator/opentelemetry-propagator-b3/benchmarks {posargs} --benchmark-json=propagator-b3-benchmark.json
+  benchmark-opentelemetry-propagator-b3: pytest {toxinidir}/propagator/opentelemetry-propagator-b3/benchmarks --benchmark-json=propagator-b3-benchmark.json {posargs}
 
   test-opentelemetry-propagator-jaeger: pytest {toxinidir}/propagator/opentelemetry-propagator-jaeger/tests {posargs}
   lint-opentelemetry-propagator-jaeger: black --diff --check --config {toxinidir}/pyproject.toml {toxinidir}/propagator/opentelemetry-propagator-jaeger


### PR DESCRIPTION
# Description
Another fix to benchmark of the SDK on CI. See https://github.com/open-telemetry/opentelemetry-python/actions/runs/9943676226/job/27468046504. Seems the file is empty