### PR TITLE
Adjust deprecation warning in LogRecord to also use deprecated decorator

### DIFF
--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -39,6 +39,8 @@ from os import environ
 from time import time_ns
 from typing import Optional, cast, overload
 
+from typing_extensions import deprecated
+
 from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.context.context import Context
 from opentelemetry.environment_variables import _OTEL_PYTHON_LOGGER_PROVIDER
@@ -73,6 +75,9 @@ class LogRecord(ABC):
     ) -> None: ...
 
     @overload
+    @deprecated(
+        "LogRecord init with `trace_id`, `span_id`, and/or `trace_flags` is deprecated since 1.35.0. Use `context` instead."
+    )
     def __init__(
         self,
         *,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -27,6 +27,8 @@ from threading import Lock
 from time import time_ns
 from typing import Any, Callable, Tuple, Union, cast, overload  # noqa
 
+from typing_extensions import deprecated
+
 from opentelemetry._logs import Logger as APILogger
 from opentelemetry._logs import LoggerProvider as APILoggerProvider
 from opentelemetry._logs import LogRecord as APILogRecord
@@ -209,6 +211,9 @@ class LogRecord(APILogRecord):
     ): ...
 
     @overload
+    @deprecated(
+        "LogRecord init with `trace_id`, `span_id`, and/or `trace_flags` is deprecated since 1.35.0. Use `context` instead."  # noqa: E501
+    )
     def __init__(
         self,
         timestamp: int | None = None,
@@ -242,7 +247,7 @@ class LogRecord(APILogRecord):
     ):
         if trace_id or span_id or trace_flags:
             warnings.warn(
-                "LogRecord init with `trace_id`, `span_id`, and/or `trace_flags` is deprecated. Use `context` instead.",
+                "LogRecord init with `trace_id`, `span_id`, and/or `trace_flags` is deprecated since 1.35.0. Use `context` instead. See do",
                 LogDeprecatedInitWarning,
                 stacklevel=2,
             )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -247,7 +247,7 @@ class LogRecord(APILogRecord):
     ):
         if trace_id or span_id or trace_flags:
             warnings.warn(
-                "LogRecord init with `trace_id`, `span_id`, and/or `trace_flags` is deprecated since 1.35.0. Use `context` instead. See do",
+                "LogRecord init with `trace_id`, `span_id`, and/or `trace_flags` is deprecated since 1.35.0. Use `context` instead.",
                 LogDeprecatedInitWarning,
                 stacklevel=2,
             )

--- a/opentelemetry-sdk/tests/logs/test_log_record.py
+++ b/opentelemetry-sdk/tests/logs/test_log_record.py
@@ -164,7 +164,7 @@ class TestLogRecord(unittest.TestCase):
                 self.assertEqual(len(cw), 1)
                 self.assertIsInstance(cw[-1].message, LogDeprecatedInitWarning)
                 self.assertIn(
-                    "LogRecord init with `trace_id`, `span_id`, and/or `trace_flags` is deprecated. Use `context` instead.",
+                    "LogRecord init with `trace_id`, `span_id`, and/or `trace_flags` is deprecated since 1.35.0. Use `context` instead.",
                     str(cw[-1].message),
                 )
 


### PR DESCRIPTION
Discussed offline with @aabmass and @tammy-baylis-swi :

> We keep the warning mechanism and also add the decorator on the deprecated overload
reason: By using the deprecated decorator, typecheckers like pyright should still alert the user that it's deprecated.