### PR TITLE
[release/v1.31.x-0.52bx] api: revert catching BaseException in trace.use_span (#4494)

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -11,4 +11,4 @@ jobs:
     uses: open-telemetry/opentelemetry-python-contrib/.github/workflows/core_contrib_test_0.yml@main
     with:
       CORE_REPO_SHA: ${{ github.sha }}
-      CONTRIB_REPO_SHA: opentelemetrybot/prepare-release-1.31.0-0.52b0
+      CONTRIB_REPO_SHA: release/v1.31.x-0.52bx

--- a/.github/workflows/lint_0.yml
+++ b/.github/workflows/lint_0.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CORE_REPO_SHA: main
-  CONTRIB_REPO_SHA: opentelemetrybot/prepare-release-1.31.0-0.52b0
+  CONTRIB_REPO_SHA: release/v1.31.x-0.52bx
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/misc_0.yml
+++ b/.github/workflows/misc_0.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CORE_REPO_SHA: main
-  CONTRIB_REPO_SHA: opentelemetrybot/prepare-release-1.31.0-0.52b0
+  CONTRIB_REPO_SHA: release/v1.31.x-0.52bx
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/test_0.yml
+++ b/.github/workflows/test_0.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CORE_REPO_SHA: main
-  CONTRIB_REPO_SHA: opentelemetrybot/prepare-release-1.31.0-0.52b0
+  CONTRIB_REPO_SHA: release/v1.31.x-0.52bx
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/test_1.yml
+++ b/.github/workflows/test_1.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CORE_REPO_SHA: main
-  CONTRIB_REPO_SHA: opentelemetrybot/prepare-release-1.31.0-0.52b0
+  CONTRIB_REPO_SHA: release/v1.31.x-0.52bx
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- api: Revert record `BaseException` change in `trace_api.use_span()`
+  ([#4494](https://github.com/open-telemetry/opentelemetry-python/pull/4494))
+
 ## Version 1.31.0/0.52b0 (2025-03-12)
 
 - semantic-conventions: Bump to 1.31.0
@@ -12,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add type annotations to context's attach & detach
   ([#4346](https://github.com/open-telemetry/opentelemetry-python/pull/4346))
 - Fix OTLP encoders missing instrumentation scope schema url and attributes
-  ([#4359](https://github.com/open-telemetry/opentelemetry-python/pull/4359))  
+  ([#4359](https://github.com/open-telemetry/opentelemetry-python/pull/4359))
 - prometheus-exporter: fix labels out of place for data points with different
   attribute sets
   ([#4413](https://github.com/open-telemetry/opentelemetry-python/pull/4413))

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -588,7 +588,10 @@ def use_span(
         finally:
             context_api.detach(token)
 
-    except BaseException as exc:  # pylint: disable=broad-exception-caught
+    # Record only exceptions that inherit Exception class but not BaseException, because
+    # classes that directly inherit BaseException are not technically errors, e.g. GeneratorExit.
+    # See https://github.com/open-telemetry/opentelemetry-python/issues/4484
+    except Exception as exc:  # pylint: disable=broad-exception-caught
         if isinstance(span, Span) and span.is_recording():
             # Record the exception as an event
             if record_exception:


### PR DESCRIPTION
Clean cherry-pick of #4494 to the [release/v1.31.x-0.52bx](https://github.com/open-telemetry/opentelemetry-python/tree/release/v1.31.x-0.52bx) branch.