### PR TITLE
update: use context instead of trace_id, span_id, trace_flags at eventsAPI

### DIFF
--- a/opentelemetry-api/src/opentelemetry/_events/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_events/__init__.py
@@ -22,7 +22,7 @@ from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.environment_variables import (
     _OTEL_PYTHON_EVENT_LOGGER_PROVIDER,
 )
-from opentelemetry.trace.span import TraceFlags
+from opentelemetry.trace.span import SpanContext
 from opentelemetry.util._once import Once
 from opentelemetry.util._providers import _load_provider
 from opentelemetry.util.types import Attributes
@@ -35,15 +35,18 @@ class Event(LogRecord):
         self,
         name: str,
         timestamp: Optional[int] = None,
-        trace_id: Optional[int] = None,
-        span_id: Optional[int] = None,
-        trace_flags: Optional["TraceFlags"] = None,
+        span_context: Optional[SpanContext] = None,
         body: Optional[Any] = None,
         severity_number: Optional[SeverityNumber] = None,
         attributes: Optional[Attributes] = None,
     ):
         attributes = attributes or {}
         event_attributes = {**attributes, "event.name": name}
+        trace_id = span_id = trace_flags = None
+        if span_context:
+            trace_id = span_context.trace_id
+            span_id = span_context.span_id
+            trace_flags = span_context.trace_flags
         super().__init__(
             timestamp=timestamp,
             trace_id=trace_id,

--- a/opentelemetry-sdk/tests/events/test_events.py
+++ b/opentelemetry-sdk/tests/events/test_events.py
@@ -123,15 +123,11 @@ class TestEventLoggerProvider(unittest.TestCase):
             "name", "version", "schema_url", {"key": "value"}
         )
         now = Mock()
-        trace_id = Mock()
-        span_id = Mock()
-        trace_flags = Mock()
+        span_context = Mock()
         event = Event(
             name="test_event",
             timestamp=now,
-            trace_id=trace_id,
-            span_id=span_id,
-            trace_flags=trace_flags,
+            span_context=span_context,
             body="test body",
             severity_number=SeverityNumber.ERROR,
             attributes={
@@ -146,9 +142,9 @@ class TestEventLoggerProvider(unittest.TestCase):
         log_record_mock.assert_called_once_with(
             timestamp=now,
             observed_timestamp=None,
-            trace_id=trace_id,
-            span_id=span_id,
-            trace_flags=trace_flags,
+            trace_id=span_context.trace_id,
+            span_id=span_context.span_id,
+            trace_flags=span_context.trace_flags,
             severity_text=None,
             severity_number=SeverityNumber.ERROR,
             body="test body",
@@ -179,15 +175,11 @@ class TestEventLoggerProvider(unittest.TestCase):
             "name", "version", "schema_url", {"key": "value"}
         )
         now = Mock()
-        trace_id = Mock()
-        span_id = Mock()
-        trace_flags = Mock()
+        span_context = Mock()
         event = Event(
             name="test_event",
             timestamp=now,
-            trace_id=trace_id,
-            span_id=span_id,
-            trace_flags=trace_flags,
+            span_context=span_context,
             body="test body",
             severity_number=SeverityNumber.ERROR,
             attributes={


### PR DESCRIPTION
# Description

Updated Event API so it accepts  `SpanContext` as a param instead of specific trace_id, span_id, trace_flags. This is helpful cause stuff like `baggage` requires a context param. Did update tests also where required.

Fixes #4328 

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e opentelemetry-api 
- [x] tox -e opentelemetry-sdk
- [x] tox -e ruff

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [x] Yes. - Link to PR: (Will continue working on this once status of EventAPI is confirmed as future plan is to drop the specific Event API.
- [] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been updated
- [ ] Documentation has been updated
