### PR TITLE
Allow opentelemetry-python forks to use CI

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -10,5 +10,6 @@ jobs:
   contrib_0:
     uses: open-telemetry/opentelemetry-python-contrib/.github/workflows/core_contrib_test_0.yml@main
     with:
+      CORE_REPO: ${{ github.repository }}
       CORE_REPO_SHA: ${{ github.sha }}
       CONTRIB_REPO_SHA: main


### PR DESCRIPTION
# Description

Adds `CORE_REPO` to allow people to use CI in forks of this repository

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] [Test A](https://github.com/check-spelling-sandbox/opentelemetry-python/pull/1)
       <img width="852" alt="image" src="https://github.com/user-attachments/assets/0ccbf8d8-0d65-4e26-ae26-f4dbd6553b06" />

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [x] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3190
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
