### PR TITLE
bump Werkzeug to 3.0.6 in test-requirements

### DIFF
--- a/docs/examples/fork-process-model/flask-gunicorn/requirements.txt
+++ b/docs/examples/fork-process-model/flask-gunicorn/requirements.txt
@@ -16,5 +16,5 @@ protobuf==3.20.3
 six==1.15.0
 thrift==0.13.0
 uWSGI==2.0.22
-Werkzeug==3.0.3
+Werkzeug==3.0.6
 wrapt==1.16.0

--- a/docs/examples/fork-process-model/flask-uwsgi/requirements.txt
+++ b/docs/examples/fork-process-model/flask-uwsgi/requirements.txt
@@ -16,5 +16,5 @@ protobuf==3.20.3
 six==1.15.0
 thrift==0.13.0
 uWSGI==2.0.22
-Werkzeug==3.0.3
+Werkzeug==3.0.6
 wrapt==1.16.0

--- a/docs/getting_started/tests/requirements.txt
+++ b/docs/getting_started/tests/requirements.txt
@@ -19,7 +19,7 @@ requests==2.32.3
 tomli==2.0.1
 typing_extensions==4.8.0
 urllib3==1.26.19
-Werkzeug==3.0.3
+Werkzeug==3.0.6
 wrapt==1.15.0
 zipp==3.19.2
 -e opentelemetry-semantic-conventions


### PR DESCRIPTION
# Description
To fix all remaining dependabot alerts in this project so we can have 0 alerts for a while. 