### PR TITLE
opentelemetry-sdk: don't print warnings if SDK is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4364](https://github.com/open-telemetry/opentelemetry-python/pull/4364))
 - Add Python 3.13 support
   ([#4353](https://github.com/open-telemetry/opentelemetry-python/pull/4353))
+- sdk: don't log or print warnings when the SDK has been disabled
+  ([#4371](https://github.com/open-telemetry/opentelemetry-python/pull/4371))
 
 ## Version 1.29.0/0.50b0 (2024-12-11)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -670,7 +670,6 @@ class LoggerProvider(APILoggerProvider):
         attributes: Optional[Attributes] = None,
     ) -> Logger:
         if self._disabled:
-            warnings.warn("SDK is disabled.")
             return NoOpLogger(
                 name,
                 version=version,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py
@@ -537,7 +537,6 @@ class MeterProvider(APIMeterProvider):
         attributes: Optional[Attributes] = None,
     ) -> Meter:
         if self._disabled:
-            _logger.warning("SDK is disabled.")
             return NoOpMeter(name, version=version, schema_url=schema_url)
 
         if self._shutdown:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -1228,7 +1228,6 @@ class TracerProvider(trace_api.TracerProvider):
         attributes: typing.Optional[types.Attributes] = None,
     ) -> "trace_api.Tracer":
         if self._disabled:
-            logger.warning("SDK is disabled.")
             return NoOpTracer()
         if not instrumenting_module_name:  # Reject empty strings too.
             instrumenting_module_name = ""

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -15,7 +15,6 @@
 import logging
 import os
 import unittest
-import warnings
 from unittest.mock import Mock, patch
 
 from opentelemetry._logs import NoOpLoggerProvider, SeverityNumber
@@ -290,11 +289,7 @@ class TestLoggingHandler(unittest.TestCase):
         processor, logger = set_up_test_logging(
             logging.NOTSET, root_logger=True
         )
-        with warnings.catch_warnings(record=True) as cw:
-            logger.warning("hello")
-
-        self.assertEqual(len(cw), 1)
-        self.assertEqual("SDK is disabled.", str(cw[0].message))
+        logger.warning("hello")
 
         self.assertEqual(processor.emit_count(), 0)
 

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -15,7 +15,6 @@
 # pylint: disable=protected-access
 
 import unittest
-import warnings
 from unittest.mock import Mock, patch
 
 from opentelemetry.sdk._logs import LoggerProvider
@@ -70,12 +69,9 @@ class TestLoggerProvider(unittest.TestCase):
 
     @patch.dict("os.environ", {OTEL_SDK_DISABLED: "true"})
     def test_get_logger_with_sdk_disabled(self):
-        with warnings.catch_warnings(record=True) as cw:
-            logger = LoggerProvider().get_logger(Mock())
+        logger = LoggerProvider().get_logger(Mock())
 
         self.assertIsInstance(logger, NoOpLogger)
-        self.assertEqual(len(cw), 1)
-        self.assertEqual("SDK is disabled.", str(cw[0].message))
 
     @patch.object(Resource, "create")
     def test_logger_provider_init(self, resource_patch):


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Remove logging or printing warnings when the SDK is not enabled because it has been explicitly done by the user.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] py310-test-opentelementry-sdk

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
