### PR TITLE
Make trace_api.use_span() record BaseException as well as Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4361](https://github.com/open-telemetry/opentelemetry-python/pull/4361))
 - semantic-conventions: Bump to 1.30.0
   ([#4337](https://github.com/open-telemetry/opentelemetry-python/pull/4397))
+- Make `trace_api.use_span()` record `BaseException` as well as `Exception`
+  ([#4406](https://github.com/open-telemetry/opentelemetry-python/pull/4406))
 
 ## Version 1.29.0/0.50b0 (2024-12-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4444](https://github.com/open-telemetry/opentelemetry-python/pull/4444))
 - Updated `tracecontext-integration-test` gitref to `d782773b2cf2fa4afd6a80a93b289d8a74ca894d`
   ([#4448](https://github.com/open-telemetry/opentelemetry-python/pull/4448))
+- Make `trace_api.use_span()` record `BaseException` as well as `Exception`
+  ([#4406](https://github.com/open-telemetry/opentelemetry-python/pull/4406))
 
 ## Version 1.30.0/0.51b0 (2025-02-03)
 
@@ -39,8 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4361](https://github.com/open-telemetry/opentelemetry-python/pull/4361))
 - semantic-conventions: Bump to 1.30.0
   ([#4337](https://github.com/open-telemetry/opentelemetry-python/pull/4397))
-- Make `trace_api.use_span()` record `BaseException` as well as `Exception`
-  ([#4406](https://github.com/open-telemetry/opentelemetry-python/pull/4406))
 
 ## Version 1.29.0/0.50b0 (2024-12-11)
 

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -590,7 +590,7 @@ def use_span(
         finally:
             context_api.detach(token)
 
-    except Exception as exc:  # pylint: disable=broad-exception-caught
+    except BaseException as exc:  # pylint: disable=broad-exception-caught
         if isinstance(span, Span) and span.is_recording():
             # Record the exception as an event
             if record_exception:

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -133,6 +133,18 @@ class TestUseTracer(unittest.TestCase):
 
         self.assertEqual(test_span.recorded_exception, exception)
 
+    def test_use_span_base_exception(self):
+        class TestUseSpanBaseException(BaseException):
+            pass
+
+        test_span = SpanTest(trace.INVALID_SPAN_CONTEXT)
+        exception = TestUseSpanBaseException("test exception")
+        with self.assertRaises(TestUseSpanBaseException):
+            with trace.use_span(test_span):
+                raise exception
+
+        self.assertEqual(test_span.recorded_exception, exception)
+
     def test_use_span_set_status(self):
         class TestUseSpanException(Exception):
             pass


### PR DESCRIPTION
# Description

The Python SDK has inconsistent handling of `BaseException`s such as `KeyboardInterrupt` and `StopIteration`.

Consider the following code:
```python
with tracer.start_span(...):
    raise BaseException("test")
```
The `BaseException` will be passed into `Span.__exit__()` ([code](https://github.com/open-telemetry/opentelemetry-python/blob/v1.29.0/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L986-L1008)), which will typically call `span.record_exception(BaseException("test"))`; set the span's status to `ERROR`; and then emit the span.

However, `start_as_current_span()` behaves differently:
```python
with tracer.start_as_current_span(...):
    raise BaseException("test")
```
The `BaseException` will be thrown into `trace_api.use_span()` ([code](https://github.com/open-telemetry/opentelemetry-python/blob/v1.29.0/opentelemetry-api/src/opentelemetry/trace/__init__.py#L565-L616)). However, `use_span()` only handles `except Exception`, not `except BaseException`. So `span.record_exception()` is not called, and the span's status is not set to `ERROR`. However, the span is still emitted via the `finally:` block.

This behavior surprised me. In particular, when a span exits due to `asyncio.CancelledError` or `trio.Cancelled`, I was surprised that the span was emitted without recording any exception or setting the status to `ERROR`. I'm guessing this probably wasn't an intentional decision.

This PR proposes to change the `except Exception` to `except BaseException`, so that `use_span()` will now record `BaseException`s in the same way as regular `Exception`s.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] New test in `opentelemetry-api/tests/trace/test_globals.py` to ensure that `BaseException` is recorded

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
