### PR TITLE
fix(exporter): convert body to str as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4494](https://github.com/open-telemetry/opentelemetry-python/pull/4494))
 - Improve CI by cancelling stale runs and setting timeouts
   ([#4498](https://github.com/open-telemetry/opentelemetry-python/pull/4498))
+- Fix logging of objects which are convertible to strings
+  ([#4510](https://github.com/open-telemetry/opentelemetry-python/pull/4510))
 
 ## Version 1.31.0/0.52b0 (2025-03-12)
 

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -70,7 +70,9 @@ def _encode_resource(resource: Resource) -> PB2Resource:
 
 
 def _encode_value(
-    value: Any, allow_null: bool = False
+    value: Any,
+    allow_null: bool = False,
+    fallback: Optional[Callable[[Any], Any]] = None,
 ) -> Optional[PB2AnyValue]:
     if allow_null is True and value is None:
         return None
@@ -99,6 +101,8 @@ def _encode_value(
                 ]
             )
         )
+    elif fallback is not None:
+        return _encode_value(fallback(value), allow_null)
     raise Exception(f"Invalid type {type(value)} of value {value}")
 
 

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
@@ -55,7 +55,7 @@ def _encode_log(log_data: LogData) -> PB2LogRecord:
         span_id=span_id,
         trace_id=trace_id,
         flags=int(log_data.log_record.trace_flags),
-        body=_encode_value(body, allow_null=True),
+        body=_encode_value(body, allow_null=True, fallback=str),
         severity_text=log_data.log_record.severity_text,
         attributes=_encode_attributes(log_data.log_record.attributes),
         dropped_attributes_count=log_data.log_record.dropped_attributes,

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
@@ -69,6 +69,21 @@ class TestOTLPLogEncoder(unittest.TestCase):
 
         self.assertEqual(encode_logs(sdk_logs), expected_encoding)
 
+    def test_encode_stringifiable(self):
+        class Stringifiable:
+            def __init__(self, data):
+                self.data = data
+            def __str__(self):
+                return self.data
+
+        sdk_logs, expected_encoding = self.get_test_logs()
+        for log in sdk_logs:
+            body = log.log_record.body
+            if isinstance(body, str):
+                log.log_record.body = Stringifiable(body)
+
+        self.assertEqual(encode_logs(sdk_logs), expected_encoding)
+
     def test_dropped_attributes_count(self):
         sdk_logs = self._get_test_logs_dropped_attributes()
         encoded_logs = encode_logs(sdk_logs)


### PR DESCRIPTION
# Description

When a message body is passed to `logging` which cannot be encoded directly, try to convert it to a string as a fallback. This makes sense because log bodies are commonly strings, and string is also the only supported interface that is immutable and may get large, so it might make sense to offer a way to compute log strings lazily.

Fixes #4509

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Fixes the minimal example and the OTLP log export in synapse.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes.
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated (is this necessary?)
