### PR TITLE
Fix prepare patch release workflow

### DIFF
--- a/.github/scripts/update-version-patch.sh
+++ b/.github/scripts/update-version-patch.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+sed -i "/\[stable\]/{n;s/version=.*/version=$1/}" eachdist.ini
+sed -i "/\[prerelease\]/{n;s/version=.*/version=$2/}" eachdist.ini
+
+./scripts/eachdist.py update_patch_versions --versions $1,$2,$3,$4

--- a/.github/scripts/update-version-patch.sh
+++ b/.github/scripts/update-version-patch.sh
@@ -3,4 +3,9 @@
 sed -i "/\[stable\]/{n;s/version=.*/version=$1/}" eachdist.ini
 sed -i "/\[prerelease\]/{n;s/version=.*/version=$2/}" eachdist.ini
 
-./scripts/eachdist.py update_patch_versions --versions $1,$2,$3,$4
+./scripts/eachdist.py update_patch_versions \
+    --stable_version=$1 \
+    --unstable_version=$2 \
+    --stable_version_prev=$3 \
+    --unstable_version_prev=$4
+

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -43,14 +43,18 @@ jobs:
             exit 1
           fi
 
+          stable_version_prev="$stable_major_minor.$((stable_patch))"
+          unstable_version_prev="0.${unstable_minor}b$((unstable_patch))"
           stable_version="$stable_major_minor.$((stable_patch + 1))"
           unstable_version="0.${unstable_minor}b$((unstable_patch + 1))"
 
           echo "STABLE_VERSION=$stable_version" >> $GITHUB_ENV
           echo "UNSTABLE_VERSION=$unstable_version" >> $GITHUB_ENV
+          echo "STABLE_VERSION_PREV=$stable_version_prev" >> $GITHUB_ENV
+          echo "UNSTABLE_VERSION_PREV=$unstable_version_prev" >> $GITHUB_ENV
 
       - name: Update version
-        run: .github/scripts/update-version.sh $STABLE_VERSION $UNSTABLE_VERSION
+        run: .github/scripts/update-version-patch.sh $STABLE_VERSION $UNSTABLE_VERSION $STABLE_VERSION_PREV $UNSTABLE_VERSION_PREV
 
       - name: Update the change log with the approximate release date
         run: |

--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -241,7 +241,11 @@ def parse_args(args=None):
         help="Updates version numbers during patch release, used by maintainers and CI",
     )
     patchreleaseparser.set_defaults(func=patch_release_args)
-    patchreleaseparser.add_argument("--versions", required=True)
+    patchreleaseparser.add_argument("--stable_version", required=True)
+    patchreleaseparser.add_argument("--unstable_version", required=True)
+    patchreleaseparser.add_argument("--stable_version_prev", required=True)
+    patchreleaseparser.add_argument("--unstable_version_prev", required=True)
+
 
     fmtparser = subparsers.add_parser(
         "format",

--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -240,8 +240,8 @@ def parse_args(args=None):
         "update_patch_versions",
         help="Updates version numbers during patch release, used by maintainers and CI",
     )
-    releaseparser.set_defaults(func=release_args)
-    releaseparser.add_argument("--versions", required=True)
+    patchreleaseparser.set_defaults(func=patch_release_args)
+    patchreleaseparser.add_argument("--versions", required=True)
 
     fmtparser = subparsers.add_parser(
         "format",
@@ -614,7 +614,6 @@ def update_patch_dependencies(targets, version, prev_version, packages):
 
     for pkg in packages:
         search = rf"({basename(pkg)}[^,]*)(\s?({operators_pattern})\s?)(.*{prev_version})"
-        print(search)
         replace = r"\1\2 " + version
         update_files(
             targets,
@@ -672,18 +671,20 @@ def patch_release_args(args):
     targets = list(find_targets_unordered(rootpath))
     cfg = ConfigParser()
     cfg.read(str(find_projectroot() / "eachdist.ini"))
-    versions = args.versions
+    versions = args.versions.split(",")
     # stable
     mcfg = cfg["stable"]
     packages = mcfg["packages"].split()
     print(f"update stable packages to {versions[0]}")
     update_patch_dependencies(targets, versions[0], versions[2], packages)
+    update_version_files(targets, versions[0], packages)
 
     # prerelease
     mcfg = cfg["prerelease"]
     packages = mcfg["packages"].split()
     print(f"update prerelease packages to {versions[1]}")
     update_patch_dependencies(targets, versions[1], versions[3], packages)
+    update_version_files(targets, versions[1], packages)
 
 
 def test_args(args):

--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -246,7 +246,6 @@ def parse_args(args=None):
     patchreleaseparser.add_argument("--stable_version_prev", required=True)
     patchreleaseparser.add_argument("--unstable_version_prev", required=True)
 
-
     fmtparser = subparsers.add_parser(
         "format",
         help="Formats all source code with black and isort.",
@@ -675,20 +674,23 @@ def patch_release_args(args):
     targets = list(find_targets_unordered(rootpath))
     cfg = ConfigParser()
     cfg.read(str(find_projectroot() / "eachdist.ini"))
-    versions = args.versions.split(",")
     # stable
     mcfg = cfg["stable"]
     packages = mcfg["packages"].split()
-    print(f"update stable packages to {versions[0]}")
-    update_patch_dependencies(targets, versions[0], versions[2], packages)
-    update_version_files(targets, versions[0], packages)
+    print(f"update stable packages to {args.stable_version}")
+    update_patch_dependencies(
+        targets, args.stable_version, args.stable_version_prev, packages
+    )
+    update_version_files(targets, args.stable_version, packages)
 
     # prerelease
     mcfg = cfg["prerelease"]
     packages = mcfg["packages"].split()
-    print(f"update prerelease packages to {versions[1]}")
-    update_patch_dependencies(targets, versions[1], versions[3], packages)
-    update_version_files(targets, versions[1], packages)
+    print(f"update prerelease packages to {args.unstable_version}")
+    update_patch_dependencies(
+        targets, args.unstable_version, args.unstable_version_prev, packages
+    )
+    update_version_files(targets, args.unstable_version, packages)
 
 
 def test_args(args):


### PR DESCRIPTION
Update `prepare-patch-release.yml` workflow to correct find and update previous versions to current patch versions.