### PR TITLE
Reset `start_time_unix_nano` in `_ViewInstrumentMatch` for aggregation creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implementation of Events API
   ([#4054](https://github.com/open-telemetry/opentelemetry-python/pull/4054))
-- Make log sdk add `exception.message` to logRecord for exceptions whose argument 
+- Make log sdk add `exception.message` to logRecord for exceptions whose argument
   is an exception not a string message
   ([#4122](https://github.com/open-telemetry/opentelemetry-python/pull/4122))
 - Fix use of `link.attributes.dropped`, which may not exist
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4134](https://github.com/open-telemetry/opentelemetry-python/pull/4134))
 - Implement Client Key and Certificate File Support for All OTLP Exporters
   ([#4116](https://github.com/open-telemetry/opentelemetry-python/pull/4116))
+- Implement Client Key and Certificate File Support for All OTLP Exporters
+  ([#4116](https://github.com/open-telemetry/opentelemetry-python/pull/4116))
+- Remove `_start_time_unix_nano` attribute from `_ViewInstrumentMatch` in favor
+  of using `time_ns()` at the moment when the aggregation object is created
+  ([#4137](https://github.com/open-telemetry/opentelemetry-python/pull/4137))
 
 ## Version 1.26.0/0.47b0 (2024-07-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4134](https://github.com/open-telemetry/opentelemetry-python/pull/4134))
 - Implement Client Key and Certificate File Support for All OTLP Exporters
   ([#4116](https://github.com/open-telemetry/opentelemetry-python/pull/4116))
-- Implement Client Key and Certificate File Support for All OTLP Exporters
-  ([#4116](https://github.com/open-telemetry/opentelemetry-python/pull/4116))
 - Remove `_start_time_unix_nano` attribute from `_ViewInstrumentMatch` in favor
   of using `time_ns()` at the moment when the aggregation object is created
   ([#4137](https://github.com/open-telemetry/opentelemetry-python/pull/4137))

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/_view_instrument_match.py
@@ -40,7 +40,6 @@ class _ViewInstrumentMatch:
         instrument: Instrument,
         instrument_class_aggregation: Dict[type, Aggregation],
     ):
-        self._start_time_unix_nano = time_ns()
         self._view = view
         self._instrument = instrument
         self._attributes_aggregation: Dict[frozenset, _Aggregation] = {}
@@ -107,7 +106,7 @@ class _ViewInstrumentMatch:
                             self._view._aggregation._create_aggregation(
                                 self._instrument,
                                 attributes,
-                                self._start_time_unix_nano,
+                                time_ns(),
                             )
                         )
                     else:
@@ -116,7 +115,7 @@ class _ViewInstrumentMatch:
                         ]._create_aggregation(
                             self._instrument,
                             attributes,
-                            self._start_time_unix_nano,
+                            time_ns(),
                         )
                     self._attributes_aggregation[aggr_key] = aggregation
 

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_time_align.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_time_align.py
@@ -26,6 +26,11 @@ from opentelemetry.sdk.metrics.export import (
 
 
 class TestTimeAlign(TestCase):
+
+    # This delay is needed for these tests to pass when they are run in
+    # Windows.
+    delay = 0.0001
+
     def test_time_align_cumulative(self):
         reader = InMemoryMetricReader()
         meter_provider = MeterProvider(metric_readers=[reader])
@@ -36,9 +41,11 @@ class TestTimeAlign(TestCase):
         counter_1 = meter.create_counter("counter_1")
 
         counter_0.add(10, {"label": "value1"})
+        sleep(self.delay)
         counter_0.add(10, {"label": "value2"})
-        sleep(0.5)
+        sleep(self.delay)
         counter_1.add(10, {"label": "value1"})
+        sleep(self.delay)
         counter_1.add(10, {"label": "value2"})
 
         metrics = reader.get_metrics_data()
@@ -56,11 +63,11 @@ class TestTimeAlign(TestCase):
             .data.data_points
         )
 
-        self.assertEqual(
+        self.assertLess(
             data_points_0_0[0].start_time_unix_nano,
             data_points_0_0[1].start_time_unix_nano,
         )
-        self.assertEqual(
+        self.assertLess(
             data_points_0_1[0].start_time_unix_nano,
             data_points_0_1[1].start_time_unix_nano,
         )
@@ -83,9 +90,11 @@ class TestTimeAlign(TestCase):
         )
 
         counter_0.add(10, {"label": "value1"})
+        sleep(self.delay)
         counter_0.add(10, {"label": "value2"})
-        sleep(0.5)
+        sleep(self.delay)
         counter_1.add(10, {"label": "value1"})
+        sleep(self.delay)
         counter_1.add(10, {"label": "value2"})
 
         metrics = reader.get_metrics_data()
@@ -103,11 +112,11 @@ class TestTimeAlign(TestCase):
             .data.data_points
         )
 
-        self.assertEqual(
+        self.assertLess(
             data_points_1_0[0].start_time_unix_nano,
             data_points_1_0[1].start_time_unix_nano,
         )
-        self.assertEqual(
+        self.assertLess(
             data_points_1_1[0].start_time_unix_nano,
             data_points_1_1[1].start_time_unix_nano,
         )
@@ -161,9 +170,11 @@ class TestTimeAlign(TestCase):
         counter_1 = meter.create_counter("counter_1")
 
         counter_0.add(10, {"label": "value1"})
+        sleep(self.delay)
         counter_0.add(10, {"label": "value2"})
-        sleep(0.5)
+        sleep(self.delay)
         counter_1.add(10, {"label": "value1"})
+        sleep(self.delay)
         counter_1.add(10, {"label": "value2"})
 
         metrics = reader.get_metrics_data()
@@ -181,11 +192,11 @@ class TestTimeAlign(TestCase):
             .data.data_points
         )
 
-        self.assertEqual(
+        self.assertLess(
             data_points_0_0[0].start_time_unix_nano,
             data_points_0_0[1].start_time_unix_nano,
         )
-        self.assertEqual(
+        self.assertLess(
             data_points_0_1[0].start_time_unix_nano,
             data_points_0_1[1].start_time_unix_nano,
         )
@@ -208,9 +219,11 @@ class TestTimeAlign(TestCase):
         )
 
         counter_0.add(10, {"label": "value1"})
+        sleep(self.delay)
         counter_0.add(10, {"label": "value2"})
-        sleep(0.5)
+        sleep(self.delay)
         counter_1.add(10, {"label": "value1"})
+        sleep(self.delay)
         counter_1.add(10, {"label": "value2"})
 
         metrics = reader.get_metrics_data()

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_time_align.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_time_align.py
@@ -29,7 +29,7 @@ class TestTimeAlign(TestCase):
 
     # This delay is needed for these tests to pass when they are run in
     # Windows.
-    delay = 0.0001
+    delay = 0.001
 
     def test_time_align_cumulative(self):
         reader = InMemoryMetricReader()
@@ -62,6 +62,8 @@ class TestTimeAlign(TestCase):
             .metrics[1]
             .data.data_points
         )
+        self.assertEqual(len(data_points_0_0), 2)
+        self.assertEqual(len(data_points_0_1), 2)
 
         self.assertLess(
             data_points_0_0[0].start_time_unix_nano,
@@ -111,6 +113,9 @@ class TestTimeAlign(TestCase):
             .metrics[1]
             .data.data_points
         )
+
+        self.assertEqual(len(data_points_1_0), 2)
+        self.assertEqual(len(data_points_1_1), 2)
 
         self.assertLess(
             data_points_1_0[0].start_time_unix_nano,
@@ -191,6 +196,8 @@ class TestTimeAlign(TestCase):
             .metrics[1]
             .data.data_points
         )
+        self.assertEqual(len(data_points_0_0), 2)
+        self.assertEqual(len(data_points_0_1), 2)
 
         self.assertLess(
             data_points_0_0[0].start_time_unix_nano,
@@ -240,6 +247,8 @@ class TestTimeAlign(TestCase):
             .metrics[1]
             .data.data_points
         )
+        self.assertEqual(len(data_points_1_0), 2)
+        self.assertEqual(len(data_points_1_1), 2)
 
         self.assertEqual(
             data_points_1_0[0].start_time_unix_nano,

--- a/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
+++ b/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
@@ -270,13 +270,15 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         collected_data_points = view_instrument_match.collect(
             AggregationTemporality.CUMULATIVE, collection_start_time_unix_nano
         )
-        # # +1 call to create_aggregation
+        # +1 call to create_aggregation
         view_instrument_match.consume_measurement(
             Measurement(
                 value=0, instrument=instrument, attributes={"foo": "bar"}
             )
         )
-
+        view_instrument_match._view._aggregation._create_aggregation.assert_called_with(
+            instrument, {"foo": "bar"}, 2
+        )
         # No new calls to _create_aggregation because attributes remain the same
         view_instrument_match.consume_measurement(
             Measurement(

--- a/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
+++ b/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
@@ -217,7 +217,7 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
 
     @patch(
         "opentelemetry.sdk.metrics._internal._view_instrument_match.time_ns",
-        side_effect=[0, time_ns()],
+        side_effect=[0, 1, 2],
     )
     def test_collect_resets_start_time_unix_nano(self, mock_time_ns):
         instrument = Mock(name="instrument")
@@ -234,10 +234,7 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
             ),
         )
         start_time_unix_nano = 0
-        self.assertEqual(mock_time_ns.call_count, 1)
-        self.assertEqual(
-            view_instrument_match._start_time_unix_nano, start_time_unix_nano
-        )
+        self.assertEqual(mock_time_ns.call_count, 0)
 
         # +1 call to _create_aggregation
         view_instrument_match.consume_measurement(
@@ -254,10 +251,6 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         )
         self.assertIsNotNone(collected_data_points)
         self.assertEqual(len(collected_data_points), 1)
-        self.assertEqual(
-            view_instrument_match._start_time_unix_nano,
-            collection_start_time_unix_nano,
-        )
 
         # +1 call to _create_aggregation
         view_instrument_match.consume_measurement(
@@ -266,7 +259,7 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
             )
         )
         view_instrument_match._view._aggregation._create_aggregation.assert_called_with(
-            instrument, {"foo": "bar1"}, collection_start_time_unix_nano
+            instrument, {"foo": "bar1"}, 1
         )
         collection_start_time_unix_nano = time_ns()
         collected_data_points = view_instrument_match.collect(
@@ -276,10 +269,6 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         self.assertEqual(len(collected_data_points), 2)
         collected_data_points = view_instrument_match.collect(
             AggregationTemporality.CUMULATIVE, collection_start_time_unix_nano
-        )
-        self.assertEqual(
-            view_instrument_match._start_time_unix_nano,
-            collection_start_time_unix_nano,
         )
         # # +1 call to create_aggregation
         view_instrument_match.consume_measurement(
@@ -305,10 +294,6 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         self.assertEqual(
             view_instrument_match._view._aggregation._create_aggregation.call_count,
             5,
-        )
-        self.assertEqual(
-            view_instrument_match._start_time_unix_nano,
-            collection_start_time_unix_nano,
         )
 
     def test_data_point_check(self):


### PR DESCRIPTION
# Description

Fixes #4123 

When new aggregations are created within the same _ViewInstrumentMatch (e.g., `histogram.record` is called multiple times with different attributes), the `start_time_unix_nano` remains constant, which seems incorrect.

The current implementation of `_ViewInstrumentMatch` reuses the initial timestamp from when the instrument match was created, even for new aggregations with different attributes.

For example, suppose I record a measurement now (e.g., histogram. record(1, {"foo": "bar"})) and later record the same histogram with different attributes (e.g., histogram.record(1, {"foo": "bar1"})). In that case, the SDK creates a new aggregation. However, it incorrectly assigns the initial `start_time_unix_nano` from when `_ViewInstrumentMatch` was initialized rather than reflecting the actual time when the new aggregation was created. This results in a constant `start_time_unix_nano` across all aggregations, regardless of when they were actually created. See a failing test in my commit [test to fail](https://github.com/open-telemetry/opentelemetry-python/actions/runs/10473814968/job/29006703530)

~A potential solution is to reset `start_time_unix_nano` each time the [collect method is called](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/_view_instrument_match.py#L139), ensuring that new aggregations are associated with a recent timestamp. I'll likely discuss this approach further.~

@ocelotl suggested a better solution to just use `time_ns()` during aggregation creation, which also fixes the issue.