### PR TITLE
Handle None in OTEL_PROPAGATORS

### DIFF
--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -132,7 +132,12 @@ environ_propagators = environ.get(
 
 for propagator in environ_propagators.split(","):
     propagator = propagator.strip()
-
+    if propagator.lower() == "none":
+        logger.debug(
+            "OTEL_PROPAGATORS environment variable contains none, removing all propagators"
+        )
+        propagators = []
+        break
     try:
         propagators.append(  # type: ignore
             next(  # type: ignore

--- a/opentelemetry-api/tests/propagators/test_propagators.py
+++ b/opentelemetry-api/tests/propagators/test_propagators.py
@@ -49,6 +49,50 @@ class TestPropagators(TestCase):
 
         reload(opentelemetry.propagate)
 
+    @patch.dict(environ, {OTEL_PROPAGATORS: "None"})
+    @patch("opentelemetry.propagators.composite.CompositePropagator")
+    def test_none_propogators(self, mock_compositehttppropagator):
+        def test_propagators(propagators):
+            propagators = {propagator.__class__ for propagator in propagators}
+
+            self.assertEqual(len(propagators), 0)
+            self.assertEqual(
+                propagators,
+                set(),
+            )
+
+        mock_compositehttppropagator.configure_mock(
+            **{"side_effect": test_propagators}
+        )
+
+        # pylint: disable=import-outside-toplevel
+        import opentelemetry.propagate
+
+        reload(opentelemetry.propagate)
+
+    @patch.dict(environ, {OTEL_PROPAGATORS: "tracecontext, None"})
+    @patch("opentelemetry.propagators.composite.CompositePropagator")
+    def test_multiple_propogators_with_none(
+        self, mock_compositehttppropagator
+    ):
+        def test_propagators(propagators):
+            propagators = {propagator.__class__ for propagator in propagators}
+
+            self.assertEqual(len(propagators), 0)
+            self.assertEqual(
+                propagators,
+                set(),
+            )
+
+        mock_compositehttppropagator.configure_mock(
+            **{"side_effect": test_propagators}
+        )
+
+        # pylint: disable=import-outside-toplevel
+        import opentelemetry.propagate
+
+        reload(opentelemetry.propagate)
+
     @patch.dict(environ, {OTEL_PROPAGATORS: "a,  b,   c  "})
     @patch("opentelemetry.propagators.composite.CompositePropagator")
     @patch("opentelemetry.util._importlib_metadata.entry_points")


### PR DESCRIPTION
# Description

<!--
Documentation suggests that setting OTEL_PROPAGATORS to none will disabled all propagators, this currently results in an error
```
{
  "message": "Uncaught exception",
  "traceback": "Traceback (most recent call last):
    File \"/usr/local/lib/python3.12/site-packages/opentelemetry/propagate/__init__.py\", line 139, in <module>
      next(  # type: ignore
  StopIteration
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File \"/cert-issuer/wsgi.py\", line 1, in <module>
      from app import app
    File \"/cert-issuer/app.py\", line 24, in <module>
      setup_instrument(app)
    File \"/cert-issuer/accredible/setup_instrument.py\", line 24, in setup_instrument
      from opentelemetry.instrumentation.flask import FlaskInstrumentor
    File \"/usr/local/lib/python3.12/site-packages/opentelemetry/instrumentation/flask/__init__.py\", line 251, in <module>
      import opentelemetry.instrumentation.wsgi as otel_wsgi
    File \"/usr/local/lib/python3.12/site-packages/opentelemetry/instrumentation/wsgi/__init__.py\", line 216, in <module>
      from opentelemetry.instrumentation._semconv import (
    File \"/usr/local/lib/python3.12/site-packages/opentelemetry/instrumentation/_semconv.py\", line 19, in <module>
      from opentelemetry.instrumentation.utils import http_status_to_status_code
    File \"/usr/local/lib/python3.12/site-packages/opentelemetry/instrumentation/utils.py\", line 32, in <module>
      from opentelemetry.propagate import extract
    File \"/usr/local/lib/python3.12/site-packages/opentelemetry/propagate/__init__.py\", line 149, in <module>
      raise ValueError(
  ValueError: Propagator none not found. It is either misspelled or not installed."
}
```
This PR resolves this.
-->

Fixes #4143 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `tox -e py312-test-opentelemetry-api`
- [x] `tox -e py312-test-opentelemetry-sdk`

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
