### PR TITLE
Fix the issue of duplicate traceId and spanId caused by RandomIdGener…

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/id_generator.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/id_generator.py
@@ -47,14 +47,17 @@ class RandomIdGenerator(IdGenerator):
     bits when generating IDs.
     """
 
+    def __init__(self):
+        self._rand = random.Random()
+
     def generate_span_id(self) -> int:
-        span_id = random.getrandbits(64)
+        span_id = self._rand.getrandbits(64)
         while span_id == trace.INVALID_SPAN_ID:
-            span_id = random.getrandbits(64)
+            span_id = self._rand.getrandbits(64)
         return span_id
 
     def generate_trace_id(self) -> int:
-        trace_id = random.getrandbits(128)
+        trace_id = self._rand.getrandbits(128)
         while trace_id == trace.INVALID_TRACE_ID:
-            trace_id = random.getrandbits(128)
+            trace_id = self._rand.getrandbits(128)
         return trace_id

--- a/opentelemetry-sdk/tests/trace/test_id_generator.py
+++ b/opentelemetry-sdk/tests/trace/test_id_generator.py
@@ -1,0 +1,15 @@
+import unittest
+
+from opentelemetry.sdk.trace import RandomIdGenerator
+
+
+class TestIdGenerator(unittest.TestCase):
+
+    def test_random_id_generator(self):
+        import random
+        random.seed(10)
+        id_generator = RandomIdGenerator()
+        trace_id = id_generator.generate_trace_id()
+        span_id = id_generator.generate_span_id()
+        self.assertNotEqual(trace_id, 164207228320579316746596838417247989971)
+        self.assertNotEqual(span_id, 273610340023782072)


### PR DESCRIPTION
…ator.

# Description

Fix the issue of duplicate traceId and spanId when the user sets the global random operator seed.


Fixes # (issue)
#4376

## Type of change

Please delete options that are not relevant.

Bug fix

# How Has This Been Tested?

- [ ] test_id_generator.py

# Does This PR Require a Contrib Repo Change?

No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
