### PR TITLE
Fix typo: `pustil` -> `psutil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4270](https://github.com/open-telemetry/opentelemetry-python/pull/4270))
 - api: fix logging of duplicate EventLogger setup warning
   ([#4299](https://github.com/open-telemetry/opentelemetry-python/pull/4299))
+- sdk: fix setting of process owner in ProcessResourceDetector
+  ([#4311](https://github.com/open-telemetry/opentelemetry-python/pull/4311))
 
 ## Version 1.28.0/0.49b0 (2024-11-05)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -84,7 +84,7 @@ psutil: Optional[ModuleType] = None
 try:
     import psutil as psutil_module
 
-    pustil = psutil_module
+    psutil = psutil_module
 except ImportError:
     pass
 

--- a/opentelemetry-sdk/test-requirements.txt
+++ b/opentelemetry-sdk/test-requirements.txt
@@ -5,7 +5,7 @@ importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.5.0
-psutil==5.9.6
+psutil==5.9.6; sys_platform == 'win32'
 py-cpuinfo==9.0.0
 pytest==7.4.4
 tomli==2.0.1

--- a/opentelemetry-sdk/test-requirements.txt
+++ b/opentelemetry-sdk/test-requirements.txt
@@ -5,7 +5,7 @@ importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.5.0
-psutil==5.9.6; sys_platform == 'win32'
+psutil==5.9.6; sys_platform != 'win32'
 py-cpuinfo==9.0.0
 pytest==7.4.4
 tomli==2.0.1

--- a/opentelemetry-sdk/test-requirements.txt
+++ b/opentelemetry-sdk/test-requirements.txt
@@ -5,6 +5,7 @@ importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.5.0
+psutil==5.9.6
 py-cpuinfo==9.0.0
 pytest==7.4.4
 tomli==2.0.1


### PR DESCRIPTION
# Description

Fixes a typo in `opentelemetry.sdk.resources` which makes user detection not functioning.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
