### PR TITLE
Don't request current context when creating a measurement

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exemplar/exemplar_filter.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exemplar/exemplar_filter.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Union
+from typing import Optional, Union
 
 from opentelemetry import trace
 from opentelemetry.context import Context
@@ -38,7 +38,7 @@ class ExemplarFilter(ABC):
         value: Union[int, float],
         time_unix_nano: int,
         attributes: Attributes,
-        context: Context,
+        context: Optional[Context],
     ) -> bool:
         """Returns whether or not a reservoir should attempt to filter a measurement.
 
@@ -65,7 +65,7 @@ class AlwaysOnExemplarFilter(ExemplarFilter):
         value: Union[int, float],
         time_unix_nano: int,
         attributes: Attributes,
-        context: Context,
+        context: Optional[Context],
     ) -> bool:
         """Returns whether or not a reservoir should attempt to filter a measurement.
 
@@ -92,7 +92,7 @@ class AlwaysOffExemplarFilter(ExemplarFilter):
         value: Union[int, float],
         time_unix_nano: int,
         attributes: Attributes,
-        context: Context,
+        context: Optional[Context],
     ) -> bool:
         """Returns whether or not a reservoir should attempt to filter a measurement.
 
@@ -118,7 +118,7 @@ class TraceBasedExemplarFilter(ExemplarFilter):
         value: Union[int, float],
         time_unix_nano: int,
         attributes: Attributes,
-        context: Context,
+        context: Optional[Context],
     ) -> bool:
         """Returns whether or not a reservoir should attempt to filter a measurement.
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py
@@ -20,7 +20,7 @@ from typing import Dict, Generator, Iterable, List, Optional, Union
 
 # This kind of import is needed to avoid Sphinx errors.
 import opentelemetry.sdk.metrics
-from opentelemetry.context import Context, get_current
+from opentelemetry.context import Context
 from opentelemetry.metrics import CallbackT
 from opentelemetry.metrics import Counter as APICounter
 from opentelemetry.metrics import Histogram as APIHistogram
@@ -138,7 +138,7 @@ class _Asynchronous:
                         api_measurement.value,
                         time_unix_nano=time_ns(),
                         instrument=self,
-                        context=api_measurement.context or get_current(),
+                        context=api_measurement.context,
                         attributes=api_measurement.attributes,
                     )
             except Exception:  # pylint: disable=broad-exception-caught
@@ -170,7 +170,7 @@ class Counter(_Synchronous, APICounter):
                 amount,
                 time_unix_nano,
                 self,
-                context or get_current(),
+                context,
                 attributes,
             )
         )
@@ -194,7 +194,7 @@ class UpDownCounter(_Synchronous, APIUpDownCounter):
                 amount,
                 time_unix_nano,
                 self,
-                context or get_current(),
+                context,
                 attributes,
             )
         )
@@ -242,7 +242,7 @@ class Histogram(_Synchronous, APIHistogram):
                 amount,
                 time_unix_nano,
                 self,
-                context or get_current(),
+                context,
                 attributes,
             )
         )
@@ -266,7 +266,7 @@ class Gauge(_Synchronous, APIGauge):
                 amount,
                 time_unix_nano,
                 self,
-                context or get_current(),
+                context,
                 attributes,
             )
         )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Union
+from typing import Optional, Union
 
 from opentelemetry.context import Context
 from opentelemetry.metrics import Instrument
@@ -41,5 +41,5 @@ class Measurement:
     value: Union[int, float]
     time_unix_nano: int
     instrument: Instrument
-    context: Context
+    context: Optional[Context] = None
     attributes: Attributes = None


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #4243

Make `Measurement.context` optional and stop requesting the current context when creating a measurement

## Type of change

Improve code performance following degradation with #4094

# How Has This Been Tested?

I run locally the benchmarks to check the improvement.
I also tried the metrics benchmark with exemplar deactivate (aka setting exemplar filter to always off); it also show slight performance boost

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- Unit tests have been added
- Documentation has been updated
