### PR TITLE
Prototype change adding a Authorization Header Setter to OTLP exporters

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
@@ -32,9 +32,9 @@ dependencies = [
   "googleapis-common-protos ~= 1.52",
   "grpcio >= 1.63.2, < 2.0.0",
   "opentelemetry-api ~= 1.15",
-  "opentelemetry-proto == 1.31.0.dev",
-  "opentelemetry-sdk ~= 1.31.0.dev",
-  "opentelemetry-exporter-otlp-proto-common == 1.31.0.dev",
+  "opentelemetry-proto ~= 1.29.0",
+  "opentelemetry-sdk ~= 1.30.0.dev0", 
+  "opentelemetry-exporter-otlp-proto-common ~= 1.29.0",
 ]
 
 [project.entry-points.opentelemetry_logs_exporter]

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
@@ -18,6 +18,7 @@ from typing import Sequence as TypingSequence
 from grpc import ChannelCredentials, Compression
 from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
 from opentelemetry.exporter.otlp.proto.grpc.exporter import (
+    BaseAuthHeaderSetter,
     OTLPExporterMixin,
     _get_credentials,
     environ_to_compression,
@@ -60,6 +61,7 @@ class OTLPLogExporter(
         ] = None,
         timeout: Optional[int] = None,
         compression: Optional[Compression] = None,
+        auth_header_setter: BaseAuthHeaderSetter = None,
     ):
         if insecure is None:
             insecure = environ.get(OTEL_EXPORTER_OTLP_LOGS_INSECURE)
@@ -99,6 +101,7 @@ class OTLPLogExporter(
                 "headers": headers,
                 "timeout": timeout or environ_timeout,
                 "compression": compression,
+                "auth_header_setter": auth_header_setter,
             }
         )
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/metric_exporter/__init__.py
@@ -25,6 +25,7 @@ from opentelemetry.exporter.otlp.proto.common.metrics_encoder import (
     encode_metrics,
 )
 from opentelemetry.exporter.otlp.proto.grpc.exporter import (  # noqa: F401
+    BaseAuthHeaderSetter,
     OTLPExporterMixin,
     _get_credentials,
     environ_to_compression,
@@ -103,6 +104,7 @@ class OTLPMetricExporter(
         preferred_temporality: Dict[type, AggregationTemporality] = None,
         preferred_aggregation: Dict[type, Aggregation] = None,
         max_export_batch_size: Optional[int] = None,
+        auth_header_setter: BaseAuthHeaderSetter = None,
     ):
         if insecure is None:
             insecure = environ.get(OTEL_EXPORTER_OTLP_METRICS_INSECURE)
@@ -144,6 +146,7 @@ class OTLPMetricExporter(
             headers=headers or environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS),
             timeout=timeout or environ_timeout,
             compression=compression,
+            auth_header_setter=auth_header_setter,
         )
 
         self._max_export_batch_size: Optional[int] = max_export_batch_size

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
@@ -23,6 +23,7 @@ from opentelemetry.exporter.otlp.proto.common.trace_encoder import (
     encode_spans,
 )
 from opentelemetry.exporter.otlp.proto.grpc.exporter import (  # noqa: F401
+    BaseAuthHeaderSetter,
     OTLPExporterMixin,
     _get_credentials,
     environ_to_compression,
@@ -93,6 +94,7 @@ class OTLPSpanExporter(
         ] = None,
         timeout: Optional[int] = None,
         compression: Optional[Compression] = None,
+        auth_header_setter: BaseAuthHeaderSetter = None,
     ):
         if insecure is None:
             insecure = environ.get(OTEL_EXPORTER_OTLP_TRACES_INSECURE)
@@ -131,6 +133,7 @@ class OTLPSpanExporter(
                 or environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS),
                 "timeout": timeout or environ_timeout,
                 "compression": compression,
+                "auth_header_setter": auth_header_setter,
             }
         )
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/version/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.31.0.dev"
+__version__ = "1.30.0"

--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -31,9 +31,9 @@ dependencies = [
   "Deprecated >= 1.2.6",
   "googleapis-common-protos ~= 1.52",
   "opentelemetry-api ~= 1.15",
-  "opentelemetry-proto == 1.31.0.dev",
-  "opentelemetry-sdk ~= 1.31.0.dev",
-  "opentelemetry-exporter-otlp-proto-common == 1.31.0.dev",
+  "opentelemetry-proto == 1.29.0",
+  "opentelemetry-sdk ~= 1.30.0.dev",
+  "opentelemetry-exporter-otlp-proto-common == 1.29.0",
   "requests ~= 2.7",
 ]
 

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/version/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.31.0.dev"
+__version__ = "1.30.0.dev"

--- a/opentelemetry-sdk/pyproject.toml
+++ b/opentelemetry-sdk/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "opentelemetry-api == 1.31.0.dev",
-  "opentelemetry-semantic-conventions == 0.52b0.dev",
+  "opentelemetry-api == 1.30.0",
+  "opentelemetry-semantic-conventions == 0.51b0",
   "typing-extensions >= 3.7.4",
 ]
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -95,6 +95,14 @@ _OTEL_SAMPLER_ENTRY_POINT_GROUP = "opentelemetry_traces_sampler"
 _logger = logging.getLogger(__name__)
 
 
+def _import_config_component(
+    selected_component: str, entry_point_name: str
+) -> object:
+    return _import_config_components([selected_component], entry_point_name)[
+        0
+    ][1]
+
+
 def _import_config_components(
     selected_components: List[str], entry_point_name: str
 ) -> Sequence[Tuple[str, object]]:
@@ -399,12 +407,10 @@ def _initialize_components(
     auth_header_setter = None
     auth_ext = os.getenv(OTEL_AUTH_HEADER_EXTENSION)
     if auth_ext:
-        auth_header_setter = next(
-            iter(entry_points(group="opentelemetry_auth_header_extension"))
-        ).load()
-        if isinstance(auth_header_setter, BaseAuthHeaderSetter):
-            auth_header_setter = auth_header_setter()
-        else:
+        auth_header_setter = _import_config_component(
+            auth_ext, "opentelemetry_auth_header_extension"
+        )()
+        if not isinstance(auth_header_setter, BaseAuthHeaderSetter):
             raise RuntimeError(f"{auth_ext} is not an BaseAuthHeaderSetter")
     if sampler is None:
         sampler_name = _get_sampler()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+OTEL_AUTH_HEADER_EXTENSION = "OTEL_AUTH_HEADER_EXTENSION"
+"""
+.. envvar:: OTEL_AUTH_HEADER_EXTENSION
+
+The :envvar:`OTEL_AUTH_HEADER_EXTENSION` environment variable sets the auth header extension to be
+used by the Trace, Log and Metric exporter classes.
+"""
+
 OTEL_SDK_DISABLED = "OTEL_SDK_DISABLED"
 """
 .. envvar:: OTEL_SDK_DISABLED

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.31.0.dev"
+__version__ = "1.30.0.dev"


### PR DESCRIPTION
This is an an alternative approach to https://github.com/open-telemetry/opentelemetry-python/pull/4431.

In order to dynamically set the authorization header a new environment variable (`OTEL_AUTH_HEADER_EXTENSION`) is added. The value of the variable must point to a Class provided via entry points that implements this interface:
```
class BaseAuthHeaderSetter(ABC):

    @abstractmethod
    def get_auth_header(self) -> Tuple[str, str]:
        pass
```

For example for Google we'd do something like:

```
class GCPAuthHeaderSetter(BaseAuthHeaderSetter):
    def __init__(self):
        self._credentials, _ = google.auth.default() # type: ignore
        self._request = requests.Request()

    def get_auth_header(self) -> Tuple[str, str]:
        if self._credentials.expired: # type: ignore
            self._credentials.refresh(self._request) # type: ignore
        return ("Authorization", f"Bearer: {self._credentials.token}") # type: ignore
```

The advantage to this approach over [this one](https://github.com/open-telemetry/opentelemetry-python/pull/4431) is that the user would only have to specify one auth header extension and it'd automatically get loaded in to all their OTLP exporters, versus having to specify a bunch of custom exporters.

