### PR TITLE
Added helper script to run multiple tox environments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,11 @@ You can run `tox` with the following arguments:
 - `tox -e spellcheck` to run a spellcheck on all the code
 - `tox -e lint-some-package` to run lint checks on `some-package`
 
+There is a helper script `./scripts/runtox.sh` for running multiple tox environments in one command:
+
+- `./scripts/runtox.sh opentelemetry-api` will run all `tox` environments containing the string `"opentelemetry-api"` (useful to run one environment in all Python versions)
+- `./scripts/runtox.sh py312` will run all `tox` environments containing the string `"py312"` (useful to run all environments in one Python version)
+
 `black` and `isort` are executed when `tox -e lint` is run. The reported errors can be tedious to fix manually.
 An easier way to do so is:
 

--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Usage: 
+#   ./scripts/runtox.sh py312 <pytest-args>
+#
+# Runs all environments with substring "py312" and the given arguments for pytest
+# 
+
+# Print commands and exit on first error
+set -ex
+
+# Find the right tox executable
+if [ -n "$TOXPATH" ]; then
+    true
+elif which tox &> /dev/null; then
+    TOXPATH=tox
+else
+    TOXPATH=./.venv/bin/tox
+fi
+
+# Find the environments matching the searchstring
+searchstring="$1"
+ENV="$($TOXPATH -l | grep -- "$searchstring" | tr $'\n' ',')"
+
+if [ -z "${ENV}" ]; then
+    echo "No targets found. Skipping."
+    exit 0
+fi
+
+# Run tox with all matching environments
+exec $TOXPATH -e "$ENV" -- "${@:2}"


### PR DESCRIPTION
# Description

This adds a simple helper script `./scripts/runtox.sh` that allows people to run multiple `tox` environments with one call.

So `./scripts/runtox.sh py312` will run all tox environments having the string `"py312"` in their name. 

This is helpful if you want to run all tox environments in one Python version, or run one environment in all Python versions. (like this: `./scripts/runtox.sh opentelemetry-api`)

Constributed the same thing in `opentelementry-python-contrib`:
https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2763

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran it locally and it works (also we have something similar in Sentry, so I just copied it over)

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
