### PR TITLE
Running mypy on sdk resources #773

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/error_handler/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/error_handler/__init__.py
@@ -61,6 +61,7 @@ exception to standard logging, the exception won't be raised any further.
 
 from abc import ABC, abstractmethod
 from logging import getLogger
+from typing import Optional
 
 from opentelemetry.util._importlib_metadata import entry_points
 
@@ -69,7 +70,7 @@ logger = getLogger(__name__)
 
 class ErrorHandler(ABC):
     @abstractmethod
-    def _handle(self, error: Exception, *args, **kwargs):
+    def _handle(self, error: Exception, *args, **kwargs) -> None:  # type: ignore
         """
         Handle an exception
         """
@@ -83,7 +84,7 @@ class _DefaultErrorHandler(ErrorHandler):
     """
 
     # pylint: disable=useless-return
-    def _handle(self, error: Exception, *args, **kwargs):
+    def _handle(self, error: Exception, *args, **kwargs) -> None:  # type: ignore
         logger.exception("Error handled by default error handler: ")
         return None
 
@@ -105,26 +106,26 @@ class GlobalErrorHandler:
 
         return cls._instance
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         pass
 
     # pylint: disable=no-self-use
-    def __exit__(self, exc_type, exc_value, traceback):
-        if exc_value is None:
+    def __exit__(self, exc_type, exc_value, traceback) -> Optional[bool]:  # type: ignore
+        if exc_value is None:  # type: ignore
             return None
 
         plugin_handled = False
 
-        error_handler_entry_points = entry_points(
+        error_handler_entry_points = entry_points(  # type: ignore
             group="opentelemetry_error_handler"
         )
 
-        for error_handler_entry_point in error_handler_entry_points:
-            error_handler_class = error_handler_entry_point.load()
+        for error_handler_entry_point in error_handler_entry_points:  # type: ignore
+            error_handler_class = error_handler_entry_point.load()  # type: ignore
 
-            if issubclass(error_handler_class, exc_value.__class__):
+            if issubclass(error_handler_class, exc_value.__class__):  # type: ignore
                 try:
-                    error_handler_class()._handle(exc_value)
+                    error_handler_class()._handle(exc_value)  # type: ignore
                     plugin_handled = True
 
                 # pylint: disable=broad-exception-caught
@@ -133,11 +134,11 @@ class GlobalErrorHandler:
                         "%s error while handling error"
                         " %s by error handler %s",
                         error_handling_error.__class__.__name__,
-                        exc_value.__class__.__name__,
-                        error_handler_class.__name__,
+                        exc_value.__class__.__name__,  # type: ignore
+                        error_handler_class.__name__,  # type: ignore
                     )
 
         if not plugin_handled:
-            _DefaultErrorHandler()._handle(exc_value)
+            _DefaultErrorHandler()._handle(exc_value)  # type: ignore
 
         return True

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exemplar/exemplar_reservoir.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exemplar/exemplar_reservoir.py
@@ -129,7 +129,7 @@ class ExemplarBucket:
             {
                 k: v
                 for k, v in self.__attributes.items()
-                if k not in point_attributes
+                if k not in point_attributes  # type: ignore
             }
             if self.__attributes
             else None
@@ -162,8 +162,8 @@ class BucketIndexError(ValueError):
 class FixedSizeExemplarReservoirABC(ExemplarReservoir):
     """Abstract class for a reservoir with fixed size."""
 
-    def __init__(self, size: int, **kwargs) -> None:
-        super().__init__(**kwargs)
+    def __init__(self, size: int, **kwargs) -> None:  # type: ignore
+        super().__init__(**kwargs)  # type: ignore
         self._size: int = size
         self._reservoir_storage: Mapping[int, ExemplarBucket] = defaultdict(
             ExemplarBucket
@@ -184,7 +184,7 @@ class FixedSizeExemplarReservoirABC(ExemplarReservoir):
         exemplars = [
             e
             for e in (
-                bucket.collect(point_attributes)
+                bucket.collect(point_attributes)  # type: ignore
                 for _, bucket in sorted(self._reservoir_storage.items())
             )
             if e is not None
@@ -257,8 +257,8 @@ class SimpleFixedSizeExemplarReservoir(FixedSizeExemplarReservoirABC):
         https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#simplefixedsizeexemplarreservoir
     """
 
-    def __init__(self, size: int = 1, **kwargs) -> None:
-        super().__init__(size, **kwargs)
+    def __init__(self, size: int = 1, **kwargs) -> None:  # type: ignore
+        super().__init__(size, **kwargs)  # type: ignore
         self._measurements_seen: int = 0
 
     def _reset(self) -> None:
@@ -292,8 +292,8 @@ class AlignedHistogramBucketExemplarReservoir(FixedSizeExemplarReservoirABC):
         https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#alignedhistogrambucketexemplarreservoir
     """
 
-    def __init__(self, boundaries: Sequence[float], **kwargs) -> None:
-        super().__init__(len(boundaries) + 1, **kwargs)
+    def __init__(self, boundaries: Sequence[float], **kwargs) -> None:  # type: ignore
+        super().__init__(len(boundaries) + 1, **kwargs)  # type: ignore
         self._boundaries: Sequence[float] = boundaries
 
     def offer(


### PR DESCRIPTION
# Description

Addressing running mypy on opentelemetry-sdk iteratively so we don't have to make one big change addressing all mypy issues at once.

Fixes # (issue)

## Type of change

Run mypy against SDK resources

# How Has This Been Tested?

I executed the following tox commands:

- tox -e mypy
- tox -e test-opentelemetry-sdk
- tox -e test-opentelemetry-api

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
