### PR TITLE
opentelemetry-sdk: fix OTLP exporting of histogram explicit buckets advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tolerates exceptions when loading resource detectors via `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS`
   ([#4373](https://github.com/open-telemetry/opentelemetry-python/pull/4373))
+- opentelemetry-sdk: fix OTLP exporting of Histograms withs explicit buckets advisory
+  ([#4434](https://github.com/open-telemetry/opentelemetry-python/pull/4434))
 
 ## Version 1.30.0/0.51b0 (2025-02-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tolerates exceptions when loading resource detectors via `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS`
   ([#4373](https://github.com/open-telemetry/opentelemetry-python/pull/4373))
-- opentelemetry-sdk: fix OTLP exporting of Histograms withs explicit buckets advisory
+- opentelemetry-sdk: fix OTLP exporting of Histograms with explicit buckets advisory
   ([#4434](https://github.com/open-telemetry/opentelemetry-python/pull/4434))
 
 ## Version 1.30.0/0.51b0 (2025-02-03)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -1367,10 +1367,6 @@ class ExplicitBucketHistogramAggregation(Aggregation):
         boundaries: Optional[Sequence[float]] = None,
         record_min_max: bool = True,
     ) -> None:
-        if boundaries is None:
-            boundaries = (
-                _DEFAULT_EXPLICIT_BUCKET_HISTOGRAM_AGGREGATION_BOUNDARIES
-            )
         self._boundaries = boundaries
         self._record_min_max = record_min_max
 
@@ -1389,6 +1385,12 @@ class ExplicitBucketHistogramAggregation(Aggregation):
         elif isinstance(instrument, Asynchronous):
             instrument_aggregation_temporality = (
                 AggregationTemporality.CUMULATIVE
+            )
+
+        if self._boundaries is None:
+            self._boundaries = (
+                instrument._advisory.explicit_bucket_boundaries
+                or _DEFAULT_EXPLICIT_BUCKET_HISTOGRAM_AGGREGATION_BOUNDARIES
             )
 
         return _ExplicitBucketHistogramAggregation(


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

OTLP exporters don't rely on the default aggregation for histogram instead they create one explicitly. So instead of setting boundaries at init time of ExplicitBucketHistogramAggregation delay it in _create_aggregation when we have the Histogram at hand.

Fixes #4428 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py310-test-opentelemetry-sdk

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
