### PR TITLE
Use `LogRecord.getMessage` to get OTLP body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4224](https://github.com/open-telemetry/opentelemetry-python/pull/4224))
 - Drop `OTEL_PYTHON_EXPERIMENTAL_DISABLE_PROMETHEUS_UNIT_NORMALIZATION` environment variable
   ([#4217](https://github.com/open-telemetry/opentelemetry-python/pull/4217))
+- Improve compatibility with other logging libraries that override
+  `LogRecord.getMessage()` in order to customize message formatting
+  ([#4216](https://github.com/open-telemetry/opentelemetry-python/pull/4216))
 
 ## Version 1.27.0/0.48b0 (2024-08-28)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -438,6 +438,7 @@ _RESERVED_ATTRS = frozenset(
         "exc_text",
         "filename",
         "funcName",
+        "getMessage",
         "message",
         "levelname",
         "levelno",
@@ -545,7 +546,7 @@ class LoggingHandler(logging.Handler):
             body = self.format(record)
         else:
             if isinstance(record.msg, str) and record.args:
-                body = record.msg % record.args
+                body = record.getMessage()
             else:
                 body = record.msg
 


### PR DESCRIPTION
# Description

This improves compatibility with logging libraries that use `logging.setLogRecordFactory()` or patching to customize the message formatting of the created `LogRecord`s. It does this by using the processed `LogRecord`'s `getMessage()` method to get the body text instead of using `record.msg % record.args`.

Also adds `"getMessage"` to the list of reserved attributes so if the customization is done by patching the `getMessage` function on the `LogRecord` directly (instead of using a subclass), it's not accidentally treated as an attribute.

Related to: #3343

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've tested this change using the [`bracelogger`](https://github.com/pR0Ps/bracelogger) library, which implements custom formatting by patching `getMessage()`. I made sure that logs produced from both `bracelogger` and the stdlib produced correct OTLP logs.

To verify:
`myapp.py`
```python
from logging import getLogger
from bracelogger import get_logger  # pip install bracelogger

l = getLogger("normal")
l.error("Normal formatting: %s", "works")

bl = get_logger("custom")
bl.error("Custom formatting: {}", "works")
```
```bash
OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true opentelemetry-instrument --logs_exporter console python myapp.py
```
Produces:
```
{
    "body": "Normal formatting: works",
    "severity_number": "<SeverityNumber.ERROR: 17>",
    "severity_text": "ERROR",
    "attributes": {
        "otelSpanID": "0",
        "otelTraceID": "0",
        "otelTraceSampled": false,
        "otelServiceName": "unknown_service",
        "code.filepath": "code.filepath": "[REDACTED]/myapp.py",
        "code.function": "<module>",
        "code.lineno": 5
    },
    "dropped_attributes": 0,
    "timestamp": "2024-10-09T14:36:24.216596Z",
    "observed_timestamp": "2024-10-09T14:36:24.216714Z",
    "trace_id": "0x00000000000000000000000000000000",
    "span_id": "0x0000000000000000",
    "trace_flags": 0,
    "resource": {
        "attributes": {
            "telemetry.sdk.language": "python",
            "telemetry.sdk.name": "opentelemetry",
            "telemetry.sdk.version": "1.27.0",
            "telemetry.auto.version": "0.48b0",
            "service.name": "unknown_service"
        },
        "schema_url": ""
    }
}
{
    "body": "Custom formatting: works",
    "severity_number": "<SeverityNumber.ERROR: 17>",
    "severity_text": "ERROR",
    "attributes": {
        "otelSpanID": "0",
        "otelTraceID": "0",
        "otelTraceSampled": false,
        "otelServiceName": "unknown_service",
        "code.filepath": "[REDACTED]/myapp.py",
        "code.function": "<module>",
        "code.lineno": 8
    },
    "dropped_attributes": 0,
    "timestamp": "2024-10-09T14:36:24.216813Z",
    "observed_timestamp": "2024-10-09T14:36:24.216838Z",
    "trace_id": "0x00000000000000000000000000000000",
    "span_id": "0x0000000000000000",
    "trace_flags": 0,
    "resource": {
        "attributes": {
            "telemetry.sdk.language": "python",
            "telemetry.sdk.name": "opentelemetry",
            "telemetry.sdk.version": "1.27.0",
            "telemetry.auto.version": "0.48b0",
            "service.name": "unknown_service"
        },
        "schema_url": ""
    }
}
```

Previously the same command would cause the error:
```
Traceback (most recent call last):
  File "[REDACTED]/myapp.py", line 8, in <module>
    bl.error("Custom formatting: {}", "works")
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1568, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "[REDACTED]/bracelogger.py", line 42, in handle
    return fcn(record)
           ^^^^^^^^^^^
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "[REDACTED]/opentelemetry/sdk/_logs/_internal/__init__.py", line 578, in emit
    self._logger.emit(self._translate(record))
                      ^^^^^^^^^^^^^^^^^^^^^^^
  File "[REDACTED]/opentelemetry/sdk/_logs/_internal/__init__.py", line 548, in _translate
    body = record.msg % record.args
           ~~~~~~~~~~~^~~~~~~~~~~~~
TypeError: not all arguments converted during string formatting
```

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
