### PR TITLE
opentelemetry-test-utils: assert explicit bucket boundaries in histogram metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4333](https://github.com/open-telemetry/opentelemetry-python/pull/4333))
 - opentelemetry-api: allow importlib-metadata 8.7.0
   ([#4593](https://github.com/open-telemetry/opentelemetry-python/pull/4593))
+- opentelemetry-test-utils: assert explicit bucket boundaries in histogram metrics
+  ([#4595](https://github.com/open-telemetry/opentelemetry-python/pull/4595))
 
 ## Version 1.33.0/0.54b0 (2025-05-09)
 

--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/test_base.py
@@ -20,6 +20,9 @@ from typing import Optional, Sequence, Tuple
 from opentelemetry import metrics as metrics_api
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics._internal.aggregation import (
+    _DEFAULT_EXPLICIT_BUCKET_HISTOGRAM_AGGREGATION_BOUNDARIES,
+)
 from opentelemetry.sdk.metrics._internal.point import Metric
 from opentelemetry.sdk.metrics.export import (
     DataPointT,
@@ -204,6 +207,12 @@ class TestBase(unittest.TestCase):
             ):
                 return False
 
+            if (
+                expected_data_point.explicit_bounds
+                != data_point.explicit_bounds
+            ):
+                return False
+
         return (
             values_diff <= est_value_delta
             and expected_data_point.attributes == dict(data_point.attributes)
@@ -239,7 +248,12 @@ class TestBase(unittest.TestCase):
 
     @staticmethod
     def create_histogram_data_point(
-        sum_data_point, count, max_data_point, min_data_point, attributes
+        sum_data_point,
+        count,
+        max_data_point,
+        min_data_point,
+        attributes,
+        explicit_bounds=None,
     ):
         return HistogramDataPoint(
             count=count,
@@ -250,7 +264,9 @@ class TestBase(unittest.TestCase):
             start_time_unix_nano=0,
             time_unix_nano=0,
             bucket_counts=[],
-            explicit_bounds=[],
+            explicit_bounds=explicit_bounds
+            if explicit_bounds is not None
+            else _DEFAULT_EXPLICIT_BUCKET_HISTOGRAM_AGGREGATION_BOUNDARIES,
         )
 
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

So we can assert in one shot histogram data points.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
