### PR TITLE
ci(benchmarks): switch runner to Oracle bare metal

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,7 +11,7 @@ jobs:
   sdk-benchmarks:
     permissions:
       contents: write # required for pushing to gh-pages
-    runs-on: equinix-bare-metal
+    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
     steps:
     - name: Checkout Core Repo @ SHA - ${{ github.sha }}
       uses: actions/checkout@v4


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## What
- Updated `.github/workflows/benchmarks.yml` to use the `oracle-bare-metal-64cpu-512gb-x86-64` runner instead of the Equinix bare metal/self-hosted pool.

## Why
The [benchmarks workflow](https://github.com/open-telemetry/opentelemetry-python/actions/workflows/benchmarks.yml) has been failing (timing out) since workflow run [#435](https://github.com/open-telemetry/opentelemetry-python/actions/runs/16590211497) for the past two weeks with the following error.

```
The job has exceeded the maximum execution time while awaiting a runner for 24h0m0s
```

**Reason**:
Equinix Metal is being sunset, and the current Equinix bare metal runners are no longer available. To restore functionality, we’re moving benchmarks execution to the Oracle bare metal runner pool.

**References**:
- Community context: [open-telemetry/community#2801](https://github.com/open-telemetry/community/issues/2801)
- Equinix announcement: https://docs.equinix.com/metal/
- Similar PR in otel-go repo: https://github.com/open-telemetry/opentelemetry-go/pull/7183

#### Open Question
For now, I’ve updated the runner. Should we switch this job to a container-based workflow, or continue running directly on the host? ([otel-rust ref](https://github.com/open-telemetry/opentelemetry-rust/blob/main/.github/workflows/benchmark.yml#L26-L29))

Fixes # *No open issue yet* (Please let me know if one is required)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

NA

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated - NA
- [x] Unit tests have been added - NA
- [x] Documentation has been updated - NA
