### PR TITLE
Change `logger.exception` to `print` statement at failed log export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Drop Final annotation from Enum in semantic conventions
   ([#4085](https://github.com/open-telemetry/opentelemetry-python/pull/4085))
+- Change `logger.exception` to `print` at failed log export triggered by SimpleLogRecordProcessor ([#4088](https://github.com/open-telemetry/opentelemetry-python/pull/4088))
 
 ## Version 1.26.0/0.47b0 (2024-07-25)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -19,10 +19,10 @@ import logging
 import os
 import sys
 import threading
+import traceback
 from os import environ, linesep
 from time import time_ns
 from typing import IO, Callable, Deque, List, Optional, Sequence
-import traceback
 
 from opentelemetry.context import (
     _SUPPRESS_INSTRUMENTATION_KEY,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -128,7 +128,7 @@ class SimpleLogRecordProcessor(LogRecordProcessor):
         token = attach(set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
         try:
             self._exporter.export((log_data,))
-        except Exception as exc:  # pylint: disable=broad-exception-caught
+        except Exception:  # pylint: disable=broad-exception-caught
             traceback_str = traceback.format_exc()
             print(f"Exception while exporting logs: {traceback_str}")
         detach(token)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -22,6 +22,7 @@ import threading
 from os import environ, linesep
 from time import time_ns
 from typing import IO, Callable, Deque, List, Optional, Sequence
+import traceback
 
 from opentelemetry.context import (
     _SUPPRESS_INSTRUMENTATION_KEY,
@@ -127,8 +128,9 @@ class SimpleLogRecordProcessor(LogRecordProcessor):
         token = attach(set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
         try:
             self._exporter.export((log_data,))
-        except Exception:  # pylint: disable=broad-exception-caught
-            _logger.exception("Exception while exporting logs.")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            traceback_str = traceback.format_exc()
+            print(f"Exception while exporting logs: {traceback_str}")
         detach(token)
 
     def shutdown(self):

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -207,6 +207,7 @@ class TestSimpleLogRecordProcessor(unittest.TestCase):
         ]
         self.assertEqual(expected, emitted)
 
+    # pylint: disable=no-self-use
     @patch("builtins.print")
     @patch("traceback.format_exc", return_value="foo trace")
     def test_simple_log_record_processor_emit_export_exception(

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -175,7 +175,7 @@ class TestSimpleLogRecordProcessor(unittest.TestCase):
 
     def test_simple_log_record_processor_different_msg_types(self):
         exporter = InMemoryLogExporter()
-        log_record_processor = BatchLogRecordProcessor(exporter)
+        log_record_processor = SimpleLogRecordProcessor(exporter)
 
         provider = LoggerProvider()
         provider.add_log_record_processor(log_record_processor)


### PR DESCRIPTION
# Description

Improve `SimpleLogProcessor` handling of exceptions that could happen at attempt to export logs. Repeated failures to export log records results in creation of more log records and therefore RecursionError.

Fixes # [#3625](https://github.com/open-telemetry/opentelemetry-python/issues/3625)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually instrument a service with Otel SDK that includes these changes. Configure the service to raise an exception at log record export, e.g. a `ConnectionError`. See [issue comment](https://github.com/open-telemetry/opentelemetry-python/issues/3625#issuecomment-2253595498) for example.

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
