### PR TITLE
Use extended attributes everywhere

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -45,7 +45,7 @@ from opentelemetry.proto.resource.v1.resource_pb2 import (
 )
 from opentelemetry.sdk.trace import Resource
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
-from opentelemetry.util.types import _ExtendedAttributes
+from opentelemetry.util.types import Attributes
 
 _logger = logging.getLogger(__name__)
 
@@ -136,7 +136,7 @@ def _encode_trace_id(trace_id: int) -> bytes:
 
 
 def _encode_attributes(
-    attributes: _ExtendedAttributes,
+    attributes: Attributes,
     allow_null: bool = False,
 ) -> Optional[List[PB2KeyValue]]:
     if attributes:

--- a/opentelemetry-api/src/opentelemetry/_events/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_events/__init__.py
@@ -25,7 +25,7 @@ from opentelemetry.environment_variables import (
 from opentelemetry.trace.span import TraceFlags
 from opentelemetry.util._once import Once
 from opentelemetry.util._providers import _load_provider
-from opentelemetry.util.types import AnyValue, _ExtendedAttributes
+from opentelemetry.util.types import AnyValue, Attributes
 
 _logger = getLogger(__name__)
 
@@ -40,7 +40,7 @@ class Event(LogRecord):
         trace_flags: Optional["TraceFlags"] = None,
         body: Optional[AnyValue] = None,
         severity_number: Optional[SeverityNumber] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ):
         attributes = attributes or {}
         event_attributes = {
@@ -65,7 +65,7 @@ class EventLogger(ABC):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ):
         self._name = name
         self._version = version
@@ -88,7 +88,7 @@ class ProxyEventLogger(EventLogger):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ):
         super().__init__(
             name=name,
@@ -125,7 +125,7 @@ class EventLoggerProvider(ABC):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ) -> EventLogger:
         """Returns an EventLoggerProvider for use."""
 
@@ -136,7 +136,7 @@ class NoOpEventLoggerProvider(EventLoggerProvider):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ) -> EventLogger:
         return NoOpEventLogger(
             name, version=version, schema_url=schema_url, attributes=attributes
@@ -149,7 +149,7 @@ class ProxyEventLoggerProvider(EventLoggerProvider):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ) -> EventLogger:
         if _EVENT_LOGGER_PROVIDER:
             return _EVENT_LOGGER_PROVIDER.get_event_logger(
@@ -211,7 +211,7 @@ def get_event_logger(
     name: str,
     version: Optional[str] = None,
     schema_url: Optional[str] = None,
-    attributes: Optional[_ExtendedAttributes] = None,
+    attributes: Optional[Attributes] = None,
     event_logger_provider: Optional[EventLoggerProvider] = None,
 ) -> "EventLogger":
     if event_logger_provider is None:

--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -44,7 +44,7 @@ from opentelemetry.environment_variables import _OTEL_PYTHON_LOGGER_PROVIDER
 from opentelemetry.trace.span import TraceFlags
 from opentelemetry.util._once import Once
 from opentelemetry.util._providers import _load_provider
-from opentelemetry.util.types import AnyValue, _ExtendedAttributes
+from opentelemetry.util.types import AnyValue, Attributes
 
 _logger = getLogger(__name__)
 
@@ -67,7 +67,7 @@ class LogRecord(ABC):
         severity_text: Optional[str] = None,
         severity_number: Optional[SeverityNumber] = None,
         body: AnyValue = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ):
         self.timestamp = timestamp
         if observed_timestamp is None:
@@ -90,7 +90,7 @@ class Logger(ABC):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ) -> None:
         super().__init__()
         self._name = name
@@ -119,7 +119,7 @@ class ProxyLogger(Logger):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ):
         self._name = name
         self._version = version
@@ -158,7 +158,7 @@ class LoggerProvider(ABC):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ) -> Logger:
         """Returns a `Logger` for use by the given instrumentation library.
 
@@ -196,7 +196,7 @@ class NoOpLoggerProvider(LoggerProvider):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ) -> Logger:
         """Returns a NoOpLogger."""
         return NoOpLogger(
@@ -210,7 +210,7 @@ class ProxyLoggerProvider(LoggerProvider):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ) -> Logger:
         if _LOGGER_PROVIDER:
             return _LOGGER_PROVIDER.get_logger(
@@ -273,7 +273,7 @@ def get_logger(
     instrumenting_library_version: str = "",
     logger_provider: Optional[LoggerProvider] = None,
     schema_url: Optional[str] = None,
-    attributes: Optional[_ExtendedAttributes] = None,
+    attributes: Optional[Attributes] = None,
 ) -> "Logger":
     """Returns a `Logger` for use within a python process.
 

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -16,13 +16,13 @@ import logging
 import threading
 from collections import OrderedDict
 from collections.abc import MutableMapping
-from typing import Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from opentelemetry.util import types
 
 # bytes are accepted as a user supplied value for attributes but
 # decoded to strings internally.
-_VALID_ATTR_VALUE_TYPES = (bool, str, bytes, int, float)
+_PRIMITIVE_ATTRIBUTES = (bool, str, bytes, int, float)
 # AnyValue possible values
 _VALID_ANY_VALUE_TYPES = (
     type(None),
@@ -35,161 +35,30 @@ _VALID_ANY_VALUE_TYPES = (
     Mapping,
 )
 
-
 _logger = logging.getLogger(__name__)
 
 
-def _clean_attribute(
-    key: str, value: types.AttributeValue, max_len: Optional[int]
-) -> Optional[Union[types.AttributeValue, Tuple[Union[str, int, float], ...]]]:
-    """Checks if attribute value is valid and cleans it if required.
+def _is_homogeneous_list_of_primitives(value: Sequence) -> tuple[bool, type]:
+    if len(value) == 0:
+        return (True, None)
 
-    The function returns the cleaned value or None if the value is not valid.
-
-    An attribute value is valid if it is either:
-        - A primitive type: string, boolean, double precision floating
-            point (IEEE 754-1985) or integer.
-        - An array of primitive type values. The array MUST be homogeneous,
-            i.e. it MUST NOT contain values of different types.
-
-    An attribute needs cleansing if:
-        - Its length is greater than the maximum allowed length.
-        - It needs to be encoded/decoded e.g, bytes to strings.
-    """
-
-    if not (key and isinstance(key, str)):
-        _logger.warning("invalid key `%s`. must be non-empty string.", key)
-        return None
-
-    if isinstance(value, _VALID_ATTR_VALUE_TYPES):
-        return _clean_attribute_value(value, max_len)
-
-    if isinstance(value, Sequence):
-        sequence_first_valid_type = None
-        cleaned_seq = []
-
-        for element in value:
-            element = _clean_attribute_value(element, max_len)  # type: ignore
-            if element is None:
-                cleaned_seq.append(element)
-                continue
-
-            element_type = type(element)
-            # Reject attribute value if sequence contains a value with an incompatible type.
-            if element_type not in _VALID_ATTR_VALUE_TYPES:
-                _logger.warning(
-                    "Invalid type %s in attribute '%s' value sequence. Expected one of "
-                    "%s or None",
-                    element_type.__name__,
-                    key,
-                    [
-                        valid_type.__name__
-                        for valid_type in _VALID_ATTR_VALUE_TYPES
-                    ],
-                )
-                return None
-
-            # The type of the sequence must be homogeneous. The first non-None
-            # element determines the type of the sequence
-            if sequence_first_valid_type is None:
-                sequence_first_valid_type = element_type
-            # use equality instead of isinstance as isinstance(True, int) evaluates to True
-            elif element_type != sequence_first_valid_type:
-                _logger.warning(
-                    "Attribute %r mixes types %s and %s in attribute value sequence",
-                    key,
-                    sequence_first_valid_type.__name__,
-                    type(element).__name__,
-                )
-                return None
-
-            cleaned_seq.append(element)
-
-        # Freeze mutable sequences defensively
-        return tuple(cleaned_seq)
-
-    _logger.warning(
-        "Invalid type %s for attribute '%s' value. Expected one of %s or a "
-        "sequence of those types",
-        type(value).__name__,
-        key,
-        [valid_type.__name__ for valid_type in _VALID_ATTR_VALUE_TYPES],
-    )
-    return None
-
-
-def _clean_extended_attribute_value(
-    value: types.AnyValue, max_len: Optional[int]
-) -> types.AnyValue:
-    # for primitive types just return the value and eventually shorten the string length
-    if value is None or isinstance(value, _VALID_ATTR_VALUE_TYPES):
-        if max_len is not None and isinstance(value, str):
-            value = value[:max_len]
-        return value
-
-    if isinstance(value, Mapping):
-        cleaned_dict: dict[str, types.AnyValue] = {}
-        for key, element in value.items():
-            # skip invalid keys
-            if not (key and isinstance(key, str)):
-                _logger.warning(
-                    "invalid key `%s`. must be non-empty string.", key
-                )
-                continue
-
-            cleaned_dict[key] = _clean_extended_attribute(
-                key=key, value=element, max_len=max_len
-            )
-
-        return cleaned_dict
-
-    if isinstance(value, Sequence):
-        sequence_first_valid_type = None
-        cleaned_seq: list[types.AnyValue] = []
-
-        for element in value:
-            if element is None:
-                cleaned_seq.append(element)
-                continue
-
-            if max_len is not None and isinstance(element, str):
-                element = element[:max_len]
-
-            element_type = type(element)
-            if element_type not in _VALID_ATTR_VALUE_TYPES:
-                element = _clean_extended_attribute_value(
-                    element, max_len=max_len
-                )
-                element_type = type(element)  # type: ignore
-
-            # The type of the sequence must be homogeneous. The first non-None
-            # element determines the type of the sequence
-            if sequence_first_valid_type is None:
-                sequence_first_valid_type = element_type
-            # use equality instead of isinstance as isinstance(True, int) evaluates to True
-            elif element_type != sequence_first_valid_type:
-                _logger.warning(
-                    "Mixed types %s and %s in attribute value sequence",
-                    sequence_first_valid_type.__name__,
-                    type(element).__name__,
-                )
-                return None
-
-            cleaned_seq.append(element)
-
-        # Freeze mutable sequences defensively
-        return tuple(cleaned_seq)
-
-    raise TypeError(
-        f"Invalid type {type(value).__name__} for attribute value. "
-        f"Expected one of {[valid_type.__name__ for valid_type in _VALID_ANY_VALUE_TYPES]} or a "
-        "sequence of those types",
-    )
+    first_type = None  # type: Optional[type]
+    for v in value:
+        if not v:
+            continue
+        if first_type is None:
+            first_type = type(v)
+        else:
+            if not isinstance(v, first_type):
+                return (False, None)
+            if not isinstance(v, _PRIMITIVE_ATTRIBUTES):
+                return (False, None)
+    return (True, first_type)
 
 
 def _clean_extended_attribute(
-    key: str, value: types.AnyValue, max_len: Optional[int]
-) -> types.AnyValue:
+    key: str, value: types.AnyValue, max_value_len: Optional[int]
+) -> tuple[types.AnyValue, bool]:
     """Checks if attribute value is valid and cleans it if required.
 
     The function returns the cleaned value or None if the value is not valid.
@@ -201,31 +70,112 @@ def _clean_extended_attribute(
 
     if not (key and isinstance(key, str)):
         _logger.warning("invalid key `%s`. must be non-empty string.", key)
-        return None
+        return (None, False)
 
     try:
-        return _clean_extended_attribute_value(value, max_len=max_len)
+        return _clean_extended_attribute_value(
+            value, max_value_len=max_value_len
+        )
     except TypeError as exception:
-        _logger.warning("Attribute %s: %s", key, exception)
-        return None
+        _logger.warning(
+            f"Error processing attribute {key}", exc_info=exception
+        )
+        return (None, False)
 
 
-def _clean_attribute_value(
-    value: types.AttributeValue, limit: Optional[int]
-) -> Optional[types.AttributeValue]:
-    if value is None:
-        return None
+def _clean_extended_attribute_value(
+    value: types.AnyValue, max_value_len: Optional[int]
+) -> tuple[types.AnyValue, bool]:
+    if value is None or isinstance(value, _PRIMITIVE_ATTRIBUTES):
+        # keeping b'string' backwards compatible with old standard
+        # attribute behavior. It also keeps it consistent
+        # across different attribute flavors.
+        if isinstance(value, bytes):
+            try:
+                return _clean_extended_attribute_value(
+                    value.decode(), max_value_len=max_value_len
+                )
+            except UnicodeDecodeError:
+                pass
 
-    if isinstance(value, bytes):
-        try:
-            value = value.decode()
-        except UnicodeDecodeError:
-            _logger.warning("Byte attribute could not be decoded.")
-            return None
+        if max_value_len is not None and isinstance(value, str):
+            return (value[:max_value_len], True)
 
-    if limit is not None and isinstance(value, str):
-        value = value[:limit]
-    return value
+        return (value, True)
+
+    if isinstance(value, Sequence):
+        if max_value_len is None:
+            (is_homogeneous, value_type) = _is_homogeneous_list_of_primitives(
+                value
+            )
+            if (
+                is_homogeneous
+                and value_type is not str
+                and value_type is not bytes
+            ):
+                return (tuple(value), True)
+
+        return (
+            (
+                tuple(
+                    [
+                        _clean_extended_attribute_value(
+                            v, max_value_len=max_value_len
+                        )[0]
+                        for v in value
+                    ]
+                )
+            ),
+            True,
+        )
+
+    if isinstance(value, Mapping):
+        cleaned_list = []
+        for k, v in value.items():
+            if not (k and isinstance(k, str)):
+                continue
+
+            cleaned_list.append(
+                (
+                    k,
+                    _clean_extended_attribute_value(
+                        v, max_value_len=max_value_len
+                    )[0],
+                )
+            )
+
+        return (OrderedDict(sorted(cleaned_list)), True)
+
+    _logger.warning(
+        "Attribute value %s is not valid. Must be one of %s",
+        value,
+        _VALID_ANY_VALUE_TYPES,
+    )
+    return (None, False)
+
+
+def _count_leaves(value: types.AnyValue) -> int:
+    # it should be possible to optimize if we have a dedicated type for
+    # AnyValue and have leaf_count as a property of the type.
+    # but we don't expect attributes with huge number of leaves
+    # and recommend to use flat attributes whenever possible,
+    # so performance in case of the complex value is not a priority.
+    if (
+        value is None
+        or isinstance(value, _PRIMITIVE_ATTRIBUTES)
+        or isinstance(value, Sequence)
+    ):
+        return 1
+
+    if isinstance(value, Mapping):
+        leaf_count = 0
+
+        for v in value.values():
+            leaf_count += _count_leaves(v)
+
+        return max(1, leaf_count)
+
+    return 0
 
 
 class BoundedAttributes(MutableMapping):  # type: ignore
@@ -238,10 +188,10 @@ class BoundedAttributes(MutableMapping):  # type: ignore
     def __init__(
         self,
         maxlen: Optional[int] = None,
-        attributes: Optional[types._ExtendedAttributes] = None,
+        attributes: Optional[types.Attributes] = None,
         immutable: bool = True,
         max_value_len: Optional[int] = None,
-        extended_attributes: bool = False,
+        extended_attributes: bool = True,
     ):
         if maxlen is not None:
             if not isinstance(maxlen, int) or maxlen < 0:
@@ -250,8 +200,8 @@ class BoundedAttributes(MutableMapping):  # type: ignore
                 )
         self.maxlen = maxlen
         self.dropped = 0
+        self.leaf_count = 0
         self.max_value_len = max_value_len
-        self._extended_attributes = extended_attributes
         # OrderedDict is not used until the maxlen is reached for efficiency.
 
         self._dict: Union[
@@ -278,30 +228,46 @@ class BoundedAttributes(MutableMapping):  # type: ignore
                 self.dropped += 1
                 return
 
-            if self._extended_attributes:
-                value = _clean_extended_attribute(
-                    key, value, self.max_value_len
-                )
-            else:
-                value = _clean_attribute(key, value, self.max_value_len)  # type: ignore
-                if value is None:
-                    return
+            (cleaned_value, is_valid) = _clean_extended_attribute(
+                key, value, self.max_value_len
+            )
+
+            if not is_valid:
+                return
+
+            leafs = _count_leaves(cleaned_value)
+
+            if (
+                self.maxlen
+                and isinstance(cleaned_value, Mapping)
+                and (self.leaf_count + leafs > self.maxlen)
+            ):
+                self.dropped += 1
+                return
 
             if key in self._dict:
-                del self._dict[key]
-            elif self.maxlen is not None and len(self._dict) == self.maxlen:
+                self._update_count_drop(self._dict.pop(key))
+            elif (
+                self.maxlen is not None
+                and (self.leaf_count + leafs) > self.maxlen
+            ):
                 if not isinstance(self._dict, OrderedDict):
                     self._dict = OrderedDict(self._dict)
-                self._dict.popitem(last=False)  # type: ignore
+                item = self._dict.popitem(last=False)  # type: ignore
+                self._update_count_drop(item[1])
                 self.dropped += 1
 
-            self._dict[key] = value  # type: ignore
+            self._dict[key] = cleaned_value  # type: ignore
+            self.leaf_count += leafs
+
+    def _update_count_drop(self, val: Any) -> None:
+        self.leaf_count -= _count_leaves(val)
 
     def __delitem__(self, key: str) -> None:
         if getattr(self, "_immutable", False):  # type: ignore
             raise TypeError
         with self._lock:
-            del self._dict[key]
+            self._update_count_drop(self._dict.pop(key))
 
     def __iter__(self):  # type: ignore
         with self._lock:

--- a/opentelemetry-api/src/opentelemetry/metrics/_internal/instrument.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/_internal/instrument.py
@@ -25,6 +25,7 @@ from typing import (
     Generator,
     Generic,
     Iterable,
+    Mapping,
     Optional,
     Sequence,
     TypeVar,
@@ -35,9 +36,6 @@ from typing import (
 from opentelemetry import metrics
 from opentelemetry.context import Context
 from opentelemetry.metrics._internal.observation import Observation
-from opentelemetry.util.types import (
-    Attributes,
-)
 
 _logger = getLogger(__name__)
 
@@ -67,6 +65,23 @@ InstrumentT = TypeVar("InstrumentT", bound="Instrument")
 CallbackT = Union[
     Callable[[CallbackOptions], Iterable[Observation]],
     Generator[Iterable[Observation], CallbackOptions, None],
+]
+
+_MetricAttributes = Optional[
+    Mapping[
+        str,
+        Union[
+            str,
+            bool,
+            int,
+            float,
+            bytes,
+            Sequence[str],
+            Sequence[bool],
+            Sequence[int],
+            Sequence[float],
+        ],
+    ]
 ]
 
 
@@ -180,7 +195,7 @@ class Counter(Synchronous):
     def add(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         pass
@@ -200,7 +215,7 @@ class NoOpCounter(Counter):
     def add(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         return super().add(amount, attributes=attributes, context=context)
@@ -210,7 +225,7 @@ class _ProxyCounter(_ProxyInstrument[Counter], Counter):
     def add(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         if self._real_instrument:
@@ -231,7 +246,7 @@ class UpDownCounter(Synchronous):
     def add(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         pass
@@ -251,7 +266,7 @@ class NoOpUpDownCounter(UpDownCounter):
     def add(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         return super().add(amount, attributes=attributes, context=context)
@@ -261,7 +276,7 @@ class _ProxyUpDownCounter(_ProxyInstrument[UpDownCounter], UpDownCounter):
     def add(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         if self._real_instrument:
@@ -373,7 +388,7 @@ class Histogram(Synchronous):
     def record(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         pass
@@ -399,7 +414,7 @@ class NoOpHistogram(Histogram):
     def record(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         return super().record(amount, attributes=attributes, context=context)
@@ -421,7 +436,7 @@ class _ProxyHistogram(_ProxyInstrument[Histogram], Histogram):
     def record(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         if self._real_instrument:
@@ -483,7 +498,7 @@ class Gauge(Synchronous):
     def set(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         pass
@@ -503,7 +518,7 @@ class NoOpGauge(Gauge):
     def set(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         return super().set(amount, attributes=attributes, context=context)
@@ -516,7 +531,7 @@ class _ProxyGauge(
     def set(
         self,
         amount: Union[int, float],
-        attributes: Optional[Attributes] = None,
+        attributes: Optional[_MetricAttributes] = None,
         context: Optional[Context] = None,
     ) -> None:
         if self._real_instrument:

--- a/opentelemetry-api/src/opentelemetry/metrics/_internal/observation.py
+++ b/opentelemetry-api/src/opentelemetry/metrics/_internal/observation.py
@@ -12,10 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union
+from typing import Mapping, Optional, Sequence, Union
 
 from opentelemetry.context import Context
-from opentelemetry.util.types import Attributes
+
+_MetricAttributes = Optional[
+    Mapping[
+        str,
+        Union[
+            str,
+            bool,
+            int,
+            float,
+            bytes,
+            Sequence[str],
+            Sequence[bool],
+            Sequence[int],
+            Sequence[float],
+        ],
+    ]
+]
 
 
 class Observation:
@@ -32,7 +48,7 @@ class Observation:
     def __init__(
         self,
         value: Union[int, float],
-        attributes: Attributes = None,
+        attributes: _MetricAttributes = None,
         context: Optional[Context] = None,
     ) -> None:
         self._value = value
@@ -44,7 +60,7 @@ class Observation:
         return self._value
 
     @property
-    def attributes(self) -> Attributes:
+    def attributes(self) -> _MetricAttributes:
         return self._attributes
 
     @property

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -79,7 +79,7 @@ class Span(abc.ABC):
 
     @abc.abstractmethod
     def set_attributes(
-        self, attributes: typing.Mapping[str, types.AttributeValue]
+        self, attributes: typing.Mapping[str, types.AnyValue]
     ) -> None:
         """Sets Attributes.
 
@@ -92,7 +92,7 @@ class Span(abc.ABC):
         """
 
     @abc.abstractmethod
-    def set_attribute(self, key: str, value: types.AttributeValue) -> None:
+    def set_attribute(self, key: str, value: types.AnyValue) -> None:
         """Sets an Attribute.
 
         Sets a single Attribute with the key and value passed as arguments.
@@ -529,11 +529,11 @@ class NonRecordingSpan(Span):
         pass
 
     def set_attributes(
-        self, attributes: typing.Mapping[str, types.AttributeValue]
+        self, attributes: typing.Mapping[str, types.AnyValue]
     ) -> None:
         pass
 
-    def set_attribute(self, key: str, value: types.AttributeValue) -> None:
+    def set_attribute(self, key: str, value: types.AnyValue) -> None:
         pass
 
     def add_event(

--- a/opentelemetry-api/src/opentelemetry/util/types.py
+++ b/opentelemetry-api/src/opentelemetry/util/types.py
@@ -28,7 +28,6 @@ AnyValue = Union[
     None,
 ]
 
-
 AttributeValue = AnyValue
 Attributes = Optional[Mapping[str, AnyValue]]
 

--- a/opentelemetry-api/src/opentelemetry/util/types.py
+++ b/opentelemetry-api/src/opentelemetry/util/types.py
@@ -28,17 +28,10 @@ AnyValue = Union[
     None,
 ]
 
-AttributeValue = Union[
-    str,
-    bool,
-    int,
-    float,
-    Sequence[str],
-    Sequence[bool],
-    Sequence[int],
-    Sequence[float],
-]
-Attributes = Optional[Mapping[str, AttributeValue]]
+
+AttributeValue = AnyValue
+Attributes = Optional[Mapping[str, AnyValue]]
+
 AttributesAsKey = Tuple[
     Tuple[
         str,
@@ -55,5 +48,3 @@ AttributesAsKey = Tuple[
     ],
     ...,
 ]
-
-_ExtendedAttributes = Mapping[str, "AnyValue"]

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -308,4 +308,3 @@ class TestBoundedAttributes(unittest.TestCase):
 
         for num in range(100):
             self.assertEqual(bdict[str(num)], num)
-

--- a/opentelemetry-api/tests/events/test_proxy_event.py
+++ b/opentelemetry-api/tests/events/test_proxy_event.py
@@ -4,7 +4,7 @@ import unittest
 
 import opentelemetry._events as events
 from opentelemetry.test.globals_test import EventsGlobalsTest
-from opentelemetry.util.types import _ExtendedAttributes
+from opentelemetry.util.types import Attributes
 
 
 class TestProvider(events.NoOpEventLoggerProvider):
@@ -13,7 +13,7 @@ class TestProvider(events.NoOpEventLoggerProvider):
         name: str,
         version: typing.Optional[str] = None,
         schema_url: typing.Optional[str] = None,
-        attributes: typing.Optional[_ExtendedAttributes] = None,
+        attributes: typing.Optional[Attributes] = None,
     ) -> events.EventLogger:
         return LoggerTest(name)
 

--- a/opentelemetry-api/tests/logs/test_proxy.py
+++ b/opentelemetry-api/tests/logs/test_proxy.py
@@ -19,7 +19,7 @@ import unittest
 import opentelemetry._logs._internal as _logs_internal
 from opentelemetry import _logs
 from opentelemetry.test.globals_test import LoggingGlobalsTest
-from opentelemetry.util.types import _ExtendedAttributes
+from opentelemetry.util.types import Attributes
 
 
 class TestProvider(_logs.NoOpLoggerProvider):
@@ -28,7 +28,7 @@ class TestProvider(_logs.NoOpLoggerProvider):
         name: str,
         version: typing.Optional[str] = None,
         schema_url: typing.Optional[str] = None,
-        attributes: typing.Optional[_ExtendedAttributes] = None,
+        attributes: typing.Optional[Attributes] = None,
     ) -> _logs.Logger:
         return LoggerTest(name)
 

--- a/opentelemetry-sdk/benchmarks/metrics/test_benchmark_metrics_histogram.py
+++ b/opentelemetry-sdk/benchmarks/metrics/test_benchmark_metrics_histogram.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # pylint: disable=invalid-name
+import json
 import random
 
 import pytest
@@ -68,38 +69,72 @@ hist50 = meter.create_histogram("test_histogram_50_bound")
 hist1000 = meter.create_histogram("test_histogram_1000_bound")
 
 
-@pytest.mark.parametrize("num_labels", [0, 1, 3, 5, 7])
-def test_histogram_record(benchmark, num_labels):
-    labels = {}
-    for i in range(num_labels):
-        labels[f"Key{i}"] = "Value{i}"
-
-    def benchmark_histogram_record():
-        hist.record(random.random() * MAX_BOUND_VALUE)
-
-    benchmark(benchmark_histogram_record)
-
-
-@pytest.mark.parametrize("num_labels", [0, 1, 3, 5, 7])
+@pytest.mark.parametrize("num_labels", [1, 3])
 def test_histogram_record_10(benchmark, num_labels):
     labels = {}
     for i in range(num_labels):
         labels[f"Key{i}"] = "Value{i}"
 
     def benchmark_histogram_record_10():
-        hist10.record(random.random() * MAX_BOUND_VALUE)
+        hist10.record(random.random() * MAX_BOUND_VALUE, attributes=labels)
 
     benchmark(benchmark_histogram_record_10)
 
+@pytest.mark.parametrize("num_labels", [1, 3])
+def test_histogram_record_10_small_mapping_attrs(benchmark, num_labels):
+    labels = {}
+    for i in range(num_labels):
+        labels[f"Key{i}"] = {"k1": "v1"}
 
-@pytest.mark.parametrize("num_labels", [0, 1, 3, 5, 7])
+    def test_histogram_record_10_complex_attrs():
+        hist10.record(random.random() * MAX_BOUND_VALUE, attributes=labels)
+
+    benchmark(test_histogram_record_10_complex_attrs)
+
+@pytest.mark.parametrize("num_labels", [1, 3])
+def test_histogram_record_10_complex_attrs(benchmark, num_labels):
+    labels = {}
+    for i in range(num_labels):
+        labels[f"Key{i}"] = {"k1": "v1", "k2": {"k3": "v3", "k4": [1, 2, 3]}}
+
+    def test_histogram_record_10_complex_attrs():
+        hist10.record(random.random() * MAX_BOUND_VALUE, attributes=labels)
+
+    benchmark(test_histogram_record_10_complex_attrs)
+
+
+@pytest.mark.parametrize("num_labels", [1, 3])
+def test_histogram_record_10_array_attrs(benchmark, num_labels):
+    labels = {}
+    for i in range(num_labels):
+        labels[f"Key{i}"] = ["k1", "v1", "k2", "k3", "v3", "k4", "1", "2", "3"]
+
+    def test_histogram_record_10_array_attrs():
+        hist10.record(random.random() * MAX_BOUND_VALUE, attributes=labels)
+
+    benchmark(test_histogram_record_10_array_attrs)
+
+
+@pytest.mark.parametrize("num_labels", [1, 3])
+def test_histogram_record_10_json_string_attrs(benchmark, num_labels):
+    labels = {}
+    for i in range(num_labels):
+        labels[f"Key{i}"] = {"k1": "v1", "k2": {"k3": "v3", "k4": [1, 2, 3]}}
+
+    def test_histogram_record_10_json_string_attrs():
+        hist10.record(random.random() * MAX_BOUND_VALUE, attributes={k: json.dumps(v) for k, v in labels.items()})
+
+    benchmark(test_histogram_record_10_json_string_attrs)
+
+
+@pytest.mark.parametrize("num_labels", [1, 3])
 def test_histogram_record_49(benchmark, num_labels):
     labels = {}
     for i in range(num_labels):
         labels[f"Key{i}"] = "Value{i}"
 
     def benchmark_histogram_record_49():
-        hist49.record(random.random() * MAX_BOUND_VALUE)
+        hist49.record(random.random() * MAX_BOUND_VALUE, attributes=labels)
 
     benchmark(benchmark_histogram_record_49)
 
@@ -111,7 +146,7 @@ def test_histogram_record_50(benchmark, num_labels):
         labels[f"Key{i}"] = "Value{i}"
 
     def benchmark_histogram_record_50():
-        hist50.record(random.random() * MAX_BOUND_VALUE)
+        hist50.record(random.random() * MAX_BOUND_VALUE, attributes=labels)
 
     benchmark(benchmark_histogram_record_50)
 
@@ -123,6 +158,6 @@ def test_histogram_record_1000(benchmark, num_labels):
         labels[f"Key{i}"] = "Value{i}"
 
     def benchmark_histogram_record_1000():
-        hist1000.record(random.random() * MAX_BOUND_VALUE)
+        hist1000.record(random.random() * MAX_BOUND_VALUE, attributes=labels)
 
     benchmark(benchmark_histogram_record_1000)

--- a/opentelemetry-sdk/benchmarks/metrics/test_benchmark_metrics_histogram.py
+++ b/opentelemetry-sdk/benchmarks/metrics/test_benchmark_metrics_histogram.py
@@ -80,6 +80,7 @@ def test_histogram_record_10(benchmark, num_labels):
 
     benchmark(benchmark_histogram_record_10)
 
+
 @pytest.mark.parametrize("num_labels", [1, 3])
 def test_histogram_record_10_small_mapping_attrs(benchmark, num_labels):
     labels = {}
@@ -90,6 +91,7 @@ def test_histogram_record_10_small_mapping_attrs(benchmark, num_labels):
         hist10.record(random.random() * MAX_BOUND_VALUE, attributes=labels)
 
     benchmark(test_histogram_record_10_complex_attrs)
+
 
 @pytest.mark.parametrize("num_labels", [1, 3])
 def test_histogram_record_10_complex_attrs(benchmark, num_labels):
@@ -122,7 +124,10 @@ def test_histogram_record_10_json_string_attrs(benchmark, num_labels):
         labels[f"Key{i}"] = {"k1": "v1", "k2": {"k3": "v3", "k4": [1, 2, 3]}}
 
     def test_histogram_record_10_json_string_attrs():
-        hist10.record(random.random() * MAX_BOUND_VALUE, attributes={k: json.dumps(v) for k, v in labels.items()})
+        hist10.record(
+            random.random() * MAX_BOUND_VALUE,
+            attributes={k: json.dumps(v) for k, v in labels.items()},
+        )
 
     benchmark(test_histogram_record_10_json_string_attrs)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_events/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_events/__init__.py
@@ -21,7 +21,7 @@ from opentelemetry._events import EventLogger as APIEventLogger
 from opentelemetry._events import EventLoggerProvider as APIEventLoggerProvider
 from opentelemetry._logs import NoOpLogger, SeverityNumber, get_logger_provider
 from opentelemetry.sdk._logs import Logger, LoggerProvider, LogRecord
-from opentelemetry.util.types import _ExtendedAttributes
+from opentelemetry.util.types import Attributes
 
 _logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class EventLogger(APIEventLogger):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ):
         super().__init__(
             name=name,
@@ -74,7 +74,7 @@ class EventLoggerProvider(APIEventLoggerProvider):
         name: str,
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
-        attributes: Optional[_ExtendedAttributes] = None,
+        attributes: Optional[Attributes] = None,
     ) -> EventLogger:
         if not name:
             _logger.warning("EventLogger created with invalid name: %s", name)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -53,7 +53,7 @@ from opentelemetry.trace import (
     get_current_span,
 )
 from opentelemetry.trace.span import TraceFlags
-from opentelemetry.util.types import AnyValue, _ExtendedAttributes
+from opentelemetry.util.types import AnyValue, Attributes
 
 _logger = logging.getLogger(__name__)
 
@@ -183,7 +183,7 @@ class LogRecord(APILogRecord):
         severity_number: SeverityNumber | None = None,
         body: AnyValue | None = None,
         resource: Resource | None = None,
-        attributes: _ExtendedAttributes | None = None,
+        attributes: Attributes | None = None,
         limits: LogLimits | None = _UnsetLogLimits,
     ):
         super().__init__(
@@ -482,7 +482,7 @@ class LoggingHandler(logging.Handler):
         self._logger_provider = logger_provider or get_logger_provider()
 
     @staticmethod
-    def _get_attributes(record: logging.LogRecord) -> _ExtendedAttributes:
+    def _get_attributes(record: logging.LogRecord) -> Attributes:
         attributes = {
             k: v for k, v in vars(record).items() if k not in _RESERVED_ATTRS
         }
@@ -643,7 +643,7 @@ class LoggerProvider(APILoggerProvider):
         name: str,
         version: str | None = None,
         schema_url: str | None = None,
-        attributes: _ExtendedAttributes | None = None,
+        attributes: Attributes | None = None,
     ) -> Logger:
         return Logger(
             self._resource,
@@ -677,7 +677,7 @@ class LoggerProvider(APILoggerProvider):
         name: str,
         version: str | None = None,
         schema_url: str | None = None,
-        attributes: _ExtendedAttributes | None = None,
+        attributes: Attributes | None = None,
     ) -> Logger:
         if self._disabled:
             return NoOpLogger(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -109,9 +109,7 @@ class ConsoleLogExporter(LogExporter):
 
     def export(self, batch: Sequence[LogData]):
         for data in batch:
-            self.out.write(
-                self.formatter(data.log_record)
-            )  #  + "oh, we forgot to add " + str(data.instrumentation_scope)
+            self.out.write(self.formatter(data.log_record))
         self.out.flush()
         return LogExportResult.SUCCESS
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -109,7 +109,9 @@ class ConsoleLogExporter(LogExporter):
 
     def export(self, batch: Sequence[LogData]):
         for data in batch:
-            self.out.write(self.formatter(data.log_record))
+            self.out.write(
+                self.formatter(data.log_record)
+            )  #  + "oh, we forgot to add " + str(data.instrumentation_scope)
         self.out.flush()
         return LogExportResult.SUCCESS
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -90,17 +90,8 @@ try:
 except ImportError:
     pass
 
-LabelValue = Union[
-    str,
-    bool,
-    int,
-    float,
-    Sequence[str],
-    Sequence[bool],
-    Sequence[int],
-    Sequence[float],
-]
-Attributes = typing.Mapping[str, LabelValue]
+LabelValue = AttributeValue
+Attributes = AllAttributes
 logger = logging.getLogger(__name__)
 
 CLOUD_PROVIDER = ResourceAttributes.CLOUD_PROVIDER
@@ -173,7 +164,7 @@ class Resource:
 
     def __init__(
         self,
-        attributes: AllAttributes,
+        attributes: Attributes,
         schema_url: typing.Optional[str] = None,
     ):
         self._attributes = BoundedAttributes(attributes=attributes)
@@ -183,7 +174,7 @@ class Resource:
 
     @staticmethod
     def create(
-        attributes: typing.Optional[AllAttributes] = None,
+        attributes: typing.Optional[Attributes] = None,
         schema_url: typing.Optional[str] = None,
     ) -> "Resource":
         """Creates a new `Resource` from attributes.
@@ -254,7 +245,7 @@ class Resource:
         return _EMPTY_RESOURCE
 
     @property
-    def attributes(self) -> AllAttributes:
+    def attributes(self) -> Attributes:
         return self._attributes
 
     @property

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -67,7 +67,7 @@ import typing
 from json import dumps
 from os import environ
 from types import ModuleType
-from typing import List, MutableMapping, Optional, cast
+from typing import List, MutableMapping, Optional, Sequence, Union, cast
 from urllib import parse
 
 from opentelemetry.attributes import BoundedAttributes
@@ -78,6 +78,7 @@ from opentelemetry.sdk.environment_variables import (
 )
 from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.util._importlib_metadata import entry_points, version
+from opentelemetry.util.types import Attributes as AllAttributes
 from opentelemetry.util.types import AttributeValue
 
 psutil: Optional[ModuleType] = None
@@ -89,7 +90,16 @@ try:
 except ImportError:
     pass
 
-LabelValue = AttributeValue
+LabelValue = Union[
+    str,
+    bool,
+    int,
+    float,
+    Sequence[str],
+    Sequence[bool],
+    Sequence[int],
+    Sequence[float],
+]
 Attributes = typing.Mapping[str, LabelValue]
 logger = logging.getLogger(__name__)
 
@@ -162,7 +172,9 @@ class Resource:
     _schema_url: str
 
     def __init__(
-        self, attributes: Attributes, schema_url: typing.Optional[str] = None
+        self,
+        attributes: AllAttributes,
+        schema_url: typing.Optional[str] = None,
     ):
         self._attributes = BoundedAttributes(attributes=attributes)
         if schema_url is None:
@@ -171,7 +183,7 @@ class Resource:
 
     @staticmethod
     def create(
-        attributes: typing.Optional[Attributes] = None,
+        attributes: typing.Optional[AllAttributes] = None,
         schema_url: typing.Optional[str] = None,
     ) -> "Resource":
         """Creates a new `Resource` from attributes.
@@ -242,7 +254,7 @@ class Resource:
         return _EMPTY_RESOURCE
 
     @property
-    def attributes(self) -> Attributes:
+    def attributes(self) -> AllAttributes:
         return self._attributes
 
     @property

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -842,9 +842,7 @@ class Span(trace_api.Span, ReadableSpan):
     def get_span_context(self):
         return self._context
 
-    def set_attributes(
-        self, attributes: Mapping[str, types.AttributeValue]
-    ) -> None:
+    def set_attributes(self, attributes: Mapping[str, types.AnyValue]) -> None:
         with self._lock:
             if self._end_time is not None:
                 logger.warning("Setting attribute on ended span.")
@@ -853,7 +851,7 @@ class Span(trace_api.Span, ReadableSpan):
             for key, value in attributes.items():
                 self._attributes[key] = value
 
-    def set_attribute(self, key: str, value: types.AttributeValue) -> None:
+    def set_attribute(self, key: str, value: types.AnyValue) -> None:
         return self.set_attributes({key: value})
 
     @_check_span_ended

--- a/opentelemetry-sdk/tests/logs/test_log_record.py
+++ b/opentelemetry-sdk/tests/logs/test_log_record.py
@@ -50,25 +50,26 @@ class TestLogRecord(unittest.TestCase):
                     "schema_url": "",
                 },
             },
-            indent=4,
+            indent=None,
         )
+        attr = {
+            "mapping": {"key": "value"},
+            "none": None,
+            "sequence": [1, 2],
+            "str": "string",
+        }
         actual = LogRecord(
             timestamp=0,
             observed_timestamp=0,
             body="a log line",
             resource=Resource({"service.name": "foo"}),
-            attributes={
-                "mapping": {"key": "value"},
-                "none": None,
-                "sequence": [1, 2],
-                "str": "string",
-            },
+            attributes=attr,
         )
 
-        self.assertEqual(expected, actual.to_json(indent=4))
+        self.maxDiff = None
         self.assertEqual(
             actual.to_json(indent=None),
-            '{"body": "a log line", "severity_number": null, "severity_text": null, "attributes": {"mapping": {"key": "value"}, "none": null, "sequence": [1, 2], "str": "string"}, "dropped_attributes": 0, "timestamp": "1970-01-01T00:00:00.000000Z", "observed_timestamp": "1970-01-01T00:00:00.000000Z", "trace_id": "", "span_id": "", "trace_flags": null, "resource": {"attributes": {"service.name": "foo"}, "schema_url": ""}}',
+            expected,
         )
 
     def test_log_record_to_json_serializes_severity_number_as_int(self):

--- a/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
+++ b/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.metrics._internal._view_instrument_match import (
+    _to_hashable,
     _ViewInstrumentMatch,
 )
 from opentelemetry.sdk.metrics._internal.aggregation import (
@@ -113,7 +114,7 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         )
         self.assertEqual(
             view_instrument_match._attributes_aggregation,
-            {frozenset([("c", "d")]): self.mock_created_aggregation},
+            {_to_hashable({"c": "d"}): self.mock_created_aggregation},
         )
 
         view_instrument_match.consume_measurement(
@@ -129,8 +130,8 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         self.assertEqual(
             view_instrument_match._attributes_aggregation,
             {
-                frozenset(): self.mock_created_aggregation,
-                frozenset([("c", "d")]): self.mock_created_aggregation,
+                _to_hashable({}): self.mock_created_aggregation,
+                _to_hashable({"c": "d"}): self.mock_created_aggregation,
             },
         )
 
@@ -159,8 +160,8 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         self.assertEqual(
             view_instrument_match._attributes_aggregation,
             {
-                frozenset(
-                    [("c", "d"), ("f", "g")]
+                _to_hashable(
+                    {"c": "d", "f": "g"}
                 ): self.mock_created_aggregation
             },
         )
@@ -190,7 +191,7 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         )
         self.assertEqual(
             view_instrument_match._attributes_aggregation,
-            {frozenset({}): self.mock_created_aggregation},
+            {_to_hashable({}): self.mock_created_aggregation},
         )
 
         # Test that a drop aggregation is handled in the same way as any
@@ -219,7 +220,7 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
             )
         )
         self.assertIsInstance(
-            view_instrument_match._attributes_aggregation[frozenset({})],
+            view_instrument_match._attributes_aggregation[_to_hashable({})],
             _DropAggregation,
         )
 
@@ -484,7 +485,7 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
 
         self.assertIsInstance(
             view_instrument_match._attributes_aggregation[
-                frozenset({("c", "d")})
+                _to_hashable({"c": "d"})
             ],
             _LastValueAggregation,
         )

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -240,25 +240,30 @@ class TestResources(unittest.TestCase):
 
     def test_invalid_resource_attribute_values(self):
         with self.assertLogs(level=WARNING):
+            guid = uuid.uuid4()
             resource = Resource(
                 {
                     SERVICE_NAME: "test",
                     "non-primitive-data-type": {},
-                    "invalid-byte-type-attribute": (
+                    "bytes-type-attribute": (
                         b"\xd8\xe1\xb7\xeb\xa8\xe5 \xd2\xb7\xe1"
                     ),
                     "": "empty-key-value",
                     None: "null-key-value",
-                    "another-non-primitive": uuid.uuid4(),
+                    "another-non-primitive": guid,
                 }
             )
         self.assertEqual(
             resource.attributes,
             {
                 SERVICE_NAME: "test",
+                "bytes-type-attribute": (
+                    b"\xd8\xe1\xb7\xeb\xa8\xe5 \xd2\xb7\xe1"
+                ),
+                "non-primitive-data-type": {},
             },
         )
-        self.assertEqual(len(resource.attributes), 1)
+        self.assertEqual(len(resource.attributes), 3)
 
     def test_aggregated_resources_no_detectors(self):
         aggregated_resources = get_aggregated_resources([])


### PR DESCRIPTION
This is a prototype of https://github.com/open-telemetry/opentelemetry-specification/pull/4485:
- extends standard attributes to include AnyValue
- use them on all public APIs type hints except metrics

TODO:
- [ ] Decide if we want MetricAttribute alias
- [ ] Tests for resource/instr scope
- [ ] More tests for hashing

Benchmarks:

Perf is not a priority - we don't really want people to use complex attributes on metrics, to goal here to show that even if they do, the impact is not huge.

Based on the results, the cost of reporting complex attribute is ~1.5-2 times higher than a standard one. 

| Name                                                    | Min (us) | Max (us) | Mean (us) | StdDev (us) | Median (us) | IQR (us) | Outliers | OPS           | Rounds | Iterations |
|---------------------------------------------------------|----------|----------|-----------|-------------|--------------|----------|----------|----------------|--------|-------------|
| test_histogram_record_10[1]                             | 2.7000   | 215.5000 | 3.1023    | 4.3836      | 3.0000       | 0.1000   | 11;247   | 322,337.2017   | 2392   | 1           |
| test_histogram_record_10[3]                             | 3.0000   | 222.4000 | 3.4215    | 2.5234      | 3.3000       | 0.1000   | 245;3827 | 292,266.1848   | 31056  | 1           |
| test_histogram_record_10_small_mapping_attrs[1]         | 3.7000   | 2908.4000| 5.3577    | 30.0136     | 4.2000       | 0.5000   | 32;2907  | 186,646.7723   | 16639  | 1           |
| test_histogram_record_10_array_attrs[1]                 | 3.9000   | 233.7000 | 4.5473    | 3.7219      | 4.3000       | 0.2000   | 400;1218 | 219,911.5654   | 32363  | 1           |
| test_histogram_record_10_json_string_attrs[1]           | 4.2000   | 362.5000 | 4.8095    | 5.1960      | 4.5000       | 0.2000   | 159;761  | 207,921.2007   | 17153  | 1           |
| test_histogram_record_10_complex_attrs[1]               | 5.7000   | 719.1000 | 6.5912    | 7.0330      | 6.3000       | 0.2000   | 176;1162 | 151,717.5248   | 27625  | 1           |
| test_histogram_record_10_small_mapping_attrs[3]         | 5.9000   | 311.1000 | 6.7337    | 4.4705      | 6.4000       | 0.3000   | 191;924  | 148,505.8706   | 22676  | 1           |
| test_histogram_record_10_array_attrs[3]                 | 6.3000   | 377.6000 | 7.1968    | 5.2675      | 6.8000       | 0.2000   | 383;1542 | 138,950.8709   | 33004  | 1           |
| test_histogram_record_10_json_string_attrs[3]           | 7.0000   | 181.4000 | 7.9721    | 4.2540      | 7.6000       | 0.2000   | 329;1026 | 125,437.0785   | 21187  | 1           |
| test_histogram_record_10_complex_attrs[3]               | 11.9000  | 407.1000 | 13.5603   | 7.4609      | 12.9000      | 0.4000   | 359;1100 | 73,744.4408    | 23530  | 1           |