### PR TITLE
sdk: remove duplicated env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4475](https://github.com/open-telemetry/opentelemetry-python/pull/4475))
 - Improve performance of baggage operations
   ([#4466](https://github.com/open-telemetry/opentelemetry-python/pull/4466))
+- sdk: remove duplicated constant definitions for `environment_variables`
+  ([#4491](https://github.com/open-telemetry/opentelemetry-python/pull/4491))
 
 ## Version 1.31.0/0.52b0 (2025-03-12)
 
@@ -19,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add type annotations to context's attach & detach
   ([#4346](https://github.com/open-telemetry/opentelemetry-python/pull/4346))
 - Fix OTLP encoders missing instrumentation scope schema url and attributes
-  ([#4359](https://github.com/open-telemetry/opentelemetry-python/pull/4359))  
+  ([#4359](https://github.com/open-telemetry/opentelemetry-python/pull/4359))
 - prometheus-exporter: fix labels out of place for data points with different
   attribute sets
   ([#4413](https://github.com/open-telemetry/opentelemetry-python/pull/4413))

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
@@ -565,25 +565,6 @@ for gRPC requests for logs. A scheme of https takes precedence over the this con
 Default: False
 """
 
-OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
-"""
-.. envvar:: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-
-The :envvar:`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` target to which the metric exporter is going to send spans.
-The endpoint MUST be a valid URL host, and MAY contain a scheme (http or https), port and path.
-A scheme of https indicates a secure connection and takes precedence over this configuration setting.
-"""
-
-OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE = (
-    "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE"
-)
-"""
-.. envvar:: OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE
-
-The :envvar:`OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE` stores the path to the certificate file for
-TLS credentials of gRPC client for metrics. Should only be used for a secure connection for metrics.
-"""
-
 OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE = "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE
@@ -592,38 +573,12 @@ The :envvar:`OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE` stores the path to the certifi
 TLS credentials of gRPC client for logs. Should only be used for a secure connection for logs.
 """
 
-OTEL_EXPORTER_OTLP_METRICS_HEADERS = "OTEL_EXPORTER_OTLP_METRICS_HEADERS"
-"""
-.. envvar:: OTEL_EXPORTER_OTLP_METRICS_HEADERS
-
-The :envvar:`OTEL_EXPORTER_OTLP_METRICS_HEADERS` contains the key-value pairs to be used as headers for metrics
-associated with gRPC or HTTP requests.
-"""
-
-OTEL_EXPORTER_OTLP_METRICS_TIMEOUT = "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT"
-"""
-.. envvar:: OTEL_EXPORTER_OTLP_METRICS_TIMEOUT
-
-The :envvar:`OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` is the maximum time the OTLP exporter will
-wait for each batch export for metrics.
-"""
-
 OTEL_EXPORTER_OTLP_LOGS_TIMEOUT = "OTEL_EXPORTER_OTLP_LOGS_TIMEOUT"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_LOGS_TIMEOUT
 
 The :envvar:`OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` is the maximum time the OTLP exporter will
 wait for each batch export for logs.
-"""
-
-OTEL_EXPORTER_OTLP_METRICS_COMPRESSION = (
-    "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION"
-)
-"""
-.. envvar:: OTEL_EXPORTER_OTLP_METRICS_COMPRESSION
-
-Same as :envvar:`OTEL_EXPORTER_OTLP_COMPRESSION` but only for the metric
-exporter. If both are present, this takes higher precedence.
 """
 
 OTEL_EXPORTER_JAEGER_CERTIFICATE = "OTEL_EXPORTER_JAEGER_CERTIFICATE"
@@ -714,13 +669,6 @@ OTEL_METRIC_EXPORT_TIMEOUT = "OTEL_METRIC_EXPORT_TIMEOUT"
 The :envvar:`OTEL_METRIC_EXPORT_TIMEOUT` is the maximum allowed time (in milliseconds) to export data.
 """
 
-OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY = "OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY"
-"""
-.. envvar:: OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY
-
-The :envvar:`OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY` is the clients private key to use in mTLS communication in PEM format.
-"""
-
 OTEL_METRICS_EXEMPLAR_FILTER = "OTEL_METRICS_EXEMPLAR_FILTER"
 """
 .. envvar:: OTEL_METRICS_EXEMPLAR_FILTER
@@ -735,15 +683,6 @@ OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION = (
 .. envvar:: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
 
 The :envvar:`OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION` is the default aggregation to use for histogram instruments.
-"""
-
-OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE = (
-    "OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE"
-)
-"""
-.. envvar:: OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE
-
-The :envvar:`OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE` is the client certificate/chain trust for clients private key to use in mTLS communication in PEM format.
 """
 
 OTEL_EXPERIMENTAL_RESOURCE_DETECTORS = "OTEL_EXPERIMENTAL_RESOURCE_DETECTORS"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,9 +103,24 @@ pythonVersion = "3.8"
 include = [
   "opentelemetry-semantic-conventions",
   "opentelemetry-api",
+  "opentelemetry-sdk",
+]
+
+exclude = [
+  "opentelemetry-sdk/tests",
+  "opentelemetry-sdk/src/opentelemetry/sdk/_configuration",
+  "opentelemetry-sdk/src/opentelemetry/sdk/_events",
+  "opentelemetry-sdk/src/opentelemetry/sdk/_logs",
+  "opentelemetry-sdk/src/opentelemetry/sdk/error_handler",
+  "opentelemetry-sdk/src/opentelemetry/sdk/resources",
+  "opentelemetry-sdk/src/opentelemetry/sdk/metrics",
+  "opentelemetry-sdk/src/opentelemetry/sdk/trace",
+  "opentelemetry-sdk/src/opentelemetry/sdk/util",
+  "opentelemetry-sdk/benchmarks",
 ]
 
 # When packages are correct typed add them to the strict list
 strict = [
   "opentelemetry-semantic-conventions",
+  "opentelemetry-sdk/src/opentelemetry/sdk/environment_variables",
 ]


### PR DESCRIPTION
Running pyright at `sdk/environment_variables`: 

```
__init__.py:568:1 - error: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" is constant (because it is uppercase) and cannot be redefined (reportConstantRedefinition)
__init__.py:577:1 - error: "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE" is constant (because it is uppercase) and cannot be redefined (reportConstantRedefinition)
__init__.py:595:1 - error: "OTEL_EXPORTER_OTLP_METRICS_HEADERS" is constant (because it is uppercase) and cannot be redefined (reportConstantRedefinition)
__init__.py:603:1 - error: "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT" is constant (because it is uppercase) and cannot be redefined (reportConstantRedefinition)
__init__.py:619:1 - error: "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION" is constant (because it is uppercase) and cannot be redefined (reportConstantRedefinition)
__init__.py:717:1 - error: "OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY" is constant (because it is uppercase) and cannot be redefined (reportConstantRedefinition)
__init__.py:740:1 - error: "OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE" is constant (because it is uppercase) and cannot be redefined (reportConstantRedefinition)
```