### PR TITLE
Filter duplicate logs out of some `logger`'s logs that might otherwise endlessly log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Overwrite logging.config.fileConfig and logging.config.dictConfig to ensure
 the OTLP `LogHandler` remains attached to the root logger. Fix a bug that
 can cause a deadlock to occur over `logging._lock` in some cases ([#4636](https://github.com/open-telemetry/opentelemetry-python/pull/4636)).
+- Filter duplicate logs emitted from the OTLP exporters to avoid endlessly logging when the OTLP logger itself
+is failing to export logs.
 
 ## Version 1.35.0/0.56b0 (2025-07-11)
 

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Sequence
 from typing import (
     Any,
@@ -26,7 +27,6 @@ from typing import (
     Optional,
     TypeVar,
 )
-import time
 
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue as PB2AnyValue
 from opentelemetry.proto.common.v1.common_pb2 import (
@@ -54,7 +54,12 @@ _ResourceDataT = TypeVar("_ResourceDataT")
 
 class DuplicateFilter(logging.Filter):
     def filter(self, record):
-        current_log = (record.module, record.levelno, record.msg, time.time() // 60)
+        current_log = (
+            record.module,
+            record.levelno,
+            record.msg,
+            time.time() // 60,
+        )
         if current_log != getattr(self, "last_log", None):
             self.last_log = current_log
             return True

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -26,6 +26,7 @@ from typing import (
     Optional,
     TypeVar,
 )
+import time
 
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue as PB2AnyValue
 from opentelemetry.proto.common.v1.common_pb2 import (
@@ -49,6 +50,15 @@ _logger = logging.getLogger(__name__)
 
 _TypingResourceT = TypeVar("_TypingResourceT")
 _ResourceDataT = TypeVar("_ResourceDataT")
+
+
+class DuplicateFilter(logging.Filter):
+    def filter(self, record):
+        current_log = (record.module, record.levelno, record.msg, time.time() // 60)
+        if current_log != getattr(self, "last_log", None):
+            self.last_log = current_log
+            return True
+        return False
 
 
 def _encode_instrumentation_scope(

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_common.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_common.py
@@ -1,0 +1,17 @@
+import unittest
+import logging
+
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    DuplicateFilter,
+)
+
+
+class TestCommonFuncs(unittest.TestCase):
+
+    def test_duplicate_logs_filter_Works(self):
+        test_logger = logging.getLogger("testLogger")
+        test_logger.addFilter(DuplicateFilter())
+        with self.assertLogs('testLogger') as cm:
+            test_logger.info("message")
+            test_logger.info("message")
+        self.assertEqual(len(cm.output), 1)

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_common.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_common.py
@@ -1,5 +1,5 @@
-import unittest
 import logging
+import unittest
 
 from opentelemetry.exporter.otlp.proto.common._internal import (
     DuplicateFilter,
@@ -7,11 +7,10 @@ from opentelemetry.exporter.otlp.proto.common._internal import (
 
 
 class TestCommonFuncs(unittest.TestCase):
-
     def test_duplicate_logs_filter_Works(self):
         test_logger = logging.getLogger("testLogger")
         test_logger.addFilter(DuplicateFilter())
-        with self.assertLogs('testLogger') as cm:
+        with self.assertLogs("testLogger") as cm:
             test_logger.info("message")
             test_logger.info("message")
         self.assertEqual(len(cm.output), 1)

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -32,6 +32,9 @@ from typing import (  # noqa: F401
     TypeVar,
     Union,
 )
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    DuplicateFilter,
+)
 from typing import Sequence as TypingSequence
 from urllib.parse import urlparse
 
@@ -87,6 +90,8 @@ _RETRYABLE_ERROR_CODES = frozenset(
 )
 _MAX_RETRYS = 6
 logger = getLogger(__name__)
+# This prevents logs generated when a log fails to be written to generate another log which fails to be written etc. etc.
+logger.addFilter(DuplicateFilter())
 SDKDataT = TypeVar("SDKDataT")
 ResourceDataT = TypeVar("ResourceDataT")
 TypingResourceT = TypeVar("TypingResourceT")

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -32,9 +32,6 @@ from typing import (  # noqa: F401
     TypeVar,
     Union,
 )
-from opentelemetry.exporter.otlp.proto.common._internal import (
-    DuplicateFilter,
-)
 from typing import Sequence as TypingSequence
 from urllib.parse import urlparse
 
@@ -51,6 +48,7 @@ from grpc import (
     ssl_channel_credentials,
 )
 from opentelemetry.exporter.otlp.proto.common._internal import (
+    DuplicateFilter,
     _get_resource_data,
 )
 from opentelemetry.exporter.otlp.proto.grpc import (

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -24,6 +24,9 @@ from typing import Dict, Optional, Sequence
 import requests
 from requests.exceptions import ConnectionError
 
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    DuplicateFilter,
+)
 from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
 from opentelemetry.exporter.otlp.proto.http import (
     _OTLP_HTTP_HEADERS,
@@ -52,9 +55,6 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_LOGS_HEADERS,
     OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
     OTEL_EXPORTER_OTLP_TIMEOUT,
-)
-from opentelemetry.exporter.otlp.proto.common._internal import (
-    DuplicateFilter,
 )
 from opentelemetry.util.re import parse_env_headers
 

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -53,9 +53,14 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
     OTEL_EXPORTER_OTLP_TIMEOUT,
 )
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    DuplicateFilter,
+)
 from opentelemetry.util.re import parse_env_headers
 
 _logger = logging.getLogger(__name__)
+# This prevents logs generated when a log fails to be written to generate another log which fails to be written etc. etc.
+_logger.addFilter(DuplicateFilter())
 
 
 DEFAULT_COMPRESSION = Compression.NoCompression


### PR DESCRIPTION
# Description

Filter duplicate logs out of some HTTP/GRPC exporter `logger`'s logs that might otherwise endlessly log.

Fixes #4688 #2701

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests

# Does This PR Require a Contrib Repo Change?

- [x ] No.

# Checklist:

- [ x] Followed the style guidelines of this project
- [ x] Changelogs have been updated
- [ x] Unit tests have been added
- [ x] Documentation has been updated
