### PR TITLE
opentelemetry-sdk: avoid recursion error with sdk disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix metrics export with exemplar and no context and filtering observable instruments
   ([#4251](https://github.com/open-telemetry/opentelemetry-python/pull/4251))
+- Fix recursion error with sdk disabled and handler added to root logger
+  ([#4259](https://github.com/open-telemetry/opentelemetry-python/pull/4259))
 
 ## Version 1.28.0/0.49b0 (2024-11-05)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -692,7 +692,7 @@ class LoggerProvider(APILoggerProvider):
         attributes: Optional[Attributes] = None,
     ) -> Logger:
         if self._disabled:
-            _logger.warning("SDK is disabled.")
+            warnings.warn("SDK is disabled.")
             return NoOpLogger(
                 name,
                 version=version,

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -15,6 +15,7 @@
 # pylint: disable=protected-access
 
 import unittest
+import warnings
 from unittest.mock import Mock, patch
 
 from opentelemetry.sdk._logs import LoggerProvider
@@ -69,8 +70,12 @@ class TestLoggerProvider(unittest.TestCase):
 
     @patch.dict("os.environ", {OTEL_SDK_DISABLED: "true"})
     def test_get_logger_with_sdk_disabled(self):
-        logger = LoggerProvider().get_logger(Mock())
+        with warnings.catch_warnings(record=True) as cw:
+            logger = LoggerProvider().get_logger(Mock())
+
         self.assertIsInstance(logger, NoOpLogger)
+        self.assertEqual(len(cw), 1)
+        self.assertEqual("SDK is disabled.", str(cw[0].message))
 
     @patch.object(Resource, "create")
     def test_logger_provider_init(self, resource_patch):


### PR DESCRIPTION
# Description

If the sdk is disable and our handler is added to the root logger we will recurse in order to log that SDK is disabled. Use the warnings facilities to print the message instead.
Fixes #4255

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py310-test-opentelemetry-sdk

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
