### PR TITLE
fix schema_url constants in semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3991](https://github.com/open-telemetry/opentelemetry-python/pull/3991))
 - Add attributes field in  `MeterProvider.get_meter` and `InstrumentationScope`
   ([#4015](https://github.com/open-telemetry/opentelemetry-python/pull/4015))
+- Fix inacessible `SCHEMA_URL` constants in `opentelemetry-semantic-conventions`
+  ([#4069](https://github.com/open-telemetry/opentelemetry-python/pull/4069))
 
 ## Version 1.25.0/0.46b0 (2024-05-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3991](https://github.com/open-telemetry/opentelemetry-python/pull/3991))
 - Add attributes field in  `MeterProvider.get_meter` and `InstrumentationScope`
   ([#4015](https://github.com/open-telemetry/opentelemetry-python/pull/4015))
-- Fix inacesible `SCHEMA_URL` constants in `opentelemetry-semantic-conventions`
+- Fix inaccessible `SCHEMA_URL` constants in `opentelemetry-semantic-conventions`
   ([#4069](https://github.com/open-telemetry/opentelemetry-python/pull/4069))
 
 ## Version 1.25.0/0.46b0 (2024-05-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#3991](https://github.com/open-telemetry/opentelemetry-python/pull/3991))
 - Add attributes field in  `MeterProvider.get_meter` and `InstrumentationScope`
   ([#4015](https://github.com/open-telemetry/opentelemetry-python/pull/4015))
-- Fix inacessible `SCHEMA_URL` constants in `opentelemetry-semantic-conventions`
+- Fix inacesible `SCHEMA_URL` constants in `opentelemetry-semantic-conventions`
   ([#4069](https://github.com/open-telemetry/opentelemetry-python/pull/4069))
 
 ## Version 1.25.0/0.46b0 (2024-05-30)

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/metrics/__init__.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/metrics/__init__.py
@@ -20,7 +20,7 @@ from deprecated import deprecated
     reason="Use metrics defined in the :py:const:`opentelemetry.semconv.metrics` and :py:const:`opentelemetry.semconv._incubating.metrics` modules instead.",
 )  # type: ignore
 class MetricInstruments:
-    SCHEMA_URL = "https://opentelemetry.io/schemas/v1.21.0"
+    SCHEMA_URL = "https://opentelemetry.io/schemas/1.21.0"
     """
     The URL of the OpenTelemetry schema for these keys and values.
     """

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/resource/__init__.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/resource/__init__.py
@@ -24,7 +24,7 @@ from deprecated import deprecated
     reason="Use attributes defined in the :py:const:`opentelemetry.semconv.attributes` and :py:const:`opentelemetry.semconv._incubating.attributes` modules instead.",
 )  # type: ignore
 class ResourceAttributes:
-    SCHEMA_URL = "https://opentelemetry.io/schemas/v1.21.0"
+    SCHEMA_URL = "https://opentelemetry.io/schemas/1.21.0"
     """
     The URL of the OpenTelemetry schema for these keys and values.
     """

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/schemas.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/schemas.py
@@ -28,7 +28,7 @@ class Schemas(Enum):
 
     V1_26_0 = "https://opentelemetry.io/schemas/1.26.0"
     """
-    The URL of the OpenTelemetry schema version v1.26.0.
+    The URL of the OpenTelemetry schema version 1.26.0.
     """
 
     # when generating new semantic conventions,

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/schemas.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/schemas.py
@@ -21,12 +21,12 @@ class Schemas(Enum):
     The URL of the OpenTelemetry schema version 1.23.1.
     """
 
-    V1_25_0 = "https://opentelemetry.io/schemas/v1.25.0"
+    V1_25_0 = "https://opentelemetry.io/schemas/1.25.0"
     """
     The URL of the OpenTelemetry schema version v1.25.0.
     """
 
-    V1_26_0 = "https://opentelemetry.io/schemas/v1.26.0"
+    V1_26_0 = "https://opentelemetry.io/schemas/1.26.0"
     """
     The URL of the OpenTelemetry schema version v1.26.0.
     """

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/schemas.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/schemas.py
@@ -23,7 +23,7 @@ class Schemas(Enum):
 
     V1_25_0 = "https://opentelemetry.io/schemas/1.25.0"
     """
-    The URL of the OpenTelemetry schema version v1.25.0.
+    The URL of the OpenTelemetry schema version 1.25.0.
     """
 
     V1_26_0 = "https://opentelemetry.io/schemas/1.26.0"

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/__init__.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/__init__.py
@@ -24,7 +24,7 @@ from deprecated import deprecated
     reason="Use attributes defined in the :py:const:`opentelemetry.semconv.attributes` and :py:const:`opentelemetry.semconv._incubating.attributes` modules instead.",
 )  # type: ignore
 class SpanAttributes:
-    SCHEMA_URL = "https://opentelemetry.io/schemas/v1.21.0"
+    SCHEMA_URL = "https://opentelemetry.io/schemas/1.21.0"
     """
     The URL of the OpenTelemetry schema for these keys and values.
     """

--- a/scripts/semconv/generate.sh
+++ b/scripts/semconv/generate.sh
@@ -5,8 +5,9 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec version to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=v1.26.0
-OTEL_SEMCONV_GEN_IMG_VERSION=0.24.0
+SEMCONV_VERSION=1.26.0
+SEMCONV_VERSION_TAG=v$SEMCONV_VERSION
+OTEL_SEMCONV_GEN_IMG_VERSION=0.25.0
 INCUBATING_DIR=_incubating
 cd ${SCRIPT_DIR}
 
@@ -16,7 +17,7 @@ cd semantic-conventions
 
 git init
 git remote add origin https://github.com/open-telemetry/semantic-conventions.git
-git fetch origin "$SEMCONV_VERSION"
+git fetch origin "$SEMCONV_VERSION_TAG"
 git reset --hard FETCH_HEAD
 cd ${SCRIPT_DIR}
 


### PR DESCRIPTION
# Description

Right now, we have an inaccessible constant for SCHEMA_URL; fix this. I don't know the impact of this in practice for users, but I can imagine that using the wrong schema_url, will lead to issues in a telemetry consumer which does schema translations when needed to compare the schema url's (i.e., [schemaprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/schemaprocessor)) . Also, this can affect the schema_url we are setting in instrumentation scope for instrumentation libraries that are being migrated to new semconv in contrib repo, see https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py#L396

- [ ] PR to update tests in contrib after this is merged