### PR TITLE
opentelemetry-sdk: setup EventLogger when initializing logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4251](https://github.com/open-telemetry/opentelemetry-python/pull/4251))
 - Fix recursion error with sdk disabled and handler added to root logger
   ([#4259](https://github.com/open-telemetry/opentelemetry-python/pull/4259))
+- sdk: setup EventLogger when OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED is set
+  ([#4270](https://github.com/open-telemetry/opentelemetry-python/pull/4270))
 
 ## Version 1.28.0/0.49b0 (2024-11-05)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -25,6 +25,7 @@ from typing import Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 from typing_extensions import Literal
 
+from opentelemetry._events import set_event_logger_provider
 from opentelemetry._logs import set_logger_provider
 from opentelemetry.environment_variables import (
     OTEL_LOGS_EXPORTER,
@@ -33,6 +34,7 @@ from opentelemetry.environment_variables import (
     OTEL_TRACES_EXPORTER,
 )
 from opentelemetry.metrics import set_meter_provider
+from opentelemetry.sdk._events import EventLoggerProvider
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, LogExporter
 from opentelemetry.sdk.environment_variables import (
@@ -247,6 +249,9 @@ def _init_logging(
     handler = LoggingHandler(level=logging.NOTSET, logger_provider=provider)
 
     logging.getLogger().addHandler(handler)
+
+    event_logger_provider = EventLoggerProvider(logger_provider=provider)
+    set_event_logger_provider(event_logger_provider)
 
 
 def _import_exporters(

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -586,14 +586,32 @@ class TestLoggingInit(TestCase):
             "opentelemetry.sdk._configuration.set_logger_provider"
         )
 
+        self.event_logger_provider_instance_mock = Mock()
+        self.event_logger_provider_patch = patch(
+            "opentelemetry.sdk._configuration.EventLoggerProvider",
+            return_value=self.event_logger_provider_instance_mock,
+        )
+        self.set_event_logger_provider_patch = patch(
+            "opentelemetry.sdk._configuration.set_event_logger_provider"
+        )
+
         self.processor_mock = self.processor_patch.start()
         self.provider_mock = self.provider_patch.start()
         self.set_provider_mock = self.set_provider_patch.start()
+
+        self.event_logger_provider_mock = (
+            self.event_logger_provider_patch.start()
+        )
+        self.set_event_logger_provider_mock = (
+            self.set_event_logger_provider_patch.start()
+        )
 
     def tearDown(self):
         self.processor_patch.stop()
         self.set_provider_patch.stop()
         self.provider_patch.stop()
+        self.event_logger_provider_patch.stop()
+        self.set_event_logger_provider_patch.stop()
         root_logger = getLogger("root")
         root_logger.handlers = [
             handler
@@ -615,6 +633,12 @@ class TestLoggingInit(TestCase):
         self.assertEqual(
             provider.resource.attributes.get("telemetry.auto.version"),
             "auto-version",
+        )
+        self.event_logger_provider_mock.assert_called_once_with(
+            logger_provider=provider
+        )
+        self.set_event_logger_provider_mock.assert_called_once_with(
+            self.event_logger_provider_instance_mock
         )
 
     @patch.dict(


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Setup the EventLogger when OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED is set so that log events works out of the box with autoinstrumentation.

Fixes #4269

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py310-test-opentelemetry-sdk

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
