### PR TITLE
opentelemetry-api: allow importlib-metadata up to 8.4.0

### DIFF
--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "Deprecated >= 1.2.6",
     # FIXME This should be able to be removed after 3.12 is released if there is a reliable API
     # in importlib.metadata.
-    "importlib-metadata >= 6.0, <= 8.2.0",
+    "importlib-metadata >= 6.0, <= 8.4.0",
 ]
 dynamic = [
     "version",

--- a/opentelemetry-api/test-requirements.txt
+++ b/opentelemetry-api/test-requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.7.2
 Deprecated==1.2.14
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.5.0


### PR DESCRIPTION
# Description

Based on [this PR](https://github.com/open-telemetry/opentelemetry-python/pull/4141).

Adjust cap on importlib-metadata
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->


## Type of change

Please delete options that are not relevant.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

    tox -e py312-test-opentelemetry-api,py311-test-opentelemetry-api,py310-test-opentelemetry-api,py39-test-opentelemetry-api,py38-test-open
    telemetry-api

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
