### PR TITLE
Add a timeout param to all OTLP grpc / http export calls

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -15,4 +15,8 @@ jobs:
     uses: open-telemetry/opentelemetry-python-contrib/.github/workflows/core_contrib_test_0.yml@main
     with:
       CORE_REPO_SHA: ${{ github.sha }}
-      CONTRIB_REPO_SHA: main
+      CONTRIB_REPO_SHA: ${{ github.event_name == 'pull_request' && (
+          contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
+          contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
+          'main'
+        ) || 'main' }}

--- a/.github/workflows/lint_0.yml
+++ b/.github/workflows/lint_0.yml
@@ -15,7 +15,15 @@ concurrency:
 
 env:
   CORE_REPO_SHA: main
-  CONTRIB_REPO_SHA: main
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
+  # For PRs you can change the inner fallback ('main')
+  # For pushes you change the outer fallback ('main')
+  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
+  CONTRIB_REPO_SHA: ${{ github.event_name == 'pull_request' && (
+       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
+       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
+       'main'
+    ) || 'main' }}
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/misc_0.yml
+++ b/.github/workflows/misc_0.yml
@@ -15,7 +15,15 @@ concurrency:
 
 env:
   CORE_REPO_SHA: main
-  CONTRIB_REPO_SHA: main
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
+  # For PRs you can change the inner fallback ('main')
+  # For pushes you change the outer fallback ('main')
+  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
+  CONTRIB_REPO_SHA: ${{ github.event_name == 'pull_request' && (
+       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
+       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
+       'main'
+    ) || 'main' }}
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -65,6 +65,7 @@ jobs:
         run: .github/scripts/use-cla-approved-github-bot.sh
 
       - name: Create pull request
+        id: create_pr
         env:
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
           GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
@@ -74,7 +75,15 @@ jobs:
 
           git commit -a -m "$message"
           git push origin HEAD:$branch
-          gh pr create --title "[$GITHUB_REF_NAME] $message" \
+          pr_url=$(gh pr create --title "[$GITHUB_REF_NAME] $message" \
                        --body "$message." \
                        --head $branch \
-                       --base $GITHUB_REF_NAME
+                       --base $GITHUB_REF_NAME)
+
+          echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+      - name: Add prepare-release label to PR
+        if: steps.create_pr.outputs.pr_url != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ steps.create_pr.outputs.pr_url }}  --add-label "prepare-release"

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -91,6 +91,7 @@ jobs:
         run: .github/scripts/use-cla-approved-github-bot.sh
 
       - name: Create pull request against the release branch
+        id: create_release_branch_pr
         env:
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
           GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
@@ -100,10 +101,18 @@ jobs:
 
           git commit -a -m "$message"
           git push origin HEAD:$branch
-          gh pr create --title "[$RELEASE_BRANCH_NAME] $message" \
+          pr_url=$(gh pr create --title "[$RELEASE_BRANCH_NAME] $message" \
                        --body "$message." \
                        --head $branch \
-                       --base $RELEASE_BRANCH_NAME
+                       --base $RELEASE_BRANCH_NAME)
+          echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+
+      - name: Add prepare-release label to PR
+        if: steps.create_release_branch_pr.outputs.pr_url != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ steps.create_release_branch_pr.outputs.pr_url }}  --add-label "prepare-release"
 
   create-pull-request-against-main:
     runs-on: ubuntu-latest
@@ -170,6 +179,7 @@ jobs:
         run: .github/scripts/use-cla-approved-github-bot.sh
 
       - name: Create pull request against main
+        id: create_main_pr
         env:
           # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
           GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
@@ -180,7 +190,15 @@ jobs:
 
           git commit -a -m "$message"
           git push origin HEAD:$branch
-          gh pr create --title "$message" \
+          pr_url=$(gh pr create --title "$message" \
                        --body "$body" \
                        --head $branch \
-                       --base main
+                       --base main)
+          echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+
+      - name: Add prepare-release label to PR
+        if: steps.create_main_pr.outputs.pr_url != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ steps.create_main_pr.outputs.pr_url }}  --add-label "prepare-release"

--- a/.github/workflows/templates/lint.yml.j2
+++ b/.github/workflows/templates/lint.yml.j2
@@ -15,7 +15,15 @@ concurrency:
 
 env:
   CORE_REPO_SHA: main
-  CONTRIB_REPO_SHA: main
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
+  # For PRs you can change the inner fallback ('main')
+  # For pushes you change the outer fallback ('main')
+  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
+  CONTRIB_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
+       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
+       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
+       'main'
+    ) || 'main' }}{% endraw %}
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/templates/misc.yml.j2
+++ b/.github/workflows/templates/misc.yml.j2
@@ -15,7 +15,15 @@ concurrency:
 
 env:
   CORE_REPO_SHA: main
-  CONTRIB_REPO_SHA: main
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
+  # For PRs you can change the inner fallback ('main')
+  # For pushes you change the outer fallback ('main')
+  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
+  CONTRIB_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
+       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
+       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
+       'main'
+    ) || 'main' }}{% endraw %}
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/templates/test.yml.j2
+++ b/.github/workflows/templates/test.yml.j2
@@ -15,7 +15,15 @@ concurrency:
 
 env:
   CORE_REPO_SHA: main
-  CONTRIB_REPO_SHA: main
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
+  # For PRs you can change the inner fallback ('main')
+  # For pushes you change the outer fallback ('main')
+  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
+  CONTRIB_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
+       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
+       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
+       'main'
+    ) || 'main' }}{% endraw %}
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/test_0.yml
+++ b/.github/workflows/test_0.yml
@@ -15,7 +15,15 @@ concurrency:
 
 env:
   CORE_REPO_SHA: main
-  CONTRIB_REPO_SHA: main
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
+  # For PRs you can change the inner fallback ('main')
+  # For pushes you change the outer fallback ('main')
+  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
+  CONTRIB_REPO_SHA: ${{ github.event_name == 'pull_request' && (
+       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
+       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
+       'main'
+    ) || 'main' }}
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/test_1.yml
+++ b/.github/workflows/test_1.yml
@@ -15,7 +15,15 @@ concurrency:
 
 env:
   CORE_REPO_SHA: main
-  CONTRIB_REPO_SHA: main
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
+  # For PRs you can change the inner fallback ('main')
+  # For pushes you change the outer fallback ('main')
+  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
+  CONTRIB_REPO_SHA: ${{ github.event_name == 'pull_request' && (
+       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
+       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
+       'main'
+    ) || 'main' }}
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- opentelemetry-sdk: use stable code attributes: `code.function` -> `code.function.name`, `code.lineno` -> `code.line.number`, `code.filepath` -> `code.file.path`
+  ([#4508](https://github.com/open-telemetry/opentelemetry-python/pull/4508))
 - Fix serialization of extended attributes for logs signal
   ([#4342](https://github.com/open-telemetry/opentelemetry-python/pull/4342))
 - docs: updated and added to the metrics and log examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix serialization of extended attributes for logs signal
   ([#4342](https://github.com/open-telemetry/opentelemetry-python/pull/4342))
+- docs: updated and added to the metrics and log examples
+  ([#4559](https://github.com/open-telemetry/opentelemetry-python/pull/4559))
 
 ## Version 1.32.0/0.53b0 (2025-04-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix intermittent `Connection aborted` error when using otlp/http exporters
+  ([#4477](https://github.com/open-telemetry/opentelemetry-python/pull/4477))
 - opentelemetry-sdk: use stable code attributes: `code.function` -> `code.function.name`, `code.lineno` -> `code.line.number`, `code.filepath` -> `code.file.path`
   ([#4508](https://github.com/open-telemetry/opentelemetry-python/pull/4508))
 - Fix serialization of extended attributes for logs signal

--- a/docs/examples/logs/README.rst
+++ b/docs/examples/logs/README.rst
@@ -52,37 +52,70 @@ The resulting logs will appear in the output from the collector and look similar
 
 .. code-block:: sh
 
-        Resource SchemaURL: 
-        Resource labels:
-            -> telemetry.sdk.language: STRING(python)
-            -> telemetry.sdk.name: STRING(opentelemetry)
-            -> telemetry.sdk.version: STRING(1.8.0)
-            -> service.name: STRING(shoppingcart)
-            -> service.instance.id: STRING(instance-12)
-        InstrumentationLibraryLogs #0
-        InstrumentationLibraryMetrics SchemaURL: 
-        InstrumentationLibrary __main__ 0.1
-        LogRecord #0
-        Timestamp: 2022-01-13 20:37:03.998733056 +0000 UTC
-        Severity: WARNING
-        ShortName: 
-        Body: Jail zesty vixen who grabbed pay from quack.
-        Trace ID: 
-        Span ID: 
-        Flags: 0
-        LogRecord #1
-        Timestamp: 2022-01-13 20:37:04.082757888 +0000 UTC
-        Severity: ERROR
-        ShortName: 
-        Body: The five boxing wizards jump quickly.
-        Trace ID: 
-        Span ID: 
-        Flags: 0
-        LogRecord #2
-        Timestamp: 2022-01-13 20:37:04.082979072 +0000 UTC
-        Severity: ERROR
-        ShortName: 
-        Body: Hyderabad, we have a major problem.
-        Trace ID: 63491217958f126f727622e41d4460f3
-        Span ID: d90c57d6e1ca4f6c
-        Flags: 1
+    ResourceLog #0
+    Resource SchemaURL: 
+    Resource attributes:
+        -> telemetry.sdk.language: Str(python)
+        -> telemetry.sdk.name: Str(opentelemetry)
+        -> telemetry.sdk.version: Str(1.33.0.dev0)
+        -> service.name: Str(shoppingcart)
+        -> service.instance.id: Str(instance-12)
+    ScopeLogs #0
+    ScopeLogs SchemaURL: 
+    InstrumentationScope myapp.area2 
+    LogRecord #0
+    ObservedTimestamp: 2025-04-22 12:16:57.315179 +0000 UTC
+    Timestamp: 2025-04-22 12:16:57.315152896 +0000 UTC
+    SeverityText: WARN
+    SeverityNumber: Warn(13)
+    Body: Str(Jail zesty vixen who grabbed pay from quack.)
+    Attributes:
+        -> code.filepath: Str(/Users/jayclifford/Repos/opentelemetry-python/docs/examples/logs/example.py)
+        -> code.function: Str(<module>)
+        -> code.lineno: Int(47)
+    Trace ID: 
+    Span ID: 
+    Flags: 0
+    LogRecord #1
+    ObservedTimestamp: 2025-04-22 12:16:57.31522 +0000 UTC
+    Timestamp: 2025-04-22 12:16:57.315213056 +0000 UTC
+    SeverityText: ERROR
+    SeverityNumber: Error(17)
+    Body: Str(The five boxing wizards jump quickly.)
+    Attributes:
+        -> code.filepath: Str(/Users/jayclifford/Repos/opentelemetry-python/docs/examples/logs/example.py)
+        -> code.function: Str(<module>)
+        -> code.lineno: Int(48)
+    Trace ID: 
+    Span ID: 
+    Flags: 0
+    LogRecord #2
+    ObservedTimestamp: 2025-04-22 12:16:57.315445 +0000 UTC
+    Timestamp: 2025-04-22 12:16:57.31543808 +0000 UTC
+    SeverityText: ERROR
+    SeverityNumber: Error(17)
+    Body: Str(Hyderabad, we have a major problem.)
+    Attributes:
+        -> code.filepath: Str(/Users/jayclifford/Repos/opentelemetry-python/docs/examples/logs/example.py)
+        -> code.function: Str(<module>)
+        -> code.lineno: Int(61)
+    Trace ID: 8a6739fffce895e694700944e2faf23e
+    Span ID: a45337020100cb63
+    Flags: 1
+    ScopeLogs #1
+    ScopeLogs SchemaURL: 
+    InstrumentationScope myapp.area1 
+    LogRecord #0
+    ObservedTimestamp: 2025-04-22 12:16:57.315242 +0000 UTC
+    Timestamp: 2025-04-22 12:16:57.315234048 +0000 UTC
+    SeverityText: ERROR
+    SeverityNumber: Error(17)
+    Body: Str(I have custom attributes.)
+    Attributes:
+        -> user_id: Str(user-123)
+        -> code.filepath: Str(/Users/jayclifford/Repos/opentelemetry-python/docs/examples/logs/example.py)
+        -> code.function: Str(<module>)
+        -> code.lineno: Int(53)
+    Trace ID: 
+    Span ID: 
+    Flags: 0

--- a/docs/examples/logs/example.py
+++ b/docs/examples/logs/example.py
@@ -47,6 +47,10 @@ logger1.info("How quickly daft jumping zebras vex.")
 logger2.warning("Jail zesty vixen who grabbed pay from quack.")
 logger2.error("The five boxing wizards jump quickly.")
 
+# Log custom attributes
+# Custom attributes are added on a per event basis
+user_id = "user-123"
+logger1.error("I have custom attributes.", extra={"user_id": user_id})
 
 # Trace context correlation
 tracer = trace.get_tracer(__name__)

--- a/docs/examples/logs/otel-collector-config.yaml
+++ b/docs/examples/logs/otel-collector-config.yaml
@@ -6,7 +6,7 @@ receivers:
 
 exporters:
   debug:
-    verbosity: debug
+    verbosity: detailed
 
 processors:
   batch:

--- a/docs/examples/metrics/reader/README.rst
+++ b/docs/examples/metrics/reader/README.rst
@@ -6,6 +6,7 @@ These examples show how to customize the metrics that are output by the SDK usin
 * preferred_aggregation.py: Shows how to configure the preferred aggregation for metric instrument types.
 * preferred_temporality.py: Shows how to configure the preferred temporality for metric instrument types.
 * preferred_exemplarfilter.py: Shows how to configure the exemplar filter.
+* synchronous_gauge_read.py: Shows how to use `PeriodicExportingMetricReader` in a synchronous manner to explicitly control the collection of metrics.
 
 The source files of these examples are available :scm_web:`here <docs/examples/metrics/reader/>`.
 

--- a/docs/examples/metrics/reader/synchronous_gauge_read.py
+++ b/docs/examples/metrics/reader/synchronous_gauge_read.py
@@ -1,0 +1,88 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from typing import Iterable
+
+from opentelemetry.metrics import (
+    CallbackOptions,
+    Observation,
+    get_meter_provider,
+    set_meter_provider,
+)
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    ConsoleMetricExporter,
+    PeriodicExportingMetricReader,
+)
+
+temperature = 0.0
+humidity = 0.0
+
+
+# Function called by the gauge to read the temperature
+def read_temperature(options: CallbackOptions) -> Iterable[Observation]:
+    global temperature
+    yield Observation(value=temperature, attributes={"room": "living-room"})
+
+
+# Function called by the gauge to read the humidity
+def read_humidity(options: CallbackOptions) -> Iterable[Observation]:
+    global humidity
+    yield Observation(value=humidity, attributes={"room": "living-room"})
+
+
+# Use console exporter for the example
+exporter = ConsoleMetricExporter()
+
+# The PeriodicExportingMetricReader If the time interval is set to math.inf
+# the reader will not invoke periodic collection
+reader = PeriodicExportingMetricReader(
+    exporter,
+    export_interval_millis=math.inf,
+)
+
+provider = MeterProvider(metric_readers=[reader])
+set_meter_provider(provider)
+
+meter = get_meter_provider().get_meter("synchronous_read", "0.1.2")
+
+gauge = meter.create_observable_gauge(
+    name="synchronous_gauge_temperature",
+    description="Gauge value captured synchronously",
+    callbacks=[read_temperature],
+)
+
+# Simulate synchronous reading of temperature
+print("--- Simulating synchronous reading of temperature ---", flush=True)
+temperature = 25.0
+reader.collect()
+# Note: The reader will only collect the last value before `collect` is called
+print("--- Last value only ---", flush=True)
+temperature = 30.0
+temperature = 35.0
+reader.collect()
+# Invoking `collect` will read all measurements assigned to the reader
+gauge2 = meter.create_observable_gauge(
+    name="synchronous_gauge_humidity",
+    description="Gauge value captured synchronously",
+    callbacks=[read_humidity],
+)
+print("--- Multiple Measurements ---", flush=True)
+temperature = 20.0
+humidity = 50.0
+reader.collect()
+# Invoking `force_flush` will read all measurements assigned to the reader
+print("--- Invoking force_flush ---", flush=True)
+provider.force_flush()

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
@@ -58,7 +58,7 @@ class OTLPLogExporter(
         headers: Optional[
             Union[TypingSequence[Tuple[str, str]], Dict[str, str], str]
         ] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
         compression: Optional[Compression] = None,
     ):
         if insecure is None:
@@ -79,7 +79,7 @@ class OTLPLogExporter(
 
         environ_timeout = environ.get(OTEL_EXPORTER_OTLP_LOGS_TIMEOUT)
         environ_timeout = (
-            int(environ_timeout) if environ_timeout is not None else None
+            float(environ_timeout) if environ_timeout is not None else None
         )
 
         compression = (
@@ -107,8 +107,12 @@ class OTLPLogExporter(
     ) -> ExportLogsServiceRequest:
         return encode_logs(data)
 
-    def export(self, batch: Sequence[LogData]) -> LogExportResult:
-        return self._export(batch)
+    def export(
+        self, batch: Sequence[LogData], timeout_millis: Optional[float] = None
+    ) -> LogExportResult:
+        return self._export(
+            batch, timeout_millis / 1e3 if timeout_millis else None
+        )
 
     def shutdown(self, timeout_millis: float = 30_000, **kwargs) -> None:
         OTLPExporterMixin.shutdown(self, timeout_millis=timeout_millis)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/metric_exporter/__init__.py
@@ -13,10 +13,11 @@
 
 from __future__ import annotations
 
+import time
 from dataclasses import replace
 from logging import getLogger
 from os import environ
-from typing import Iterable, List, Tuple, Union
+from typing import Iterable, List, Optional, Tuple, Union
 from typing import Sequence as TypingSequence
 
 from grpc import ChannelCredentials, Compression
@@ -99,7 +100,7 @@ class OTLPMetricExporter(
         credentials: ChannelCredentials | None = None,
         headers: Union[TypingSequence[Tuple[str, str]], dict[str, str], str]
         | None = None,
-        timeout: int | None = None,
+        timeout: float | None = None,
         compression: Compression | None = None,
         preferred_temporality: dict[type, AggregationTemporality]
         | None = None,
@@ -124,7 +125,7 @@ class OTLPMetricExporter(
 
         environ_timeout = environ.get(OTEL_EXPORTER_OTLP_METRICS_TIMEOUT)
         environ_timeout = (
-            int(environ_timeout) if environ_timeout is not None else None
+            float(environ_timeout) if environ_timeout is not None else None
         )
 
         compression = (
@@ -158,17 +159,22 @@ class OTLPMetricExporter(
     def export(
         self,
         metrics_data: MetricsData,
-        timeout_millis: float = 10_000,
+        timeout_millis: Optional[float] = None,
         **kwargs,
     ) -> MetricExportResult:
-        # TODO(#2663): OTLPExporterMixin should pass timeout to gRPC
+        timeout_sec = (
+            timeout_millis / 1e3 if timeout_millis else self._timeout  # pylint: disable=protected-access
+        )
         if self._max_export_batch_size is None:
-            return self._export(data=metrics_data)
+            return self._export(metrics_data, timeout_sec)
 
         export_result = MetricExportResult.SUCCESS
-
+        deadline_sec = time.time() + timeout_sec
         for split_metrics_data in self._split_metrics_data(metrics_data):
-            split_export_result = self._export(data=split_metrics_data)
+            time_remaining_sec = deadline_sec - time.time()
+            split_export_result = self._export(
+                split_metrics_data, time_remaining_sec
+            )
 
             if split_export_result is MetricExportResult.FAILURE:
                 export_result = MetricExportResult.FAILURE

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
@@ -91,7 +91,7 @@ class OTLPSpanExporter(
         headers: Optional[
             Union[TypingSequence[Tuple[str, str]], Dict[str, str], str]
         ] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
         compression: Optional[Compression] = None,
     ):
         if insecure is None:
@@ -112,7 +112,7 @@ class OTLPSpanExporter(
 
         environ_timeout = environ.get(OTEL_EXPORTER_OTLP_TRACES_TIMEOUT)
         environ_timeout = (
-            int(environ_timeout) if environ_timeout is not None else None
+            float(environ_timeout) if environ_timeout is not None else None
         )
 
         compression = (
@@ -139,8 +139,14 @@ class OTLPSpanExporter(
     ) -> ExportTraceServiceRequest:
         return encode_spans(data)
 
-    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
-        return self._export(spans)
+    def export(
+        self,
+        spans: Sequence[ReadableSpan],
+        timeout_millis: Optional[float] = None,
+    ) -> SpanExportResult:
+        return self._export(
+            spans, timeout_millis / 1e3 if timeout_millis else None
+        )
 
     def shutdown(self) -> None:
         OTLPExporterMixin.shutdown(self)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.7.2
 Deprecated==1.2.14
 googleapis-common-protos==1.63.2
 grpcio==1.66.2
+grpcio-status==1.66.0
 importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
@@ -18,7 +18,7 @@ from os import environ
 from os.path import dirname
 from typing import List
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from grpc import ChannelCredentials, Compression
 
@@ -297,7 +297,9 @@ class TestOTLPMetricExporter(TestCase):
             insecure=True, compression=Compression.NoCompression
         )
         mock_insecure_channel.assert_called_once_with(
-            "localhost:4317", compression=Compression.NoCompression
+            "localhost:4317",
+            compression=Compression.NoCompression,
+            options=ANY,
         )
 
     def test_split_metrics_data_many_data_points(self):

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -16,7 +16,7 @@
 
 import os
 from unittest import TestCase
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch, ANY
 
 from grpc import ChannelCredentials, Compression
 
@@ -333,7 +333,9 @@ class TestOTLPSpanExporter(TestCase):
         """Specifying kwarg should take precedence over env"""
         OTLPSpanExporter(insecure=True, compression=Compression.NoCompression)
         mock_insecure_channel.assert_called_once_with(
-            "localhost:4317", compression=Compression.NoCompression
+            "localhost:4317",
+            compression=Compression.NoCompression,
+            options=ANY,
         )
 
     # pylint: disable=no-self-use
@@ -350,7 +352,9 @@ class TestOTLPSpanExporter(TestCase):
         """
         OTLPSpanExporter(insecure=True)
         mock_insecure_channel.assert_called_once_with(
-            "localhost:4317", compression=Compression.Gzip
+            "localhost:4317",
+            compression=Compression.Gzip,
+            options=ANY,
         )
 
     def test_translate_spans(self):

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -16,7 +16,7 @@
 
 import os
 from unittest import TestCase
-from unittest.mock import Mock, PropertyMock, patch, ANY
+from unittest.mock import ANY, Mock, PropertyMock, patch
 
 from grpc import ChannelCredentials, Compression
 

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -21,6 +21,7 @@ from time import sleep
 from typing import Dict, Optional, Sequence
 
 import requests
+from requests.exceptions import ConnectionError
 
 from opentelemetry.exporter.otlp.proto.common._internal import (
     _create_exp_backoff_generator,
@@ -133,13 +134,27 @@ class OTLPLogExporter(LogExporter):
         elif self._compression == Compression.Deflate:
             data = zlib.compress(serialized_data)
 
-        return self._session.post(
-            url=self._endpoint,
-            data=data,
-            verify=self._certificate_file,
-            timeout=self._timeout,
-            cert=self._client_cert,
-        )
+        # By default, keep-alive is enabled in Session's request
+        # headers. Backends may choose to close the connection
+        # while a post happens which causes an unhandled
+        # exception. This try/except will retry the post on such exceptions
+        try:
+            resp = self._session.post(
+                url=self._endpoint,
+                data=data,
+                verify=self._certificate_file,
+                timeout=self._timeout,
+                cert=self._client_cert,
+            )
+        except ConnectionError:
+            resp = self._session.post(
+                url=self._endpoint,
+                data=data,
+                verify=self._certificate_file,
+                timeout=self._timeout,
+                cert=self._client_cert,
+            )
+        return resp
 
     @staticmethod
     def _retryable(resp: requests.Response) -> bool:

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -17,15 +17,12 @@ import logging
 import zlib
 from io import BytesIO
 from os import environ
-from time import sleep
+from time import sleep, time
 from typing import Dict, Optional, Sequence
 
 import requests
 from requests.exceptions import ConnectionError
 
-from opentelemetry.exporter.otlp.proto.common._internal import (
-    _create_exp_backoff_generator,
-)
 from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
 from opentelemetry.exporter.otlp.proto.http import (
     _OTLP_HTTP_HEADERS,
@@ -64,8 +61,6 @@ DEFAULT_TIMEOUT = 10  # in seconds
 
 
 class OTLPLogExporter(LogExporter):
-    _MAX_RETRY_TIMEOUT = 64
-
     def __init__(
         self,
         endpoint: Optional[str] = None,
@@ -73,7 +68,7 @@ class OTLPLogExporter(LogExporter):
         client_key_file: Optional[str] = None,
         client_certificate_file: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
         compression: Optional[Compression] = None,
         session: Optional[requests.Session] = None,
     ):
@@ -108,7 +103,7 @@ class OTLPLogExporter(LogExporter):
         self._headers = headers or parse_env_headers(
             headers_string, liberal=True
         )
-        self._timeout = timeout or int(
+        self._timeout = timeout or float(
             environ.get(
                 OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
                 environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, DEFAULT_TIMEOUT),
@@ -124,7 +119,7 @@ class OTLPLogExporter(LogExporter):
             )
         self._shutdown = False
 
-    def _export(self, serialized_data: bytes):
+    def _export(self, serialized_data: bytes, timeout_sec: float):
         data = serialized_data
         if self._compression == Compression.Gzip:
             gzip_data = BytesIO()
@@ -143,7 +138,7 @@ class OTLPLogExporter(LogExporter):
                 url=self._endpoint,
                 data=data,
                 verify=self._certificate_file,
-                timeout=self._timeout,
+                timeout=timeout_sec,
                 cert=self._client_cert,
             )
         except ConnectionError:
@@ -151,7 +146,7 @@ class OTLPLogExporter(LogExporter):
                 url=self._endpoint,
                 data=data,
                 verify=self._certificate_file,
-                timeout=self._timeout,
+                timeout=timeout_sec,
                 cert=self._client_cert,
             )
         return resp
@@ -164,7 +159,9 @@ class OTLPLogExporter(LogExporter):
             return True
         return False
 
-    def export(self, batch: Sequence[LogData]) -> LogExportResult:
+    def export(
+        self, batch: Sequence[LogData], timeout_millis: Optional[float] = None
+    ) -> LogExportResult:
         # After the call to Shutdown subsequent calls to Export are
         # not allowed and should return a Failure result.
         if self._shutdown:
@@ -172,18 +169,20 @@ class OTLPLogExporter(LogExporter):
             return LogExportResult.FAILURE
 
         serialized_data = encode_logs(batch).SerializeToString()
-
-        for delay in _create_exp_backoff_generator(
-            max_value=self._MAX_RETRY_TIMEOUT
-        ):
-            if delay == self._MAX_RETRY_TIMEOUT:
+        deadline_sec = time() + (
+            timeout_millis / 1e3 if timeout_millis else self._timeout
+        )
+        for delay in [1, 2, 4, 8, 16, 32]:
+            remaining_time_sec = deadline_sec - time()
+            if remaining_time_sec < 1e-09:
                 return LogExportResult.FAILURE
-
-            resp = self._export(serialized_data)
+            resp = self._export(serialized_data, remaining_time_sec)
             # pylint: disable=no-else-return
             if resp.ok:
                 return LogExportResult.SUCCESS
             elif self._retryable(resp):
+                if delay > (deadline_sec - time()):
+                    return LogExportResult.FAILURE
                 _logger.warning(
                     "Transient error %s encountered while exporting logs batch, retrying in %ss.",
                     resp.reason,

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -21,6 +21,7 @@ from time import sleep
 from typing import Dict, Optional
 
 import requests
+from requests.exceptions import ConnectionError
 
 from opentelemetry.exporter.otlp.proto.common._internal import (
     _create_exp_backoff_generator,
@@ -130,13 +131,27 @@ class OTLPSpanExporter(SpanExporter):
         elif self._compression == Compression.Deflate:
             data = zlib.compress(serialized_data)
 
-        return self._session.post(
-            url=self._endpoint,
-            data=data,
-            verify=self._certificate_file,
-            timeout=self._timeout,
-            cert=self._client_cert,
-        )
+        # By default, keep-alive is enabled in Session's request
+        # headers. Backends may choose to close the connection
+        # while a post happens which causes an unhandled
+        # exception. This try/except will retry the post on such exceptions
+        try:
+            resp = self._session.post(
+                url=self._endpoint,
+                data=data,
+                verify=self._certificate_file,
+                timeout=self._timeout,
+                cert=self._client_cert,
+            )
+        except ConnectionError:
+            resp = self._session.post(
+                url=self._endpoint,
+                data=data,
+                verify=self._certificate_file,
+                timeout=self._timeout,
+                cert=self._client_cert,
+            )
+        return resp
 
     @staticmethod
     def _retryable(resp: requests.Response) -> bool:

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
@@ -15,12 +15,14 @@
 # pylint: disable=protected-access
 
 import unittest
+from logging import WARNING
 from typing import List
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import requests
-import responses
 from google.protobuf.json_format import MessageToDict
+from requests import Session
+from requests.models import Response
 
 from opentelemetry._logs import SeverityNumber
 from opentelemetry.exporter.otlp.proto.http import Compression
@@ -267,25 +269,6 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         else:
             self.fail("No log records found")
 
-    @responses.activate
-    @patch("opentelemetry.exporter.otlp.proto.http._log_exporter.sleep")
-    def test_exponential_backoff(self, mock_sleep):
-        # return a retryable error
-        responses.add(
-            responses.POST,
-            "http://logs.example.com/export",
-            json={"error": "something exploded"},
-            status=500,
-        )
-
-        exporter = OTLPLogExporter(endpoint="http://logs.example.com/export")
-        logs = self._get_sdk_log_data()
-
-        exporter.export(logs)
-        mock_sleep.assert_has_calls(
-            [call(1), call(2), call(4), call(8), call(16), call(32)]
-        )
-
     @staticmethod
     def _get_sdk_log_data() -> List[LogData]:
         log1 = LogData(
@@ -365,3 +348,46 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         self.assertEqual(
             OTLPLogExporter().export(MagicMock()), LogExportResult.SUCCESS
         )
+
+    @patch.object(Session, "post")
+    def test_retry_timeout(self, mock_post):
+        exporter = OTLPLogExporter(timeout=3.5)
+
+        resp = Response()
+        resp.status_code = 503
+        resp.reason = "UNAVAILABLE"
+        mock_post.return_value = resp
+        with self.assertLogs(level=WARNING) as warning:
+            # Set timeout to 1.5 seconds
+            self.assertEqual(
+                exporter.export(self._get_sdk_log_data(), 1500),
+                LogExportResult.FAILURE,
+            )
+            # Code should return failure after retrying once.
+            self.assertEqual(len(warning.records), 1)
+            self.assertEqual(
+                "Transient error UNAVAILABLE encountered while exporting logs batch, retrying in 1s.",
+                warning.records[0].message,
+            )
+        with self.assertLogs(level=WARNING) as warning:
+            # This time don't pass in a timeout, so it will fallback to 3.5 second set on class.
+            self.assertEqual(
+                exporter.export(self._get_sdk_log_data()),
+                LogExportResult.FAILURE,
+            )
+            # 2 retrys (after 1s, 3s).
+            self.assertEqual(len(warning.records), 2)
+
+    @patch.object(Session, "post")
+    def test_timeout_set_correctly(self, mock_post):
+        resp = Response()
+        resp.status_code = 200
+
+        def export_side_effect(*args, **kwargs):
+            # Timeout should be set to something slightly less than 400 milliseconds depending on how much time has passed.
+            self.assertTrue(0.4 - kwargs["timeout"] < 0.0005)
+            return resp
+
+        mock_post.side_effect = export_side_effect
+        exporter = OTLPLogExporter()
+        exporter.export(self._get_sdk_log_data(), 400)

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import MagicMock, Mock, call, patch
+from logging import WARNING
+from unittest.mock import MagicMock, Mock, patch
 
 import requests
-import responses
+from requests import Session
+from requests.models import Response
 
 from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
@@ -52,6 +54,16 @@ OS_ENV_CLIENT_CERTIFICATE = "os/env/client-cert.pem"
 OS_ENV_CLIENT_KEY = "os/env/client-key.pem"
 OS_ENV_HEADERS = "envHeader1=val1,envHeader2=val2"
 OS_ENV_TIMEOUT = "30"
+BASIC_SPAN = _Span(
+    "abc",
+    context=Mock(
+        **{
+            "trace_state": {"a": "b", "c": "d"},
+            "span_id": 10217189687419569865,
+            "trace_id": 67545097771067222548457157018666467027,
+        }
+    ),
+)
 
 
 # pylint: disable=protected-access
@@ -227,37 +239,6 @@ class TestOTLPSpanExporter(unittest.TestCase):
                 ),
             )
 
-    # pylint: disable=no-self-use
-    @responses.activate
-    @patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.sleep")
-    def test_exponential_backoff(self, mock_sleep):
-        # return a retryable error
-        responses.add(
-            responses.POST,
-            "http://traces.example.com/export",
-            json={"error": "something exploded"},
-            status=500,
-        )
-
-        exporter = OTLPSpanExporter(
-            endpoint="http://traces.example.com/export"
-        )
-        span = _Span(
-            "abc",
-            context=Mock(
-                **{
-                    "trace_state": {"a": "b", "c": "d"},
-                    "span_id": 10217189687419569865,
-                    "trace_id": 67545097771067222548457157018666467027,
-                }
-            ),
-        )
-
-        exporter.export([span])
-        mock_sleep.assert_has_calls(
-            [call(1), call(2), call(4), call(8), call(16), call(32)]
-        )
-
     @patch.object(OTLPSpanExporter, "_export", return_value=Mock(ok=True))
     def test_2xx_status_code(self, mock_otlp_metric_exporter):
         """
@@ -267,3 +248,46 @@ class TestOTLPSpanExporter(unittest.TestCase):
         self.assertEqual(
             OTLPSpanExporter().export(MagicMock()), SpanExportResult.SUCCESS
         )
+
+    @patch.object(Session, "post")
+    def test_retry_timeout(self, mock_post):
+        exporter = OTLPSpanExporter(timeout=3.5)
+
+        resp = Response()
+        resp.status_code = 503
+        resp.reason = "UNAVAILABLE"
+        mock_post.return_value = resp
+        with self.assertLogs(level=WARNING) as warning:
+            # Set timeout to 1.5 seconds
+            self.assertEqual(
+                exporter.export([BASIC_SPAN], 1500),
+                SpanExportResult.FAILURE,
+            )
+            # Code should return failure after retrying once.
+            self.assertEqual(len(warning.records), 1)
+            self.assertEqual(
+                "Transient error UNAVAILABLE encountered while exporting span batch, retrying in 1s.",
+                warning.records[0].message,
+            )
+        with self.assertLogs(level=WARNING) as warning:
+            # This time don't pass in a timeout, so it will fallback to 3.5 second set on class.
+            self.assertEqual(
+                exporter.export([BASIC_SPAN]),
+                SpanExportResult.FAILURE,
+            )
+            # 2 retrys (after 1s, 3s).
+            self.assertEqual(len(warning.records), 2)
+
+    @patch.object(Session, "post")
+    def test_timeout_set_correctly(self, mock_post):
+        resp = Response()
+        resp.status_code = 200
+
+        def export_side_effect(*args, **kwargs):
+            # Timeout should be set to something slightly less than 400 milliseconds depending on how much time has passed.
+            self.assertTrue(0.4 - kwargs["timeout"] < 0.0005)
+            return resp
+
+        mock_post.side_effect = export_side_effect
+        exporter = OTLPSpanExporter()
+        exporter.export([BASIC_SPAN], 400)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -45,7 +45,8 @@ from opentelemetry.sdk.environment_variables import (
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.util import ns_to_iso_str
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes import code_attributes
+from opentelemetry.semconv.attributes import exception_attributes
 from opentelemetry.trace import (
     format_span_id,
     format_trace_id,
@@ -487,22 +488,24 @@ class LoggingHandler(logging.Handler):
         }
 
         # Add standard code attributes for logs.
-        attributes[SpanAttributes.CODE_FILEPATH] = record.pathname
-        attributes[SpanAttributes.CODE_FUNCTION] = record.funcName
-        attributes[SpanAttributes.CODE_LINENO] = record.lineno
+        attributes[code_attributes.CODE_FILE_PATH] = record.pathname
+        attributes[code_attributes.CODE_FUNCTION_NAME] = record.funcName
+        attributes[code_attributes.CODE_LINE_NUMBER] = record.lineno
 
         if record.exc_info:
             exctype, value, tb = record.exc_info
             if exctype is not None:
-                attributes[SpanAttributes.EXCEPTION_TYPE] = exctype.__name__
+                attributes[exception_attributes.EXCEPTION_TYPE] = (
+                    exctype.__name__
+                )
             if value is not None and value.args:
-                attributes[SpanAttributes.EXCEPTION_MESSAGE] = str(
+                attributes[exception_attributes.EXCEPTION_MESSAGE] = str(
                     value.args[0]
                 )
             if tb is not None:
-                # https://github.com/open-telemetry/opentelemetry-specification/blob/9fa7c656b26647b27e485a6af7e38dc716eba98a/specification/trace/semantic_conventions/exceptions.md#stacktrace-representation
-                attributes[SpanAttributes.EXCEPTION_STACKTRACE] = "".join(
-                    traceback.format_exception(*record.exc_info)
+                # https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/#stacktrace-representation
+                attributes[exception_attributes.EXCEPTION_STACKTRACE] = (
+                    "".join(traceback.format_exception(*record.exc_info))
                 )
         return attributes
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -210,6 +210,7 @@ class BatchLogRecordProcessor(LogRecordProcessor):
         self._schedule_delay = schedule_delay_millis / 1e3
         self._max_export_batch_size = max_export_batch_size
         # Not used. No way currently to pass timeout to export.
+        # TODO(https://github.com/open-telemetry/opentelemetry-python/issues/4555): figure out what this should do.
         self._export_timeout_millis = export_timeout_millis
         # Deque is thread safe.
         self._queue = collections.deque([], max_queue_size)
@@ -218,9 +219,10 @@ class BatchLogRecordProcessor(LogRecordProcessor):
             target=self.worker,
             daemon=True,
         )
+
         self._shutdown = False
         self._export_lock = threading.Lock()
-        self._worker_sleep = threading.Event()
+        self._worker_awaken = threading.Event()
         self._worker_thread.start()
         if hasattr(os, "register_at_fork"):
             weak_reinit = weakref.WeakMethod(self._at_fork_reinit)
@@ -235,15 +237,15 @@ class BatchLogRecordProcessor(LogRecordProcessor):
         # Always continue to export while queue length exceeds max batch size.
         if len(self._queue) >= self._max_export_batch_size:
             return True
-        if batch_strategy == BatchLogExportStrategy.EXPORT_ALL:
+        if batch_strategy is BatchLogExportStrategy.EXPORT_ALL:
             return True
-        if batch_strategy == BatchLogExportStrategy.EXPORT_AT_LEAST_ONE_BATCH:
+        if batch_strategy is BatchLogExportStrategy.EXPORT_AT_LEAST_ONE_BATCH:
             return num_iterations == 0
         return False
 
     def _at_fork_reinit(self):
         self._export_lock = threading.Lock()
-        self._worker_sleep = threading.Event()
+        self._worker_awaken = threading.Event()
         self._queue.clear()
         self._worker_thread = threading.Thread(
             name="OtelBatchLogRecordProcessor",
@@ -258,7 +260,7 @@ class BatchLogRecordProcessor(LogRecordProcessor):
             # Lots of strategies in the spec for setting next timeout.
             # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#batching-processor.
             # Shutdown will interrupt this sleep. Emit will interrupt this sleep only if the queue is bigger then threshold.
-            sleep_interrupted = self._worker_sleep.wait(self._schedule_delay)
+            sleep_interrupted = self._worker_awaken.wait(self._schedule_delay)
             if self._shutdown:
                 break
             self._export(
@@ -266,7 +268,7 @@ class BatchLogRecordProcessor(LogRecordProcessor):
                 if sleep_interrupted
                 else BatchLogExportStrategy.EXPORT_AT_LEAST_ONE_BATCH
             )
-            self._worker_sleep.clear()
+            self._worker_awaken.clear()
         self._export(BatchLogExportStrategy.EXPORT_ALL)
 
     def _export(self, batch_strategy: BatchLogExportStrategy) -> None:
@@ -296,7 +298,7 @@ class BatchLogRecordProcessor(LogRecordProcessor):
 
     def emit(self, log_data: LogData) -> None:
         if self._shutdown:
-            _logger.warning("Shutdown called, ignoring log.")
+            _logger.info("Shutdown called, ignoring log.")
             return
         if self._pid != os.getpid():
             _BSP_RESET_ONCE.do_once(self._at_fork_reinit)
@@ -305,7 +307,7 @@ class BatchLogRecordProcessor(LogRecordProcessor):
             _logger.warning("Queue full, dropping log.")
         self._queue.appendleft(log_data)
         if len(self._queue) >= self._max_export_batch_size:
-            self._worker_sleep.set()
+            self._worker_awaken.set()
 
     def shutdown(self):
         if self._shutdown:
@@ -313,7 +315,7 @@ class BatchLogRecordProcessor(LogRecordProcessor):
         # Prevents emit and force_flush from further calling export.
         self._shutdown = True
         # Interrupts sleep in the worker, if it's sleeping.
-        self._worker_sleep.set()
+        self._worker_awaken.set()
         # Main worker loop should exit after one final export call with flush all strategy.
         self._worker_thread.join()
         self._exporter.shutdown()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -72,11 +72,14 @@ class LogExporter(abc.ABC):
     """
 
     @abc.abstractmethod
-    def export(self, batch: Sequence[LogData]):
+    def export(
+        self, batch: Sequence[LogData], timeout_millis: Optional[int] = None
+    ):
         """Exports a batch of logs.
 
         Args:
-            batch: The list of `LogData` objects to be exported
+            batch: The list of `LogData` objects to be exported.
+            timeout_millis: Optional milliseconds until Export should timeout if it hasn't succeded.
 
         Returns:
             The result of the export
@@ -87,6 +90,13 @@ class LogExporter(abc.ABC):
         """Shuts down the exporter.
 
         Called when the SDK is shut down.
+        """
+
+    @abc.abstractmethod
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Hint to ensure that the export of any spans the exporter has received
+        prior to the call to ForceFlush SHOULD be completed as soon as possible, preferably
+        before returning from this method.
         """
 
 
@@ -107,6 +117,7 @@ class ConsoleLogExporter(LogExporter):
         self.out = out
         self.formatter = formatter
 
+    # pylint: disable=arguments-differ
     def export(self, batch: Sequence[LogData]):
         for data in batch:
             self.out.write(self.formatter(data.log_record))

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/in_memory_log_exporter.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/in_memory_log_exporter.py
@@ -40,6 +40,7 @@ class InMemoryLogExporter(LogExporter):
         with self._lock:
             return tuple(self._logs)
 
+    # pylint: disable=arguments-differ
     def export(self, batch: typing.Sequence[LogData]) -> LogExportResult:
         if self._stopped:
             return LogExportResult.FAILURE

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
@@ -87,6 +87,7 @@ OTEL_BLRP_EXPORT_TIMEOUT = "OTEL_BLRP_EXPORT_TIMEOUT"
 .. envvar:: OTEL_BLRP_EXPORT_TIMEOUT
 
 The :envvar:`OTEL_BLRP_EXPORT_TIMEOUT` represents the maximum allowed time to export data from the BatchLogRecordProcessor.
+This environment variable currently does nothing, see https://github.com/open-telemetry/opentelemetry-python/issues/4555.
 Default: 30000
 """
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
@@ -334,7 +334,7 @@ OTEL_EXPORTER_OTLP_TIMEOUT = "OTEL_EXPORTER_OTLP_TIMEOUT"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_TIMEOUT
 
-The :envvar:`OTEL_EXPORTER_OTLP_TIMEOUT` is the maximum time the OTLP exporter will wait for each batch export.
+The :envvar:`OTEL_EXPORTER_OTLP_TIMEOUT` is the maximum number of seconds the OTLP exporter will wait for each batch export.
 Default: 10
 """
 
@@ -536,7 +536,7 @@ OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_TRACES_TIMEOUT
 
-The :envvar:`OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` is the maximum time the OTLP exporter will
+The :envvar:`OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` is the maximum number of seconds the OTLP exporter will
 wait for each batch export for spans.
 """
 
@@ -544,7 +544,7 @@ OTEL_EXPORTER_OTLP_METRICS_TIMEOUT = "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_METRICS_TIMEOUT
 
-The :envvar:`OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` is the maximum time the OTLP exporter will
+The :envvar:`OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` is the maximum number of seconds the OTLP exporter will
 wait for each batch export for metrics.
 """
 
@@ -578,7 +578,7 @@ OTEL_EXPORTER_OTLP_LOGS_TIMEOUT = "OTEL_EXPORTER_OTLP_LOGS_TIMEOUT"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_LOGS_TIMEOUT
 
-The :envvar:`OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` is the maximum time the OTLP exporter will
+The :envvar:`OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` is the maximum number of seconds the OTLP exporter will
 wait for each batch export for logs.
 """
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import abc
 import collections
 import logging
 import os
@@ -56,7 +57,7 @@ class SpanExportResult(Enum):
     FAILURE = 1
 
 
-class SpanExporter:
+class SpanExporter(abc.ABC):
     """Interface for exporting spans.
 
     Interface to be implemented by services that want to export spans recorded
@@ -66,24 +67,30 @@ class SpanExporter:
     `SimpleSpanProcessor` or a `BatchSpanProcessor`.
     """
 
+    @abc.abstractmethod
     def export(
-        self, spans: typing.Sequence[ReadableSpan]
+        self,
+        spans: typing.Sequence[ReadableSpan],
+        timeout_millis: typing.Optional[int] = None,
     ) -> "SpanExportResult":
         """Exports a batch of telemetry data.
 
         Args:
             spans: The list of `opentelemetry.trace.Span` objects to be exported
+            timeout_millis: Optional milliseconds until Export should timeout if it hasn't succeded.
 
         Returns:
             The result of the export
         """
 
+    @abc.abstractmethod
     def shutdown(self) -> None:
         """Shuts down the exporter.
 
         Called when the SDK is shut down.
         """
 
+    @abc.abstractmethod
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         """Hint to ensure that the export of any spans the exporter has received
         prior to the call to ForceFlush SHOULD be completed as soon as possible, preferably

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -486,24 +486,20 @@ class TestBatchLogRecordProcessor(unittest.TestCase):
         exporter.export.assert_called_once()
         after_export = time.time_ns()
         # Shows the worker's 30 second sleep was interrupted within a second.
-        self.assertTrue((after_export - before_export) < 1e9)
+        self.assertLess(after_export - before_export, 1e9)
 
     # pylint: disable=no-self-use
     def test_logs_exported_once_schedule_delay_reached(self):
         exporter = Mock()
         log_record_processor = BatchLogRecordProcessor(
             exporter=exporter,
-            # Should not reach this during the test, instead export should be called when delay millis is hit.
             max_queue_size=15,
             max_export_batch_size=15,
             schedule_delay_millis=100,
         )
-        for _ in range(15):
-            log_record_processor.emit(EMPTY_LOG)
-            time.sleep(0.11)
-        exporter.export.assert_has_calls(
-            [call([EMPTY_LOG]) for _ in range(15)]
-        )
+        log_record_processor.emit(EMPTY_LOG)
+        time.sleep(0.2)
+        exporter.export.assert_called_once_with([EMPTY_LOG])
 
     def test_logs_flushed_before_shutdown_and_dropped_after_shutdown(self):
         exporter = Mock()
@@ -520,13 +516,13 @@ class TestBatchLogRecordProcessor(unittest.TestCase):
         exporter.export.assert_called_once_with([EMPTY_LOG])
         self.assertTrue(exporter._stopped)
 
-        with self.assertLogs(level="WARNING") as log:
+        with self.assertLogs(level="INFO") as log:
             # This log should not be flushed.
             log_record_processor.emit(EMPTY_LOG)
             self.assertEqual(len(log.output), 1)
             self.assertEqual(len(log.records), 1)
             self.assertIn("Shutdown called, ignoring log.", log.output[0])
-        exporter.export.assert_called_once_with([EMPTY_LOG])
+        exporter.export.assert_called_once()
 
     # pylint: disable=no-self-use
     def test_force_flush_flushes_logs(self):
@@ -555,6 +551,7 @@ class TestBatchLogRecordProcessor(unittest.TestCase):
         with ThreadPoolExecutor(max_workers=69) as executor:
             for idx in range(69):
                 executor.submit(bulk_log_and_flush, idx + 1)
+
             executor.shutdown()
 
         finished_logs = exporter.get_finished_logs()
@@ -564,16 +561,20 @@ class TestBatchLogRecordProcessor(unittest.TestCase):
         hasattr(os, "fork"),
         "needs *nix",
     )
-    def test_batch_log_record_processor_fork(self):
+    def test_batch_log_record_processor_fork_clears_logs_from_child(self):
         exporter = InMemoryLogExporter()
         log_record_processor = BatchLogRecordProcessor(
             exporter,
             max_export_batch_size=64,
             schedule_delay_millis=30000,
         )
-        # These are not expected to be flushed. Calling fork clears any logs not flushed.
+        # These logs should be flushed only from the parent process.
+        # _at_fork_reinit should be called in the child process, to
+        # clear these logs in the child process.
         for _ in range(10):
             log_record_processor.emit(EMPTY_LOG)
+
+        # The below test also needs this, but it can only be set once.
         multiprocessing.set_start_method("fork")
 
         def child(conn):
@@ -603,8 +604,10 @@ class TestBatchLogRecordProcessor(unittest.TestCase):
         )
 
         def child(conn):
-            for _ in range(100):
+            def _target():
                 log_record_processor.emit(EMPTY_LOG)
+
+            ConcurrencyTestBase.run_with_many_threads(_target, 100)
             log_record_processor.force_flush()
             logs = exporter.get_finished_logs()
             conn.send(len(logs) == 100)
@@ -615,7 +618,6 @@ class TestBatchLogRecordProcessor(unittest.TestCase):
         process.start()
         self.assertTrue(parent_conn.recv())
         process.join()
-        self.assertTrue(len(exporter.get_finished_logs()) == 0)
 
     def test_batch_log_record_processor_gc(self):
         # Given a BatchLogRecordProcessor
@@ -677,4 +679,5 @@ class TestConsoleLogExporter(unittest.TestCase):
         mock_stdout = Mock()
         exporter = ConsoleLogExporter(out=mock_stdout, formatter=formatter)
         exporter.export([EMPTY_LOG])
+
         mock_stdout.write.assert_called_once_with(mock_record_str)

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -27,7 +27,8 @@ from opentelemetry.sdk._logs import (
     LoggingHandler,
     LogRecordProcessor,
 )
-from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv._incubating.attributes import code_attributes
+from opentelemetry.semconv.attributes import exception_attributes
 from opentelemetry.trace import INVALID_SPAN_CONTEXT
 
 
@@ -127,17 +128,19 @@ class TestLoggingHandler(unittest.TestCase):
         self.assertEqual(len(log_record.attributes), 4)
         self.assertEqual(log_record.attributes["http.status_code"], 200)
         self.assertTrue(
-            log_record.attributes[SpanAttributes.CODE_FILEPATH].endswith(
+            log_record.attributes[code_attributes.CODE_FILE_PATH].endswith(
                 "test_handler.py"
             )
         )
         self.assertEqual(
-            log_record.attributes[SpanAttributes.CODE_FUNCTION],
+            log_record.attributes[code_attributes.CODE_FUNCTION_NAME],
             "test_log_record_user_attributes",
         )
         # The line of the log statement is not a constant (changing tests may change that),
         # so only check that the attribute is present.
-        self.assertTrue(SpanAttributes.CODE_LINENO in log_record.attributes)
+        self.assertTrue(
+            code_attributes.CODE_LINE_NUMBER in log_record.attributes
+        )
         self.assertTrue(isinstance(log_record.attributes, BoundedAttributes))
 
     def test_log_record_exception(self):
@@ -156,15 +159,15 @@ class TestLoggingHandler(unittest.TestCase):
         self.assertTrue(isinstance(log_record.body, str))
         self.assertEqual(log_record.body, "Zero Division Error")
         self.assertEqual(
-            log_record.attributes[SpanAttributes.EXCEPTION_TYPE],
+            log_record.attributes[exception_attributes.EXCEPTION_TYPE],
             ZeroDivisionError.__name__,
         )
         self.assertEqual(
-            log_record.attributes[SpanAttributes.EXCEPTION_MESSAGE],
+            log_record.attributes[exception_attributes.EXCEPTION_MESSAGE],
             "division by zero",
         )
         stack_trace = log_record.attributes[
-            SpanAttributes.EXCEPTION_STACKTRACE
+            exception_attributes.EXCEPTION_STACKTRACE
         ]
         self.assertIsInstance(stack_trace, str)
         self.assertTrue("Traceback" in stack_trace)
@@ -189,15 +192,15 @@ class TestLoggingHandler(unittest.TestCase):
         self.assertIsNotNone(log_record)
         self.assertEqual(log_record.body, "Zero Division Error")
         self.assertEqual(
-            log_record.attributes[SpanAttributes.EXCEPTION_TYPE],
+            log_record.attributes[exception_attributes.EXCEPTION_TYPE],
             ZeroDivisionError.__name__,
         )
         self.assertEqual(
-            log_record.attributes[SpanAttributes.EXCEPTION_MESSAGE],
+            log_record.attributes[exception_attributes.EXCEPTION_MESSAGE],
             "division by zero",
         )
         stack_trace = log_record.attributes[
-            SpanAttributes.EXCEPTION_STACKTRACE
+            exception_attributes.EXCEPTION_STACKTRACE
         ]
         self.assertIsInstance(stack_trace, str)
         self.assertTrue("Traceback" in stack_trace)
@@ -219,12 +222,14 @@ class TestLoggingHandler(unittest.TestCase):
 
         self.assertIsNotNone(log_record)
         self.assertEqual(log_record.body, "Zero Division Error")
-        self.assertNotIn(SpanAttributes.EXCEPTION_TYPE, log_record.attributes)
         self.assertNotIn(
-            SpanAttributes.EXCEPTION_MESSAGE, log_record.attributes
+            exception_attributes.EXCEPTION_TYPE, log_record.attributes
         )
         self.assertNotIn(
-            SpanAttributes.EXCEPTION_STACKTRACE, log_record.attributes
+            exception_attributes.EXCEPTION_MESSAGE, log_record.attributes
+        )
+        self.assertNotIn(
+            exception_attributes.EXCEPTION_STACKTRACE, log_record.attributes
         )
 
     def test_log_record_exception_with_object_payload(self):
@@ -246,15 +251,15 @@ class TestLoggingHandler(unittest.TestCase):
         self.assertTrue(isinstance(log_record.body, str))
         self.assertEqual(log_record.body, "CustomException stringified")
         self.assertEqual(
-            log_record.attributes[SpanAttributes.EXCEPTION_TYPE],
+            log_record.attributes[exception_attributes.EXCEPTION_TYPE],
             CustomException.__name__,
         )
         self.assertEqual(
-            log_record.attributes[SpanAttributes.EXCEPTION_MESSAGE],
+            log_record.attributes[exception_attributes.EXCEPTION_MESSAGE],
             "CustomException message",
         )
         stack_trace = log_record.attributes[
-            SpanAttributes.EXCEPTION_STACKTRACE
+            exception_attributes.EXCEPTION_STACKTRACE
         ]
         self.assertIsInstance(stack_trace, str)
         self.assertTrue("Traceback" in stack_trace)


### PR DESCRIPTION
# Description

Update `export` on OTLP / HTTP exporters to include a timeout param. Make `timeout` encompass retries, rather than  being applied per-request.

Update the grpc exporter to us the `retry` config, which lets `grpc` handle retries / timeout automatically based on our config, so we can delete a lot of code.

There is no equivalent for HTTP (there is a `urlilib3.RetryConfig`, but it's retries are not inclusive of `timeout` - instead each retry gets passed the same timeout), so I manually updated the HTTP exporters.

I also cleaned up the HTTP exporter code a tiny bit.

https://github.com/open-telemetry/opentelemetry-python/pull/4183 -- similar to this PR and what's discussed in https://github.com/open-telemetry/opentelemetry-python/issues/4043, but I implemented it in as minimal a way as I could.. 

I updated the `LogExporter` and `SpanExporter` interfaces to include `timeout_millis` (`MetricExporter` already has it), this isn't a breaking change because `@abstractmethod` just checks that classes implementin have a method with a particular name, it doesn't check method parameters at all.. It does cause a pylint error, but I think that's a good thing.

In future PRs I plan to update `shutdown` and `forceFlush` to pass their timeouts along to export.. We could potentially pass [these env var timeouts](https://github.com/open-telemetry/opentelemetry-python/issues/4555) along to all other `export` calls too..



Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Lots of unit tests.

# Does This PR Require a Contrib Repo Change?
- [ ] Yes. - Link to PR: 
- [x ] No.

# Checklist:

- [ x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x ] Unit tests have been added
- [ ] Documentation has been updated
