### PR TITLE
fix: reinitialize locks after fork to prevent deadlocks in child processes

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -21,7 +21,8 @@ import logging
 import threading
 import traceback
 import warnings
-from os import environ
+import weakref
+from os import environ, register_at_fork
 from threading import Lock
 from time import time_ns
 from typing import Any, Callable, Tuple, Union, cast  # noqa
@@ -317,6 +318,11 @@ class SynchronousMultiLogRecordProcessor(LogRecordProcessor):
         # iterating through it on "emit".
         self._log_record_processors = ()  # type: Tuple[LogRecordProcessor, ...]
         self._lock = threading.Lock()
+        weak_reinit = weakref.WeakMethod(self._at_fork_reinit)
+        register_at_fork(after_in_child=lambda: weak_reinit()())
+
+    def _at_fork_reinit(self):
+        self._lock._at_fork_reinit()
 
     def add_log_record_processor(
         self, log_record_processor: LogRecordProcessor
@@ -379,6 +385,11 @@ class ConcurrentMultiLogRecordProcessor(LogRecordProcessor):
         self._executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=max_workers
         )
+        weak_reinit = weakref.WeakMethod(self._at_fork_reinit)
+        register_at_fork(after_in_child=lambda: weak_reinit()())
+
+    def _at_fork_reinit(self):
+        self._lock._at_fork_reinit()
 
     def add_log_record_processor(
         self, log_record_processor: LogRecordProcessor
@@ -633,6 +644,11 @@ class LoggerProvider(APILoggerProvider):
             self._at_exit_handler = atexit.register(self.shutdown)
         self._logger_cache = {}
         self._logger_cache_lock = Lock()
+        weak_reinit = weakref.WeakMethod(self._at_fork_reinit)
+        register_at_fork(after_in_child=lambda: weak_reinit()())
+
+    def _at_fork_reinit(self):
+        self._logger_cache_lock._at_fork_reinit()
 
     @property
     def resource(self):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exponential_histogram/mapping/exponent_mapping.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exponential_histogram/mapping/exponent_mapping.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from math import ldexp
+from os import register_at_fork
 from threading import Lock
 
 from opentelemetry.sdk.metrics._internal.exponential_histogram.mapping import (
@@ -41,6 +42,11 @@ class ExponentMapping(Mapping):
 
     _min_scale = -10
     _max_scale = 0
+
+    # Add a class method for initialization that includes fork handler registration
+    @classmethod
+    def _register_fork_handlers(cls):
+        register_at_fork(after_in_child=cls._mappings_lock._at_fork_reinit)
 
     def _get_min_scale(self):
         # _min_scale defines the point at which the exponential mapping
@@ -139,3 +145,6 @@ class ExponentMapping(Mapping):
     @property
     def scale(self) -> int:
         return self._scale
+
+# Call the method after the class is fully defined
+ExponentMapping._register_fork_handlers()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exponential_histogram/mapping/logarithm_mapping.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exponential_histogram/mapping/logarithm_mapping.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from math import exp, floor, ldexp, log
+from os import register_at_fork
 from threading import Lock
 
 from opentelemetry.sdk.metrics._internal.exponential_histogram.mapping import (
@@ -40,6 +41,11 @@ class LogarithmMapping(Mapping):
 
     _min_scale = 1
     _max_scale = 20
+
+    # Add a class method for initialization that includes fork handler registration
+    @classmethod
+    def _register_fork_handlers(cls):
+        register_at_fork(after_in_child=cls._mappings_lock._at_fork_reinit)
 
     def _get_min_scale(self):
         # _min_scale ensures that ExponentMapping is used for zero and negative
@@ -136,3 +142,6 @@ class LogarithmMapping(Mapping):
     @property
     def scale(self) -> int:
         return self._scale
+
+# Call the method after the class is fully defined
+LogarithmMapping._register_fork_handlers()


### PR DESCRIPTION
# Description

This commit adds post-fork reinitialization of threading locks across multiple components in the OpenTelemetry Python SDK and API. It ensures that threading.Lock() instances are safely reinitialized in child processes after a fork(), preventing potential deadlocks and undefined behavior.

# Details
 - Introduced usage of register_at_fork(after_in_child=...) from the os module to reinitialize thread locks.
 - Used weakref.WeakMethod() to safely refer to bound instance methods in register_at_fork.
 - Added _at_fork_reinit() methods to classes using threading locks and registered them to run in child processes post-fork.
 - Applied this to all usages of Lock, RLock

# Rationale

Forked child processes inherit thread state from the parent, including the internal state of locks. This can cause deadlocks or runtime errors if a lock was held at the time of the fork. By reinitializing locks using the register_at_fork mechanism, we ensure child processes start with clean lock states.

This is especially relevant for WSGI servers and environments that use pre-fork models (e.g., gunicorn, uWSGI), where instrumentation and telemetry components may misbehave without this precaution.

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
