### PR TITLE
Prototype passing a Customizer Class to the Configurator

### DIFF
--- a/opentelemetry-sdk/pyproject.toml
+++ b/opentelemetry-sdk/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "opentelemetry-api == 1.31.0.dev",
-  "opentelemetry-semantic-conventions == 0.52b0.dev",
+  "opentelemetry-api == 1.30.0",
+  "opentelemetry-semantic-conventions == 0.51b0",
   "typing-extensions >= 3.7.4",
 ]
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_config_customizer/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_config_customizer/__init__.py
@@ -1,0 +1,34 @@
+from abc import ABC, abstractmethod
+from opentelemetry.sdk._logs.export import LogExporter
+from opentelemetry.sdk.metrics.export import (
+    MetricExporter,
+)
+from typing import Type
+from opentelemetry.sdk.trace.export import SpanExporter
+
+
+# Class which can be used to customize the configurator.
+class _BaseConfiguratorCustomizer(ABC):
+    @abstractmethod
+    def init_log_exporter(
+        self, log_exporter: Type[LogExporter]
+    ) -> LogExporter:
+        pass
+
+    @abstractmethod
+    def init_metric_exporter(
+        self,
+        metric_exporter: Type[MetricExporter],
+    ) -> MetricExporter:
+        pass
+
+    @abstractmethod
+    def init_span_exporter(
+        self,
+        span_exporter: Type[SpanExporter],
+    ) -> SpanExporter:
+        pass
+
+    @abstractmethod
+    def init_resource(self):
+        pass

--- a/opentelemetry-sdk/src/opentelemetry/sdk/version/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/version/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.31.0.dev"
+__version__ = "1.30.0"


### PR DESCRIPTION
Add a generic Customizer class with methods for initializing the exporters and the resource, it could be extended to customize all the initialization done by the configurator.

The lets vendors customize auto instrumentation in a way that isn't possible right now with just environment variables.

https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/388 -- this is an example of what an implementation of the Customizer class by a vendor might look like. 

See https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3353 for the change that'd be needed for contrib
