### PR TITLE
Add a resource detector for populating `service.instance.id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3991](https://github.com/open-telemetry/opentelemetry-python/pull/3991))
 - Add attributes field in  `MeterProvider.get_meter` and `InstrumentationScope`
   ([#4015](https://github.com/open-telemetry/opentelemetry-python/pull/4015))
+- Added a `opentelemetry.sdk.resources.ServiceInstanceIdResourceDetector` that
+  adds the 'service.instance.id' resource attribute
 
 ## Version 1.25.0/0.46b0 (2024-05-30)
 

--- a/opentelemetry-sdk/pyproject.toml
+++ b/opentelemetry-sdk/pyproject.toml
@@ -67,6 +67,7 @@ console = "opentelemetry.sdk.trace.export:ConsoleSpanExporter"
 [project.entry-points.opentelemetry_resource_detector]
 otel = "opentelemetry.sdk.resources:OTELResourceDetector"
 process = "opentelemetry.sdk.resources:ProcessResourceDetector"
+serviceinstanceid = "opentelemetry.sdk.resources:ServiceInstanceIdResourceDetector"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-sdk"

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -64,6 +64,7 @@ import typing
 from json import dumps
 from os import environ
 from urllib import parse
+import uuid
 
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk.environment_variables import (
@@ -369,6 +370,12 @@ class ProcessResourceDetector(ResourceDetector):
             resource_info[PROCESS_OWNER] = process.username()
 
         return Resource(resource_info)
+
+
+class ServiceInstanceIdResourceDetector(ResourceDetector):
+    # pylint: disable=no-self-use
+    def detect(self) -> "Resource":
+        return Resource({SERVICE_INSTANCE_ID: str(uuid.uuid4())})
 
 
 def get_aggregated_resources(


### PR DESCRIPTION
# Description

This adds a resource detector for populating `service.instance.id` in accordance with [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#service-experimental).

Currently this resource detector is not enabled by default, however, once semantic conventions demand this attribute to be present by default (which is [planned](https://github.com/open-telemetry/semantic-conventions/issues/311)), then this detector can easily be added as a default (similar to the `otel` detector).

Fixes #2113

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This is tested via unit tests

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
