### PR TITLE
Update environment variable descriptions to match signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4176](https://github.com/open-telemetry/opentelemetry-python/pull/4176))
 - Update semantic conventions to version 1.28.0
   ([#4218](https://github.com/open-telemetry/opentelemetry-python/pull/4218))
+- Update environment variable descriptions to match signal
+  ([#4222](https://github.com/open-telemetry/opentelemetry-python/pull/4222))
 
 ## Version 1.27.0/0.48b0 (2024-08-28)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
@@ -561,7 +561,7 @@ OTEL_EXPORTER_OTLP_LOGS_INSECURE = "OTEL_EXPORTER_OTLP_LOGS_INSECURE"
 .. envvar:: OTEL_EXPORTER_OTLP_LOGS_INSECURE
 
 The :envvar:`OTEL_EXPORTER_OTLP_LOGS_INSECURE` represents whether to enable client transport security
-for gRPC requests for metrics. A scheme of https takes precedence over the this configuration setting.
+for gRPC requests for logs. A scheme of https takes precedence over the this configuration setting.
 Default: False
 """
 
@@ -581,7 +581,7 @@ OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE = (
 .. envvar:: OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE
 
 The :envvar:`OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE` stores the path to the certificate file for
-TLS credentials of gRPC client for traces. Should only be used for a secure connection for tracing.
+TLS credentials of gRPC client for metrics. Should only be used for a secure connection for metrics.
 """
 
 OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE = "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE"
@@ -589,7 +589,7 @@ OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE = "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE"
 .. envvar:: OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE
 
 The :envvar:`OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE` stores the path to the certificate file for
-TLS credentials of gRPC client for traces. Should only be used for a secure connection for tracing.
+TLS credentials of gRPC client for logs. Should only be used for a secure connection for logs.
 """
 
 OTEL_EXPORTER_OTLP_METRICS_HEADERS = "OTEL_EXPORTER_OTLP_METRICS_HEADERS"

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
@@ -270,7 +270,7 @@ OTEL_EXPORTER_OTLP_PROTOCOL = "OTEL_EXPORTER_OTLP_PROTOCOL"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_PROTOCOL
 
-The :envvar:`OTEL_EXPORTER_OTLP_PROTOCOL` represents the the transport protocol for the
+The :envvar:`OTEL_EXPORTER_OTLP_PROTOCOL` represents the transport protocol for the
 OTLP exporter.
 """
 
@@ -278,21 +278,21 @@ OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
 
-The :envvar:`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` represents the the transport protocol for spans.
+The :envvar:`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` represents the transport protocol for spans.
 """
 
 OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
 
-The :envvar:`OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` represents the the transport protocol for metrics.
+The :envvar:`OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` represents the transport protocol for metrics.
 """
 
 OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_LOGS_PROTOCOL
 
-The :envvar:`OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` represents the the transport protocol for logs.
+The :envvar:`OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` represents the transport protocol for logs.
 """
 
 OTEL_EXPORTER_OTLP_CERTIFICATE = "OTEL_EXPORTER_OTLP_CERTIFICATE"


### PR DESCRIPTION
# Description

Hi Python! 👋  I'm normally in Rubyland, but today I'm investigating OpenTelemetry implementations across different languages to learn more about how they manage configuration. While I was reading `opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py`, I realized some of the documentation might reference the wrong signals. It seems like they were minor copy/paste oversights.

## Type of change

- [X] This change requires a documentation update

# How Has This Been Tested?

Since this is a documentation update, I haven't attempted to test the changes. Happy to find a way to do so if this is required.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added _(I don't think they're necessary for this change?)_
- [x] Documentation has been updated
