### PR TITLE
4143 handle OTEL_PROPAGATORS set to none

### DIFF
--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -133,9 +133,9 @@ environ_propagators = environ.get(
 for propagator in environ_propagators.split(","):
     propagator = propagator.strip()
     if propagator.lower() == "none":
-        logger.debug(f"OTEL_PROPAGATORS environment variable set to: {environ_propagators}")
+        logger.debug(f"OTEL_PROPAGATORS environment variable contains none, removing all propagators")
+        propagators = []
         break
-
     try:
         propagators.append(  # type: ignore
             next(  # type: ignore

--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -132,6 +132,9 @@ environ_propagators = environ.get(
 
 for propagator in environ_propagators.split(","):
     propagator = propagator.strip()
+    if propagator.lower() == "none":
+        logger.debug(f"OTEL_PROPAGATORS environment variable set to: {environ_propagators}")
+        break
 
     try:
         propagators.append(  # type: ignore

--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -133,7 +133,9 @@ environ_propagators = environ.get(
 for propagator in environ_propagators.split(","):
     propagator = propagator.strip()
     if propagator.lower() == "none":
-        logger.debug(f"OTEL_PROPAGATORS environment variable contains none, removing all propagators")
+        logger.debug(
+            "OTEL_PROPAGATORS environment variable contains none, removing all propagators"
+        )
         propagators = []
         break
     try:

--- a/opentelemetry-api/tests/propagators/test_propagators.py
+++ b/opentelemetry-api/tests/propagators/test_propagators.py
@@ -72,6 +72,29 @@ class TestPropagators(TestCase):
 
         reload(opentelemetry.propagate)
 
+    @patch.dict(
+        environ, {OTEL_PROPAGATORS: "tracecontext, None"}
+    )
+    @patch("opentelemetry.propagators.composite.CompositePropagator")
+    def test_multiple_propogators_with_none(self, mock_compositehttppropagator):
+        def test_propagators(propagators):
+            propagators = {propagator.__class__ for propagator in propagators}
+
+            self.assertEqual(len(propagators), 0)
+            self.assertEqual(
+                propagators,
+                set(),
+            )
+
+        mock_compositehttppropagator.configure_mock(
+            **{"side_effect": test_propagators}
+        )
+
+        # pylint: disable=import-outside-toplevel
+        import opentelemetry.propagate
+
+        reload(opentelemetry.propagate)
+
     @patch.dict(environ, {OTEL_PROPAGATORS: "a,  b,   c  "})
     @patch("opentelemetry.propagators.composite.CompositePropagator")
     @patch("opentelemetry.util._importlib_metadata.entry_points")

--- a/opentelemetry-api/tests/propagators/test_propagators.py
+++ b/opentelemetry-api/tests/propagators/test_propagators.py
@@ -49,6 +49,29 @@ class TestPropagators(TestCase):
 
         reload(opentelemetry.propagate)
 
+    @patch.dict(
+        environ, {OTEL_PROPAGATORS: "None"}
+    )
+    @patch("opentelemetry.propagators.composite.CompositePropagator")
+    def test_none_propogators(self, mock_compositehttppropagator):
+        def test_propagators(propagators):
+            propagators = {propagator.__class__ for propagator in propagators}
+
+            self.assertEqual(len(propagators), 0)
+            self.assertEqual(
+                propagators,
+                set(),
+            )
+
+        mock_compositehttppropagator.configure_mock(
+            **{"side_effect": test_propagators}
+        )
+
+        # pylint: disable=import-outside-toplevel
+        import opentelemetry.propagate
+
+        reload(opentelemetry.propagate)
+
     @patch.dict(environ, {OTEL_PROPAGATORS: "a,  b,   c  "})
     @patch("opentelemetry.propagators.composite.CompositePropagator")
     @patch("opentelemetry.util._importlib_metadata.entry_points")

--- a/opentelemetry-api/tests/propagators/test_propagators.py
+++ b/opentelemetry-api/tests/propagators/test_propagators.py
@@ -49,9 +49,7 @@ class TestPropagators(TestCase):
 
         reload(opentelemetry.propagate)
 
-    @patch.dict(
-        environ, {OTEL_PROPAGATORS: "None"}
-    )
+    @patch.dict(environ, {OTEL_PROPAGATORS: "None"})
     @patch("opentelemetry.propagators.composite.CompositePropagator")
     def test_none_propogators(self, mock_compositehttppropagator):
         def test_propagators(propagators):
@@ -72,11 +70,11 @@ class TestPropagators(TestCase):
 
         reload(opentelemetry.propagate)
 
-    @patch.dict(
-        environ, {OTEL_PROPAGATORS: "tracecontext, None"}
-    )
+    @patch.dict(environ, {OTEL_PROPAGATORS: "tracecontext, None"})
     @patch("opentelemetry.propagators.composite.CompositePropagator")
-    def test_multiple_propogators_with_none(self, mock_compositehttppropagator):
+    def test_multiple_propogators_with_none(
+        self, mock_compositehttppropagator
+    ):
         def test_propagators(propagators):
             propagators = {propagator.__class__ for propagator in propagators}
 


### PR DESCRIPTION
# Description

<!--
This resolves issue #4143. The documentation suggests we can set OTEL_PROPAGATORS to a comma delimited string containing "none". I've seen another PR that handles when the only value is none but technically it is possible to have it as one of the options in a delimited list.

This adds an if statement to check the value of the propagators before appending and if the value is none it resets propagators variable to an empty list and breaks out of the for loop.
-->

Fixes #4143 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `tox -e py312-test-opentelemetry-api`

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
