### PR TITLE
opentelemetry-test-utils: don't crash in TestBase.get_sorted_metrics without metrics

### DIFF
--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
@@ -144,8 +144,9 @@ class TestBase(unittest.TestCase):
             logging.disable(logging.NOTSET)
 
     def get_sorted_metrics(self):
+        metrics_data = self.memory_metrics_reader.get_metrics_data()
         resource_metrics = (
-            self.memory_metrics_reader.get_metrics_data().resource_metrics
+            metrics_data.resource_metrics if metrics_data else []
         )
 
         all_metrics = []

--- a/tests/opentelemetry-test-utils/tests/test_base.py
+++ b/tests/opentelemetry-test-utils/tests/test_base.py
@@ -1,0 +1,21 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opentelemetry.test.test_base import TestBase
+
+
+class TestBaseTestCase(TestBase):
+    def test_get_sorted_metrics_works_without_metrics(self):
+        metrics = self.get_sorted_metrics()
+        self.assertEqual(metrics, [])


### PR DESCRIPTION
# Description

When calling the functions with no metrics recorded it will crash because `self.memory_metrics_reader.get_metrics_data()` is None

```
    def get_sorted_metrics(self):
        resource_metrics = (
>           self.memory_metrics_reader.get_metrics_data().resource_metrics
        )
E       AttributeError: 'NoneType' object has no attribute 'resource_metrics'
```


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
