### PR TITLE
bugfix(exporter): ensure response is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4406](https://github.com/open-telemetry/opentelemetry-python/pull/4406))
 - Fix env var error message for TraceLimits/SpanLimits
   ([#4458](https://github.com/open-telemetry/opentelemetry-python/pull/4458))
+- Fix intermittent `Connection aborted` error when using otlp/http exporters
+  ([#4477](https://github.com/open-telemetry/opentelemetry-python/pull/4477))
 
 ## Version 1.30.0/0.51b0 (2025-02-03)
 

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -167,8 +167,10 @@ class OTLPLogExporter(LogExporter):
             resp = self._export(serialized_data)
             # pylint: disable=no-else-return
             if resp.ok:
+                resp.close()
                 return LogExportResult.SUCCESS
             elif self._retryable(resp):
+                resp.close()
                 _logger.warning(
                     "Transient error %s encountered while exporting logs batch, retrying in %ss.",
                     resp.reason,
@@ -177,6 +179,7 @@ class OTLPLogExporter(LogExporter):
                 sleep(delay)
                 continue
             else:
+                resp.close()
                 _logger.error(
                     "Failed to export logs batch code: %s, reason: %s",
                     resp.status_code,

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
@@ -206,8 +206,10 @@ class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
             resp = self._export(serialized_data.SerializeToString())
             # pylint: disable=no-else-return
             if resp.ok:
+                resp.close()
                 return MetricExportResult.SUCCESS
             elif self._retryable(resp):
+                resp.close()
                 _logger.warning(
                     "Transient error %s encountered while exporting metric batch, retrying in %ss.",
                     resp.reason,
@@ -216,6 +218,7 @@ class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
                 sleep(delay)
                 continue
             else:
+                resp.close()
                 _logger.error(
                     "Failed to export batch code: %s, reason: %s",
                     resp.status_code,

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -159,8 +159,10 @@ class OTLPSpanExporter(SpanExporter):
             resp = self._export(serialized_data)
             # pylint: disable=no-else-return
             if resp.ok:
+                resp.close()
                 return SpanExportResult.SUCCESS
             elif self._retryable(resp):
+                resp.close()
                 _logger.warning(
                     "Transient error %s encountered while exporting span batch, retrying in %ss.",
                     resp.reason,
@@ -169,6 +171,7 @@ class OTLPSpanExporter(SpanExporter):
                 sleep(delay)
                 continue
             else:
+                resp.close()
                 _logger.error(
                     "Failed to export batch code: %s, reason: %s",
                     resp.status_code,


### PR DESCRIPTION
# Description

I was experiencing connection aborted when using the OTLP exporters to emit metrics. After reading the documentation for the requests library, it appears that if the body is not read, it is not necessarily returned to the connection pool.

Fix #4476

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested to validate that the connection aborted errors no longer happen.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
