### PR TITLE
[logs] Rename LogRecordProcessor.emit to on_emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4637](https://github.com/open-telemetry/opentelemetry-python/pull/4637))
 - Logging API accepts optional `context`; deprecates `trace_id`, `span_id`, `trace_flags`.
   ([#4597](https://github.com/open-telemetry/opentelemetry-python/pull/4597))
+- Rename LogRecordProcessor.emit to on_emit
+  ([#](https://github.com/open-telemetry/opentelemetry-python/pull/))
 
 ## Version 1.34.0/0.55b0 (2025-06-04)
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -354,7 +354,7 @@ class LogRecordProcessor(abc.ABC):
     """
 
     @abc.abstractmethod
-    def emit(self, log_data: LogData):
+    def on_emit(self, log_data: LogData):
         """Emits the `LogData`"""
 
     @abc.abstractmethod
@@ -398,9 +398,9 @@ class SynchronousMultiLogRecordProcessor(LogRecordProcessor):
         with self._lock:
             self._log_record_processors += (log_record_processor,)
 
-    def emit(self, log_data: LogData) -> None:
+    def on_emit(self, log_data: LogData) -> None:
         for lp in self._log_record_processors:
-            lp.emit(log_data)
+            lp.on_emit(log_data)
 
     def shutdown(self) -> None:
         """Shutdown the log processors one by one"""
@@ -472,8 +472,8 @@ class ConcurrentMultiLogRecordProcessor(LogRecordProcessor):
         for future in futures:
             future.result()
 
-    def emit(self, log_data: LogData):
-        self._submit_and_wait(lambda lp: lp.emit, log_data)
+    def on_emit(self, log_data: LogData):
+        self._submit_and_wait(lambda lp: lp.on_emit, log_data)
 
     def shutdown(self):
         self._submit_and_wait(lambda lp: lp.shutdown)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -112,7 +112,7 @@ class SimpleLogRecordProcessor(LogRecordProcessor):
         self._exporter = exporter
         self._shutdown = False
 
-    def emit(self, log_data: LogData):
+    def on_emit(self, log_data: LogData):
         if self._shutdown:
             _logger.warning("Processor is already shutdown, ignoring call")
             return
@@ -186,8 +186,8 @@ class BatchLogRecordProcessor(LogRecordProcessor):
             "Log",
         )
 
-    def emit(self, log_data: LogData) -> None:
-        return self._batch_processor.emit(log_data)
+    def on_emit(self, log_data: LogData) -> None:
+        return self._batch_processor.on_emit(log_data)
 
     def shutdown(self):
         return self._batch_processor.shutdown()


### PR DESCRIPTION
# Description

Rename  LogRecordProcessor.emit to on_emit to align with specification
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#onemit

Fixes #4312

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [ ] No.
