### PR TITLE
Fix max recursion bug by removing logging.log calls in emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor `BatchLogRecordProcessor` to simplify code and make the control flow more
   clear ([#4562](https://github.com/open-telemetry/opentelemetry-python/pull/4562/)
   and [#4535](https://github.com/open-telemetry/opentelemetry-python/pull/4535)).
+- Remove log messages from `BatchLogRecordProcessor.emit`, this caused the program
+  to crash at shutdown with a max recursion error ([#4586](https://github.com/open-telemetry/opentelemetry-python/pull/4586)).
 
 ## Version 1.33.0/0.54b0 (2025-05-09)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
@@ -167,15 +167,14 @@ class BatchProcessor(Generic[Telemetry]):
                     )
                 detach(token)
 
+    # Do not add any logging.log statements to this function, they can be being routed back to this `emit` function,
+    # resulting in endless recursive calls that crash the program.
     def emit(self, data: Telemetry) -> None:
         if self._shutdown:
-            self._logger.info("Shutdown called, ignoring %s.", self._exporting)
             return
         if self._pid != os.getpid():
             self._bsp_reset_once.do_once(self._at_fork_reinit)
-
-        if len(self._queue) == self._max_queue_size:
-            self._logger.warning("Queue full, dropping %s.", self._exporting)
+        # This will drop a log from the right side if the queue is at _max_queue_length.
         self._queue.appendleft(data)
         if len(self._queue) >= self._max_export_batch_size:
             self._worker_awaken.set()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
@@ -169,6 +169,7 @@ class BatchProcessor(Generic[Telemetry]):
 
     # Do not add any logging.log statements to this function, they can be being routed back to this `emit` function,
     # resulting in endless recursive calls that crash the program.
+    # See https://github.com/open-telemetry/opentelemetry-python/issues/4261 
     def emit(self, data: Telemetry) -> None:
         if self._shutdown:
             return

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
@@ -172,6 +172,7 @@ class BatchProcessor(Generic[Telemetry]):
     # See https://github.com/open-telemetry/opentelemetry-python/issues/4261
     def emit(self, data: Telemetry) -> None:
         if self._shutdown:
+            self._logger.info("shutdowing")
             return
         if self._pid != os.getpid():
             self._bsp_reset_once.do_once(self._at_fork_reinit)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
@@ -169,7 +169,7 @@ class BatchProcessor(Generic[Telemetry]):
 
     # Do not add any logging.log statements to this function, they can be being routed back to this `emit` function,
     # resulting in endless recursive calls that crash the program.
-    # See https://github.com/open-telemetry/opentelemetry-python/issues/4261 
+    # See https://github.com/open-telemetry/opentelemetry-python/issues/4261
     def emit(self, data: Telemetry) -> None:
         if self._shutdown:
             return

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
@@ -172,7 +172,6 @@ class BatchProcessor(Generic[Telemetry]):
     # See https://github.com/open-telemetry/opentelemetry-python/issues/4261
     def emit(self, data: Telemetry) -> None:
         if self._shutdown:
-            self._logger.info("shutdowing")
             return
         if self._pid != os.getpid():
             self._bsp_reset_once.do_once(self._at_fork_reinit)

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -20,8 +20,6 @@ import unittest
 from unittest.mock import Mock, patch
 
 from opentelemetry._logs import SeverityNumber
-from opentelemetry._logs import set_logger_provider
-
 from opentelemetry.sdk import trace
 from opentelemetry.sdk._logs import (
     LogData,
@@ -42,11 +40,11 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_BLRP_MAX_QUEUE_SIZE,
     OTEL_BLRP_SCHEDULE_DELAY,
 )
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.resources import Resource as SDKResource
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.trace import TraceFlags
 from opentelemetry.trace.span import INVALID_SPAN_CONTEXT
-from opentelemetry.sdk.resources import Resource
 
 EMPTY_LOG = LogData(
     log_record=LogRecord(),

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -350,6 +350,7 @@ class TestBatchLogRecordProcessor(unittest.TestCase):
         reason="assertNoLogs only exists in python 3.10+.",
     )
     def test_logging_lib_not_invoked_in_batch_log_record_emit(self):  # pylint: disable=no-self-use
+        # See https://github.com/open-telemetry/opentelemetry-python/issues/4261
         exporter = Mock()
         processor = BatchLogRecordProcessor(exporter)
         logger_provider = LoggerProvider(
@@ -375,9 +376,8 @@ class TestBatchLogRecordProcessor(unittest.TestCase):
             with self.assertNoLogs(sdk_logger, logging.NOTSET):
                 processor.emit(EMPTY_LOG)
             sdk_logger.removeHandler(handler)
-        except Exception as exc:
+        finally:
             sdk_logger.removeHandler(handler)
-            raise exc
 
     def test_args(self):
         exporter = InMemoryLogExporter()

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -20,6 +20,8 @@ import unittest
 from unittest.mock import Mock, patch
 
 from opentelemetry._logs import SeverityNumber
+from sys import version_info
+from pytest import mark
 from opentelemetry.sdk import trace
 from opentelemetry.sdk._logs import (
     LogData,
@@ -342,6 +344,10 @@ class TestBatchLogRecordProcessor(unittest.TestCase):
         logger.error("error")
         self.assertEqual(log_record_processor.emit.call_count, 1)
 
+    @mark.skipif(
+        version_info < (3, 10),
+        reason="assertNoLogs only exists in python 3.10+.",
+    )
     def test_logging_lib_not_invoked_in_batch_log_record_emit(self):  # pylint: disable=no-self-use
         exporter = Mock()
         processor = BatchLogRecordProcessor(exporter)

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -375,7 +375,6 @@ class TestBatchLogRecordProcessor(unittest.TestCase):
             processor.shutdown()
             with self.assertNoLogs(sdk_logger, logging.NOTSET):
                 processor.emit(EMPTY_LOG)
-            sdk_logger.removeHandler(handler)
         finally:
             sdk_logger.removeHandler(handler)
 

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -17,11 +17,12 @@ import logging
 import os
 import time
 import unittest
+from sys import version_info
 from unittest.mock import Mock, patch
 
-from opentelemetry._logs import SeverityNumber
-from sys import version_info
 from pytest import mark
+
+from opentelemetry._logs import SeverityNumber
 from opentelemetry.sdk import trace
 from opentelemetry.sdk._logs import (
     LogData,

--- a/opentelemetry-sdk/tests/shared_internal/test_batch_processor.py
+++ b/opentelemetry-sdk/tests/shared_internal/test_batch_processor.py
@@ -34,7 +34,6 @@ from opentelemetry.sdk._logs import (
 from opentelemetry.sdk._logs.export import (
     BatchLogRecordProcessor,
 )
-from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 
 EMPTY_LOG = LogData(

--- a/opentelemetry-sdk/tests/shared_internal/test_batch_processor.py
+++ b/opentelemetry-sdk/tests/shared_internal/test_batch_processor.py
@@ -14,6 +14,7 @@
 
 # pylint: disable=protected-access
 import gc
+import logging
 import multiprocessing
 import os
 import time
@@ -27,13 +28,17 @@ from unittest.mock import Mock
 import pytest
 from pytest import mark
 
+from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk._logs import (
     LogData,
+    LoggerProvider,
+    LoggingHandler,
     LogRecord,
 )
 from opentelemetry.sdk._logs.export import (
     BatchLogRecordProcessor,
 )
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 
 EMPTY_LOG = LogData(
@@ -88,7 +93,7 @@ class TestBatchProcessor:
         exporter.export.assert_called_once_with([telemetry])
 
     def test_telemetry_flushed_before_shutdown_and_dropped_after_shutdown(
-        self, batch_processor_class, telemetry, caplog
+        self, batch_processor_class, telemetry
     ):
         exporter = Mock()
         batch_processor = batch_processor_class(
@@ -107,8 +112,6 @@ class TestBatchProcessor:
 
         # This should not be flushed.
         batch_processor.emit(telemetry)
-        assert len(caplog.records) == 1
-        assert "Shutdown called, ignoring" in caplog.text
         exporter.export.assert_called_once()
 
     # pylint: disable=no-self-use
@@ -211,3 +214,29 @@ class TestBatchProcessor:
 
         # Then the reference to the processor should no longer exist
         assert weak_ref() is None
+
+    def test_logging_lib_not_invoked_in_emit(
+        self, batch_processor_class, telemetry
+    ):
+        exporter = Mock()
+        processor = batch_processor_class(exporter)
+        processor._batch_processor.emit(telemetry)
+        logger_provider = LoggerProvider(
+            resource=Resource.create(
+                {
+                    "service.name": "shoppingcart",
+                    "service.instance.id": "instance-12",
+                }
+            ),
+        )
+        set_logger_provider(logger_provider)
+        logger_provider.add_log_record_processor(processor)
+        handler = LoggingHandler(
+            level=logging.INFO, logger_provider=logger_provider
+        )
+        # Attach OTLP handler to root logger
+        logging.getLogger().addHandler(handler)
+        # If `emit` calls logging.log then this test will throw a maximum recursion depth exceeded exception and fail.
+        processor.emit(telemetry)
+        processor.shutdown()
+        processor.emit(telemetry)


### PR DESCRIPTION
# Description

Remove logging.log calls from `BatchProcessor.emit`. Any log calls in that function can get routed back to `emit` and ultimately result in a maximum recursion depth exceeded exception.

fixes #4585
# How Has This Been Tested?

Added a unit test to prevent this.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x ] No.

# Checklist:

- [ x] Followed the style guidelines of this project
- [ x] Changelogs have been updated
- [ x] Unit tests have been added
- [ x] Documentation has been updated
