### PR TITLE
[WIP/Draft] Change Logs API (and Events API) to accept whole SpanContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor `BatchLogRecordProcessor` to simplify code and make the control flow more
   clear ([#4562](https://github.com/open-telemetry/opentelemetry-python/pull/4562/)
   and [#4535](https://github.com/open-telemetry/opentelemetry-python/pull/4535)).
+- Logging API and Events API accept SpanContext instead of trace_id, span_id, trace_flags
+  ([#4584](https://github.com/open-telemetry/opentelemetry-python/pull/4584))
 
 ## Version 1.33.0/0.54b0 (2025-05-09)
 

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
@@ -50,6 +50,7 @@ from opentelemetry.sdk._logs import LogRecord as SDKLogRecord
 from opentelemetry.sdk.resources import Resource as SDKResource
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.trace import TraceFlags
+from opentelemetry.trace.span import SpanContext
 
 
 class TestOTLPLogEncoder(unittest.TestCase):
@@ -88,9 +89,12 @@ class TestOTLPLogEncoder(unittest.TestCase):
             log_record=SDKLogRecord(
                 timestamp=1644650195189786880,
                 observed_timestamp=1644650195189786881,
-                trace_id=89564621134313219400156819398935297684,
-                span_id=1312458408527513268,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    89564621134313219400156819398935297684,
+                    1312458408527513268,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="WARN",
                 severity_number=SeverityNumber.WARN,
                 body="Do not go gentle into that good night. Rage, rage against the dying of the light",
@@ -109,9 +113,12 @@ class TestOTLPLogEncoder(unittest.TestCase):
             log_record=SDKLogRecord(
                 timestamp=1644650249738562048,
                 observed_timestamp=1644650249738562049,
-                trace_id=0,
-                span_id=0,
-                trace_flags=TraceFlags.DEFAULT,
+                span_context=SpanContext(
+                    0,
+                    0,
+                    True,
+                    TraceFlags.DEFAULT,
+                ),
                 severity_text="WARN",
                 severity_number=SeverityNumber.WARN,
                 body="Cooper, this is no time for caution!",
@@ -127,9 +134,12 @@ class TestOTLPLogEncoder(unittest.TestCase):
             log_record=SDKLogRecord(
                 timestamp=1644650427658989056,
                 observed_timestamp=1644650427658989057,
-                trace_id=271615924622795969659406376515024083555,
-                span_id=4242561578944770265,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    271615924622795969659406376515024083555,
+                    4242561578944770265,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="DEBUG",
                 severity_number=SeverityNumber.DEBUG,
                 body="To our galaxy",
@@ -143,9 +153,12 @@ class TestOTLPLogEncoder(unittest.TestCase):
             log_record=SDKLogRecord(
                 timestamp=1644650584292683008,
                 observed_timestamp=1644650584292683009,
-                trace_id=212592107417388365804938480559624925555,
-                span_id=6077757853989569223,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    212592107417388365804938480559624925555,
+                    6077757853989569223,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="INFO",
                 severity_number=SeverityNumber.INFO,
                 body="Love is the one thing that transcends time and space",
@@ -164,9 +177,12 @@ class TestOTLPLogEncoder(unittest.TestCase):
             log_record=SDKLogRecord(
                 timestamp=1644650584292683009,
                 observed_timestamp=1644650584292683010,
-                trace_id=212592107417388365804938480559624925555,
-                span_id=6077757853989569445,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    212592107417388365804938480559624925555,
+                    6077757853989569445,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="INFO",
                 severity_number=SeverityNumber.INFO,
                 body={"error": None, "array_with_nones": [1, None, 2]},
@@ -182,9 +198,12 @@ class TestOTLPLogEncoder(unittest.TestCase):
             log_record=SDKLogRecord(
                 timestamp=1644650584292683022,
                 observed_timestamp=1644650584292683022,
-                trace_id=212592107417388365804938480559624925522,
-                span_id=6077757853989569222,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    212592107417388365804938480559624925522,
+                    6077757853989569222,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="ERROR",
                 severity_number=SeverityNumber.ERROR,
                 body="This instrumentation scope has a schema url",
@@ -205,9 +224,12 @@ class TestOTLPLogEncoder(unittest.TestCase):
             log_record=SDKLogRecord(
                 timestamp=1644650584292683033,
                 observed_timestamp=1644650584292683033,
-                trace_id=212592107417388365804938480559624925533,
-                span_id=6077757853989569233,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    212592107417388365804938480559624925533,
+                    6077757853989569233,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="FATAL",
                 severity_number=SeverityNumber.FATAL,
                 body="This instrumentation scope has a schema url and attributes",
@@ -229,9 +251,12 @@ class TestOTLPLogEncoder(unittest.TestCase):
             log_record=SDKLogRecord(
                 timestamp=1644650584292683044,
                 observed_timestamp=1644650584292683044,
-                trace_id=212592107417388365804938480559624925566,
-                span_id=6077757853989569466,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    212592107417388365804938480559624925566,
+                    6077757853989569466,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="INFO",
                 severity_number=SeverityNumber.INFO,
                 body="Test export of extended attributes",
@@ -547,9 +572,12 @@ class TestOTLPLogEncoder(unittest.TestCase):
         log1 = LogData(
             log_record=SDKLogRecord(
                 timestamp=1644650195189786880,
-                trace_id=89564621134313219400156819398935297684,
-                span_id=1312458408527513268,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    89564621134313219400156819398935297684,
+                    1312458408527513268,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="WARN",
                 severity_number=SeverityNumber.WARN,
                 body="Do not go gentle into that good night. Rage, rage against the dying of the light",
@@ -565,9 +593,12 @@ class TestOTLPLogEncoder(unittest.TestCase):
         log2 = LogData(
             log_record=SDKLogRecord(
                 timestamp=1644650249738562048,
-                trace_id=0,
-                span_id=0,
-                trace_flags=TraceFlags.DEFAULT,
+                span_context=SpanContext(
+                    0,
+                    0,
+                    True,
+                    TraceFlags.DEFAULT,
+                ),
                 severity_text="WARN",
                 severity_number=SeverityNumber.WARN,
                 body="Cooper, this is no time for caution!",

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
@@ -52,6 +52,7 @@ from opentelemetry.sdk.environment_variables import (
 from opentelemetry.sdk.resources import Resource as SDKResource
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.trace import TraceFlags
+from opentelemetry.trace.span import SpanContext
 
 THIS_DIR = dirname(__file__)
 
@@ -62,9 +63,12 @@ class TestOTLPLogExporter(TestCase):
         self.log_data_1 = LogData(
             log_record=LogRecord(
                 timestamp=int(time.time() * 1e9),
-                trace_id=2604504634922341076776623263868986797,
-                span_id=5213367945872657620,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    2604504634922341076776623263868986797,
+                    5213367945872657620,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="WARNING",
                 severity_number=SeverityNumber.WARN,
                 body="Zhengzhou, We have a heaviest rains in 1000 years",
@@ -78,9 +82,12 @@ class TestOTLPLogExporter(TestCase):
         self.log_data_2 = LogData(
             log_record=LogRecord(
                 timestamp=int(time.time() * 1e9),
-                trace_id=2604504634922341076776623263868986799,
-                span_id=5213367945872657623,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    2604504634922341076776623263868986799,
+                    5213367945872657623,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="INFO",
                 severity_number=SeverityNumber.INFO2,
                 body="Sydney, Opera House is closed",
@@ -94,9 +101,12 @@ class TestOTLPLogExporter(TestCase):
         self.log_data_3 = LogData(
             log_record=LogRecord(
                 timestamp=int(time.time() * 1e9),
-                trace_id=2604504634922341076776623263868986800,
-                span_id=5213367945872657628,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    2604504634922341076776623263868986800,
+                    5213367945872657628,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="ERROR",
                 severity_number=SeverityNumber.WARN,
                 body="Mumbai, Boil water before drinking",
@@ -109,9 +119,12 @@ class TestOTLPLogExporter(TestCase):
         self.log_data_4 = LogData(
             log_record=LogRecord(
                 timestamp=int(time.time() * 1e9),
-                trace_id=0,
-                span_id=5213367945872657629,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    0,
+                    213367945872657629,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="ERROR",
                 severity_number=SeverityNumber.WARN,
                 body="Invalid trace id check",
@@ -124,9 +137,12 @@ class TestOTLPLogExporter(TestCase):
         self.log_data_5 = LogData(
             log_record=LogRecord(
                 timestamp=int(time.time() * 1e9),
-                trace_id=2604504634922341076776623263868986801,
-                span_id=0,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    2604504634922341076776623263868986801,
+                    0,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="ERROR",
                 severity_number=SeverityNumber.WARN,
                 body="Invalid span id check",

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
@@ -57,6 +57,7 @@ from opentelemetry.sdk.environment_variables import (
 from opentelemetry.sdk.resources import Resource as SDKResource
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.trace import TraceFlags
+from opentelemetry.trace.span import SpanContext
 
 ENV_ENDPOINT = "http://localhost.env:8080/"
 ENV_CERTIFICATE = "/etc/base.crt"
@@ -217,9 +218,12 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         log = LogData(
             log_record=SDKLogRecord(
                 timestamp=1644650195189786182,
-                trace_id=0,
-                span_id=1312458408527513292,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    0,
+                    1312458408527513292,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="WARN",
                 severity_number=SeverityNumber.WARN,
                 body="Invalid trace id check",
@@ -244,9 +248,12 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         log = LogData(
             log_record=SDKLogRecord(
                 timestamp=1644650195189786360,
-                trace_id=89564621134313219400156819398935297696,
-                span_id=0,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    89564621134313219400156819398935297696,
+                    0,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="WARN",
                 severity_number=SeverityNumber.WARN,
                 body="Invalid span id check",
@@ -291,9 +298,12 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         log1 = LogData(
             log_record=SDKLogRecord(
                 timestamp=1644650195189786880,
-                trace_id=89564621134313219400156819398935297684,
-                span_id=1312458408527513268,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    89564621134313219400156819398935297684,
+                    1312458408527513268,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="WARN",
                 severity_number=SeverityNumber.WARN,
                 body="Do not go gentle into that good night. Rage, rage against the dying of the light",
@@ -308,9 +318,12 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         log2 = LogData(
             log_record=SDKLogRecord(
                 timestamp=1644650249738562048,
-                trace_id=0,
-                span_id=0,
-                trace_flags=TraceFlags.DEFAULT,
+                span_context=SpanContext(
+                    0,
+                    0,
+                    True,
+                    TraceFlags.DEFAULT,
+                ),
                 severity_text="WARN",
                 severity_number=SeverityNumber.WARN,
                 body="Cooper, this is no time for caution!",
@@ -325,9 +338,12 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         log3 = LogData(
             log_record=SDKLogRecord(
                 timestamp=1644650427658989056,
-                trace_id=271615924622795969659406376515024083555,
-                span_id=4242561578944770265,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    271615924622795969659406376515024083555,
+                    4242561578944770265,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="DEBUG",
                 severity_number=SeverityNumber.DEBUG,
                 body="To our galaxy",
@@ -340,9 +356,12 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         log4 = LogData(
             log_record=SDKLogRecord(
                 timestamp=1644650584292683008,
-                trace_id=212592107417388365804938480559624925555,
-                span_id=6077757853989569223,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    212592107417388365804938480559624925555,
+                    6077757853989569223,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="INFO",
                 severity_number=SeverityNumber.INFO,
                 body="Love is the one thing that transcends time and space",

--- a/opentelemetry-api/src/opentelemetry/_events/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_events/__init__.py
@@ -22,7 +22,7 @@ from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.environment_variables import (
     _OTEL_PYTHON_EVENT_LOGGER_PROVIDER,
 )
-from opentelemetry.trace.span import TraceFlags
+from opentelemetry.trace.span import SpanContext
 from opentelemetry.util._once import Once
 from opentelemetry.util._providers import _load_provider
 from opentelemetry.util.types import AnyValue, _ExtendedAttributes
@@ -35,9 +35,7 @@ class Event(LogRecord):
         self,
         name: str,
         timestamp: Optional[int] = None,
-        trace_id: Optional[int] = None,
-        span_id: Optional[int] = None,
-        trace_flags: Optional["TraceFlags"] = None,
+        span_context: Optional[SpanContext] = None,
         body: Optional[AnyValue] = None,
         severity_number: Optional[SeverityNumber] = None,
         attributes: Optional[_ExtendedAttributes] = None,
@@ -49,9 +47,7 @@ class Event(LogRecord):
         }
         super().__init__(
             timestamp=timestamp,
-            trace_id=trace_id,
-            span_id=span_id,
-            trace_flags=trace_flags,
+            span_context=span_context,
             body=body,
             severity_number=severity_number,
             attributes=event_attributes,

--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -41,7 +41,7 @@ from typing import Optional, cast
 
 from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.environment_variables import _OTEL_PYTHON_LOGGER_PROVIDER
-from opentelemetry.trace.span import TraceFlags
+from opentelemetry.trace.span import SpanContext
 from opentelemetry.util._once import Once
 from opentelemetry.util._providers import _load_provider
 from opentelemetry.util.types import AnyValue, _ExtendedAttributes
@@ -61,9 +61,7 @@ class LogRecord(ABC):
         self,
         timestamp: Optional[int] = None,
         observed_timestamp: Optional[int] = None,
-        trace_id: Optional[int] = None,
-        span_id: Optional[int] = None,
-        trace_flags: Optional["TraceFlags"] = None,
+        span_context: Optional[SpanContext] = None,
         severity_text: Optional[str] = None,
         severity_number: Optional[SeverityNumber] = None,
         body: AnyValue = None,
@@ -73,9 +71,12 @@ class LogRecord(ABC):
         if observed_timestamp is None:
             observed_timestamp = time_ns()
         self.observed_timestamp = observed_timestamp
-        self.trace_id = trace_id
-        self.span_id = span_id
-        self.trace_flags = trace_flags
+        self.span_context = span_context
+        self.trace_id = self.span_id = self.trace_flags = None
+        if span_context:
+            self.trace_id = span_context.trace_id
+            self.span_id = span_context.span_id
+            self.trace_flags = span_context.trace_flags
         self.severity_text = severity_text
         self.severity_number = severity_number
         self.body = body

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_events/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_events/__init__.py
@@ -53,9 +53,7 @@ class EventLogger(APIEventLogger):
         log_record = LogRecord(
             timestamp=event.timestamp or time_ns(),
             observed_timestamp=None,
-            trace_id=event.trace_id or span_context.trace_id,
-            span_id=event.span_id or span_context.span_id,
-            trace_flags=event.trace_flags or span_context.trace_flags,
+            span_context=event.span_context or span_context,
             severity_text=None,
             severity_number=event.severity_number or SeverityNumber.INFO,
             body=event.body,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -24,7 +24,7 @@ import warnings
 from os import environ
 from threading import Lock
 from time import time_ns
-from typing import Any, Callable, Tuple, Union, cast  # noqa
+from typing import Any, Callable, Optional, Tuple, Union, cast  # noqa
 
 from opentelemetry._logs import Logger as APILogger
 from opentelemetry._logs import LoggerProvider as APILoggerProvider
@@ -52,7 +52,7 @@ from opentelemetry.trace import (
     format_trace_id,
     get_current_span,
 )
-from opentelemetry.trace.span import TraceFlags
+from opentelemetry.trace.span import SpanContext
 from opentelemetry.util.types import AnyValue, _ExtendedAttributes
 
 _logger = logging.getLogger(__name__)
@@ -176,9 +176,7 @@ class LogRecord(APILogRecord):
         self,
         timestamp: int | None = None,
         observed_timestamp: int | None = None,
-        trace_id: int | None = None,
-        span_id: int | None = None,
-        trace_flags: TraceFlags | None = None,
+        span_context: Optional[SpanContext] = None,
         severity_text: str | None = None,
         severity_number: SeverityNumber | None = None,
         body: AnyValue | None = None,
@@ -190,9 +188,7 @@ class LogRecord(APILogRecord):
             **{
                 "timestamp": timestamp,
                 "observed_timestamp": observed_timestamp,
-                "trace_id": trace_id,
-                "span_id": span_id,
-                "trace_flags": trace_flags,
+                "span_context": span_context,
                 "severity_text": severity_text,
                 "severity_number": severity_number,
                 "body": body,
@@ -548,9 +544,7 @@ class LoggingHandler(logging.Handler):
         return LogRecord(
             timestamp=timestamp,
             observed_timestamp=observered_timestamp,
-            trace_id=span_context.trace_id,
-            span_id=span_context.span_id,
-            trace_flags=span_context.trace_flags,
+            span_context=span_context,
             severity_text=level_name,
             severity_number=severity_number,
             body=body,

--- a/opentelemetry-sdk/tests/events/test_events.py
+++ b/opentelemetry-sdk/tests/events/test_events.py
@@ -23,6 +23,8 @@ from opentelemetry.sdk._events import EventLoggerProvider
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs._internal import Logger, NoOpLogger
 from opentelemetry.sdk.environment_variables import OTEL_SDK_DISABLED
+from opentelemetry.trace import TraceFlags
+from opentelemetry.trace.span import SpanContext
 
 
 class TestEventLoggerProvider(unittest.TestCase):
@@ -123,15 +125,17 @@ class TestEventLoggerProvider(unittest.TestCase):
             "name", "version", "schema_url", {"key": "value"}
         )
         now = Mock()
-        trace_id = Mock()
-        span_id = Mock()
-        trace_flags = Mock()
+        trace_flags = TraceFlags(0x01)
+        span_context = SpanContext(
+            2604504634922341076776623263868986797,
+            5213367945872657620,
+            True,
+            trace_flags,
+        )
         event = Event(
             name="test_event",
             timestamp=now,
-            trace_id=trace_id,
-            span_id=span_id,
-            trace_flags=trace_flags,
+            span_context=span_context,
             body="test body",
             severity_number=SeverityNumber.ERROR,
             attributes={
@@ -146,9 +150,7 @@ class TestEventLoggerProvider(unittest.TestCase):
         log_record_mock.assert_called_once_with(
             timestamp=now,
             observed_timestamp=None,
-            trace_id=trace_id,
-            span_id=span_id,
-            trace_flags=trace_flags,
+            span_context=span_context,
             severity_text=None,
             severity_number=SeverityNumber.ERROR,
             body="test body",
@@ -179,15 +181,16 @@ class TestEventLoggerProvider(unittest.TestCase):
             "name", "version", "schema_url", {"key": "value"}
         )
         now = Mock()
-        trace_id = Mock()
-        span_id = Mock()
-        trace_flags = Mock()
+        span_context = SpanContext(
+            2604504634922341076776623263868986797,
+            5213367945872657620,
+            True,
+            Mock(),
+        )
         event = Event(
             name="test_event",
             timestamp=now,
-            trace_id=trace_id,
-            span_id=span_id,
-            trace_flags=trace_flags,
+            span_context=span_context,
             body="test body",
             severity_number=SeverityNumber.ERROR,
             attributes={

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -43,7 +43,10 @@ from opentelemetry.sdk.environment_variables import (
 from opentelemetry.sdk.resources import Resource as SDKResource
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.trace import TraceFlags
-from opentelemetry.trace.span import INVALID_SPAN_CONTEXT
+from opentelemetry.trace.span import (
+    INVALID_SPAN_CONTEXT,
+    SpanContext,
+)
 
 EMPTY_LOG = LogData(
     log_record=LogRecord(),
@@ -522,9 +525,12 @@ class TestConsoleLogExporter(unittest.TestCase):
         log_data = LogData(
             log_record=LogRecord(
                 timestamp=int(time.time() * 1e9),
-                trace_id=2604504634922341076776623263868986797,
-                span_id=5213367945872657620,
-                trace_flags=TraceFlags(0x01),
+                span_context=SpanContext(
+                    2604504634922341076776623263868986797,
+                    5213367945872657620,
+                    True,
+                    TraceFlags(0x01),
+                ),
                 severity_text="WARN",
                 severity_number=SeverityNumber.WARN,
                 body="Zhengzhou, We have a heaviest rains in 1000 years",


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/4328

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3528
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
