### PR TITLE
Add optional type hinting to arguments

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/metrics_encoder/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/metrics_encoder/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 from os import environ
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from opentelemetry.exporter.otlp.proto.common._internal import (
     _encode_attributes,
@@ -66,8 +66,10 @@ _logger = logging.getLogger(__name__)
 class OTLPMetricExporterMixin:
     def _common_configuration(
         self,
-        preferred_temporality: Dict[type, AggregationTemporality] = None,
-        preferred_aggregation: Dict[type, Aggregation] = None,
+        preferred_temporality: Optional[
+            Dict[type, AggregationTemporality]
+        ] = None,
+        preferred_aggregation: Optional[Dict[type, Aggregation]] = None,
     ) -> None:
         MetricExporter.__init__(
             self,

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/metric_exporter/__init__.py
@@ -100,8 +100,10 @@ class OTLPMetricExporter(
         ] = None,
         timeout: Optional[int] = None,
         compression: Optional[Compression] = None,
-        preferred_temporality: Dict[type, AggregationTemporality] = None,
-        preferred_aggregation: Dict[type, Aggregation] = None,
+        preferred_temporality: Optional[
+            Dict[type, AggregationTemporality]
+        ] = None,
+        preferred_aggregation: Optional[Dict[type, Aggregation]] = None,
         max_export_batch_size: Optional[int] = None,
     ):
         if insecure is None:

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
@@ -109,8 +109,8 @@ class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
         timeout: Optional[int] = None,
         compression: Optional[Compression] = None,
         session: Optional[requests.Session] = None,
-        preferred_temporality: Dict[type, AggregationTemporality] = None,
-        preferred_aggregation: Dict[type, Aggregation] = None,
+        preferred_temporality: Optional[Dict[type, AggregationTemporality]] = None,
+        preferred_aggregation: Optional[Dict[type, Aggregation]] = None,
     ):
         self._endpoint = endpoint or environ.get(
             OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
@@ -109,7 +109,9 @@ class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
         timeout: Optional[int] = None,
         compression: Optional[Compression] = None,
         session: Optional[requests.Session] = None,
-        preferred_temporality: Optional[Dict[type, AggregationTemporality]] = None,
+        preferred_temporality: Optional[
+            Dict[type, AggregationTemporality]
+        ] = None,
         preferred_aggregation: Optional[Dict[type, Aggregation]] = None,
     ):
         self._endpoint = endpoint or environ.get(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
@@ -191,9 +191,9 @@ def _get_exporter_names(
 
 def _init_tracing(
     exporters: Dict[str, Type[SpanExporter]],
-    id_generator: IdGenerator = None,
-    sampler: Sampler = None,
-    resource: Resource = None,
+    id_generator: Optional[IdGenerator] = None,
+    sampler: Optional[Sampler] = None,
+    resource: Optional[Resource] = None,
 ):
     provider = TracerProvider(
         id_generator=id_generator,
@@ -213,7 +213,7 @@ def _init_metrics(
     exporters_or_readers: Dict[
         str, Union[Type[MetricExporter], Type[MetricReader]]
     ],
-    resource: Resource = None,
+    resource: Optional[Resource] = None,
 ):
     metric_readers = []
 
@@ -235,7 +235,7 @@ def _init_metrics(
 
 def _init_logging(
     exporters: Dict[str, Type[LogExporter]],
-    resource: Resource = None,
+    resource: Optional[Resource] = None,
     setup_logging_handler: bool = True,
 ):
     provider = LoggerProvider(resource=resource)
@@ -366,7 +366,7 @@ def _initialize_components(
     log_exporter_names: Optional[List[str]] = None,
     sampler: Optional[Sampler] = None,
     resource_attributes: Optional[Attributes] = None,
-    id_generator: IdGenerator = None,
+    id_generator: Optional[IdGenerator] = None,
     setup_logging_handler: Optional[bool] = None,
 ):
     if trace_exporter_names is None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -602,11 +602,13 @@ class Logger(APILogger):
 class LoggerProvider(APILoggerProvider):
     def __init__(
         self,
-        resource: Resource = None,
+        resource: Optional[Resource] = None,
         shutdown_on_exit: bool = True,
-        multi_log_record_processor: Union[
-            SynchronousMultiLogRecordProcessor,
-            ConcurrentMultiLogRecordProcessor,
+        multi_log_record_processor: Optional[
+            Union[
+                SynchronousMultiLogRecordProcessor,
+                ConcurrentMultiLogRecordProcessor,
+            ]
         ] = None,
     ):
         if resource is None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -171,10 +171,10 @@ class BatchLogRecordProcessor(LogRecordProcessor):
     def __init__(
         self,
         exporter: LogExporter,
-        schedule_delay_millis: float = None,
-        max_export_batch_size: int = None,
-        export_timeout_millis: float = None,
-        max_queue_size: int = None,
+        schedule_delay_millis: Optional[float] = None,
+        max_export_batch_size: Optional[int] = None,
+        export_timeout_millis: Optional[float] = None,
+        max_queue_size: Optional[int] = None,
     ):
         if max_queue_size is None:
             max_queue_size = BatchLogRecordProcessor._default_max_queue_size()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
@@ -91,9 +91,11 @@ class MetricExporter(ABC):
 
     def __init__(
         self,
-        preferred_temporality: Dict[type, AggregationTemporality] = None,
-        preferred_aggregation: Dict[
-            type, "opentelemetry.sdk.metrics.view.Aggregation"
+        preferred_temporality: Optional[
+            Dict[type, AggregationTemporality]
+        ] = None,
+        preferred_aggregation: Optional[
+            Dict[type, "opentelemetry.sdk.metrics.view.Aggregation"]
         ] = None,
     ) -> None:
         self._preferred_temporality = preferred_temporality
@@ -144,9 +146,11 @@ class ConsoleMetricExporter(MetricExporter):
         formatter: Callable[
             ["opentelemetry.sdk.metrics.export.MetricsData"], str
         ] = lambda metrics_data: metrics_data.to_json() + linesep,
-        preferred_temporality: Dict[type, AggregationTemporality] = None,
-        preferred_aggregation: Dict[
-            type, "opentelemetry.sdk.metrics.view.Aggregation"
+        preferred_temporality: Optional[
+            Dict[type, AggregationTemporality]
+        ] = None,
+        preferred_aggregation: Optional[
+            Dict[type, "opentelemetry.sdk.metrics.view.Aggregation"]
         ] = None,
     ):
         super().__init__(
@@ -209,9 +213,11 @@ class MetricReader(ABC):
 
     def __init__(
         self,
-        preferred_temporality: Dict[type, AggregationTemporality] = None,
-        preferred_aggregation: Dict[
-            type, "opentelemetry.sdk.metrics.view.Aggregation"
+        preferred_temporality: Optional[
+            Dict[type, AggregationTemporality]
+        ] = None,
+        preferred_aggregation: Optional[
+            Dict[type, "opentelemetry.sdk.metrics.view.Aggregation"]
         ] = None,
     ) -> None:
         self._collect: Callable[
@@ -387,9 +393,11 @@ class InMemoryMetricReader(MetricReader):
 
     def __init__(
         self,
-        preferred_temporality: Dict[type, AggregationTemporality] = None,
-        preferred_aggregation: Dict[
-            type, "opentelemetry.sdk.metrics.view.Aggregation"
+        preferred_temporality: Optional[
+            Dict[type, AggregationTemporality]
+        ] = None,
+        preferred_aggregation: Optional[
+            Dict[type, "opentelemetry.sdk.metrics.view.Aggregation"]
         ] = None,
     ) -> None:
         super().__init__(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py
@@ -159,7 +159,7 @@ class Counter(_Synchronous, APICounter):
     def add(
         self,
         amount: Union[int, float],
-        attributes: Dict[str, str] = None,
+        attributes: Optional[Dict[str, str]] = None,
         context: Optional[Context] = None,
     ):
         if amount < 0:
@@ -188,7 +188,7 @@ class UpDownCounter(_Synchronous, APIUpDownCounter):
     def add(
         self,
         amount: Union[int, float],
-        attributes: Dict[str, str] = None,
+        attributes: Optional[Dict[str, str]] = None,
         context: Optional[Context] = None,
     ):
         time_unix_nano = time_ns()
@@ -250,7 +250,7 @@ class Histogram(_Synchronous, APIHistogram):
     def record(
         self,
         amount: Union[int, float],
-        attributes: Dict[str, str] = None,
+        attributes: Optional[Dict[str, str]] = None,
         context: Optional[Context] = None,
     ):
         if amount < 0:
@@ -280,7 +280,7 @@ class Gauge(_Synchronous, APIGauge):
     def set(
         self,
         amount: Union[int, float],
-        attributes: Dict[str, str] = None,
+        attributes: Optional[Dict[str, str]] = None,
         context: Optional[Context] = None,
     ):
         time_unix_nano = time_ns()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -155,10 +155,10 @@ class BatchSpanProcessor(SpanProcessor):
     def __init__(
         self,
         span_exporter: SpanExporter,
-        max_queue_size: int = None,
-        schedule_delay_millis: float = None,
-        max_export_batch_size: int = None,
-        export_timeout_millis: float = None,
+        max_queue_size: Optional[int] = None,
+        schedule_delay_millis: Optional[float] = None,
+        max_export_batch_size: Optional[int] = None,
+        export_timeout_millis: Optional[float] = None,
     ):
         if max_queue_size is None:
             max_queue_size = BatchSpanProcessor._default_max_queue_size()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -376,7 +376,7 @@ class BatchSpanProcessor(SpanProcessor):
         while self.queue:
             self._export_batch()
 
-    def force_flush(self, timeout_millis: int = None) -> bool:
+    def force_flush(self, timeout_millis: Optional[int] = None) -> bool:
         if timeout_millis is None:
             timeout_millis = self.export_timeout_millis
 

--- a/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
+++ b/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
@@ -15,7 +15,7 @@
 # pylint: disable=protected-access
 
 from time import time_ns
-from typing import Callable, Sequence, Type
+from typing import Callable, Optional, Sequence, Type
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
@@ -50,7 +50,7 @@ from opentelemetry.sdk.metrics.view import (
 
 
 def generalized_reservoir_factory(
-    size: int = 1, boundaries: Sequence[float] = None
+    size: int = 1, boundaries: Optional[Sequence[float]] = None
 ) -> Callable[[Type[_Aggregation]], ExemplarReservoirBuilder]:
     def factory(
         aggregation_type: Type[_Aggregation],

--- a/opentelemetry-sdk/tests/test_configurator.py
+++ b/opentelemetry-sdk/tests/test_configurator.py
@@ -136,8 +136,10 @@ class DummyMetricReader(MetricReader):
     def __init__(
         self,
         exporter: MetricExporter,
-        preferred_temporality: Dict[type, AggregationTemporality] = None,
-        preferred_aggregation: Dict[type, Aggregation] = None,
+        preferred_temporality: Optional[
+            Dict[type, AggregationTemporality]
+        ] = None,
+        preferred_aggregation: Optional[Dict[type, Aggregation]] = None,
         export_interval_millis: Optional[float] = None,
         export_timeout_millis: Optional[float] = None,
     ) -> None:
@@ -253,10 +255,10 @@ class CustomRatioSampler(TraceIdRatioBased):
         parent_context: Optional["Context"],
         trace_id: int,
         name: str,
-        kind: SpanKind = None,
+        kind: Optional[SpanKind] = None,
         attributes: Attributes = None,
-        links: Sequence[Link] = None,
-        trace_state: TraceState = None,
+        links: Optional[Sequence[Link]] = None,
+        trace_state: Optional[TraceState] = None,
     ) -> "SamplingResult":
         return SamplingResult(
             Decision.RECORD_AND_SAMPLE,

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
@@ -219,7 +219,7 @@ class SpanShim(Span):
         self._otel_span.update_name(operation_name)
         return self
 
-    def finish(self, finish_time: float = None):
+    def finish(self, finish_time: Optional[float] = None):
         """Ends the OpenTelemetry span wrapped by this :class:`SpanShim`.
 
         If *finish_time* is provided, the time value is converted to the
@@ -255,7 +255,7 @@ class SpanShim(Span):
         return self
 
     def log_kv(
-        self, key_values: Attributes, timestamp: float = None
+        self, key_values: Attributes, timestamp: Optional[float] = None
     ) -> "SpanShim":
         """Logs an event for the wrapped OpenTelemetry span.
 
@@ -560,10 +560,10 @@ class TracerShim(Tracer):
     def start_active_span(
         self,
         operation_name: str,
-        child_of: Union[SpanShim, SpanContextShim] = None,
-        references: list = None,
+        child_of: Optional[Union[SpanShim, SpanContextShim]] = None,
+        references: Optional[list] = None,
         tags: Attributes = None,
-        start_time: float = None,
+        start_time: Optional[float] = None,
         ignore_active_span: bool = False,
         finish_on_close: bool = True,
     ) -> "ScopeShim":
@@ -613,11 +613,11 @@ class TracerShim(Tracer):
 
     def start_span(
         self,
-        operation_name: str = None,
-        child_of: Union[SpanShim, SpanContextShim] = None,
-        references: list = None,
+        operation_name: Optional[str] = None,
+        child_of: Optional[Union[SpanShim, SpanContextShim]] = None,
+        references: Optional[list] = None,
         tags: Attributes = None,
-        start_time: float = None,
+        start_time: Optional[float] = None,
         ignore_active_span: bool = False,
     ) -> SpanShim:
         """Implements the ``start_span()`` method from the base class.


### PR DESCRIPTION
# Description

Adds `Optional` type hint in all places where arguments default to `None` and so are clearly `Optional`

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/4454

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Temporarily comment out `typeCheckingMode = "off"` in the `pyproject.toml`
2. Run `pyright .` on `main` and see 1560 errors
3. Run `pyright .` on this branch and see 1508 errors

# Does This PR Require a Contrib Repo Change?

Don't think so?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
