### PR TITLE
infra: fix for benchmark CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,7 +3,6 @@ name: SDK Benchmark Tests
 on:
   push:
     branches: [ main ]
-  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Even after #4721 benchmark CI is failing. Fix that.

https://github.com/open-telemetry/opentelemetry-python/actions/runs/16969028303/job/48100647263 