### PR TITLE
Add experimental consistent sampler

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/__init__.py
@@ -1,0 +1,17 @@
+__all__ = [
+    "ComposableSampler",
+    "ConsistentSampler",
+    "SamplingIntent",
+    "consistent_always_off",
+    "consistent_always_on",
+    "consistent_parent_based",
+    "consistent_probability_based",
+]
+
+
+from ._always_off import consistent_always_off
+from ._always_on import consistent_always_on
+from ._composable import ComposableSampler, SamplingIntent
+from ._fixed_threshold import consistent_probability_based
+from ._parent_based import consistent_parent_based
+from ._sampler import ConsistentSampler

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_always_off.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_always_off.py
@@ -1,0 +1,37 @@
+from typing import Optional, Sequence
+
+from opentelemetry.context import Context
+from opentelemetry.trace import Link, SpanKind, TraceState
+from opentelemetry.util.types import Attributes
+
+from ._composable import ComposableSampler, SamplingIntent
+from ._sampler import ConsistentSampler
+from ._util import INVALID_THRESHOLD
+
+_intent = SamplingIntent(
+    threshold=INVALID_THRESHOLD, adjusted_count_reliable=False
+)
+
+
+class ConsistentAlwaysOffSampler(ComposableSampler):
+    def sampling_intent(
+        self,
+        parent_ctx: Optional[Context],
+        name: str,
+        span_kind: Optional[SpanKind],
+        attributes: Attributes,
+        links: Optional[Sequence[Link]],
+        trace_state: Optional[TraceState] = None,
+    ) -> SamplingIntent:
+        return _intent
+
+    def get_description(self) -> str:
+        return "ConsistentAlwaysOffSampler"
+
+
+_always_off = ConsistentSampler(ConsistentAlwaysOffSampler())
+
+
+def consistent_always_off() -> ConsistentSampler:
+    """Returns a consistent sampler that does not sample any span."""
+    return _always_off

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_always_on.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_always_on.py
@@ -1,0 +1,35 @@
+from typing import Optional, Sequence
+
+from opentelemetry.context import Context
+from opentelemetry.trace import Link, SpanKind, TraceState
+from opentelemetry.util.types import Attributes
+
+from ._composable import ComposableSampler, SamplingIntent
+from ._sampler import ConsistentSampler
+from ._util import MIN_THRESHOLD
+
+_intent = SamplingIntent(threshold=MIN_THRESHOLD)
+
+
+class ConsistentAlwaysOnSampler(ComposableSampler):
+    def sampling_intent(
+        self,
+        parent_ctx: Optional[Context],
+        name: str,
+        span_kind: Optional[SpanKind],
+        attributes: Attributes,
+        links: Optional[Sequence[Link]],
+        trace_state: Optional[TraceState] = None,
+    ) -> SamplingIntent:
+        return _intent
+
+    def get_description(self) -> str:
+        return "ConsistentAlwaysOnSampler"
+
+
+_always_on = ConsistentSampler(ConsistentAlwaysOnSampler())
+
+
+def consistent_always_on() -> ConsistentSampler:
+    """Returns a consistent sampler that samples all spans."""
+    return _always_on

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_composable.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_composable.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Protocol, Sequence
+
+from opentelemetry.context import Context
+from opentelemetry.trace import Link, SpanKind, TraceState
+from opentelemetry.util.types import Attributes
+
+
+@dataclass(frozen=True)
+class SamplingIntent:
+    """Information to make a consistent sampling decision."""
+
+    threshold: int
+    adjusted_count_reliable: bool = field(default=True)
+    attributes: Attributes = field(default=None)
+    update_trace_state: Callable[[TraceState], TraceState] = field(
+        default=lambda ts: ts
+    )
+
+
+class ComposableSampler(Protocol):
+    """A sampler that can be composed to make a final consistent sampling decision."""
+
+    def sampling_intent(
+        self,
+        parent_ctx: Optional[Context],
+        name: str,
+        span_kind: Optional[SpanKind],
+        attributes: Attributes,
+        links: Optional[Sequence[Link]],
+        trace_state: Optional[TraceState],
+    ) -> SamplingIntent:
+        """Returns information to make a consistent sampling decision."""
+        ...
+
+    def get_description(self) -> str:
+        """Returns a description of the sampler."""
+        ...

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_fixed_threshold.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_fixed_threshold.py
@@ -1,0 +1,53 @@
+from typing import Optional, Sequence
+
+from opentelemetry.context import Context
+from opentelemetry.trace import Link, SpanKind, TraceState
+from opentelemetry.util.types import Attributes
+
+from ._composable import ComposableSampler, SamplingIntent
+from ._sampler import ConsistentSampler
+from ._trace_state import serialize_th
+from ._util import INVALID_THRESHOLD, MAX_THRESHOLD, calculate_threshold
+
+
+class ConsistentFixedThresholdSampler(ComposableSampler):
+    _threshold: int
+    _description: str
+
+    def __init__(self, sampling_probability: float):
+        threshold = calculate_threshold(sampling_probability)
+        if threshold == MAX_THRESHOLD:
+            threshold_str = "max"
+        else:
+            threshold_str = serialize_th(threshold)
+        threshold = (
+            INVALID_THRESHOLD if threshold == MAX_THRESHOLD else threshold
+        )
+        self._intent = SamplingIntent(threshold=threshold)
+        self._description = f"ConsistentFixedThresholdSampler{{threshold={threshold_str}, sampling probability={sampling_probability}}}"
+
+    def sampling_intent(
+        self,
+        parent_ctx: Optional[Context],
+        name: str,
+        span_kind: Optional[SpanKind],
+        attributes: Attributes,
+        links: Optional[Sequence[Link]],
+        trace_state: Optional[TraceState] = None,
+    ) -> SamplingIntent:
+        return self._intent
+
+    def get_description(self) -> str:
+        return self._description
+
+
+def consistent_probability_based(
+    sampling_probability: float,
+) -> ConsistentSampler:
+    """Returns a consistent sampler that samples each span with a fixed probability."""
+    if not (0.0 <= sampling_probability <= 1.0):
+        raise ValueError("Sampling probability must be between 0.0 and 1.0")
+
+    return ConsistentSampler(
+        ConsistentFixedThresholdSampler(sampling_probability)
+    )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_parent_based.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_parent_based.py
@@ -1,0 +1,65 @@
+from typing import Optional, Sequence
+
+from opentelemetry.context import Context
+from opentelemetry.trace import Link, SpanKind, TraceState, get_current_span
+from opentelemetry.util.types import Attributes
+
+from ._composable import ComposableSampler, SamplingIntent
+from ._sampler import ConsistentSampler
+from ._trace_state import OtelTraceState
+from ._util import (
+    INVALID_THRESHOLD,
+    MIN_THRESHOLD,
+    is_valid_threshold,
+)
+
+
+class ConsistentParentBasedSampler(ComposableSampler):
+    def __init__(self, root_sampler: ComposableSampler):
+        self._root_sampler = root_sampler
+        self._description = f"ConsistentParentBasedSampler{{root_sampler={root_sampler.get_description()}}}"
+
+    def sampling_intent(
+        self,
+        parent_ctx: Optional[Context],
+        name: str,
+        span_kind: Optional[SpanKind],
+        attributes: Attributes,
+        links: Optional[Sequence[Link]],
+        trace_state: Optional[TraceState] = None,
+    ) -> SamplingIntent:
+        parent_span = get_current_span(parent_ctx)
+        parent_span_ctx = parent_span.get_span_context()
+        is_root = not parent_span_ctx.is_valid
+        if is_root:
+            return self._root_sampler.sampling_intent(
+                parent_ctx, name, span_kind, attributes, links, trace_state
+            )
+
+        ot_trace_state = OtelTraceState.parse(trace_state)
+
+        if is_valid_threshold(ot_trace_state.threshold):
+            return SamplingIntent(
+                threshold=ot_trace_state.threshold,
+                adjusted_count_reliable=True,
+            )
+        else:
+            threshold = (
+                MIN_THRESHOLD
+                if parent_span_ctx.trace_flags.sampled
+                else INVALID_THRESHOLD
+            )
+            return SamplingIntent(
+                threshold=threshold, adjusted_count_reliable=False
+            )
+
+    def get_description(self) -> str:
+        return self._description
+
+
+def consistent_parent_based(
+    root_sampler: ComposableSampler,
+) -> ConsistentSampler:
+    """Returns a consistent sampler that respects the sampling decision of
+    the parent span or falls-back to the given sampler if it is a root span."""
+    return ConsistentSampler(ConsistentParentBasedSampler(root_sampler))

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_sampler.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_sampler.py
@@ -1,0 +1,83 @@
+from typing import Optional, Sequence
+
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
+from opentelemetry.trace import Link, SpanKind, TraceState
+from opentelemetry.util.types import Attributes
+
+from ._composable import ComposableSampler, SamplingIntent
+from ._trace_state import OTEL_TRACE_STATE_KEY, OtelTraceState
+from ._util import INVALID_THRESHOLD, is_valid_random_value, is_valid_threshold
+
+
+class ConsistentSampler(Sampler, ComposableSampler):
+    """A sampler that uses a consistent sampling strategy based on a delegate sampler."""
+
+    def __init__(self, delegate: ComposableSampler):
+        self._delegate = delegate
+
+    def should_sample(
+        self,
+        parent_context: Optional[Context],
+        trace_id: int,
+        name: str,
+        kind: Optional[SpanKind] = None,
+        attributes: Attributes = None,
+        links: Optional[Sequence[Link]] = None,
+        trace_state: Optional[TraceState] = None,
+    ) -> SamplingResult:
+        ot_trace_state = OtelTraceState.parse(trace_state)
+
+        intent = self._delegate.sampling_intent(
+            parent_context, name, kind, attributes, links, trace_state
+        )
+        threshold = intent.threshold
+
+        if is_valid_threshold(threshold):
+            adjusted_count_correct = intent.adjusted_count_reliable
+            if is_valid_random_value(ot_trace_state.random_value):
+                randomness = ot_trace_state.random_value
+            else:
+                # Use last 56 bits of trace_id as randomness
+                randomness = trace_id & 0x00FFFFFFFFFFFFFF
+            sampled = threshold <= randomness
+        else:
+            sampled = False
+            adjusted_count_correct = False
+
+        decision = Decision.RECORD_AND_SAMPLE if sampled else Decision.DROP
+        if sampled and adjusted_count_correct:
+            ot_trace_state.threshold = threshold
+        else:
+            ot_trace_state.threshold = INVALID_THRESHOLD
+
+        otts = ot_trace_state.serialize()
+        if not trace_state:
+            if otts:
+                new_trace_state = TraceState(((OTEL_TRACE_STATE_KEY, otts),))
+            else:
+                new_trace_state = None
+        else:
+            new_trace_state = intent.update_trace_state(trace_state)
+            if otts:
+                new_trace_state = new_trace_state.update(
+                    OTEL_TRACE_STATE_KEY, otts
+                )
+
+        return SamplingResult(decision, intent.attributes, new_trace_state)
+
+    def sampling_intent(
+        self,
+        parent_ctx: Optional[Context],
+        name: str,
+        span_kind: Optional[SpanKind],
+        attributes: Attributes,
+        links: Optional[Sequence[Link]],
+        trace_state: Optional[TraceState],
+    ) -> SamplingIntent:
+        return self._delegate.sampling_intent(
+            parent_ctx, name, span_kind, attributes, links, trace_state
+        )
+
+    def get_description(self) -> str:
+        return self._delegate.get_description()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_trace_state.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_trace_state.py
@@ -1,0 +1,120 @@
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+from opentelemetry.trace import TraceState
+
+from ._util import (
+    INVALID_RANDOM_VALUE,
+    INVALID_THRESHOLD,
+    MAX_THRESHOLD,
+    is_valid_random_value,
+    is_valid_threshold,
+)
+
+OTEL_TRACE_STATE_KEY = "ot"
+
+_TRACE_STATE_SIZE_LIMIT = 256
+_MAX_VALUE_LENGTH = 14  # 56 bits, 4 bits per hex digit
+
+
+@dataclass
+class OtelTraceState:
+    random_value: int
+    threshold: int
+    rest: Sequence[str]
+
+    @staticmethod
+    def invalid() -> "OtelTraceState":
+        return OtelTraceState(INVALID_RANDOM_VALUE, INVALID_THRESHOLD, ())
+
+    @staticmethod
+    def parse(trace_state: Optional[TraceState]) -> "OtelTraceState":
+        if not trace_state:
+            return OtelTraceState.invalid()
+
+        ot = trace_state.get(OTEL_TRACE_STATE_KEY, "")
+
+        if not ot or len(ot) > _TRACE_STATE_SIZE_LIMIT:
+            return OtelTraceState.invalid()
+
+        threshold = INVALID_THRESHOLD
+        random_value = INVALID_RANDOM_VALUE
+
+        members = ot.split(";")
+        rest: Optional[list[str]] = None
+        for member in members:
+            if member.startswith("th:"):
+                threshold = _parse_th(member[len("th:") :], INVALID_THRESHOLD)
+                continue
+            if member.startswith("rv:"):
+                random_value = _parse_rv(
+                    member[len("rv:") :], INVALID_RANDOM_VALUE
+                )
+                continue
+            if rest is None:
+                rest = [member]
+            else:
+                rest.append(member)
+
+        return OtelTraceState(
+            random_value=random_value, threshold=threshold, rest=rest or ()
+        )
+
+    def serialize(self) -> str:
+        if (
+            not is_valid_threshold(self.threshold)
+            and not is_valid_random_value(self.random_value)
+            and not self.rest
+        ):
+            return ""
+
+        parts: list[str] = []
+        if (
+            is_valid_threshold(self.threshold)
+            and self.threshold != MAX_THRESHOLD
+        ):
+            parts.append(f"th:{serialize_th(self.threshold)}")
+        if is_valid_random_value(self.random_value):
+            parts.append(f"rv:{_serialize_rv(self.random_value)}")
+        if self.rest:
+            parts.extend(self.rest)
+        res = ";".join(parts)
+        while len(res) > _TRACE_STATE_SIZE_LIMIT:
+            delim_idx = res.rfind(";")
+            if delim_idx == -1:
+                break
+            res = res[:delim_idx]
+        return res
+
+
+def _parse_th(value: str, default: int) -> int:
+    if not value or len(value) > _MAX_VALUE_LENGTH:
+        return default
+
+    try:
+        parsed = int(value, 16)
+    except ValueError:
+        return default
+
+    trailing_zeros = _MAX_VALUE_LENGTH - len(value)
+    return parsed << (trailing_zeros * 4)
+
+
+def _parse_rv(value: str, default: int) -> int:
+    if not value or len(value) != _MAX_VALUE_LENGTH:
+        return default
+
+    try:
+        return int(value, 16)
+    except ValueError:
+        return default
+
+
+def serialize_th(threshold: int) -> str:
+    if not threshold:
+        return "0"
+    return f"{threshold:014x}".rstrip("0")
+
+
+def _serialize_rv(random_value: int) -> str:
+    return f"{random_value:014x}"

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_util.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/_sampling_experimental/_util.py
@@ -1,0 +1,22 @@
+RANDOM_VALUE_BITS = 56
+MAX_THRESHOLD = 1 << RANDOM_VALUE_BITS  # 0% sampling
+MIN_THRESHOLD = 0  # 100% sampling
+MAX_RANDOM_VALUE = MAX_THRESHOLD - 1
+INVALID_THRESHOLD = -1
+INVALID_RANDOM_VALUE = -1
+
+_probability_threshold_scale = float.fromhex("0x1p56")
+
+
+def calculate_threshold(sampling_probability: float) -> int:
+    return MAX_THRESHOLD - round(
+        sampling_probability * _probability_threshold_scale
+    )
+
+
+def is_valid_threshold(threshold: int) -> bool:
+    return MIN_THRESHOLD <= threshold <= MAX_THRESHOLD
+
+
+def is_valid_random_value(random_value: int) -> bool:
+    return 0 <= random_value <= MAX_RANDOM_VALUE

--- a/opentelemetry-sdk/tests/conftest.py
+++ b/opentelemetry-sdk/tests/conftest.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
 from os import environ
+
+import pytest
 
 from opentelemetry.environment_variables import OTEL_PYTHON_CONTEXT
 
@@ -25,3 +28,9 @@ def pytest_sessionstart(session):
 def pytest_sessionfinish(session):
     # pylint: disable=unused-argument
     environ.pop(OTEL_PYTHON_CONTEXT)
+
+
+@pytest.fixture(autouse=True)
+def random_seed():
+    # We use random numbers a lot in sampling tests, make sure they are always the same.
+    random.seed(0)

--- a/opentelemetry-sdk/tests/trace/consistent_sampler/test_always_off.py
+++ b/opentelemetry-sdk/tests/trace/consistent_sampler/test_always_off.py
@@ -1,0 +1,37 @@
+from testutil import random_trace_id
+
+from opentelemetry.sdk.trace._sampling_experimental import (
+    consistent_always_off,
+)
+from opentelemetry.sdk.trace.sampling import Decision
+
+
+def test_description():
+    assert (
+        consistent_always_off().get_description()
+        == "ConsistentAlwaysOffSampler"
+    )
+
+
+def test_threshold():
+    assert (
+        consistent_always_off()
+        .sampling_intent(None, "test", None, {}, None, None)
+        .threshold
+        == -1
+    )
+
+
+def test_sampling():
+    sampler = consistent_always_off()
+
+    num_sampled = 0
+    for _ in range(10000):
+        res = sampler.should_sample(
+            None, random_trace_id(), "span", None, None, None, None
+        )
+        if res.decision == Decision.RECORD_AND_SAMPLE:
+            num_sampled += 1
+        assert not res.trace_state
+
+    assert num_sampled == 0

--- a/opentelemetry-sdk/tests/trace/consistent_sampler/test_always_on.py
+++ b/opentelemetry-sdk/tests/trace/consistent_sampler/test_always_on.py
@@ -1,0 +1,35 @@
+from testutil import random_trace_id
+
+from opentelemetry.sdk.trace._sampling_experimental import consistent_always_on
+from opentelemetry.sdk.trace.sampling import Decision
+
+
+def test_description():
+    assert (
+        consistent_always_on().get_description() == "ConsistentAlwaysOnSampler"
+    )
+
+
+def test_threshold():
+    assert (
+        consistent_always_on()
+        .sampling_intent(None, "test", None, {}, None, None)
+        .threshold
+        == 0
+    )
+
+
+def test_sampling():
+    sampler = consistent_always_on()
+
+    num_sampled = 0
+    for _ in range(10000):
+        res = sampler.should_sample(
+            None, random_trace_id(), "span", None, None, None, None
+        )
+        if res.decision == Decision.RECORD_AND_SAMPLE:
+            num_sampled += 1
+            assert res.trace_state is not None
+            assert res.trace_state.get("ot", "") == "th:0"
+
+    assert num_sampled == 10000

--- a/opentelemetry-sdk/tests/trace/consistent_sampler/test_fixed_threshold.py
+++ b/opentelemetry-sdk/tests/trace/consistent_sampler/test_fixed_threshold.py
@@ -1,0 +1,60 @@
+import pytest
+from testutil import random_trace_id
+
+from opentelemetry.sdk.trace._sampling_experimental import (
+    consistent_probability_based,
+)
+from opentelemetry.sdk.trace._sampling_experimental._trace_state import (
+    OtelTraceState,
+)
+from opentelemetry.sdk.trace.sampling import Decision
+
+
+@pytest.mark.parametrize(
+    "probability,threshold",
+    (
+        (1.0, "0"),
+        (0.5, "8"),
+        (0.25, "c"),
+        (1e-300, "max"),
+        (0, "max"),
+    ),
+)
+def test_description(probability: float, threshold: str):
+    assert (
+        consistent_probability_based(probability).get_description()
+        == f"ConsistentFixedThresholdSampler{{threshold={threshold}, sampling probability={probability}}}"
+    )
+
+
+@pytest.mark.parametrize(
+    "probability,threshold",
+    (
+        (1.0, 0),
+        (0.5, 36028797018963968),
+        (0.25, 54043195528445952),
+        (0.125, 63050394783186944),
+        (0.0, 72057594037927936),
+        (0.45, 39631676720860364),
+        (0.2, 57646075230342348),
+        (0.13, 62690106812997304),
+        (0.05, 68454714336031539),
+    ),
+)
+def test_sampling(probability: float, threshold: int):
+    sampler = consistent_probability_based(probability)
+
+    num_sampled = 0
+    for _ in range(10000):
+        res = sampler.should_sample(
+            None, random_trace_id(), "span", None, None, None, None
+        )
+        if res.decision == Decision.RECORD_AND_SAMPLE:
+            num_sampled += 1
+            assert res.trace_state is not None
+            otts = OtelTraceState.parse(res.trace_state)
+            assert otts.threshold == threshold
+            assert otts.random_value == -1
+
+    expected_num_sampled = int(10000 * probability)
+    assert abs(num_sampled - expected_num_sampled) < 50

--- a/opentelemetry-sdk/tests/trace/consistent_sampler/test_sampler.py
+++ b/opentelemetry-sdk/tests/trace/consistent_sampler/test_sampler.py
@@ -1,0 +1,155 @@
+from typing import Optional
+
+import pytest
+from pytest import param as p
+
+from opentelemetry.sdk.trace._sampling_experimental import (
+    consistent_always_off,
+    consistent_always_on,
+    consistent_parent_based,
+    consistent_probability_based,
+)
+from opentelemetry.sdk.trace._sampling_experimental._trace_state import (
+    OtelTraceState,
+)
+from opentelemetry.sdk.trace._sampling_experimental._util import (
+    INVALID_RANDOM_VALUE,
+    INVALID_THRESHOLD,
+)
+from opentelemetry.sdk.trace.sampling import Decision, Sampler
+from opentelemetry.trace import (
+    NonRecordingSpan,
+    SpanContext,
+    TraceFlags,
+    TraceState,
+    set_span_in_context,
+)
+
+TRACE_ID = int("00112233445566778800000000000000", 16)
+SPAN_ID = int("0123456789abcdef", 16)
+
+
+@pytest.mark.parametrize(
+    "sampler,parent_sampled,parent_threshold,parent_random_value,sampled,threshold,random_value",
+    (
+        p(
+            consistent_always_on(),
+            True,
+            None,
+            None,
+            True,
+            0,
+            INVALID_RANDOM_VALUE,
+            id="min threshold no parent random value",
+        ),
+        p(
+            consistent_always_on(),
+            True,
+            None,
+            0x7F99AA40C02744,
+            True,
+            0,
+            0x7F99AA40C02744,
+            id="min threshold with parent random value",
+        ),
+        p(
+            consistent_always_off(),
+            True,
+            None,
+            None,
+            False,
+            INVALID_THRESHOLD,
+            INVALID_RANDOM_VALUE,
+            id="max threshold",
+        ),
+        p(
+            consistent_parent_based(consistent_always_on()),
+            False,  # should be ignored
+            0x7F99AA40C02744,
+            0x7F99AA40C02744,
+            True,
+            0x7F99AA40C02744,
+            0x7F99AA40C02744,
+            id="parent based in consistent mode",
+        ),
+        p(
+            consistent_parent_based(consistent_always_on()),
+            True,
+            None,
+            None,
+            True,
+            INVALID_THRESHOLD,
+            INVALID_RANDOM_VALUE,
+            id="parent based in legacy mode",
+        ),
+        p(
+            consistent_probability_based(0.5),
+            True,
+            None,
+            0x7FFFFFFFFFFFFF,
+            False,
+            INVALID_THRESHOLD,
+            0x7FFFFFFFFFFFFF,
+            id="half threshold not sampled",
+        ),
+        p(
+            consistent_probability_based(0.5),
+            False,
+            None,
+            0x80000000000000,
+            True,
+            0x80000000000000,
+            0x80000000000000,
+            id="half threshold sampled",
+        ),
+        p(
+            consistent_probability_based(1.0),
+            False,
+            0x80000000000000,
+            0x80000000000000,
+            True,
+            0,
+            0x80000000000000,
+            id="half threshold sampled",
+        ),
+    ),
+)
+def test_sample(
+    sampler: Sampler,
+    parent_sampled: bool,
+    parent_threshold: Optional[int],
+    parent_random_value: Optional[int],
+    sampled: bool,
+    threshold: float,
+    random_value: float,
+):
+    parent_state = OtelTraceState.invalid()
+    if parent_threshold is not None:
+        parent_state.threshold = parent_threshold
+    if parent_random_value is not None:
+        parent_state.random_value = parent_random_value
+    parent_state_str = parent_state.serialize()
+    parent_trace_state = (
+        TraceState((("ot", parent_state_str),)) if parent_state_str else None
+    )
+    flags = (
+        TraceFlags(TraceFlags.SAMPLED)
+        if parent_sampled
+        else TraceFlags.get_default()
+    )
+    parent_span_context = SpanContext(
+        TRACE_ID, SPAN_ID, False, flags, parent_trace_state
+    )
+    parent_span = NonRecordingSpan(parent_span_context)
+    parent_context = set_span_in_context(parent_span)
+
+    result = sampler.should_sample(
+        parent_context, TRACE_ID, "name", trace_state=parent_trace_state
+    )
+
+    decision = Decision.RECORD_AND_SAMPLE if sampled else Decision.DROP
+    state = OtelTraceState.parse(result.trace_state)
+
+    assert result.decision == decision
+    assert state.threshold == threshold
+    assert state.random_value == random_value

--- a/opentelemetry-sdk/tests/trace/consistent_sampler/test_tracestate.py
+++ b/opentelemetry-sdk/tests/trace/consistent_sampler/test_tracestate.py
@@ -1,0 +1,55 @@
+import pytest
+
+from opentelemetry.sdk.trace._sampling_experimental._trace_state import (
+    OtelTraceState,
+)
+from opentelemetry.trace import TraceState
+
+
+@pytest.mark.parametrize(
+    "input_str,output_str",
+    (
+        ("a", "a"),
+        ("#", "#"),
+        ("rv:1234567890abcd", "rv:1234567890abcd"),
+        ("rv:01020304050607", "rv:01020304050607"),
+        ("rv:1234567890abcde", ""),
+        ("th:1234567890abcd", "th:1234567890abcd"),
+        ("th:1234567890abcd", "th:1234567890abcd"),
+        ("th:10000000000000", "th:1"),
+        ("th:1234500000000", "th:12345"),
+        ("th:0", "th:0"),
+        ("th:100000000000000", ""),
+        ("th:1234567890abcde", ""),
+        pytest.param(
+            f"a:{'X' * 214};rv:1234567890abcd;th:1234567890abcd;x:3",
+            f"th:1234567890abcd;rv:1234567890abcd;a:{'X' * 214};x:3",
+            id="long",
+        ),
+        ("th:x", ""),
+        ("th:100000000000000", ""),
+        ("th:10000000000000", "th:1"),
+        ("th:1000000000000", "th:1"),
+        ("th:100000000000", "th:1"),
+        ("th:10000000000", "th:1"),
+        ("th:1000000000", "th:1"),
+        ("th:100000000", "th:1"),
+        ("th:10000000", "th:1"),
+        ("th:1000000", "th:1"),
+        ("th:100000", "th:1"),
+        ("th:10000", "th:1"),
+        ("th:1000", "th:1"),
+        ("th:100", "th:1"),
+        ("th:10", "th:1"),
+        ("th:1", "th:1"),
+        ("th:10000000000001", "th:10000000000001"),
+        ("th:10000000000010", "th:1000000000001"),
+        ("rv:x", ""),
+        ("rv:100000000000000", ""),
+        ("rv:10000000000000", "rv:10000000000000"),
+        ("rv:1000000000000", ""),
+    ),
+)
+def test_marshal(input_str: str, output_str: str):
+    state = OtelTraceState.parse(TraceState((("ot", input_str),))).serialize()
+    assert state == output_str

--- a/opentelemetry-sdk/tests/trace/consistent_sampler/testutil.py
+++ b/opentelemetry-sdk/tests/trace/consistent_sampler/testutil.py
@@ -1,0 +1,5 @@
+import random
+
+
+def random_trace_id() -> int:
+    return random.getrandbits(128)


### PR DESCRIPTION
This is a reopening of https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3668 as was recommended to target this repo.

Looking at some other similar `_` exports for experimental features, they seem to be complete concepts (i.e. logs), while this is a type of an existing concept, sampler. So I tried the `_sampling_experimental` name to clarify that it is an experimental part of sampling. Let me know any thoughts.

# Description

Adds an implementation of consistent samplers

https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/

Based on the Java implementation

https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56

Some differences from Java

- Does not add non-standard samplers for now, e.g. ratelimited, rule based
- Some trace state validation is assumed to be done by the SDK and invalid cases aren't tested (the API doesn't accept string but SDK `TraceState`)

/cc @xrmx @tammy-baylis-swi
/cc @peterf778 as original author in Java if interested

## Type of change

- [C] New feature (non-breaking change which adds functionality)- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Unit tests

# Does This PR Require a Core Repo Change?

- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [X] Unit tests have been added
- [X] Documentation has been updated
