### PR TITLE
Handle case when first value is `0` in `test_cumulative_aggregation_with_random_data`

### DIFF
--- a/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
+++ b/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
@@ -1043,7 +1043,7 @@ class TestExponentialBucketHistogramAggregation(TestCase):
         # run this test case with the same values used in a previous execution,
         # check the value printed by that previous execution of this test case
         # and use the same value for the seed variable in the line below.
-        # seed = 4539544373807492135
+        seed = 3373389994391084876
 
         random_generator = Random(seed)
         print(f"seed for {currentframe().f_code.co_name} is {seed}")

--- a/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
+++ b/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
@@ -1043,7 +1043,7 @@ class TestExponentialBucketHistogramAggregation(TestCase):
         # run this test case with the same values used in a previous execution,
         # check the value printed by that previous execution of this test case
         # and use the same value for the seed variable in the line below.
-        seed = 3373389994391084876
+        # seed = 3373389994391084876
 
         random_generator = Random(seed)
         print(f"seed for {currentframe().f_code.co_name} is {seed}")
@@ -1051,6 +1051,8 @@ class TestExponentialBucketHistogramAggregation(TestCase):
         values = []
         for i in range(2000):
             value = random_generator.randint(0, 1000)
+            while i == 0 and value == 0:
+                value = random_generator.randint(0, 1000)
             values.append(value)
             histogram.aggregate(Measurement(value, Mock()))
             if i % 20 == 0:

--- a/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
+++ b/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
@@ -1050,9 +1050,8 @@ class TestExponentialBucketHistogramAggregation(TestCase):
 
         values = []
         for i in range(2000):
-            value = random_generator.randint(0, 1000)
-            while i == 0 and value == 0:
-                value = random_generator.randint(0, 1000)
+            # avoid both values being 0
+            value = random_generator.randint(0 if i else 1, 1000)
             values.append(value)
             histogram.aggregate(Measurement(value, Mock()))
             if i % 20 == 0:


### PR DESCRIPTION
This is a PR to show the failure mentioned in #4138.

Adding this change to show how the test case fails with a particular seed value.