### PR TITLE
Exclude attributes without stability from stable semconv part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4371](https://github.com/open-telemetry/opentelemetry-python/pull/4371))
 - Fix span context manager typing by using ParamSpec from typing_extensions
   ([#4389](https://github.com/open-telemetry/opentelemetry-python/pull/4389))
-- semantic-conventions: Remove `opentelemetry.semconv.attributes.network_attributes.NETWORK_INTERFACE_NAME`
+- [BREAKING] semantic-conventions: Remove `opentelemetry.semconv.attributes.network_attributes.NETWORK_INTERFACE_NAME`
   introduced by mistake in the wrong module.
   ([#4391](https://github.com/open-telemetry/opentelemetry-python/pull/4391))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4371](https://github.com/open-telemetry/opentelemetry-python/pull/4371))
 - Fix span context manager typing by using ParamSpec from typing_extensions
   ([#4389](https://github.com/open-telemetry/opentelemetry-python/pull/4389))
+- semantic-conventions: Remove `opentelemetry.semconv.attributes.network_attributes.NETWORK_INTERFACE_NAME`
+  introduced by mistake in wrong module.
+  ([#4391](https://github.com/open-telemetry/opentelemetry-python/pull/4391))
 
 ## Version 1.29.0/0.50b0 (2024-12-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix span context manager typing by using ParamSpec from typing_extensions
   ([#4389](https://github.com/open-telemetry/opentelemetry-python/pull/4389))
 - semantic-conventions: Remove `opentelemetry.semconv.attributes.network_attributes.NETWORK_INTERFACE_NAME`
-  introduced by mistake in wrong module.
+  introduced by mistake in the wrong module.
   ([#4391](https://github.com/open-telemetry/opentelemetry-python/pull/4391))
 
 ## Version 1.29.0/0.50b0 (2024-12-11)

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/hw_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/hw_metrics.py
@@ -98,7 +98,7 @@ HW_STATUS: Final = "hw.status"
 Operational status: `1` (true) or `0` (false) for each of the possible states
 Instrument: updowncounter
 Unit: 1
-Note: `hw.status` is currently specified as an *UpDownCounter* but would ideally be represented using a [*StateSet* as defined in OpenMetrics](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#stateset). This semantic convention will be updated once *StateSet* is specified in OpenTelemetry. This planned change is not expected to have any consequence on the way users query their timeseries backend to retrieve the values of `hw.status` over time.
+Note: `hw.status` is currently specified as an *UpDownCounter* but would ideally be represented using a [*StateSet* as defined in OpenMetrics](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#stateset). This semantic convention will be updated once *StateSet* is specified in OpenTelemetry. This planned change is not expected to have any consequence on the way users query their timeseries backend to retrieve the values of `hw.status` over time.
 """
 
 

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/network_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/network_attributes.py
@@ -15,11 +15,6 @@
 from enum import Enum
 from typing import Final
 
-NETWORK_INTERFACE_NAME: Final = "network.interface.name"
-"""
-The network interface name.
-"""
-
 NETWORK_LOCAL_ADDRESS: Final = "network.local.address"
 """
 Local address of the network connection - IP address or Unix domain socket name.

--- a/scripts/semconv/templates/registry/weaver.yaml
+++ b/scripts/semconv/templates/registry/weaver.yaml
@@ -28,7 +28,7 @@ templates:
     filter: >
       semconv_grouped_metrics({
         "exclude_root_namespace": $excluded_namespaces,
-        "exclude_stability": if $filter == "any" then [] else ["experimental"] end,
+        "exclude_stability": if $filter == "any" then [] else ["experimental", "", null] end,
       })
       | map({
         root_namespace: .root_namespace,

--- a/scripts/semconv/templates/registry/weaver.yaml
+++ b/scripts/semconv/templates/registry/weaver.yaml
@@ -13,7 +13,7 @@ templates:
     filter: >
       semconv_grouped_attributes({
         "exclude_root_namespace": $excluded_namespaces,
-        "exclude_stability": if $filter == "any" then [] else ["experimental"] end,
+        "exclude_stability": if $filter == "any" then [] else ["experimental", "", null] end,
       })
       | map({
           root_namespace: .root_namespace,


### PR DESCRIPTION
See https://github.com/open-telemetry/semantic-conventions/issues/1777

Semconv should not have attributes without stability, but this one slipped in. 
We'll fix it in semconv and also enforce it better to prevent this in the future - https://github.com/open-telemetry/semantic-conventions/pull/1781, but let's exclude attributes without stability from the stable part.

Since semconv artifact is at `0.50b0`, I assume it's allowed to have breaking changes?
This attribute is not used by anything in OTel python, was introduced in prev version of semconv and I'm suggesting to drop it. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
