### PR TITLE
Fix invalid `type: ignore` that causes mypy to ignore the whole file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- opentelemetry-sdk: Fix invalid `type: ignore` that causes mypy to ignore the whole file
+  ([#4618](https://github.com/open-telemetry/opentelemetry-python/pull/4618))
+
 ## Version 1.34.0/0.55b0 (2025-06-04)
 
 - typecheck: add sdk/resources and drop mypy

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# type: ignore[reportDeprecated]  # ResourceAttributes is deprecated
-
 """
 This package implements `OpenTelemetry Resources
 <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#resource-sdk>`_:
@@ -57,6 +55,9 @@ Note that the OpenTelemetry project documents certain `"standard attributes"
 that have prescribed semantic meanings, for example ``service.name`` in the
 above example.
 """
+
+# ResourceAttributes is deprecated
+# pyright: reportDeprecated=false
 
 import abc
 import concurrent.futures


### PR DESCRIPTION
# Description

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/4615

Explanation in https://github.com/open-telemetry/opentelemetry-python/issues/4615#issuecomment-2946177912. Let's backport this into the patch release we're planning for next week.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested against the repro in https://github.com/open-telemetry/opentelemetry-python/issues/4615 with mypy.

```console
Success: no issues found in 1 source file
```

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
