### PR TITLE
Add ExponentialHistograms to data types supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4103](https://github.com/open-telemetry/opentelemetry-python/pull/4103))
 - Update semantic conventions to version 1.27.0
   ([#4104](https://github.com/open-telemetry/opentelemetry-python/pull/4104))
+- Export ExponentialHistogram and ExponentialHistogramDataPoint
+  ([#4134](https://github.com/open-telemetry/opentelemetry-python/pull/4134))
 
 ## Version 1.26.0/0.47b0 (2024-07-25)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
@@ -183,8 +183,10 @@ class Histogram:
 
 
 # pylint: disable=invalid-name
-DataT = Union[Sum, Gauge, Histogram]
-DataPointT = Union[NumberDataPoint, HistogramDataPoint]
+DataT = Union[Sum, Gauge, Histogram, ExponentialHistogram]
+DataPointT = Union[
+    NumberDataPoint, HistogramDataPoint, ExponentialHistogramDataPoint
+]
 
 
 @dataclass(frozen=True)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
@@ -43,6 +43,7 @@ from opentelemetry.sdk.metrics._internal.point import (  # noqa: F401
 
 __all__ = [
     "AggregationTemporality",
+    "Buckets",
     "ConsoleMetricExporter",
     "InMemoryMetricReader",
     "MetricExporter",
@@ -51,6 +52,8 @@ __all__ = [
     "PeriodicExportingMetricReader",
     "DataPointT",
     "DataT",
+    "ExponentialHistogram",
+    "ExponentialHistogramDataPoint",
     "Gauge",
     "Histogram",
     "HistogramDataPoint",


### PR DESCRIPTION
ExponentialHistogram support was added long time ago https://github.com/open-telemetry/opentelemetry-python/pull/2964, but the types were not properly exported and some linters will complain about this.

This PR exports the ExponentialHistogram and ExponentialHistogramDataPoint and marks the Metric.data to support this new types.