### PR TITLE
feat: functionality to configure instrumentation_scope from logging handler class (WIP)

### DIFF
--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -41,6 +41,7 @@ from typing import Any, Optional, cast
 
 from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.environment_variables import _OTEL_PYTHON_LOGGER_PROVIDER
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.trace.span import TraceFlags
 from opentelemetry.util._once import Once
 from opentelemetry.util._providers import _load_provider
@@ -159,6 +160,7 @@ class LoggerProvider(ABC):
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
         attributes: Optional[Attributes] = None,
+        instrumentation_scope: Optional[InstrumentationScope] = None,
     ) -> Logger:
         """Returns a `Logger` for use by the given instrumentation library.
 
@@ -274,6 +276,7 @@ def get_logger(
     logger_provider: Optional[LoggerProvider] = None,
     schema_url: Optional[str] = None,
     attributes: Optional[Attributes] = None,
+    instrumentation_scope: Optional[InstrumentationScope] = None,
 ) -> "Logger":
     """Returns a `Logger` for use within a python process.
 
@@ -284,9 +287,17 @@ def get_logger(
     """
     if logger_provider is None:
         logger_provider = get_logger_provider()
+    if isinstance(logger_provider, NoOpLoggerProvider):
+        return NoOpLogger(
+            instrumenting_module_name,
+            version=instrumenting_library_version,
+            schema_url=schema_url,
+            attributes=attributes,
+        )
     return logger_provider.get_logger(
         instrumenting_module_name,
         instrumenting_library_version,
         schema_url,
         attributes,
+        instrumentation_scope,
     )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -468,11 +468,14 @@ class LoggingHandler(logging.Handler):
         self,
         level=logging.NOTSET,
         logger_provider=None,
+        instrumentation_scope=None,
     ) -> None:
         super().__init__(level=level)
         self._logger_provider = logger_provider or get_logger_provider()
         self._logger = get_logger(
-            __name__, logger_provider=self._logger_provider
+            __name__,
+            logger_provider=self._logger_provider,
+            instrumentation_scope=instrumentation_scope,
         )
 
     @staticmethod
@@ -648,6 +651,7 @@ class LoggerProvider(APILoggerProvider):
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
         attributes: Optional[Attributes] = None,
+        instrumentation_scope: Optional[InstrumentationScope] = None,
     ) -> Logger:
         if self._disabled:
             _logger.warning("SDK is disabled.")
@@ -656,6 +660,17 @@ class LoggerProvider(APILoggerProvider):
                 version=version,
                 schema_url=schema_url,
                 attributes=attributes,
+            )
+        if instrumentation_scope:
+            return Logger(
+                self._resource,
+                self._multi_log_record_processor,
+                InstrumentationScope(
+                    instrumentation_scope.name,
+                    instrumentation_scope.version,
+                    instrumentation_scope.schema_url,
+                    instrumentation_scope.attributes,
+                ),
             )
         return Logger(
             self._resource,

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -24,6 +24,7 @@ from opentelemetry.sdk._logs._internal import (
 )
 from opentelemetry.sdk.environment_variables import OTEL_SDK_DISABLED
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 
 
 class TestLoggerProvider(unittest.TestCase):
@@ -65,6 +66,37 @@ class TestLoggerProvider(unittest.TestCase):
         )
         self.assertEqual(
             logger._instrumentation_scope.attributes, {"key": "value"}
+        )
+
+    def test_get_logger_instrumentation(self):
+        """
+        `LoggerProvider.get_logger` arguments are used to create an
+        `InstrumentationScope` object on the created `Logger`.
+        """
+        instruments = {
+            "name": "instrument_name",
+            "version": "instrument_version",
+            "schema_url": "instrument_schema_url",
+            "attributes": {"instrument_key": "instrument_value"},
+        }
+        logger = LoggerProvider().get_logger(
+            "name",
+            version="version",
+            schema_url="schema_url",
+            attributes={"key": "value"},
+            instrumentation_scope=InstrumentationScope(**instruments),
+        )
+
+        self.assertEqual(logger._instrumentation_scope.name, "instrument_name")
+        self.assertEqual(
+            logger._instrumentation_scope.version, "instrument_version"
+        )
+        self.assertEqual(
+            logger._instrumentation_scope.schema_url, "instrument_schema_url"
+        )
+        self.assertEqual(
+            logger._instrumentation_scope.attributes,
+            {"instrument_key": "instrument_value"},
         )
 
     @patch.dict("os.environ", {OTEL_SDK_DISABLED: "true"})


### PR DESCRIPTION
…andler

# Description

Add a way to instantiate the InstrumentationScope object through LoggingHandler

Fixes #4060 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added a test to create a different InstrumentationScope object through the LogProvider class

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
