### PR TITLE
Add a timeout param to all OTLP grpc / http export calls -- fixed merge conflicts

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
@@ -58,7 +58,7 @@ class OTLPLogExporter(
         headers: Optional[
             Union[TypingSequence[Tuple[str, str]], Dict[str, str], str]
         ] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
         compression: Optional[Compression] = None,
     ):
         if insecure is None:
@@ -79,7 +79,7 @@ class OTLPLogExporter(
 
         environ_timeout = environ.get(OTEL_EXPORTER_OTLP_LOGS_TIMEOUT)
         environ_timeout = (
-            int(environ_timeout) if environ_timeout is not None else None
+            float(environ_timeout) if environ_timeout is not None else None
         )
 
         compression = (
@@ -107,8 +107,12 @@ class OTLPLogExporter(
     ) -> ExportLogsServiceRequest:
         return encode_logs(data)
 
-    def export(self, batch: Sequence[LogData]) -> LogExportResult:
-        return self._export(batch)
+    def export(
+        self, batch: Sequence[LogData], timeout_millis: Optional[int] = None
+    ) -> LogExportResult:
+        return self._export(
+            batch, timeout_millis / 1e3 if timeout_millis else None
+        )
 
     def shutdown(self, timeout_millis: float = 30_000, **kwargs) -> None:
         OTLPExporterMixin.shutdown(self, timeout_millis=timeout_millis)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
@@ -91,7 +91,7 @@ class OTLPSpanExporter(
         headers: Optional[
             Union[TypingSequence[Tuple[str, str]], Dict[str, str], str]
         ] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
         compression: Optional[Compression] = None,
     ):
         if insecure is None:
@@ -112,7 +112,7 @@ class OTLPSpanExporter(
 
         environ_timeout = environ.get(OTEL_EXPORTER_OTLP_TRACES_TIMEOUT)
         environ_timeout = (
-            int(environ_timeout) if environ_timeout is not None else None
+            float(environ_timeout) if environ_timeout is not None else None
         )
 
         compression = (
@@ -139,8 +139,14 @@ class OTLPSpanExporter(
     ) -> ExportTraceServiceRequest:
         return encode_spans(data)
 
-    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
-        return self._export(spans)
+    def export(
+        self,
+        spans: Sequence[ReadableSpan],
+        timeout_millis: Optional[int] = None,
+    ) -> SpanExportResult:
+        return self._export(
+            spans, timeout_millis / 1e3 if timeout_millis else None
+        )
 
     def shutdown(self) -> None:
         OTLPExporterMixin.shutdown(self)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.7.2
 Deprecated==1.2.14
 googleapis-common-protos==1.63.2
 grpcio==1.66.2
+grpcio-status==1.66.0
 importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_metrics_exporter.py
@@ -18,7 +18,7 @@ from os import environ
 from os.path import dirname
 from typing import List
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from grpc import ChannelCredentials, Compression
 
@@ -297,7 +297,9 @@ class TestOTLPMetricExporter(TestCase):
             insecure=True, compression=Compression.NoCompression
         )
         mock_insecure_channel.assert_called_once_with(
-            "localhost:4317", compression=Compression.NoCompression
+            "localhost:4317",
+            compression=Compression.NoCompression,
+            options=ANY,
         )
 
     def test_split_metrics_data_many_data_points(self):

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -16,7 +16,7 @@
 
 import os
 from unittest import TestCase
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import ANY, Mock, PropertyMock, patch
 
 from grpc import ChannelCredentials, Compression
 
@@ -333,7 +333,9 @@ class TestOTLPSpanExporter(TestCase):
         """Specifying kwarg should take precedence over env"""
         OTLPSpanExporter(insecure=True, compression=Compression.NoCompression)
         mock_insecure_channel.assert_called_once_with(
-            "localhost:4317", compression=Compression.NoCompression
+            "localhost:4317",
+            compression=Compression.NoCompression,
+            options=ANY,
         )
 
     # pylint: disable=no-self-use
@@ -350,7 +352,9 @@ class TestOTLPSpanExporter(TestCase):
         """
         OTLPSpanExporter(insecure=True)
         mock_insecure_channel.assert_called_once_with(
-            "localhost:4317", compression=Compression.Gzip
+            "localhost:4317",
+            compression=Compression.Gzip,
+            options=ANY,
         )
 
     def test_translate_spans(self):

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -17,15 +17,12 @@ import logging
 import zlib
 from io import BytesIO
 from os import environ
-from time import sleep
+from time import sleep, time
 from typing import Dict, Optional, Sequence
 
 import requests
 from requests.exceptions import ConnectionError
 
-from opentelemetry.exporter.otlp.proto.common._internal import (
-    _create_exp_backoff_generator,
-)
 from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
 from opentelemetry.exporter.otlp.proto.http import (
     _OTLP_HTTP_HEADERS,
@@ -64,8 +61,6 @@ DEFAULT_TIMEOUT = 10  # in seconds
 
 
 class OTLPLogExporter(LogExporter):
-    _MAX_RETRY_TIMEOUT = 64
-
     def __init__(
         self,
         endpoint: Optional[str] = None,
@@ -73,7 +68,7 @@ class OTLPLogExporter(LogExporter):
         client_key_file: Optional[str] = None,
         client_certificate_file: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
         compression: Optional[Compression] = None,
         session: Optional[requests.Session] = None,
     ):
@@ -108,7 +103,7 @@ class OTLPLogExporter(LogExporter):
         self._headers = headers or parse_env_headers(
             headers_string, liberal=True
         )
-        self._timeout = timeout or int(
+        self._timeout = timeout or float(
             environ.get(
                 OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
                 environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, DEFAULT_TIMEOUT),
@@ -124,7 +119,7 @@ class OTLPLogExporter(LogExporter):
             )
         self._shutdown = False
 
-    def _export(self, serialized_data: bytes):
+    def _export(self, serialized_data: bytes, timeout_sec: float):
         data = serialized_data
         if self._compression == Compression.Gzip:
             gzip_data = BytesIO()
@@ -143,7 +138,7 @@ class OTLPLogExporter(LogExporter):
                 url=self._endpoint,
                 data=data,
                 verify=self._certificate_file,
-                timeout=self._timeout,
+                timeout=timeout_sec
                 cert=self._client_cert,
             )
         except ConnectionError:
@@ -151,7 +146,7 @@ class OTLPLogExporter(LogExporter):
                 url=self._endpoint,
                 data=data,
                 verify=self._certificate_file,
-                timeout=self._timeout,
+                timeout=timeout_sec
                 cert=self._client_cert,
             )
         return resp
@@ -164,7 +159,9 @@ class OTLPLogExporter(LogExporter):
             return True
         return False
 
-    def export(self, batch: Sequence[LogData]) -> LogExportResult:
+    def export(
+        self, batch: Sequence[LogData], timeout_millis: Optional[float] = None
+    ) -> LogExportResult:
         # After the call to Shutdown subsequent calls to Export are
         # not allowed and should return a Failure result.
         if self._shutdown:
@@ -172,18 +169,20 @@ class OTLPLogExporter(LogExporter):
             return LogExportResult.FAILURE
 
         serialized_data = encode_logs(batch).SerializeToString()
-
-        for delay in _create_exp_backoff_generator(
-            max_value=self._MAX_RETRY_TIMEOUT
-        ):
-            if delay == self._MAX_RETRY_TIMEOUT:
+        deadline_sec = time() + (
+            timeout_millis / 1e3 if timeout_millis else self._timeout
+        )
+        for delay in [1, 2, 4, 8, 16, 32]:
+            remaining_time_sec = deadline_sec - time()
+            if remaining_time_sec < 1e-09:
                 return LogExportResult.FAILURE
-
-            resp = self._export(serialized_data)
+            resp = self._export(serialized_data, remaining_time_sec)
             # pylint: disable=no-else-return
             if resp.ok:
                 return LogExportResult.SUCCESS
             elif self._retryable(resp):
+                if delay > (deadline_sec - time()):
+                    return LogExportResult.FAILURE
                 _logger.warning(
                     "Transient error %s encountered while exporting logs batch, retrying in %ss.",
                     resp.reason,

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -138,7 +138,7 @@ class OTLPLogExporter(LogExporter):
                 url=self._endpoint,
                 data=data,
                 verify=self._certificate_file,
-                timeout=timeout_sec
+                timeout=timeout_sec,
                 cert=self._client_cert,
             )
         except ConnectionError:
@@ -146,7 +146,7 @@ class OTLPLogExporter(LogExporter):
                 url=self._endpoint,
                 data=data,
                 verify=self._certificate_file,
-                timeout=timeout_sec
+                timeout=timeout_sec,
                 cert=self._client_cert,
             )
         return resp

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
@@ -15,12 +15,14 @@
 # pylint: disable=protected-access
 
 import unittest
+from logging import WARNING
 from typing import List
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import requests
-import responses
 from google.protobuf.json_format import MessageToDict
+from requests import Session
+from requests.models import Response
 
 from opentelemetry._logs import SeverityNumber
 from opentelemetry.exporter.otlp.proto.http import Compression
@@ -267,25 +269,6 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         else:
             self.fail("No log records found")
 
-    @responses.activate
-    @patch("opentelemetry.exporter.otlp.proto.http._log_exporter.sleep")
-    def test_exponential_backoff(self, mock_sleep):
-        # return a retryable error
-        responses.add(
-            responses.POST,
-            "http://logs.example.com/export",
-            json={"error": "something exploded"},
-            status=500,
-        )
-
-        exporter = OTLPLogExporter(endpoint="http://logs.example.com/export")
-        logs = self._get_sdk_log_data()
-
-        exporter.export(logs)
-        mock_sleep.assert_has_calls(
-            [call(1), call(2), call(4), call(8), call(16), call(32)]
-        )
-
     @staticmethod
     def _get_sdk_log_data() -> List[LogData]:
         log1 = LogData(
@@ -365,3 +348,46 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         self.assertEqual(
             OTLPLogExporter().export(MagicMock()), LogExportResult.SUCCESS
         )
+
+    @patch.object(Session, "post")
+    def test_retry_timeout(self, mock_post):
+        exporter = OTLPLogExporter(timeout=3.5)
+
+        resp = Response()
+        resp.status_code = 503
+        resp.reason = "UNAVAILABLE"
+        mock_post.return_value = resp
+        with self.assertLogs(level=WARNING) as warning:
+            # Set timeout to 1.5 seconds
+            self.assertEqual(
+                exporter.export(self._get_sdk_log_data(), 1500),
+                LogExportResult.FAILURE,
+            )
+            # Code should return failure after retrying once.
+            self.assertEqual(len(warning.records), 1)
+            self.assertEqual(
+                "Transient error UNAVAILABLE encountered while exporting logs batch, retrying in 1s.",
+                warning.records[0].message,
+            )
+        with self.assertLogs(level=WARNING) as warning:
+            # This time don't pass in a timeout, so it will fallback to 3.5 second set on class.
+            self.assertEqual(
+                exporter.export(self._get_sdk_log_data()),
+                LogExportResult.FAILURE,
+            )
+            # 2 retrys (after 1s, 3s).
+            self.assertEqual(len(warning.records), 2)
+
+    @patch.object(Session, "post")
+    def test_timeout_set_correctly(self, mock_post):
+        resp = Response()
+        resp.status_code = 200
+
+        def export_side_effect(*args, **kwargs):
+            # Timeout should be set to something slightly less than 400 milliseconds depending on how much time has passed.
+            self.assertTrue(0.4 - kwargs["timeout"] < 0.0005)
+            return resp
+
+        mock_post.side_effect = export_side_effect
+        exporter = OTLPLogExporter()
+        exporter.export(self._get_sdk_log_data(), 400)

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import MagicMock, Mock, call, patch
+from logging import WARNING
+from unittest.mock import MagicMock, Mock, patch
 
 import requests
-import responses
+from requests import Session
+from requests.models import Response
 
 from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
@@ -52,6 +54,16 @@ OS_ENV_CLIENT_CERTIFICATE = "os/env/client-cert.pem"
 OS_ENV_CLIENT_KEY = "os/env/client-key.pem"
 OS_ENV_HEADERS = "envHeader1=val1,envHeader2=val2"
 OS_ENV_TIMEOUT = "30"
+BASIC_SPAN = _Span(
+    "abc",
+    context=Mock(
+        **{
+            "trace_state": {"a": "b", "c": "d"},
+            "span_id": 10217189687419569865,
+            "trace_id": 67545097771067222548457157018666467027,
+        }
+    ),
+)
 
 
 # pylint: disable=protected-access
@@ -227,37 +239,6 @@ class TestOTLPSpanExporter(unittest.TestCase):
                 ),
             )
 
-    # pylint: disable=no-self-use
-    @responses.activate
-    @patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.sleep")
-    def test_exponential_backoff(self, mock_sleep):
-        # return a retryable error
-        responses.add(
-            responses.POST,
-            "http://traces.example.com/export",
-            json={"error": "something exploded"},
-            status=500,
-        )
-
-        exporter = OTLPSpanExporter(
-            endpoint="http://traces.example.com/export"
-        )
-        span = _Span(
-            "abc",
-            context=Mock(
-                **{
-                    "trace_state": {"a": "b", "c": "d"},
-                    "span_id": 10217189687419569865,
-                    "trace_id": 67545097771067222548457157018666467027,
-                }
-            ),
-        )
-
-        exporter.export([span])
-        mock_sleep.assert_has_calls(
-            [call(1), call(2), call(4), call(8), call(16), call(32)]
-        )
-
     @patch.object(OTLPSpanExporter, "_export", return_value=Mock(ok=True))
     def test_2xx_status_code(self, mock_otlp_metric_exporter):
         """
@@ -267,3 +248,46 @@ class TestOTLPSpanExporter(unittest.TestCase):
         self.assertEqual(
             OTLPSpanExporter().export(MagicMock()), SpanExportResult.SUCCESS
         )
+
+    @patch.object(Session, "post")
+    def test_retry_timeout(self, mock_post):
+        exporter = OTLPSpanExporter(timeout=3.5)
+
+        resp = Response()
+        resp.status_code = 503
+        resp.reason = "UNAVAILABLE"
+        mock_post.return_value = resp
+        with self.assertLogs(level=WARNING) as warning:
+            # Set timeout to 1.5 seconds
+            self.assertEqual(
+                exporter.export([BASIC_SPAN], 1500),
+                SpanExportResult.FAILURE,
+            )
+            # Code should return failure after retrying once.
+            self.assertEqual(len(warning.records), 1)
+            self.assertEqual(
+                "Transient error UNAVAILABLE encountered while exporting span batch, retrying in 1s.",
+                warning.records[0].message,
+            )
+        with self.assertLogs(level=WARNING) as warning:
+            # This time don't pass in a timeout, so it will fallback to 3.5 second set on class.
+            self.assertEqual(
+                exporter.export([BASIC_SPAN]),
+                SpanExportResult.FAILURE,
+            )
+            # 2 retrys (after 1s, 3s).
+            self.assertEqual(len(warning.records), 2)
+
+    @patch.object(Session, "post")
+    def test_timeout_set_correctly(self, mock_post):
+        resp = Response()
+        resp.status_code = 200
+
+        def export_side_effect(*args, **kwargs):
+            # Timeout should be set to something slightly less than 400 milliseconds depending on how much time has passed.
+            self.assertTrue(0.4 - kwargs["timeout"] < 0.0005)
+            return resp
+
+        mock_post.side_effect = export_side_effect
+        exporter = OTLPSpanExporter()
+        exporter.export([BASIC_SPAN], 400)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -92,13 +92,6 @@ class LogExporter(abc.ABC):
         Called when the SDK is shut down.
         """
 
-    @abc.abstractmethod
-    def force_flush(self, timeout_millis: int = 30000) -> bool:
-        """Hint to ensure that the export of any spans the exporter has received
-        prior to the call to ForceFlush SHOULD be completed as soon as possible, preferably
-        before returning from this method.
-        """
-
 
 class ConsoleLogExporter(LogExporter):
     """Implementation of :class:`LogExporter` that prints log records to the
@@ -126,7 +119,6 @@ class ConsoleLogExporter(LogExporter):
 
     def shutdown(self):
         pass
-
 
 class SimpleLogRecordProcessor(LogRecordProcessor):
     """This is an implementation of LogRecordProcessor which passes

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/in_memory_log_exporter.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/in_memory_log_exporter.py
@@ -40,6 +40,7 @@ class InMemoryLogExporter(LogExporter):
         with self._lock:
             return tuple(self._logs)
 
+    # pylint: disable=arguments-differ
     def export(self, batch: typing.Sequence[LogData]) -> LogExportResult:
         if self._stopped:
             return LogExportResult.FAILURE

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import abc
 import collections
 import logging
 import os
@@ -56,7 +57,8 @@ class SpanExportResult(Enum):
     FAILURE = 1
 
 
-class SpanExporter:
+
+class SpanExporter(abc.ABC):
     """Interface for exporting spans.
 
     Interface to be implemented by services that want to export spans recorded
@@ -66,24 +68,30 @@ class SpanExporter:
     `SimpleSpanProcessor` or a `BatchSpanProcessor`.
     """
 
+    @abc.abstractmethod
     def export(
-        self, spans: typing.Sequence[ReadableSpan]
+        self,
+        spans: typing.Sequence[ReadableSpan],
+        timeout_millis: typing.Optional[int] = None,
     ) -> "SpanExportResult":
         """Exports a batch of telemetry data.
 
         Args:
             spans: The list of `opentelemetry.trace.Span` objects to be exported
+            timeout_millis: Optional milliseconds until Export should timeout if it hasn't succeded.
 
         Returns:
             The result of the export
         """
 
+    @abc.abstractmethod
     def shutdown(self) -> None:
         """Shuts down the exporter.
 
         Called when the SDK is shut down.
         """
 
+    @abc.abstractmethod
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         """Hint to ensure that the export of any spans the exporter has received
         prior to the call to ForceFlush SHOULD be completed as soon as possible, preferably

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -57,7 +57,6 @@ class SpanExportResult(Enum):
     FAILURE = 1
 
 
-
 class SpanExporter(abc.ABC):
     """Interface for exporting spans.
 
@@ -91,7 +90,6 @@ class SpanExporter(abc.ABC):
         Called when the SDK is shut down.
         """
 
-    @abc.abstractmethod
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         """Hint to ensure that the export of any spans the exporter has received
         prior to the call to ForceFlush SHOULD be completed as soon as possible, preferably
@@ -517,11 +515,15 @@ class ConsoleSpanExporter(SpanExporter):
         self.formatter = formatter
         self.service_name = service_name
 
+    # pylint: disable=arguments-differ
     def export(self, spans: typing.Sequence[ReadableSpan]) -> SpanExportResult:
         for span in spans:
             self.out.write(self.formatter(span))
         self.out.flush()
         return SpanExportResult.SUCCESS
 
-    def force_flush(self, timeout_millis: int = 30000) -> bool:
+    def force_flush(self, timeout_millis: int = 30000):
         return True
+
+    def shutdown(self):
+        pass

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/in_memory_span_exporter.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/in_memory_span_exporter.py
@@ -42,6 +42,7 @@ class InMemorySpanExporter(SpanExporter):
         with self._lock:
             return tuple(self._finished_spans)
 
+    # pylint: disable=arguments-differ
     def export(self, spans: typing.Sequence[ReadableSpan]) -> SpanExportResult:
         """Stores a list of spans in memory."""
         if self._stopped:

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -60,6 +60,7 @@ class MySpanExporter(export.SpanExporter):
         self.export_timeout = export_timeout_millis / 1e3
         self.export_event = export_event
 
+    # pylint: disable=arguments-differ
     def export(self, spans: trace.Span) -> export.SpanExportResult:
         if (
             self.max_export_batch_size is not None
@@ -74,6 +75,9 @@ class MySpanExporter(export.SpanExporter):
 
     def shutdown(self):
         self.is_shutdown = True
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
 
 
 class TestSimpleSpanProcessor(unittest.TestCase):


### PR DESCRIPTION
# Description

Update `export` on OTLP / HTTP exporters to include a timeout param. Make `timeout` encompass retries, rather than  being applied per-request.

Update the grpc exporter to us the `retry` config, which lets `grpc` handle retries / timeout automatically based on our config, so we can delete a lot of code.

There is no equivalent for HTTP (there is a `urlilib3.RetryConfig`, but it's retries are not inclusive of `timeout` - instead each retry gets passed the same timeout), so I manually updated the HTTP exporters.

I also cleaned up the HTTP exporter code a tiny bit.

https://github.com/open-telemetry/opentelemetry-python/pull/4183 -- similar to this PR and what's discussed in https://github.com/open-telemetry/opentelemetry-python/issues/4043, but I implemented it in as minimal a way as I could.. 

I updated the `LogExporter` and `SpanExporter` interfaces to include `timeout_millis` (`MetricExporter` already has it), this isn't a breaking change because `@abstractmethod` just checks that classes implementin have a method with a particular name, it doesn't check method parameters at all.. It does cause a pylint error, but I think that's a good thing.

In future PRs I plan to update `shutdown` and `forceFlush` to pass their timeouts along to export.. We could potentially pass [these env var timeouts](https://github.com/open-telemetry/opentelemetry-python/issues/4555) along to all other `export` calls too..



Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Lots of unit tests.

# Does This PR Require a Contrib Repo Change?
- [ ] Yes. - Link to PR: 
- [x ] No.

# Checklist:

- [ x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x ] Unit tests have been added
- [ ] Documentation has been updated
