### PR TITLE
1.30.1 backport: opentelemetry-sdk: fix OTLP exporting of histogram explicit buckets advisory (#4434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- opentelemetry-sdk: fix OTLP exporting of Histograms with explicit buckets advisory
+  ([#4434](https://github.com/open-telemetry/opentelemetry-python/pull/4434))
+
 ## Version 1.30.0/0.51b0 (2025-02-03)
 
 - Always setup logs sdk, OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED only controls python `logging` module handler setup

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -1367,10 +1367,6 @@ class ExplicitBucketHistogramAggregation(Aggregation):
         boundaries: Optional[Sequence[float]] = None,
         record_min_max: bool = True,
     ) -> None:
-        if boundaries is None:
-            boundaries = (
-                _DEFAULT_EXPLICIT_BUCKET_HISTOGRAM_AGGREGATION_BOUNDARIES
-            )
         self._boundaries = boundaries
         self._record_min_max = record_min_max
 
@@ -1389,6 +1385,12 @@ class ExplicitBucketHistogramAggregation(Aggregation):
         elif isinstance(instrument, Asynchronous):
             instrument_aggregation_temporality = (
                 AggregationTemporality.CUMULATIVE
+            )
+
+        if self._boundaries is None:
+            self._boundaries = (
+                instrument._advisory.explicit_bucket_boundaries
+                or _DEFAULT_EXPLICIT_BUCKET_HISTOGRAM_AGGREGATION_BOUNDARIES
             )
 
         return _ExplicitBucketHistogramAggregation(


### PR DESCRIPTION
OTLP exporters don't rely on the default aggregation for histogram instead they do it explicitly. So instead of setting boundaries at init time of ExplicitBucketHistogramAggregation delay it in _create_aggregation when we have the Histogram at hand.