### PR TITLE
Fix oltp exporter shutdown race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4475](https://github.com/open-telemetry/opentelemetry-python/pull/4475))
 - Improve performance of baggage operations
   ([#4466](https://github.com/open-telemetry/opentelemetry-python/pull/4466))
+- opentelemetry-exporter-otlp-proto-grpc: fix shutdown race condition
+  ([#4490](https://github.com/open-telemetry/opentelemetry-python/pull/4490))
 
 ## Version 1.31.0/0.52b0 (2025-03-12)
 

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -356,9 +356,10 @@ class OTLPExporterMixin(
         if self._shutdown:
             logger.warning("Exporter already shutdown, ignoring call")
             return
+        # set shutdown flag to prevent new exports
+        self._shutdown = True
         # wait for the last export if any
         self._export_lock.acquire(timeout=timeout_millis / 1e3)
-        self._shutdown = True
         self._channel.close()
         self._export_lock.release()
 


### PR DESCRIPTION
# Description

Exports can start after the lock is acquired but before the shutdown flag is set, this raises an error if the channel has already been closed. 
Avoid this race condition by setting the shutdown flag before acquiring the lock.


Fixes #4465

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc`

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
