### PR TITLE
Add fallback handling for encode log body

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -135,6 +135,15 @@ def _encode_trace_id(trace_id: int) -> bytes:
     return trace_id.to_bytes(length=16, byteorder="big", signed=False)
 
 
+def _encode_log_body(
+    value: Any
+) -> Optional[PB2AnyValue]:
+    try:
+        return _encode_value(value, allow_null=True)
+    except Exception:
+        return _encode_value(str(value))
+
+
 def _encode_attributes(
     attributes: _ExtendedAttributes,
     allow_null: bool = False,

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/_log_encoder/__init__.py
@@ -17,10 +17,10 @@ from typing import List, Sequence
 from opentelemetry.exporter.otlp.proto.common._internal import (
     _encode_attributes,
     _encode_instrumentation_scope,
+    _encode_log_body,
     _encode_resource,
     _encode_span_id,
     _encode_trace_id,
-    _encode_value,
 )
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
     ExportLogsServiceRequest,
@@ -55,7 +55,7 @@ def _encode_log(log_data: LogData) -> PB2LogRecord:
         span_id=span_id,
         trace_id=trace_id,
         flags=int(log_data.log_record.trace_flags),
-        body=_encode_value(body, allow_null=True),
+        body=_encode_log_body(body),
         severity_text=log_data.log_record.severity_text,
         attributes=_encode_attributes(
             log_data.log_record.attributes, allow_null=True

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
@@ -85,11 +85,11 @@ class TestOTLPLogEncoder(unittest.TestCase):
     def test_encode_object_body(self):
         expected_log_bodies = self._get_test_logs_object_bodies()
         encoded_logs = encode_logs(self._get_test_logs_object_body())
-        for i, body_value in enumerate(expected_log_bodies):
+        for index, body_value in enumerate(expected_log_bodies):
             self.assertEqual(
                 encoded_logs.resource_logs[0]
                 .scope_logs[0]
-                .log_records[i]
+                .log_records[index]
                 .body,
                 body_value,
             )
@@ -646,7 +646,8 @@ class TestOTLPLogEncoder(unittest.TestCase):
 
         return [log1, log2, log3]
 
-    def _get_test_logs_object_bodies(self) -> List[PB2AnyValue]:
+    @staticmethod
+    def _get_test_logs_object_bodies() -> List[PB2AnyValue]:
         return [
             PB2AnyValue(
                 string_value="This is an exception message"
@@ -660,11 +661,11 @@ class TestOTLPLogEncoder(unittest.TestCase):
         ]
 
 class LogBodyStr():
-        def __init__(self):
-            pass
+    def __init__(self):
+        pass
 
-        def __str__(self):
-            return "This is a string from a class __str__ method"
+    def __str__(self):
+        return "This is a string from a class __str__ method"
 
 class LogBodyRepr():
     def __init__(self):

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_log_encoder.py
@@ -82,6 +82,18 @@ class TestOTLPLogEncoder(unittest.TestCase):
             2,
         )
 
+    def test_encode_object_body(self):
+        expected_log_bodies = self._get_test_logs_object_bodies()
+        encoded_logs = encode_logs(self._get_test_logs_object_body())
+        for i, body_value in enumerate(expected_log_bodies):
+            self.assertEqual(
+                encoded_logs.resource_logs[0]
+                .scope_logs[0]
+                .log_records[i]
+                .body,
+                body_value,
+            )
+
     @staticmethod
     def _get_sdk_log_data() -> List[LogData]:
         log1 = LogData(
@@ -246,6 +258,7 @@ class TestOTLPLogEncoder(unittest.TestCase):
                 "extended_name", "extended_version"
             ),
         )
+
         return [log1, log2, log3, log4, log5, log6, log7, log8]
 
     def get_test_logs(
@@ -580,3 +593,82 @@ class TestOTLPLogEncoder(unittest.TestCase):
         )
 
         return [log1, log2]
+
+    @staticmethod
+    def _get_test_logs_object_body() -> List[LogData]:
+        log1 = LogData(
+            log_record=SDKLogRecord(
+                timestamp=1644650584292683009,
+                observed_timestamp=1644650584292683010,
+                trace_id=212592107417388365804938480559624925555,
+                span_id=6077757853989569445,
+                trace_flags=TraceFlags(0x01),
+                severity_text="INFO",
+                severity_number=SeverityNumber.INFO,
+                body=Exception("This is an exception message"),
+                resource=SDKResource({}),
+                attributes={},
+            ),
+            instrumentation_scope=None,
+        )
+
+        log2 = LogData(
+            log_record=SDKLogRecord(
+                timestamp=1644650584292683009,
+                observed_timestamp=1644650584292683010,
+                trace_id=212592107417388365804938480559624925555,
+                span_id=6077757853989569445,
+                trace_flags=TraceFlags(0x01),
+                severity_text="INFO",
+                severity_number=SeverityNumber.INFO,
+                body=LogBodyStr(),
+                resource=SDKResource({}),
+                attributes={},
+            ),
+            instrumentation_scope=None,
+        )
+
+        log3 = LogData(
+            log_record=SDKLogRecord(
+                timestamp=1644650584292683009,
+                observed_timestamp=1644650584292683010,
+                trace_id=212592107417388365804938480559624925555,
+                span_id=6077757853989569445,
+                trace_flags=TraceFlags(0x01),
+                severity_text="INFO",
+                severity_number=SeverityNumber.INFO,
+                body=LogBodyRepr(),
+                resource=SDKResource({}),
+                attributes={},
+            ),
+            instrumentation_scope=None,
+        )
+
+        return [log1, log2, log3]
+
+    def _get_test_logs_object_bodies(self) -> List[PB2AnyValue]:
+        return [
+            PB2AnyValue(
+                string_value="This is an exception message"
+            ),
+            PB2AnyValue(
+                string_value="This is a string from a class __str__ method"
+            ),
+            PB2AnyValue(
+                string_value="This is a string from a class __repr__ method"
+            ),
+        ]
+
+class LogBodyStr():
+        def __init__(self):
+            pass
+
+        def __str__(self):
+            return "This is a string from a class __str__ method"
+
+class LogBodyRepr():
+    def __init__(self):
+        pass
+
+    def __repr__(self):
+        return "This is a string from a class __repr__ method"


### PR DESCRIPTION
# Description

Add a fallback handling for log body encoding, if it cannot be handled by `_encode_value` then it will be converted to string by calling `str` first.

Fixes #4100 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Unit test

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
