### PR TITLE
changed path to contributing guide url in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ and [**Maintainer**](https://github.com/open-telemetry/community/blob/main/commu
 
 Before you can contribute, you will need to sign the [Contributor License Agreement](https://docs.linuxfoundation.org/lfx/easycla/contributors).
 
-Please also read the [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md).
+Please also read the [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md).
 
 # Find your right repo
 


### PR DESCRIPTION
# Description

<!--
changed the URL pointing to contributing guidelines 
from this : https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md
to this: https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md
-->

Fixes # (4108)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ans: Verified by opening the URL after changes are committed

# Does This PR Require a Contrib Repo Change?
Ans: No


# Checklist:

- [ yes] Documentation has been updated
