### PR TITLE
events: use optional context for initialiation instead of trace_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Overwrite logging.config.fileConfig and logging.config.dictConfig to ensure
 the OTLP `LogHandler` remains attached to the root logger. Fix a bug that
 can cause a deadlock to occur over `logging._lock` in some cases ([#4636](https://github.com/open-telemetry/opentelemetry-python/pull/4636)).
+- events: use optional `context` for initialiation instead of (`trace_id`, `span_id`, `trace_flag`)
+  ([#4690](https://github.com/open-telemetry/opentelemetry-python/pull/4636))
 
 ## Version 1.35.0/0.56b0 (2025-07-11)
 
@@ -31,7 +33,7 @@ can cause a deadlock to occur over `logging._lock` in some cases ([#4636](https:
 - Update logger level to NOTSET in logs example
   ([#4637](https://github.com/open-telemetry/opentelemetry-python/pull/4637))
 - Logging API accepts optional `context`; deprecates `trace_id`, `span_id`, `trace_flags`.
-  ([#4597](https://github.com/open-telemetry/opentelemetry-python/pull/4597)) and 
+  ([#4597](https://github.com/open-telemetry/opentelemetry-python/pull/4597)) and
   ([#4668](https://github.com/open-telemetry/opentelemetry-python/pull/4668))
 - sdk: use context instead of trace_id,span_id for initializing LogRecord
   ([#4653](https://github.com/open-telemetry/opentelemetry-python/pull/4653))

--- a/opentelemetry-api/src/opentelemetry/_events/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_events/__init__.py
@@ -19,10 +19,10 @@ from typing import Optional, cast
 
 from opentelemetry._logs import LogRecord
 from opentelemetry._logs.severity import SeverityNumber
+from opentelemetry.context import Context
 from opentelemetry.environment_variables import (
     _OTEL_PYTHON_EVENT_LOGGER_PROVIDER,
 )
-from opentelemetry.trace.span import TraceFlags
 from opentelemetry.util._once import Once
 from opentelemetry.util._providers import _load_provider
 from opentelemetry.util.types import AnyValue, _ExtendedAttributes
@@ -35,9 +35,7 @@ class Event(LogRecord):
         self,
         name: str,
         timestamp: Optional[int] = None,
-        trace_id: Optional[int] = None,
-        span_id: Optional[int] = None,
-        trace_flags: Optional["TraceFlags"] = None,
+        context: Optional[Context] = None,
         body: Optional[AnyValue] = None,
         severity_number: Optional[SeverityNumber] = None,
         attributes: Optional[_ExtendedAttributes] = None,
@@ -49,9 +47,7 @@ class Event(LogRecord):
         }
         super().__init__(
             timestamp=timestamp,
-            trace_id=trace_id,
-            span_id=span_id,
-            trace_flags=trace_flags,
+            context=context,
             body=body,
             severity_number=severity_number,
             attributes=event_attributes,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_events/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_events/__init__.py
@@ -15,11 +15,11 @@ import logging
 from time import time_ns
 from typing import Optional
 
-from opentelemetry import trace
 from opentelemetry._events import Event
 from opentelemetry._events import EventLogger as APIEventLogger
 from opentelemetry._events import EventLoggerProvider as APIEventLoggerProvider
 from opentelemetry._logs import NoOpLogger, SeverityNumber, get_logger_provider
+from opentelemetry.context import get_current
 from opentelemetry.sdk._logs import Logger, LoggerProvider, LogRecord
 from opentelemetry.util.types import _ExtendedAttributes
 
@@ -49,13 +49,10 @@ class EventLogger(APIEventLogger):
         if isinstance(self._logger, NoOpLogger):
             # Do nothing if SDK is disabled
             return
-        span_context = trace.get_current_span().get_span_context()
         log_record = LogRecord(
             timestamp=event.timestamp or time_ns(),
             observed_timestamp=None,
-            trace_id=event.trace_id or span_context.trace_id,
-            span_id=event.span_id or span_context.span_id,
-            trace_flags=event.trace_flags or span_context.trace_flags,
+            context=event.context or get_current(),
             severity_text=None,
             severity_number=event.severity_number or SeverityNumber.INFO,
             body=event.body,


### PR DESCRIPTION
# Description

Fix #4687 