### PR TITLE
opentelemetry-api: allow importlib-metadata 8.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to crash at shutdown with a max recursion error ([#4586](https://github.com/open-telemetry/opentelemetry-python/pull/4586)).
 - Configurable max retry timeout for grpc exporter
   ([#4333](https://github.com/open-telemetry/opentelemetry-python/pull/4333))
+- opentelemetry-api: allow importlib-metadata 8.7.0
+  ([#4593](https://github.com/open-telemetry/opentelemetry-python/pull/4593))
 
 ## Version 1.33.0/0.54b0 (2025-05-09)
 

--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "Deprecated >= 1.2.6",
     # FIXME This should be able to be removed after 3.12 is released if there is a reliable API
     # in importlib.metadata.
-    "importlib-metadata >= 6.0, < 8.7.0",
+    "importlib-metadata >= 6.0, < 8.8.0",
 ]
 dynamic = [
     "version",

--- a/opentelemetry-api/test-requirements.txt
+++ b/opentelemetry-api/test-requirements.txt
@@ -1,7 +1,7 @@
 asgiref==3.7.2
 Deprecated==1.2.14
 importlib-metadata==8.5.0 ; python_version < "3.9"
-importlib-metadata==8.6.1 ; python_version >= "3.9"
+importlib-metadata==8.7.0 ; python_version >= "3.9"
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.5.0

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "deprecated", specifier = ">=1.2.6" },
-    { name = "importlib-metadata", specifier = ">=6.0,<8.7.0" },
+    { name = "importlib-metadata", specifier = ">=6.0,<8.8.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tox -e py310-test-opentelemetry-api

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
