### PR TITLE
Ensure a console logging handler is set when using auto-instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4494](https://github.com/open-telemetry/opentelemetry-python/pull/4494))
 - Improve CI by cancelling stale runs and setting timeouts
   ([#4498](https://github.com/open-telemetry/opentelemetry-python/pull/4498))
+- Patch logging.basicConfig so OTel logs don't cause console logs to disappear
+  ([#4436](https://github.com/open-telemetry/opentelemetry-python/pull/4436))
 
 ## Version 1.31.0/0.52b0 (2025-03-12)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -271,8 +271,7 @@ def _patch_basic_config():
             root.handlers[0], LoggingHandler
         )
         if has_only_otel:
-            otel_handler = root.handlers[0]
-            root.handlers = []
+            otel_handler = root.handlers.pop()
             original_basic_config(*args, **kwargs)
             root.addHandler(otel_handler)
         else:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -266,29 +266,18 @@ def _patch_basic_config():
     original_basic_config = logging.basicConfig
 
     def patched_basic_config(*args, **kwargs):
-        # Get the root logger
         root = logging.getLogger()
-
-        # Check if the only handler is our OTel handler
         has_only_otel = len(root.handlers) == 1 and isinstance(
             root.handlers[0], LoggingHandler
         )
-
         if has_only_otel:
-            # Temporarily remove OTel handler
             otel_handler = root.handlers[0]
             root.handlers = []
-
-            # Call original basicConfig
             original_basic_config(*args, **kwargs)
-
-            # Add OTel handler back
             root.addHandler(otel_handler)
         else:
-            # Normal behavior
             original_basic_config(*args, **kwargs)
 
-    # Apply the monkey patch
     logging.basicConfig = patched_basic_config
 
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -253,6 +253,37 @@ def _init_logging(
     set_event_logger_provider(event_logger_provider)
 
     if setup_logging_handler:
+        # noinspection PyPep8Naming
+        original_basicConfig = logging.basicConfig
+
+        # noinspection PyPep8Naming
+        def patched_basicConfig(*args, **kwargs):
+            # Get the root logger
+            root = logging.getLogger()
+
+            # Check if the only handler is our OTel handler
+            has_only_otel = len(root.handlers) == 1 and isinstance(
+                root.handlers[0], LoggingHandler
+            )
+
+            if has_only_otel:
+                # Temporarily remove OTel handler
+                otel_handler = root.handlers[0]
+                root.handlers = []
+
+                # Call original basicConfig
+                original_basicConfig(*args, **kwargs)
+
+                # Add OTel handler back
+                root.addHandler(otel_handler)
+            else:
+                # Normal behavior
+                original_basicConfig(*args, **kwargs)
+
+        # Apply the monkey patch
+        logging.basicConfig = patched_basicConfig
+
+        # Add OTel handler
         handler = LoggingHandler(
             level=logging.NOTSET, logger_provider=provider
         )

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -45,6 +45,7 @@ from opentelemetry.sdk._configuration import (
     _OTelSDKConfigurator,
 )
 from opentelemetry.sdk._logs import LoggingHandler
+from opentelemetry.sdk._logs._internal.export import LogExporter
 from opentelemetry.sdk._logs.export import ConsoleLogExporter
 from opentelemetry.sdk.environment_variables import (
     OTEL_TRACES_SAMPLER,
@@ -204,7 +205,7 @@ class OTLPSpanExporter:
     pass
 
 
-class DummyOTLPLogExporter:
+class DummyOTLPLogExporter(LogExporter):
     def __init__(self, *args, **kwargs):
         self.export_called = False
 

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -842,6 +842,32 @@ class TestLoggingInit(TestCase):
             True,
         )
 
+    def test_basicConfig_works_with_otel_handler(self):
+        with ClearLoggingHandlers():
+            # Initialize auto-instrumentation with logging enabled
+            _init_logging(
+                {"otlp": DummyOTLPLogExporter},
+                Resource.create({}),
+                setup_logging_handler=True,
+            )
+
+            # Call basicConfig - this should work despite OTel handler being present
+            logging.basicConfig(level=logging.INFO)
+
+            # Verify a StreamHandler was added
+            root_logger = logging.getLogger()
+            stream_handlers = [
+                h
+                for h in root_logger.handlers
+                if isinstance(h, logging.StreamHandler)
+                and not isinstance(h, LoggingHandler)
+            ]
+            self.assertEqual(
+                len(stream_handlers),
+                1,
+                "basicConfig should add a StreamHandler even when OTel handler exists",
+            )
+
 
 class TestMetricsInit(TestCase):
     def setUp(self):


### PR DESCRIPTION
If a user sets up auto-instrumentation and sets `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` to true, any calls to `logging.basicConfig()` will be no-ops. This means that if console logging was previously enabled via `basicConfig` and logs were printed to the console, after turning on logging auto-instrumentation, logs will be exported to OTel and will no longer be printed to the console.

This change patches `basicConfig` so that, before calling `basicConfig`, the patched version removes the OTel logging handler if it was added, then calls the original `basicConfig`, then re-adds the handler.

Addresses https://github.com/open-telemetry/opentelemetry-python/issues/4427