### PR TITLE
add benchmark test for baggage

### DIFF
--- a/opentelemetry-sdk/benchmarks/test_baggage.py
+++ b/opentelemetry-sdk/benchmarks/test_baggage.py
@@ -1,0 +1,68 @@
+import pytest
+
+from opentelemetry import trace
+from opentelemetry.baggage import (
+    clear,
+    get_all,
+    get_baggage,
+    remove_baggage,
+    set_baggage,
+)
+
+tracer = trace.get_tracer(__name__)
+
+
+@pytest.fixture(params=[10, 100, 1000, 10000])
+def baggage_size(request):
+    return request.param
+
+
+def set_baggage_operation(baggage_size=10):
+    with tracer.start_span(name="root span"):
+        ctx = get_all()
+        for i in range(baggage_size):
+            ctx = set_baggage(f"foo{i}", f"bar{i}", context=ctx)
+    return ctx
+
+
+def test_set_baggage(benchmark, baggage_size):
+    ctx = benchmark(set_baggage_operation, baggage_size)
+    result = get_all(ctx)
+    assert len(result) == baggage_size
+
+
+def test_get_baggage(benchmark, baggage_size):
+    ctx = set_baggage_operation(baggage_size)
+
+    def get_baggage_operation():
+        return [get_baggage(f"foo{i}", ctx) for i in range(baggage_size)]
+
+    result = benchmark(get_baggage_operation)
+    assert result == [f"bar{i}" for i in range(baggage_size)]
+
+
+def test_remove_baggage(benchmark, baggage_size):
+    ctx = set_baggage_operation(baggage_size)
+
+    def remove_operation():
+        tmp_ctx = ctx
+        for i in range(baggage_size):
+            tmp_ctx = remove_baggage(f"foo{i}", tmp_ctx)
+        return tmp_ctx
+
+    cleared_context = benchmark(remove_operation)
+    result = get_all(cleared_context)
+    # After removing all baggage items, it should be empty.
+    assert len(result) == 0
+
+
+def test_clear_baggage(benchmark, baggage_size):
+    ctx = set_baggage_operation(baggage_size)
+
+    def clear_operation():
+        return clear(ctx)
+
+    cleared_context = benchmark(clear_operation)
+    result = get_all(cleared_context)
+    # After clearing the baggage should be empty.
+    assert len(result) == 0

--- a/opentelemetry-sdk/benchmarks/test_baggage.py
+++ b/opentelemetry-sdk/benchmarks/test_baggage.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name, invalid-name
 import pytest
 
 from opentelemetry import trace
@@ -17,10 +18,10 @@ def baggage_size(request):
     return request.param
 
 
-def set_baggage_operation(baggage_size=10):
+def set_baggage_operation(size=10):
     with tracer.start_span(name="root span"):
         ctx = get_all()
-        for i in range(baggage_size):
+        for i in range(size):
             ctx = set_baggage(f"foo{i}", f"bar{i}", context=ctx)
     return ctx
 


### PR DESCRIPTION
To help show outcomes from #4466

```
$ tox -f benchmark-sdk -- -k 'baggage'
```

```
opentelemetry-sdk/benchmarks/test_baggage.py::test_set_baggage[10] PASSED                                                                                                                      [  6%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_set_baggage[100] PASSED                                                                                                                     [ 12%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_set_baggage[1000] PASSED                                                                                                                    [ 18%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_set_baggage[10000] PASSED                                                                                                                   [ 25%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_get_baggage[10] PASSED                                                                                                                      [ 31%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_get_baggage[100] PASSED                                                                                                                     [ 37%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_get_baggage[1000] PASSED                                                                                                                    [ 43%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_get_baggage[10000] PASSED                                                                                                                   [ 50%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_remove_baggage[10] PASSED                                                                                                                   [ 56%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_remove_baggage[100] PASSED                                                                                                                  [ 62%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_remove_baggage[1000] PASSED                                                                                                                 [ 68%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_remove_baggage[10000] PASSED                                                                                                                [ 75%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_clear_baggage[10] PASSED                                                                                                                    [ 81%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_clear_baggage[100] PASSED                                                                                                                   [ 87%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_clear_baggage[1000] PASSED                                                                                                                  [ 93%]
opentelemetry-sdk/benchmarks/test_baggage.py::test_clear_baggage[10000] PASSED                                                                                                                 [100%]
```

I'm adding the test under opentelemetry-sdk benchmarks because we have only one job to run benchmarks and it's tailored to SDK. For now, I think it's more important to have the benchmark published.