### PR TITLE
fix: make client.py runnable without CLI arguments

### DIFF
--- a/docs/examples/auto-instrumentation/client.py
+++ b/docs/examples/auto-instrumentation/client.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sys import argv
 
 from requests import get
 
@@ -31,16 +30,13 @@ trace.get_tracer_provider().add_span_processor(
     BatchSpanProcessor(ConsoleSpanExporter())
 )
 
-
-assert len(argv) == 2
-
 with tracer.start_as_current_span("client"):
     with tracer.start_as_current_span("client-server"):
         headers = {}
         inject(headers)
         requested = get(
             "http://localhost:8082/server_request",
-            params={"param": argv[1]},
+            params={"param": "testing"},
             headers=headers,
         )
 

--- a/docs/examples/auto-instrumentation/client.py
+++ b/docs/examples/auto-instrumentation/client.py
@@ -31,6 +31,7 @@ trace.get_tracer_provider().add_span_processor(
     BatchSpanProcessor(ConsoleSpanExporter())
 )
 
+# Get parameter from command line argument or use default value "testing"
 param_value = sys.argv[1] if len(sys.argv) > 1 else "testing"
 
 with tracer.start_as_current_span("client"):

--- a/docs/examples/auto-instrumentation/client.py
+++ b/docs/examples/auto-instrumentation/client.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 
 from requests import get
 
@@ -30,13 +31,15 @@ trace.get_tracer_provider().add_span_processor(
     BatchSpanProcessor(ConsoleSpanExporter())
 )
 
+param_value = sys.argv[1] if len(sys.argv) > 1 else "testing"
+
 with tracer.start_as_current_span("client"):
     with tracer.start_as_current_span("client-server"):
         headers = {}
         inject(headers)
         requested = get(
             "http://localhost:8082/server_request",
-            params={"param": "testing"},
+            params={"param": param_value},
             headers=headers,
         )
 


### PR DESCRIPTION
There was an issue in the auto-instrumentation Example shown here:
https://opentelemetry.io/docs/zero-code/python/example/#execute-the-automatically-instrumented-server

The documentation refers to a `client.py` script located in [docs/examples/auto-instrumentation](https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/auto-instrumentation), but the script previously required passing "testing" as a command-line argument each time (`python client.py testing`).

I've updated the script so that `testing` is now used as the default argument when none is provided. Users can still override it by passing a custom argument, but it will fall back to `testing` if nothing passed.

Refs: open-telemetry/opentelemetry.io#6721