### PR TITLE
opentelemetry-sdk: serialize logs severity_number as int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4270](https://github.com/open-telemetry/opentelemetry-python/pull/4270))
 - api: fix logging of duplicate EventLogger setup warning
   ([#4299](https://github.com/open-telemetry/opentelemetry-python/pull/4299))
+- sdk: fix serialization of logs severity_number field to int
+  ([#4324](https://github.com/open-telemetry/opentelemetry-python/pull/4324))
 
 ## Version 1.28.0/0.49b0 (2024-11-05)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -221,7 +221,9 @@ class LogRecord(APILogRecord):
         return json.dumps(
             {
                 "body": self.body,
-                "severity_number": repr(self.severity_number),
+                "severity_number": self.severity_number.value
+                if self.severity_number is not None
+                else None,
                 "severity_text": self.severity_text,
                 "attributes": (
                     dict(self.attributes) if bool(self.attributes) else None

--- a/opentelemetry-sdk/tests/logs/test_log_record.py
+++ b/opentelemetry-sdk/tests/logs/test_log_record.py
@@ -16,6 +16,7 @@ import json
 import unittest
 import warnings
 
+from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk._logs import (
     LogDroppedAttributesWarning,
@@ -30,7 +31,7 @@ class TestLogRecord(unittest.TestCase):
         expected = json.dumps(
             {
                 "body": "a log line",
-                "severity_number": "None",
+                "severity_number": None,
                 "severity_text": None,
                 "attributes": None,
                 "dropped_attributes": 0,
@@ -56,8 +57,20 @@ class TestLogRecord(unittest.TestCase):
         self.assertEqual(expected, actual.to_json(indent=4))
         self.assertEqual(
             actual.to_json(indent=None),
-            '{"body": "a log line", "severity_number": "None", "severity_text": null, "attributes": null, "dropped_attributes": 0, "timestamp": "1970-01-01T00:00:00.000000Z", "observed_timestamp": "1970-01-01T00:00:00.000000Z", "trace_id": "", "span_id": "", "trace_flags": null, "resource": {"attributes": {"service.name": "foo"}, "schema_url": ""}}',
+            '{"body": "a log line", "severity_number": null, "severity_text": null, "attributes": null, "dropped_attributes": 0, "timestamp": "1970-01-01T00:00:00.000000Z", "observed_timestamp": "1970-01-01T00:00:00.000000Z", "trace_id": "", "span_id": "", "trace_flags": null, "resource": {"attributes": {"service.name": "foo"}, "schema_url": ""}}',
         )
+
+    def test_log_record_to_json_serializes_severity_number_as_int(self):
+        actual = LogRecord(
+            timestamp=0,
+            severity_number=SeverityNumber.WARN,
+            observed_timestamp=0,
+            body="a log line",
+            resource=Resource({"service.name": "foo"}),
+        )
+
+        decoded = json.loads(actual.to_json())
+        self.assertEqual(SeverityNumber.WARN.value, decoded["severity_number"])
 
     def test_log_record_bounded_attributes(self):
         attr = {"key": "value"}


### PR DESCRIPTION


# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Instead of a string.

Fixes #4271
Fixes #4322

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py310-test-opentelemetry-sdk

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
