### PR TITLE
Use `@pytest.mark.flaky` decorator instead of `@flaky.flaky`

### DIFF
--- a/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
+++ b/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
@@ -22,7 +22,7 @@ from time import sleep, time_ns
 from typing import Optional, Sequence
 from unittest.mock import Mock
 
-from flaky import flaky
+import pytest
 
 from opentelemetry.sdk.metrics import Counter, MetricsTimeoutError
 from opentelemetry.sdk.metrics._internal import _Counter
@@ -194,7 +194,7 @@ class TestPeriodicExportingMetricReader(ConcurrencyTestBase):
             export_interval_millis=-100,
         )
 
-    @flaky(max_runs=3, min_passes=1)
+    @pytest.mark.flaky(max_runs=3, min_passes=1)
     def test_ticker_collects_metrics(self):
         exporter = FakeMetricsExporter()
 


### PR DESCRIPTION
# Description

Use the modern `@pytest.mark.flaky` decorator over `@flaky.flaky` in tests. This avoids typing issues, and makes the tests compatible with other implementations of that decorator, such as `pytest-rerunfailures`.

## Type of change

Internal test change.

# How Has This Been Tested?

```
tox -e py313-test-opentelemetry-sdk
```

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
