### PR TITLE
[release/v1.28.x-0.49bx] Support logs with no body (#4276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version 1.28.1/0.49b1 (2024-11-08)
+## Unreleased
 
 - Fix crash exporting a log record with None body
   ([#4276](https://github.com/open-telemetry/opentelemetry-python/pull/4276))
+
+## Version 1.28.1/0.49b1 (2024-11-08)
+
 - Fix metrics export with exemplar and no context and filtering observable instruments
   ([#4251](https://github.com/open-telemetry/opentelemetry-python/pull/4251))
 - Fix recursion error with sdk disabled and handler added to root logger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version 1.28.1/0.49b1 (2024-11-08)
 
+- Fix crash exporting a log record with None body
+  ([#4276](https://github.com/open-telemetry/opentelemetry-python/pull/4276))
 - Fix metrics export with exemplar and no context and filtering observable instruments
   ([#4251](https://github.com/open-telemetry/opentelemetry-python/pull/4251))
 - Fix recursion error with sdk disabled and handler added to root logger

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
@@ -48,13 +48,14 @@ def _encode_log(log_data: LogData) -> PB2LogRecord:
         if log_data.log_record.trace_id == 0
         else _encode_trace_id(log_data.log_record.trace_id)
     )
+    body = log_data.log_record.body
     return PB2LogRecord(
         time_unix_nano=log_data.log_record.timestamp,
         observed_time_unix_nano=log_data.log_record.observed_timestamp,
         span_id=span_id,
         trace_id=trace_id,
         flags=int(log_data.log_record.trace_flags),
-        body=_encode_value(log_data.log_record.body),
+        body=_encode_value(body) if body is not None else None,
         severity_text=log_data.log_record.severity_text,
         attributes=_encode_attributes(log_data.log_record.attributes),
         dropped_attributes_count=log_data.log_record.dropped_attributes,

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
@@ -51,6 +51,18 @@ class TestOTLPLogEncoder(unittest.TestCase):
         sdk_logs, expected_encoding = self.get_test_logs()
         self.assertEqual(encode_logs(sdk_logs), expected_encoding)
 
+    def test_encode_no_body(self):
+        sdk_logs, expected_encoding = self.get_test_logs()
+        for log in sdk_logs:
+            log.log_record.body = None
+
+        for resource_log in expected_encoding.resource_logs:
+            for scope_log in resource_log.scope_logs:
+                for log_record in scope_log.log_records:
+                    log_record.ClearField("body")
+
+        self.assertEqual(encode_logs(sdk_logs), expected_encoding)
+
     def test_dropped_attributes_count(self):
         sdk_logs = self._get_test_logs_dropped_attributes()
         encoded_logs = encode_logs(sdk_logs)


### PR DESCRIPTION
Clean cherry-pick of https://github.com/open-telemetry/opentelemetry-python/pull/4276 to the [release/v1.28.x-0.49bx](https://github.com/open-telemetry/opentelemetry-python/tree/release/v1.28.x-0.49bx) branch.

Part of https://github.com/open-telemetry/opentelemetry-python/issues/4281