### PR TITLE
revert BaseException change

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -588,7 +588,7 @@ def use_span(
         finally:
             context_api.detach(token)
 
-    except BaseException as exc:  # pylint: disable=broad-exception-caught
+    except Exception as exc:  # pylint: disable=broad-exception-caught
         if isinstance(span, Span) and span.is_recording():
             # Record the exception as an event
             if record_exception:

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -133,18 +133,6 @@ class TestUseTracer(unittest.TestCase):
 
         self.assertEqual(test_span.recorded_exception, exception)
 
-    def test_use_span_base_exception(self):
-        class TestUseSpanBaseException(BaseException):
-            pass
-
-        test_span = SpanTest(trace.INVALID_SPAN_CONTEXT)
-        exception = TestUseSpanBaseException("test exception")
-        with self.assertRaises(TestUseSpanBaseException):
-            with trace.use_span(test_span):
-                raise exception
-
-        self.assertEqual(test_span.recorded_exception, exception)
-
     def test_use_span_set_status(self):
         class TestUseSpanException(Exception):
             pass


### PR DESCRIPTION
# Description
Revert the change https://github.com/open-telemetry/opentelemetry-python/pull/4406 
since it's setting span as error for non error exceptions
see https://github.com/open-telemetry/opentelemetry-python/issues/4493
https://github.com/open-telemetry/opentelemetry-python/issues/4484 