### PR TITLE
Adding `ruff` rule `A`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ sys.path[:0] = source_dirs + exp_dirs + shim_dirs
 # -- Project information -----------------------------------------------------
 
 project = "OpenTelemetry Python"
-copyright = "OpenTelemetry Authors"  # pylint: disable=redefined-builtin
+docs_copyright = "OpenTelemetry Authors"  # pylint: disable=redefined-builtin
 author = "OpenTelemetry Authors"
 
 

--- a/opentelemetry-api/src/opentelemetry/baggage/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/baggage/__init__.py
@@ -121,8 +121,8 @@ def _is_valid_value(value: object) -> bool:
     parts = str(value).split(";")
     is_valid_value = _VALUE_PATTERN.fullmatch(parts[0]) is not None
     if len(parts) > 1:  # one or more properties metadata
-        for property in parts[1:]:
-            if _PROPERT_PATTERN.fullmatch(property) is None:
+        for properties in parts[1:]:
+            if _PROPERT_PATTERN.fullmatch(properties) is None:
                 is_valid_value = False
                 break
     return is_valid_value

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "opentelemetry-python",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ select = [
   "PLC", # pylint convention
   "PLE", # pylint error
   "Q",   # flake8-quotes
+  "A",   # flake8-builtins
 ]
 
 ignore = [

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
@@ -684,7 +684,7 @@ class TracerShim(Tracer):
         context = SpanContextShim(span.get_span_context())
         return SpanShim(self, context, span)
 
-    def inject(self, span_context, format: object, carrier: object):
+    def inject(self, span_context, formats: object, carrier: object):
         """Injects ``span_context`` into ``carrier``.
 
         See base class for more details.
@@ -703,7 +703,7 @@ class TracerShim(Tracer):
         # TODO: Support Format.BINARY once it is supported in
         # opentelemetry-python.
 
-        if format not in self._supported_formats:
+        if formats not in self._supported_formats:
             raise UnsupportedFormatException
 
         propagator = get_global_textmap()
@@ -715,7 +715,7 @@ class TracerShim(Tracer):
         ctx = set_span_in_context(span)
         propagator.inject(carrier, context=ctx)
 
-    def extract(self, format: object, carrier: object):
+    def extract(self, formats: object, carrier: object):
         """Returns an ``opentracing.SpanContext`` instance extracted from a
         ``carrier``.
 
@@ -737,7 +737,7 @@ class TracerShim(Tracer):
         # uses the configured propagators in opentelemetry.propagators.
         # TODO: Support Format.BINARY once it is supported in
         # opentelemetry-python.
-        if format not in self._supported_formats:
+        if formats not in self._supported_formats:
             raise UnsupportedFormatException
 
         propagator = get_global_textmap()


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes # 4227

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [x] ruff check .  (This test lints all discovered Python files. Adding rule `A` affects variable, argument, import, module names.)

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [x] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
