### PR TITLE
fix: add attributes to get_meter wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 - Add `attributes` field in `metrics.get_meter` wrapper function
   ([#4364](https://github.com/open-telemetry/opentelemetry-python/pull/4364))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Add `attributes` field in `metrics.get_meter` wrapper function
+  ([#4364](https://github.com/open-telemetry/opentelemetry-python/pull/4364))
 
 ## Version 1.29.0/0.50b0 (2024-12-11)
 

--- a/opentelemetry-api/src/opentelemetry/metrics/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/_internal/__init__.py
@@ -764,6 +764,7 @@ def get_meter(
     version: str = "",
     meter_provider: Optional[MeterProvider] = None,
     schema_url: Optional[str] = None,
+    attributes: Optional[Attributes] = None,
 ) -> "Meter":
     """Returns a `Meter` for use by the given instrumentation library.
 
@@ -774,7 +775,7 @@ def get_meter(
     """
     if meter_provider is None:
         meter_provider = get_meter_provider()
-    return meter_provider.get_meter(name, version, schema_url)
+    return meter_provider.get_meter(name, version, schema_url, attributes)
 
 
 def _set_meter_provider(meter_provider: MeterProvider, log: bool) -> None:

--- a/opentelemetry-api/tests/metrics/test_meter_provider.py
+++ b/opentelemetry-api/tests/metrics/test_meter_provider.py
@@ -29,7 +29,11 @@ from opentelemetry.metrics import (
     get_meter_provider,
     set_meter_provider,
 )
-from opentelemetry.metrics._internal import _ProxyMeter, _ProxyMeterProvider, get_meter
+from opentelemetry.metrics._internal import (
+    _ProxyMeter,
+    _ProxyMeterProvider,
+    get_meter,
+)
 from opentelemetry.metrics._internal.instrument import (
     _ProxyCounter,
     _ProxyGauge,
@@ -140,7 +144,7 @@ class TestGetMeter(TestCase):
         self.assertTrue(isinstance(meter, NoOpMeter))
 
         self.assertEqual(meter.name, None)
-    
+
     def test_get_meter_wrapper(self):
         """
         `metrics._internal.get_meter` called with valid parameters and a NoOpMeterProvider
@@ -149,10 +153,10 @@ class TestGetMeter(TestCase):
 
         meter = get_meter(
             "name",
-            version = "version",
-            meter_provider = NoOpMeterProvider(),
-            schema_url = "schema_url",
-            attributes = {"key": "value", "key2": 5, "key3": "value3"},
+            version="version",
+            meter_provider=NoOpMeterProvider(),
+            schema_url="schema_url",
+            attributes={"key": "value", "key2": 5, "key3": "value3"},
         )
 
         self.assertIsInstance(meter, NoOpMeter)

--- a/opentelemetry-api/tests/metrics/test_meter_provider.py
+++ b/opentelemetry-api/tests/metrics/test_meter_provider.py
@@ -29,7 +29,7 @@ from opentelemetry.metrics import (
     get_meter_provider,
     set_meter_provider,
 )
-from opentelemetry.metrics._internal import _ProxyMeter, _ProxyMeterProvider
+from opentelemetry.metrics._internal import _ProxyMeter, _ProxyMeterProvider, get_meter
 from opentelemetry.metrics._internal.instrument import (
     _ProxyCounter,
     _ProxyGauge,
@@ -140,6 +140,25 @@ class TestGetMeter(TestCase):
         self.assertTrue(isinstance(meter, NoOpMeter))
 
         self.assertEqual(meter.name, None)
+    
+    def test_get_meter_wrapper(self):
+        """
+        `metrics._internal.get_meter` called with valid parameters and a NoOpMeterProvider
+        should return a NoOpMeter with the same parameters.
+        """
+
+        meter = get_meter(
+            "name",
+            version = "version",
+            meter_provider = NoOpMeterProvider(),
+            schema_url = "schema_url",
+            attributes = {"key": "value", "key2": 5, "key3": "value3"},
+        )
+
+        self.assertIsInstance(meter, NoOpMeter)
+        self.assertEqual(meter.name, "name")
+        self.assertEqual(meter.version, "version")
+        self.assertEqual(meter.schema_url, "schema_url")
 
 
 class TestProxy(MetricsGlobalsTest, TestCase):


### PR DESCRIPTION
# Description

On #4015 the `attributes` parameter was added for meter providers, and all interfaces were updated, but the global wrapper was not updated with the new API.

Since the function doc says that "This function is a convenience wrapper for `opentelemetry.metrics.MeterProvider.get_meter`." I expect this to have the same parameters.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

First I started a aws-otel-collector docker container for testing
Then I run this minimal script.

```
from opentelemetry import metrics
from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
from opentelemetry.sdk.metrics import MeterProvider
from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader

exporter = OTLPMetricExporter(endpoint="localhost:4317", insecure=True)
metric_reader = PeriodicExportingMetricReader(exporter)
metrics.set_meter_provider(MeterProvider(metric_readers=[metric_reader]))
meter = metrics.get_meter("test", attributes={})
```

Without this PR this fails with 
```
TypeError: get_meter() got an unexpected keyword argument 'attributes'
```
Now is working as expected.

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
