### PR TITLE
Fixes #4143 Added "none" value for OTEL_PROPAGATORS

### DIFF
--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -130,28 +130,31 @@ environ_propagators = environ.get(
 )
 
 
-for propagator in environ_propagators.split(","):
-    propagator = propagator.strip()
+if environ_propagators.lower() == "none":
+    propagators = []
+else:
+    for propagator in environ_propagators.split(","):
+        propagator = propagator.strip()
 
-    try:
+        try:
 
-        propagators.append(  # type: ignore
-            next(  # type: ignore
-                iter(  # type: ignore
-                    entry_points(  # type: ignore
-                        group="opentelemetry_propagator",
-                        name=propagator,
+            propagators.append(  # type: ignore
+                next(  # type: ignore
+                    iter(  # type: ignore
+                        entry_points(  # type: ignore
+                            group="opentelemetry_propagator",
+                            name=propagator,
+                        )
                     )
-                )
-            ).load()()
-        )
-    except StopIteration:
-        raise ValueError(
-            f"Propagator {propagator} not found. It is either misspelled or not installed."
-        )
-    except Exception:  # pylint: disable=broad-exception-caught
-        logger.exception("Failed to load propagator: %s", propagator)
-        raise
+                ).load()()
+            )
+        except StopIteration:
+            raise ValueError(
+                f"Propagator {propagator} not found. It is either misspelled or not installed."
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("Failed to load propagator: %s", propagator)
+            raise
 
 
 _HTTP_TEXT_FORMAT = composite.CompositePropagator(propagators)  # type: ignore

--- a/opentelemetry-api/tests/propagators/test_propagators.py
+++ b/opentelemetry-api/tests/propagators/test_propagators.py
@@ -50,6 +50,24 @@ class TestPropagators(TestCase):
 
         reload(opentelemetry.propagate)
 
+    @patch.dict(environ, {OTEL_PROPAGATORS: "none"})
+    @patch("opentelemetry.propagators.composite.CompositePropagator")
+    def test_no_propagators_loaded(self, mock_compositehttppropagator):
+        def test_propagators(propagators):
+            self.assertEqual(
+                propagators, []
+            )  # Expecting an empty list of propagators
+
+        mock_compositehttppropagator.configure_mock(
+            **{"side_effect": test_propagators}
+        )
+
+        from importlib import reload
+
+        import opentelemetry.propagate
+
+        reload(opentelemetry.propagate)
+
     @patch.dict(environ, {OTEL_PROPAGATORS: "a,  b,   c  "})
     @patch("opentelemetry.propagators.composite.CompositePropagator")
     @patch("opentelemetry.util._importlib_metadata.entry_points")


### PR DESCRIPTION
Fixes #4143 OTEL_PROPAGATORS does not support "none" value  #4143

# Description

This PR introduces changes to the test suite to verify the behavior of the OTEL_PROPAGATORS environment variable when set to "none". The following updates were made:

1. **Added a new test case:**

Verifies that when OTEL_PROPAGATORS="none", no propagators are loaded, and the list of propagators is empty.

2. **Modified test setup:**

Reloaded the opentelemetry.propagate module in the new test to apply the environment variable settings and trigger the correct propagator configuration.
These changes ensure that:

When `OTEL_PROPAGATORS="none"`, propagators are an empty list.
Default propagators (tracecontext, baggage) are not loaded when` OTEL_PROPAGATORS `is set to `"none"`.
The existing tests for default and non-default propagators remain intact.





## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

tox test keeps on running forever. I'm wondering if there are instructions for specific tests?

Successfully ran:
```
.tox\lint\Scripts\black . 
.tox\lint\Scripts\isort . 
```


# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [x] Yes. - Link to PR: Will open a PR once the code changes are approved. 
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
