### PR TITLE
Update LogRecord.to_json to handle bytes field in the body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Update ConsoleLogExporter.export to handle LogRecord's containing bytes type
+  in the body ([#4614](https://github.com/open-telemetry/opentelemetry-python/pull/4614/)).
 - typecheck: add sdk/resources and drop mypy
   ([#4578](https://github.com/open-telemetry/opentelemetry-python/pull/4578))
 - Refactor `BatchLogRecordProcessor` to simplify code and make the control flow more

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -14,6 +14,7 @@
 
 
 from opentelemetry.sdk._logs._internal import (
+    BytesEncoder,
     LogData,
     LogDroppedAttributesWarning,
     Logger,
@@ -25,6 +26,7 @@ from opentelemetry.sdk._logs._internal import (
 )
 
 __all__ = [
+    "BytesEncoder",
     "LogData",
     "Logger",
     "LoggerProvider",

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/__init__.py
@@ -14,7 +14,6 @@
 
 
 from opentelemetry.sdk._logs._internal import (
-    BytesEncoder,
     LogData,
     LogDroppedAttributesWarning,
     Logger,
@@ -26,7 +25,6 @@ from opentelemetry.sdk._logs._internal import (
 )
 
 __all__ = [
-    "BytesEncoder",
     "LogData",
     "Logger",
     "LoggerProvider",

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -20,6 +20,7 @@ import json
 import logging
 import threading
 import traceback
+import base64
 import warnings
 from os import environ
 from threading import Lock
@@ -59,6 +60,12 @@ _logger = logging.getLogger(__name__)
 
 _DEFAULT_OTEL_ATTRIBUTE_COUNT_LIMIT = 128
 _ENV_VALUE_UNSET = ""
+
+class BytesEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, bytes):
+            return base64.b64encode(o).decode()
+        return super().default(o)
 
 
 class LogDroppedAttributesWarning(UserWarning):
@@ -248,6 +255,7 @@ class LogRecord(APILogRecord):
                 "resource": json.loads(self.resource.to_json()),
             },
             indent=indent,
+            cls=BytesEncoder,
         )
 
     @property

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -15,12 +15,12 @@ from __future__ import annotations
 
 import abc
 import atexit
+import base64
 import concurrent.futures
 import json
 import logging
 import threading
 import traceback
-import base64
 import warnings
 from os import environ
 from threading import Lock
@@ -60,6 +60,7 @@ _logger = logging.getLogger(__name__)
 
 _DEFAULT_OTEL_ATTRIBUTE_COUNT_LIMIT = 128
 _ENV_VALUE_UNSET = ""
+
 
 class BytesEncoder(json.JSONEncoder):
     def default(self, o):

--- a/opentelemetry-sdk/tests/logs/test_log_record.py
+++ b/opentelemetry-sdk/tests/logs/test_log_record.py
@@ -19,10 +19,10 @@ import warnings
 from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk._logs import (
+    BytesEncoder,
     LogDroppedAttributesWarning,
     LogLimits,
     LogRecord,
-    BytesEncoder,
 )
 from opentelemetry.sdk.resources import Resource
 
@@ -31,7 +31,7 @@ class TestLogRecord(unittest.TestCase):
     def test_log_record_to_json(self):
         expected = json.dumps(
             {
-                "body": {'key': 'logLine', 'bytes': b'123'},
+                "body": {"key": "logLine", "bytes": b"123"},
                 "severity_number": None,
                 "severity_text": None,
                 "attributes": {
@@ -57,7 +57,7 @@ class TestLogRecord(unittest.TestCase):
         actual = LogRecord(
             timestamp=0,
             observed_timestamp=0,
-            body={'key': 'logLine', 'bytes': b'123'},
+            body={"key": "logLine", "bytes": b"123"},
             resource=Resource({"service.name": "foo"}),
             attributes={
                 "mapping": {"key": "value"},
@@ -70,7 +70,7 @@ class TestLogRecord(unittest.TestCase):
         self.assertEqual(expected, actual.to_json(indent=4))
         self.assertEqual(
             actual.to_json(indent=None),
-            '{"body": "a log line", "severity_number": null, "severity_text": null, "attributes": {"mapping": {"key": "value"}, "none": null, "sequence": [1, 2], "str": "string"}, "dropped_attributes": 0, "timestamp": "1970-01-01T00:00:00.000000Z", "observed_timestamp": "1970-01-01T00:00:00.000000Z", "trace_id": "", "span_id": "", "trace_flags": null, "resource": {"attributes": {"service.name": "foo"}, "schema_url": ""}}',
+            '{"body": {"key": "logLine", "bytes": "MTIz"}, "severity_number": null, "severity_text": null, "attributes": {"mapping": {"key": "value"}, "none": null, "sequence": [1, 2], "str": "string"}, "dropped_attributes": 0, "timestamp": "1970-01-01T00:00:00.000000Z", "observed_timestamp": "1970-01-01T00:00:00.000000Z", "trace_id": "", "span_id": "", "trace_flags": null, "resource": {"attributes": {"service.name": "foo"}, "schema_url": ""}}',
         )
 
     def test_log_record_to_json_serializes_severity_number_as_int(self):

--- a/opentelemetry-sdk/tests/logs/test_log_record.py
+++ b/opentelemetry-sdk/tests/logs/test_log_record.py
@@ -19,7 +19,6 @@ import warnings
 from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk._logs import (
-    BytesEncoder,
     LogDroppedAttributesWarning,
     LogLimits,
     LogRecord,
@@ -29,32 +28,7 @@ from opentelemetry.sdk.resources import Resource
 
 class TestLogRecord(unittest.TestCase):
     def test_log_record_to_json(self):
-        expected = json.dumps(
-            {
-                "body": {"key": "logLine", "bytes": b"123"},
-                "severity_number": None,
-                "severity_text": None,
-                "attributes": {
-                    "mapping": {"key": "value"},
-                    "none": None,
-                    "sequence": [1, 2],
-                    "str": "string",
-                },
-                "dropped_attributes": 0,
-                "timestamp": "1970-01-01T00:00:00.000000Z",
-                "observed_timestamp": "1970-01-01T00:00:00.000000Z",
-                "trace_id": "",
-                "span_id": "",
-                "trace_flags": None,
-                "resource": {
-                    "attributes": {"service.name": "foo"},
-                    "schema_url": "",
-                },
-            },
-            indent=4,
-            cls=BytesEncoder,
-        )
-        actual = LogRecord(
+        log_record = LogRecord(
             timestamp=0,
             observed_timestamp=0,
             body={"key": "logLine", "bytes": b"123"},
@@ -67,9 +41,8 @@ class TestLogRecord(unittest.TestCase):
             },
         )
 
-        self.assertEqual(expected, actual.to_json(indent=4))
         self.assertEqual(
-            actual.to_json(indent=None),
+            log_record.to_json(indent=None),
             '{"body": {"key": "logLine", "bytes": "MTIz"}, "severity_number": null, "severity_text": null, "attributes": {"mapping": {"key": "value"}, "none": null, "sequence": [1, 2], "str": "string"}, "dropped_attributes": 0, "timestamp": "1970-01-01T00:00:00.000000Z", "observed_timestamp": "1970-01-01T00:00:00.000000Z", "trace_id": "", "span_id": "", "trace_flags": null, "resource": {"attributes": {"service.name": "foo"}, "schema_url": ""}}',
         )
 

--- a/opentelemetry-sdk/tests/logs/test_log_record.py
+++ b/opentelemetry-sdk/tests/logs/test_log_record.py
@@ -22,6 +22,7 @@ from opentelemetry.sdk._logs import (
     LogDroppedAttributesWarning,
     LogLimits,
     LogRecord,
+    BytesEncoder,
 )
 from opentelemetry.sdk.resources import Resource
 
@@ -30,7 +31,7 @@ class TestLogRecord(unittest.TestCase):
     def test_log_record_to_json(self):
         expected = json.dumps(
             {
-                "body": "a log line",
+                "body": {'key': 'logLine', 'bytes': b'123'},
                 "severity_number": None,
                 "severity_text": None,
                 "attributes": {
@@ -51,11 +52,12 @@ class TestLogRecord(unittest.TestCase):
                 },
             },
             indent=4,
+            cls=BytesEncoder,
         )
         actual = LogRecord(
             timestamp=0,
             observed_timestamp=0,
-            body="a log line",
+            body={'key': 'logLine', 'bytes': b'123'},
             resource=Resource({"service.name": "foo"}),
             attributes={
                 "mapping": {"key": "value"},


### PR DESCRIPTION
# Description

Update LogRecord.to_json to handle bytes field in the body -- it is valid/possible for this to occur given the OTLP LogRecord format.

Fixes #4606 

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [ x] No.

# Checklist:

- [ x] Followed the style guidelines of this project
- [ x] Changelogs have been updated
- [ x] Unit tests have been added
- [ x] Documentation has been updated
