### PR TITLE
Fix broken link in Prometheus exporter README. Fixes #4399

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus/README.rst
+++ b/exporter/opentelemetry-exporter-prometheus/README.rst
@@ -18,6 +18,6 @@ Installation
 References
 ----------
 
-* `OpenTelemetry Prometheus Exporter <https://opentelemetry-python.readthedocs.io/en/latest/exporter/prometheus/prometheus.html>`_
+* `OpenTelemetry Prometheus Exporter <https://opentelemetry.io/docs/instrumentation/python/exporters/#prometheus>`_
 * `Prometheus <https://prometheus.io/>`_
 * `OpenTelemetry Project <https://opentelemetry.io/>`_


### PR DESCRIPTION
 Description

This PR fixes the broken link in the Prometheus exporter README.rst by updating it to point to the current documentation location on opentelemetry.io.

The old link pointed to a non-existent page on readthedocs:
https://opentelemetry-python.readthedocs.io/en/latest/exporter/prometheus/prometheus.html

The new link points to the current documentation:
https://opentelemetry.io/docs/instrumentation/python/exporters/#prometheus

Fixes #4399

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Verified that the new link is accessible and points to the correct documentation
- [x] Checked that the RST formatting is correct in the README file

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated
