### PR TITLE
Update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/opentelemetry-proto/src/opentelemetry/proto/metrics/v1/metrics_pb2.pyi
+++ b/opentelemetry-proto/src/opentelemetry/proto/metrics/v1/metrics_pb2.pyi
@@ -959,7 +959,7 @@ class HistogramDataPoint(google.protobuf.message.Message):
     events, and is assumed to be monotonic over the values of these events.
     Negative events *can* be recorded, but sum should not be filled out when
     doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-    see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+    see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
     """
     @property
     def bucket_counts(
@@ -1205,7 +1205,7 @@ class ExponentialHistogramDataPoint(google.protobuf.message.Message):
     events, and is assumed to be monotonic over the values of these events.
     Negative events *can* be recorded, but sum should not be filled out when
     doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-    see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+    see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
     """
     scale: builtins.int
     """scale describes the resolution of the histogram.  Boundaries are
@@ -1451,7 +1451,7 @@ class SummaryDataPoint(google.protobuf.message.Message):
     events, and is assumed to be monotonic over the values of these events.
     Negative events *can* be recorded, but sum should not be filled out when
     doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-    see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
+    see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#summary
     """
     @property
     def quantile_values(

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/hw_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/hw_metrics.py
@@ -98,7 +98,7 @@ HW_STATUS: Final = "hw.status"
 Operational status: `1` (true) or `0` (false) for each of the possible states
 Instrument: updowncounter
 Unit: 1
-Note: `hw.status` is currently specified as an *UpDownCounter* but would ideally be represented using a [*StateSet* as defined in OpenMetrics](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#stateset). This semantic convention will be updated once *StateSet* is specified in OpenTelemetry. This planned change is not expected to have any consequence on the way users query their timeseries backend to retrieve the values of `hw.status` over time.
+Note: `hw.status` is currently specified as an *UpDownCounter* but would ideally be represented using a [*StateSet* as defined in OpenMetrics](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#stateset). This semantic convention will be updated once *StateSet* is specified in OpenTelemetry. This planned change is not expected to have any consequence on the way users query their timeseries backend to retrieve the values of `hw.status` over time.
 """
 
 


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.