### PR TITLE
ci: consider only pull request event when running public-symbols-check

### DIFF
--- a/.github/workflows/misc_0.yml
+++ b/.github/workflows/misc_0.yml
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !contains(github.event.pull_request.labels.*.name, 'Approve Public API check')
-      && github.actor != 'opentelemetrybot'
+      && github.actor != 'opentelemetrybot' && github.event_name == 'pull_request'
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Every public symbol is something that has to be kept in order to maintain backwa
 
 To check if your PR is adding public symbols, run `tox -e public-symbols-check`. This will always fail if public symbols are being added/removed. The idea
 behind this is that every PR that adds/removes public symbols fails in CI, forcing reviewers to check the symbols to make sure they are strictly necessary.
-If after checking them, it is considered that they are indeed necessary, the PR will be labeled with `Skip Public API check` so that this check is not
+If after checking them, it is considered that they are indeed necessary, the PR will be labeled with `Approve Public API check` so that this check is not
 run.
 
 Also, we try to keep our console output as clean as possible. Most of the time this means catching expected log messages in the test cases:

--- a/scripts/public_symbols_checker.py
+++ b/scripts/public_symbols_checker.py
@@ -139,7 +139,7 @@ if added_symbols or removed_symbols:
     print(
         "Please make sure that all of them are strictly necessary, if not, "
         "please consider prefixing them with an underscore to make them "
-        'private. After that, please label this PR with "Skip Public API '
+        'private. After that, please label this PR with "Approve Public API '
         'check".'
     )
     print()
@@ -154,7 +154,7 @@ if added_symbols or removed_symbols:
     print(
         "Please make sure no public symbols are removed, if so, please "
         "consider deprecating them instead. After that, please label this "
-        'PR with "Skip Public API check".'
+        'PR with "Approve Public API check".'
     )
     exit(1)
 else:


### PR DESCRIPTION
# Description

Not sure it's the right fix but intuitively we need to look for pull request event label only if the event is a pull request. As previously done for the changelog in 43d818e77b9c6af817a66c7304619e087d7e5d95 . While at it fix the label name in docs and scripts.

Refs #4185

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
