### PR TITLE
fix: bump grpcio for Python 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4373](https://github.com/open-telemetry/opentelemetry-python/pull/4373))
 - opentelemetry-sdk: fix OTLP exporting of Histograms with explicit buckets advisory
   ([#4434](https://github.com/open-telemetry/opentelemetry-python/pull/4434))
+- opentelemetry-exporter-otlp-proto-grpc: better dependency version range for Python 3.13
+  ([#4444](https://github.com/open-telemetry/opentelemetry-python/pull/4444))
+- opentelemetry-exporter-opencensus: better dependency version range for Python 3.13
+  ([#4444](https://github.com/open-telemetry/opentelemetry-python/pull/4444))
 
 ## Version 1.30.0/0.51b0 (2025-02-03)
 

--- a/exporter/opentelemetry-exporter-opencensus/pyproject.toml
+++ b/exporter/opentelemetry-exporter-opencensus/pyproject.toml
@@ -29,7 +29,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "grpcio >= 1.0.0, < 2.0.0",
+  "grpcio >= 1.63.2, < 2.0.0; python_version < '3.13'",
+  "grpcio >= 1.66.2, < 2.0.0; python_version >= '3.13'",
   "opencensus-proto >= 0.1.0, < 1.0.0",
   "opentelemetry-api >= 1.31.0.dev",
   "opentelemetry-sdk >= 1.15",

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/pyproject.toml
@@ -30,7 +30,8 @@ classifiers = [
 dependencies = [
   "Deprecated >= 1.2.6",
   "googleapis-common-protos ~= 1.52",
-  "grpcio >= 1.63.2, < 2.0.0",
+  "grpcio >= 1.63.2, < 2.0.0; python_version < '3.13'",
+  "grpcio >= 1.66.2, < 2.0.0; python_version >= '3.13'",
   "opentelemetry-api ~= 1.15",
   "opentelemetry-proto == 1.31.0.dev",
   "opentelemetry-sdk ~= 1.31.0.dev",


### PR DESCRIPTION
# Description

The lowest bound for grpcio dependency allows such grpcio version that cannot be compiled against Python 3.13.

This PR bumps the dependency lower bound for Python 3.13 and newer.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #4443

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
