### PR TITLE
Broaden accepted values in non-urlencoded headers

### DIFF
--- a/opentelemetry-api/src/opentelemetry/util/re.py
+++ b/opentelemetry-api/src/opentelemetry/util/re.py
@@ -32,12 +32,14 @@ _KEY_FORMAT = (
 # A value contains a URL-encoded UTF-8 string. The encoded form can contain any
 # printable US-ASCII characters (0x20-0x7f) other than SP, DEL, and ",;/
 _VALUE_FORMAT = r"[\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*"
+# Like above with SP included
+_LIBERAL_VALUE_FORMAT = r"[\x20\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*"
 # A key-value is key=value, with optional whitespace surrounding key and value
 _KEY_VALUE_FORMAT = rf"{_OWS}{_KEY_FORMAT}{_OWS}={_OWS}{_VALUE_FORMAT}{_OWS}"
 
 _HEADER_PATTERN = compile(_KEY_VALUE_FORMAT)
 _LIBERAL_HEADER_PATTERN = compile(
-    rf"{_OWS}{_KEY_FORMAT}{_OWS}={_OWS}[\w ]*{_OWS}"
+    rf"{_OWS}{_KEY_FORMAT}{_OWS}={_OWS}{_LIBERAL_VALUE_FORMAT}{_OWS}"
 )
 _DELIMITER_PATTERN = compile(r"[ \t]*,[ \t]*")
 

--- a/opentelemetry-api/tests/util/test_re.py
+++ b/opentelemetry-api/tests/util/test_re.py
@@ -89,6 +89,11 @@ class TestParseHeaders(unittest.TestCase):
         inp = self._common_test_cases() + [
             # valid header value
             ("key=value othervalue", [("key", "value othervalue")], False),
+            (
+                "key=value Other_Value==",
+                [("key", "value Other_Value==")],
+                False,
+            ),
         ]
         for case_ in inp:
             headers, expected, warn = case_


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

After #4103 we accept non url-encoded headers for OTLP. Naively this implementation only accepts digits, ascii letters, underscores (\w) and spaces. Instead broaden the accepted chars to what we accept for urlencoded values so that we accepts = to allow for base64 encoded values.

Refs #4103

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py310-test-opentelemetry-api

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
