### PR TITLE
Fix span context manager typing by using ParamSpec from typing_extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4353](https://github.com/open-telemetry/opentelemetry-python/pull/4353))
 - sdk: don't log or print warnings when the SDK has been disabled
   ([#4371](https://github.com/open-telemetry/opentelemetry-python/pull/4371))
+- Fix span context manager typing by using ParamSpec from typing_extensions
+  ([#4389](https://github.com/open-telemetry/opentelemetry-python/pull/4389))
 
 ## Version 1.29.0/0.50b0 (2024-12-11)
 

--- a/opentelemetry-api/src/opentelemetry/util/_decorator.py
+++ b/opentelemetry-api/src/opentelemetry/util/_decorator.py
@@ -15,18 +15,20 @@
 import asyncio
 import contextlib
 import functools
-import typing
-from typing import Callable, Generic, Iterator, TypeVar
+from typing import TYPE_CHECKING, Callable, Generic, Iterator, TypeVar
 
 V = TypeVar("V")
 R = TypeVar("R")  # Return type
 Pargs = TypeVar("Pargs")  # Generic type for arguments
 Pkwargs = TypeVar("Pkwargs")  # Generic type for arguments
 
-if hasattr(typing, "ParamSpec"):
-    # only available in python 3.10+
-    # https://peps.python.org/pep-0612/
-    P = typing.ParamSpec("P")  # Generic type for all arguments
+# We don't actually depend on typing_extensions but we can use it in CI with this conditional
+# import. ParamSpec can be imported directly from typing after python 3.9 is dropped
+# https://peps.python.org/pep-0612/.
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    P = ParamSpec("P")  # Generic type for all arguments
 
 
 class _AgnosticContextManager(


### PR DESCRIPTION
# Description

Span context manager functions that use the `_agnosticcontextmanager` decorator (like `start_as_current_span()`) are currently of type `Unknown` when type checking for python <3.10 with pyright. This was coming up in https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3192 ([failed run](https://github.com/open-telemetry/opentelemetry-python-contrib/actions/runs/12816796229/job/35738603547)).

Also Fix #3836 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Type checking passed on https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3192

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
