### PR TITLE
Update tracecontext integration test gitref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4444](https://github.com/open-telemetry/opentelemetry-python/pull/4444))
 - opentelemetry-exporter-opencensus: better dependency version range for Python 3.13
   ([#4444](https://github.com/open-telemetry/opentelemetry-python/pull/4444))
+- Updated `tracecontext-integration-test` gitref to `d782773b2cf2fa4afd6a80a93b289d8a74ca894d`
+  ([#4448](https://github.com/open-telemetry/opentelemetry-python/pull/4448))
 
 ## Version 1.30.0/0.51b0 (2025-02-03)
 

--- a/scripts/tracecontext-integration-test.sh
+++ b/scripts/tracecontext-integration-test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e 
 # hard-coding the git tag to ensure stable builds.
-TRACECONTEXT_GIT_TAG="98f210efd89c63593dce90e2bae0a1bdcb986f51"
+TRACECONTEXT_GIT_TAG="d782773b2cf2fa4afd6a80a93b289d8a74ca894d"
 # clone w3c tracecontext tests
 mkdir -p target
 rm -rf ./target/trace-context
@@ -24,4 +24,11 @@ onshutdown()
 }
 trap onshutdown EXIT
 cd ./target/trace-context/test
-python test.py http://127.0.0.1:5000/verify-tracecontext
+
+# The disabled test is not compatible with an optional part of the W3C 
+# spec that we have implemented (dropping duplicated keys from tracestate).
+# W3C are planning to include flags for optional features in the test suite.
+# https://github.com/w3c/trace-context/issues/529
+# FIXME: update test to use flags for optional features when available.
+export SERVICE_ENDPOINT=http://127.0.0.1:5000/verify-tracecontext
+pytest test.py -k "not test_tracestate_duplicated_keys"

--- a/tox.ini
+++ b/tox.ini
@@ -271,6 +271,7 @@ basepython: python3
 deps =
   # needed for tracecontext
   aiohttp~=3.6
+  pytest==7.4.4
   # needed for example trace integration
   flask~=2.3
   requests~=2.7


### PR DESCRIPTION
# Description

We're currently using an outdated version of the W3C test, this results in warnings in CI.
Updated gitref in `scripts/tracecontext-integration-test.sh` to latest from [wc3/trace-context](https://github.com/w3c/trace-context).
Skipped changed test that is incompatible with our implementation (we drop duplicated keys which is optional in the spec).
Added fixme comment to track setting flags for the test suite when they are available ([wc3 issue](https://github.com/w3c/trace-context/issues/529))

Fixes #4105
Closes #4109

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Executed test suite locally

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
