### PR TITLE
Update logs example re root logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added py.typed file to top-level module ([#4084](https://github.com/open-telemetry/opentelemetry-python/pull/4084))
 - Drop Final annotation from Enum in semantic conventions
   ([#4085](https://github.com/open-telemetry/opentelemetry-python/pull/4085))
+- Update log export example to not use root logger ([#4090](https://github.com/open-telemetry/opentelemetry-python/pull/4090))
 
 ## Version 1.26.0/0.47b0 (2024-07-25)
 

--- a/docs/examples/logs/example.py
+++ b/docs/examples/logs/example.py
@@ -36,10 +36,9 @@ handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
 # Attach OTLP handler to root logger
 logging.getLogger().addHandler(handler)
 
-# Log directly
-logging.info("Jackdaws love my big sphinx of quartz.")
-
 # Create different namespaced loggers
+# It is recommended to not use the root logger with OTLP handler
+# so telemetry is collected only for the application
 logger1 = logging.getLogger("myapp.area1")
 logger2 = logging.getLogger("myapp.area2")
 


### PR DESCRIPTION
# Description

Updates logs export setup example so that it no longer uses the root logger. Currently it does because it's a direct call to `logging.info` without prior `getLogger("some name")`, like in the [simple example](https://docs.python.org/3/howto/logging.html#a-simple-example).

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/3625

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
