### PR TITLE
Fix stable READTHEDOCS build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,13 +2,13 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 version: 2
 
-sphinx:
-  configuration: docs/conf.py
-
 build:
   os: "ubuntu-22.04"
   tools:
     python: "3.8"
+  
+sphinx:
+  configuration: docs/conf.py
 
 python:
   install:


### PR DESCRIPTION
Readthedocs build was [failing](https://app.readthedocs.org/projects/opentelemetry-python/builds/26209734/) prior to [changing readthedocs.yml](https://github.com/open-telemetry/opentelemetry-python/blob/stable/.readthedocs.yml) manually on `stable` tag in which docs build is [passing after](https://app.readthedocs.org/projects/opentelemetry-python/builds/26209867/. This pr is applying the same change to main.