### PR TITLE
Add span exporter property to batch span processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - opentelemetry-sdk: Fix invalid `type: ignore` that causes mypy to ignore the whole file
   ([#4618](https://github.com/open-telemetry/opentelemetry-python/pull/4618))
-- Add `span_exporter` property back to `BatchSpanProcessor` class ([#4621](https://github.com/open-telemetry/opentelemetry-python/pull/4621)).
+- Add `span_exporter` property back to `BatchSpanProcessor` class
+  ([#4621](https://github.com/open-telemetry/opentelemetry-python/pull/4621))
 
 ## Version 1.34.0/0.55b0 (2025-06-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - opentelemetry-sdk: Fix invalid `type: ignore` that causes mypy to ignore the whole file
   ([#4618](https://github.com/open-telemetry/opentelemetry-python/pull/4618))
+- Add `span_exporter` property back to `BatchSpanProcessor` class ([#4621](https://github.com/open-telemetry/opentelemetry-python/pull/4621)).
 
 ## Version 1.34.0/0.55b0 (2025-06-04)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -177,6 +177,11 @@ class BatchSpanProcessor(SpanProcessor):
             "Span",
         )
 
+    # Added for backward compatibility. Not recommended to directly access/use underlying exporter.
+    @property
+    def span_exporter(self):
+        return self._batch_processor._exporter #pylint: disable=protected-access
+
     def on_start(
         self, span: Span, parent_context: Context | None = None
     ) -> None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -180,7 +180,7 @@ class BatchSpanProcessor(SpanProcessor):
     # Added for backward compatibility. Not recommended to directly access/use underlying exporter.
     @property
     def span_exporter(self):
-        return self._batch_processor._exporter #pylint: disable=protected-access
+        return self._batch_processor._exporter  # pylint: disable=protected-access
 
     def on_start(
         self, span: Span, parent_context: Context | None = None

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -150,6 +150,11 @@ class TestSimpleSpanProcessor(unittest.TestCase):
 # before the end of the test, otherwise the worker thread will continue
 # to run after the end of the test.
 class TestBatchSpanProcessor(unittest.TestCase):
+    def test_get_span_exporter(self):
+        exporter = MySpanExporter(destination=[])
+        batch_span_processor = export.BatchSpanProcessor(exporter)
+        self.assertEqual(exporter, batch_span_processor.span_exporter)
+
     @mock.patch.dict(
         "os.environ",
         {


### PR DESCRIPTION
# Description

See https://github.com/open-telemetry/opentelemetry-python/issues/4616 -- someone was relying on accessing the span exporter from the batch span processor, this PR adds a way to do that again 

Fixes #4616

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test

# Does This PR Require a Contrib Repo Change?

- [x ] No.

# Checklist:

- [ x] Followed the style guidelines of this project
- [ N/A] Changelogs have been updated
- [ x] Unit tests have been added
- [ x] Documentation has been updated
