### PR TITLE
Optional JSON indent to allow storing data as json-lines

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -483,7 +483,7 @@ class ReadableSpan:
     def instrumentation_scope(self) -> Optional[InstrumentationScope]:
         return self._instrumentation_scope
 
-    def to_json(self, indent: int = 4):
+    def to_json(self, indent: Optional[int] = 4):
         parent_id = None
         if self.parent is not None:
             parent_id = f"0x{trace_api.format_span_id(self.parent.span_id)}"


### PR DESCRIPTION
# Description

Would the OTEL project be open to making JSON identation optional?

That would allow, for example, dumping spans into jsonl files.

## Type of change

Please delete options that are not relevant.

- [x] Relaxation of type hints (minor feature)

# How Has This Been Tested?


- [x] Tested locally, can post code later

# Contrib Repo Change?

no

# Checklist:

Not yet, let's discuss this first.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated

P.S. I'm happy to contribute this change throughout the codebase (also logging, metrics, unit tests, etc.)