### PR TITLE
Type json indent as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Type indent parameter in to_json
-- ([#4402](https://github.com/open-telemetry/opentelemetry-python/pull/4402))
+  ([#4402](https://github.com/open-telemetry/opentelemetry-python/pull/4402))
 - Tolerates exceptions when loading resource detectors via `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS`
   ([#4373](https://github.com/open-telemetry/opentelemetry-python/pull/4373))
 - opentelemetry-sdk: fix OTLP exporting of Histograms with explicit buckets advisory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Type indent parameter in to_json
+- ([#4402](https://github.com/open-telemetry/opentelemetry-python/pull/4402))
 - Always setup logs sdk, OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED only controls python `logging` module handler setup
   ([#4340](https://github.com/open-telemetry/opentelemetry-python/pull/4340))
 - Add `attributes` field in `metrics.get_meter` wrapper function

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -217,7 +217,7 @@ class LogRecord(APILogRecord):
             return NotImplemented
         return self.__dict__ == other.__dict__
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return json.dumps(
             {
                 "body": self.body,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
@@ -38,7 +38,7 @@ class NumberDataPoint:
     value: Union[int, float]
     exemplars: Sequence[Exemplar] = field(default_factory=list)
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(asdict(self), indent=indent)
 
 
@@ -59,7 +59,7 @@ class HistogramDataPoint:
     max: float
     exemplars: Sequence[Exemplar] = field(default_factory=list)
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(asdict(self), indent=indent)
 
 
@@ -90,7 +90,7 @@ class ExponentialHistogramDataPoint:
     max: float
     exemplars: Sequence[Exemplar] = field(default_factory=list)
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(asdict(self), indent=indent)
 
 
@@ -105,7 +105,7 @@ class ExponentialHistogram:
         "opentelemetry.sdk.metrics.export.AggregationTemporality"
     )
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(
             {
                 "data_points": [
@@ -129,7 +129,7 @@ class Sum:
     )
     is_monotonic: bool
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(
             {
                 "data_points": [
@@ -151,7 +151,7 @@ class Gauge:
 
     data_points: Sequence[NumberDataPoint]
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(
             {
                 "data_points": [
@@ -173,7 +173,7 @@ class Histogram:
         "opentelemetry.sdk.metrics.export.AggregationTemporality"
     )
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(
             {
                 "data_points": [
@@ -203,7 +203,7 @@ class Metric:
     unit: Optional[str]
     data: DataT
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(
             {
                 "name": self.name,
@@ -223,7 +223,7 @@ class ScopeMetrics:
     metrics: Sequence[Metric]
     schema_url: str
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(
             {
                 "scope": loads(self.scope.to_json(indent=indent)),
@@ -245,7 +245,7 @@ class ResourceMetrics:
     scope_metrics: Sequence[ScopeMetrics]
     schema_url: str
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(
             {
                 "resource": loads(self.resource.to_json(indent=indent)),
@@ -265,7 +265,7 @@ class MetricsData:
 
     resource_metrics: Sequence[ResourceMetrics]
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(
             {
                 "resource_metrics": [

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -290,7 +290,7 @@ class Resource:
             f"{dumps(self._attributes.copy(), sort_keys=True)}|{self._schema_url}"  # type: ignore
         )
 
-    def to_json(self, indent: int = 4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         attributes: MutableMapping[str, AttributeValue] = dict(
             self._attributes
         )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -483,7 +483,7 @@ class ReadableSpan:
     def instrumentation_scope(self) -> Optional[InstrumentationScope]:
         return self._instrumentation_scope
 
-    def to_json(self, indent: int = 4):
+    def to_json(self, indent: Optional[int] = 4):
         parent_id = None
         if self.parent is not None:
             parent_id = f"0x{trace_api.format_span_id(self.parent.span_id)}"

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/instrumentation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/instrumentation.py
@@ -153,7 +153,7 @@ class InstrumentationScope:
     def attributes(self) -> Attributes:
         return self._attributes
 
-    def to_json(self, indent=4) -> str:
+    def to_json(self, indent: Optional[int] = 4) -> str:
         return dumps(
             {
                 "name": self._name,

--- a/opentelemetry-sdk/tests/logs/test_log_record.py
+++ b/opentelemetry-sdk/tests/logs/test_log_record.py
@@ -45,7 +45,7 @@ class TestLogRecord(unittest.TestCase):
                     "schema_url": "",
                 },
             },
-            indent: Optional[int] = 4,
+            indent=4,
         )
         actual = LogRecord(
             timestamp=0,
@@ -54,7 +54,7 @@ class TestLogRecord(unittest.TestCase):
             resource=Resource({"service.name": "foo"}),
         )
 
-        self.assertEqual(expected, actual.to_json(indent: Optional[int] = 4))
+        self.assertEqual(expected, actual.to_json(indent=4))
         self.assertEqual(
             actual.to_json(indent=None),
             '{"body": "a log line", "severity_number": null, "severity_text": null, "attributes": null, "dropped_attributes": 0, "timestamp": "1970-01-01T00:00:00.000000Z", "observed_timestamp": "1970-01-01T00:00:00.000000Z", "trace_id": "", "span_id": "", "trace_flags": null, "resource": {"attributes": {"service.name": "foo"}, "schema_url": ""}}',

--- a/opentelemetry-sdk/tests/logs/test_log_record.py
+++ b/opentelemetry-sdk/tests/logs/test_log_record.py
@@ -45,7 +45,7 @@ class TestLogRecord(unittest.TestCase):
                     "schema_url": "",
                 },
             },
-            indent=4,
+            indent: Optional[int] = 4,
         )
         actual = LogRecord(
             timestamp=0,
@@ -54,7 +54,7 @@ class TestLogRecord(unittest.TestCase):
             resource=Resource({"service.name": "foo"}),
         )
 
-        self.assertEqual(expected, actual.to_json(indent=4))
+        self.assertEqual(expected, actual.to_json(indent: Optional[int] = 4))
         self.assertEqual(
             actual.to_json(indent=None),
             '{"body": "a log line", "severity_number": null, "severity_text": null, "attributes": null, "dropped_attributes": 0, "timestamp": "1970-01-01T00:00:00.000000Z", "observed_timestamp": "1970-01-01T00:00:00.000000Z", "trace_id": "", "span_id": "", "trace_flags": null, "resource": {"attributes": {"service.name": "foo"}, "schema_url": ""}}',


### PR DESCRIPTION
# Description

Python `json.dumps` has optional indent parameter which is not reflected in the API.
This is not a breaking change, only the type is updated.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No test is needed, it is only typing change.

# Does This PR Require a Contrib Repo Change?
7
<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
