### PR TITLE
opentelemetry-sdk: fix explicit histogram aggregation to handle multiple explicit bucket advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4494](https://github.com/open-telemetry/opentelemetry-python/pull/4494))
 - Improve CI by cancelling stale runs and setting timeouts
   ([#4498](https://github.com/open-telemetry/opentelemetry-python/pull/4498))
-- Fix ExplicitBucketHistogramAggregation to handle multiple explicit bucket boundaries advisories ([#4521](https://github.com/open-telemetry/opentelemetry-python/pull/4521))
+- Fix ExplicitBucketHistogramAggregation to handle multiple explicit bucket boundaries advisories
+ ([#4521](https://github.com/open-telemetry/opentelemetry-python/pull/4521))
 
 ## Version 1.31.0/0.52b0 (2025-03-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4494](https://github.com/open-telemetry/opentelemetry-python/pull/4494))
 - Improve CI by cancelling stale runs and setting timeouts
   ([#4498](https://github.com/open-telemetry/opentelemetry-python/pull/4498))
+- Fix ExplicitBucketHistogramAggregation to handle multiple explicit bucket boundaries advisories ([#4521](https://github.com/open-telemetry/opentelemetry-python/pull/4521))
 
 ## Version 1.31.0/0.52b0 (2025-03-12)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -1387,7 +1387,7 @@ class ExplicitBucketHistogramAggregation(Aggregation):
                 AggregationTemporality.CUMULATIVE
             )
 
-        if self._boundaries:
+        if self._boundaries is not None:
             boundaries = self._boundaries
         else:
             boundaries = instrument._advisory.explicit_bucket_boundaries

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -1387,18 +1387,17 @@ class ExplicitBucketHistogramAggregation(Aggregation):
                 AggregationTemporality.CUMULATIVE
             )
 
-        if self._boundaries is None:
-            self._boundaries = (
-                instrument._advisory.explicit_bucket_boundaries
-                or _DEFAULT_EXPLICIT_BUCKET_HISTOGRAM_AGGREGATION_BOUNDARIES
-            )
+        if self._boundaries:
+            boundaries = self._boundaries
+        else:
+            boundaries = instrument._advisory.explicit_bucket_boundaries
 
         return _ExplicitBucketHistogramAggregation(
             attributes,
             instrument_aggregation_temporality,
             start_time_unix_nano,
             reservoir_factory(_ExplicitBucketHistogramAggregation),
-            self._boundaries,
+            boundaries,
             self._record_min_max,
         )
 

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_histogram_advisory_explicit_buckets.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_histogram_advisory_explicit_buckets.py
@@ -223,12 +223,12 @@ class TestHistogramAdvisory(TestCase):
         )
         meter = meter_provider.get_meter("testmeter")
 
-        histogram1 = meter.create_histogram(
+        histogram = meter.create_histogram(
             "testhistogram",
         )
-        histogram1.record(1, {"label": "value"})
-        histogram1.record(2, {"label": "value"})
-        histogram1.record(3, {"label": "value"})
+        histogram.record(1, {"label": "value"})
+        histogram.record(2, {"label": "value"})
+        histogram.record(3, {"label": "value"})
 
         metrics = reader.get_metrics_data()
         self.assertEqual(len(metrics.resource_metrics), 1)

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_histogram_advisory_explicit_buckets.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_histogram_advisory_explicit_buckets.py
@@ -164,3 +164,47 @@ class TestHistogramAdvisory(TestCase):
         self.assertEqual(
             metric.data.data_points[0].explicit_bounds, (1.0, 2.0, 3.0)
         )
+
+    def test_explicit_aggregation_multiple_histograms(self):
+        reader = InMemoryMetricReader(
+            preferred_aggregation={
+                Histogram: ExplicitBucketHistogramAggregation()
+            }
+        )
+        meter_provider = MeterProvider(
+            metric_readers=[reader],
+        )
+        meter = meter_provider.get_meter("testmeter")
+
+        histogram1 = meter.create_histogram(
+            "testhistogram1",
+            explicit_bucket_boundaries_advisory=[1.0, 2.0, 3.0],
+        )
+        histogram1.record(1, {"label": "value"})
+        histogram1.record(2, {"label": "value"})
+        histogram1.record(3, {"label": "value"})
+
+        histogram2 = meter.create_histogram(
+            "testhistogram2",
+            explicit_bucket_boundaries_advisory=[4.0, 5.0, 6.0],
+        )
+        histogram2.record(4, {"label": "value"})
+        histogram2.record(5, {"label": "value"})
+        histogram2.record(6, {"label": "value"})
+
+        metrics = reader.get_metrics_data()
+        self.assertEqual(len(metrics.resource_metrics), 1)
+        self.assertEqual(len(metrics.resource_metrics[0].scope_metrics), 1)
+        self.assertEqual(
+            len(metrics.resource_metrics[0].scope_metrics[0].metrics), 2
+        )
+        metric1 = metrics.resource_metrics[0].scope_metrics[0].metrics[0]
+        self.assertEqual(metric1.name, "testhistogram1")
+        self.assertEqual(
+            metric1.data.data_points[0].explicit_bounds, (1.0, 2.0, 3.0)
+        )
+        metric2 = metrics.resource_metrics[0].scope_metrics[0].metrics[1]
+        self.assertEqual(metric2.name, "testhistogram2")
+        self.assertEqual(
+            metric2.data.data_points[0].explicit_bounds, (4.0, 5.0, 6.0)
+        )


### PR DESCRIPTION
# Description

https://github.com/open-telemetry/opentelemetry-python/pull/4434 merged a fix that allowed the `ExplicitBucketHistogramAggregation` created by the OTLP exporter to take into account histogram buckets advice.

However, unlike the `DefaultAggregation`, it does not allow setting independent bucket boundaries for multiple histograms. The first histogram will set the explicit boundaries based on the advice, but the explicit bucket boundaries of further histograms are ignored.

This keeps the behavior of the View's explicit settings taking precedence over the advisory, except when `ExplicitBucketHistogramAggregation` uses the default bucket boundaries.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py311-test-opentelemetry-sdk

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [X] Unit tests have been added
- [ ] Documentation has been updated
