### PR TITLE
refactor(zipkin-exporter): simplify success status check and add test for 204 response

### DIFF
--- a/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/json/__init__.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/json/__init__.py
@@ -91,7 +91,6 @@ from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.trace import Span
 
 DEFAULT_ENDPOINT = "http://localhost:9411/api/v2/spans"
-REQUESTS_SUCCESS_STATUS_CODES = (200, 202)
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +170,7 @@ class ZipkinExporter(SpanExporter):
             timeout=self.timeout,
         )
 
-        if result.status_code not in REQUESTS_SUCCESS_STATUS_CODES:
+        if not result.ok:
             logger.error(
                 "Traces cannot be uploaded; status code: %s, message %s",
                 result.status_code,

--- a/exporter/opentelemetry-exporter-zipkin-json/tests/test_zipkin_exporter.py
+++ b/exporter/opentelemetry-exporter-zipkin-json/tests/test_zipkin_exporter.py
@@ -145,6 +145,14 @@ class TestZipkinExporter(unittest.TestCase):
         self.assertEqual(SpanExportResult.SUCCESS, status)
 
     @patch("requests.Session.post")
+    def test_export_success_no_content(self, mock_post):
+        mock_post.return_value = MockResponse(204)
+        spans = []
+        exporter = ZipkinExporter()
+        status = exporter.export(spans)
+        self.assertEqual(SpanExportResult.SUCCESS, status)
+
+    @patch("requests.Session.post")
     def test_export_invalid_response(self, mock_post):
         mock_post.return_value = MockResponse(404)
         spans = []

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/src/opentelemetry/exporter/zipkin/proto/http/__init__.py
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/src/opentelemetry/exporter/zipkin/proto/http/__init__.py
@@ -88,7 +88,6 @@ from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.trace import Span
 
 DEFAULT_ENDPOINT = "http://localhost:9411/api/v2/spans"
-REQUESTS_SUCCESS_STATUS_CODES = (200, 202)
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +162,7 @@ class ZipkinExporter(SpanExporter):
             timeout=self.timeout,
         )
 
-        if result.status_code not in REQUESTS_SUCCESS_STATUS_CODES:
+        if not result.ok:
             logger.error(
                 "Traces cannot be uploaded; status code: %s, message %s",
                 result.status_code,

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/tests/test_zipkin_exporter.py
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/tests/test_zipkin_exporter.py
@@ -145,6 +145,14 @@ class TestZipkinExporter(unittest.TestCase):
         self.assertEqual(SpanExportResult.SUCCESS, status)
 
     @patch("requests.Session.post")
+    def test_export_success_no_content(self, mock_post):
+        mock_post.return_value = MockResponse(204)
+        spans = []
+        exporter = ZipkinExporter()
+        status = exporter.export(spans)
+        self.assertEqual(SpanExportResult.SUCCESS, status)
+
+    @patch("requests.Session.post")
     def test_export_invalid_response(self, mock_post):
         mock_post.return_value = MockResponse(404)
         spans = []


### PR DESCRIPTION
… for 204 response

# Description

Simplify success status check and add test for 204 response

Fixes #4338 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
