### PR TITLE
Always use `LogRecord.getMessage` to get the log body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4935](https://github.com/open-telemetry/opentelemetry-python/pull/4935))
 - `opentelemetry-sdk`: upgrade vendored OTel configuration schema from v1.0.0-rc.3 to v1.0.0
   ([#4965](https://github.com/open-telemetry/opentelemetry-python/pull/4965))
+- Further improve compatibility with other logging libraries that override
+  `LogRecord.getMessage()` in order to customize message formatting
+  ([#4327](https://github.com/open-telemetry/opentelemetry-python/pull/4327))
 
 ## Version 1.40.0/0.61b0 (2026-03-04)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -39,7 +39,7 @@ from opentelemetry._logs import (
     get_logger,
     get_logger_provider,
 )
-from opentelemetry.attributes import _VALID_ANY_VALUE_TYPES, BoundedAttributes
+from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.context import get_current
 from opentelemetry.context.context import Context
 from opentelemetry.metrics import MeterProvider, get_meter_provider
@@ -572,25 +572,7 @@ class LoggingHandler(logging.Handler):
         if self.formatter:
             body = self.format(record)
         else:
-            # `record.getMessage()` uses `record.msg` as a template to format
-            # `record.args` into. There is a special case in `record.getMessage()`
-            # where it will only attempt formatting if args are provided,
-            # otherwise, it just stringifies `record.msg`.
-            #
-            # Since the OTLP body field has a type of 'any' and the logging module
-            # is sometimes used in such a way that objects incorrectly end up
-            # set as record.msg, in those cases we would like to bypass
-            # `record.getMessage()` completely and set the body to the object
-            # itself instead of its string representation.
-            # For more background, see: https://github.com/open-telemetry/opentelemetry-python/pull/4216
-            if not record.args and not isinstance(record.msg, str):
-                #  if record.msg is not a value we can export, cast it to string
-                if not isinstance(record.msg, _VALID_ANY_VALUE_TYPES):
-                    body = str(record.msg)
-                else:
-                    body = record.msg
-            else:
-                body = record.getMessage()
+            body = record.getMessage()
 
         # related to https://github.com/open-telemetry/opentelemetry-python/issues/3548
         # Severity Text = WARN as defined in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#displaying-severity.

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -292,8 +292,8 @@ class TestSimpleLogRecordProcessor(unittest.TestCase):
                 "Temperature hits high 420 C in Hyderabad",
                 "CRITICAL",
             ),
-            (["list", "of", "strings"], "WARN"),
-            ({"key": "value"}, "ERROR"),
+            ("['list', 'of', 'strings']", "WARN"),
+            ("{'key': 'value'}", "ERROR"),
         ]
         emitted = [
             (item.log_record.body, item.log_record.severity_text)
@@ -307,8 +307,7 @@ class TestSimpleLogRecordProcessor(unittest.TestCase):
 
     def test_simple_log_record_processor_custom_single_obj(self):
         """
-        Tests that special-case handling for logging a single non-string object
-        is correctly applied.
+        Tests that logging a single non-string object uses getMessage
         """
         exporter = InMemoryLogRecordExporter()
         log_record_processor = BatchLogRecordProcessor(exporter)
@@ -334,9 +333,7 @@ class TestSimpleLogRecordProcessor(unittest.TestCase):
         logger.warning("a string with a percent-s: %s", "and arg")
         # non-string msg with args - getMessage stringifies msg and formats args into it
         logger.warning(["a non-string with a percent-s", "%s"], "and arg")
-        # non-string msg with no args:
-        #  - normally getMessage would stringify the object and bypass formatting
-        #  - SPECIAL CASE: bypass stringification as well to keep the raw object
+        # non-string msg with no args - getMessage stringifies the object and bypasses formatting
         logger.warning(["a non-string with a percent-s", "%s"])
         log_record_processor.shutdown()
 
@@ -345,7 +342,7 @@ class TestSimpleLogRecordProcessor(unittest.TestCase):
             ("a string with a percent-s: %s"),
             ("a string with a percent-s: and arg"),
             ("['a non-string with a percent-s', 'and arg']"),
-            (["a non-string with a percent-s", "%s"]),
+            ("['a non-string with a percent-s', '%s']"),
         ]
         for emitted, expected in zip(finished_logs, expected):
             self.assertEqual(emitted.log_record.body, expected)


### PR DESCRIPTION
See context in #4216

This is mostly a revert of #3343 

Related: #4528

# Description

This change makes the log exporting always call `LogRecord.getMessage()` in order to format and return the record's body text. Previously in #3343 a special case was added so that the `record.msg` object was used directly if no args were provided. This special case was further scoped down and changed to call `record.getMessage()` to improve compatibility with other Python logging libraries in #4216 . This PR proposes doing away with the special case entirely and always calling `record.getMessage()` in order to get the body text.

The reason for preserving the original type of the `record.msg` given in #3343 was that the body field type in the OTel 1.22.0 [Logs Data Model](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-body) is supposed to be "any", not "str", so the `record.msg` should not be converted to a string before being set as the body.

However, this goes against the Python documentation that states that the `record.msg` is only supposed to be a format string[1] or an object to convert into a format string[2] and not an actual object to be logged.

[1]: From [logging.Logger.debug(msg, *args, **kwargs) docs](https://docs.python.org/3/library/logging.html#logging.Logger.debug) (emphasis mine):
> The msg is the message **format string**, and the args are the arguments which are merged into msg using the string formatting operator. [...] No % formatting operation is performed on msg when no args are supplied.

[2]: From [logging.LogRecord.getMessage() docs](https://docs.python.org/3/library/logging.html#logging.LogRecord.getMessage) (emphasis mine):
> If the user-supplied message argument to the logging call is not a string, [`str()`](https://docs.python.org/3/library/stdtypes.html#str) is called on it to convert it to a string. This allows use of user-defined classes as messages, whose `__str__` method can return the actual **format string** to be used.

Note that while the ["Using arbitrary objects as messages"](https://docs.python.org/3/howto/logging.html#arbitrary-object-messages) section of the logging HOWTO states:
> You can pass an arbitrary object as a message, and its [`__str__()`](https://docs.python.org/3/reference/datamodel.html#object.__str__) method will be called when the logging system needs to convert it to a string representation.

this doesn't mean that the `msg` itself should be an object to log out. The "when the logging system needs to convert it to a string" part happens when the `LogRecord` is processed by a handler, applies the logic in [2] and converts the `msg` to a format string that it then formats the `record.args` into (if any).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've updated and run the unit tests, as well as run manual tests of the functionality (see #4216 for details)

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
