### PR TITLE
docs: updated the "Read The Docs" documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## Version 1.36.0/0.57b0 (2025-07-29)
-- Updated Read The Docs linking the examples with their github source code location and added Prometheus example.
+- docs: linked the examples with their github source code location and added Prometheus example
   ([#4728](https://github.com/open-telemetry/opentelemetry-python/pull/4728))
+
+## Version 1.36.0/0.57b0 (2025-07-29)
+
 
 - Add missing Prometheus exporter documentation
   ([#4485](https://github.com/open-telemetry/opentelemetry-python/pull/4485))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## Version 1.36.0/0.57b0 (2025-07-29)
+- Updated Read The Docs linking the examples with their github source code location and added Prometheus example.
+  ([#4728](https://github.com/open-telemetry/opentelemetry-python/pull/4728))
 
 - Add missing Prometheus exporter documentation
   ([#4485](https://github.com/open-telemetry/opentelemetry-python/pull/4485))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version 1.36.0/0.57b0 (2025-07-29)
 
-
 - Add missing Prometheus exporter documentation
   ([#4485](https://github.com/open-telemetry/opentelemetry-python/pull/4485))
 - Overwrite logging.config.fileConfig and logging.config.dictConfig to ensure

--- a/docs/examples/django/README.rst
+++ b/docs/examples/django/README.rst
@@ -4,7 +4,7 @@ Django Instrumentation
 This shows how to use ``opentelemetry-instrumentation-django`` to automatically instrument a
 Django app.
 
-For more user convenience, a Django app is already provided in this directory.
+The source files of these examples are available :scm_web:`here <docs/examples/django/>`.
 
 Preparation
 -----------

--- a/docs/examples/error_handler/README.rst
+++ b/docs/examples/error_handler/README.rst
@@ -6,6 +6,7 @@ Overview
 
 This example shows how to use the global error handler.
 
+The source files of these examples are available :scm_web:`here <docs/examples/error_handler/>`.
 
 Preparation
 -----------

--- a/docs/examples/fork-process-model/README.rst
+++ b/docs/examples/fork-process-model/README.rst
@@ -10,6 +10,8 @@ get around this limitation of the span processor.
 Please see http://bugs.python.org/issue6721 for the problems about Python locks in (multi)threaded
 context with fork.
 
+The source code for the examples with Flask app are available :scm_web:`here <docs/examples/fork-process-model/>`.
+
 Gunicorn post_fork hook
 -----------------------
 
@@ -61,6 +63,3 @@ uWSGI postfork decorator
             OTLPSpanExporter(endpoint="http://localhost:4317")
         )
         trace.get_tracer_provider().add_span_processor(span_processor)
-
-
-The source code for the examples with Flask app are available :scm_web:`here <docs/examples/fork-process-model/>`.

--- a/docs/examples/logs/README.rst
+++ b/docs/examples/logs/README.rst
@@ -6,6 +6,8 @@ OpenTelemetry Logs SDK
    :mod:`opentelemetry.sdk._logs` are subject to change in minor/patch releases and make no
    backward compatibility guarantees at this time.
 
+The source files of these examples are available :scm_web:`here <docs/examples/logs/>`.
+
 Start the Collector locally to see data being exported. Write the following file:
 
 .. code-block:: yaml

--- a/docs/examples/metrics/instruments/README.rst
+++ b/docs/examples/metrics/instruments/README.rst
@@ -1,6 +1,8 @@
 OpenTelemetry Metrics SDK
 =========================
 
+The source files of these examples are available :scm_web:`here <docs/examples/metrics/instruments/>`.
+
 Start the Collector locally to see data being exported. Write the following file:
 
 .. code-block:: yaml

--- a/docs/examples/metrics/prometheus-grafana/README.rst
+++ b/docs/examples/metrics/prometheus-grafana/README.rst
@@ -33,7 +33,7 @@ Execution
     $ python ./prometheus-monitor.py
     $ Server is running at http://localhost:8000
 
-Now you can visit `localhost:8000/metrics <http://localhost:8000/metrics>` to see Prometheus metrics. 
+Now you can visit `http://localhost:8000/metrics` to see Prometheus metrics. 
 You should see something like:
 
 .. code-block::

--- a/docs/examples/metrics/prometheus-grafana/README.rst
+++ b/docs/examples/metrics/prometheus-grafana/README.rst
@@ -33,7 +33,7 @@ Execution
     $ python ./prometheus-monitor.py
     $ Server is running at http://localhost:8000
 
-Now you can visit `http://localhost:8000/metrics` to see Prometheus metrics. 
+Now you can visit http://localhost:8000/metrics to see Prometheus metrics. 
 You should see something like:
 
 .. code-block::

--- a/docs/examples/metrics/prometheus-grafana/README.rst
+++ b/docs/examples/metrics/prometheus-grafana/README.rst
@@ -1,7 +1,7 @@
 Prometheus Instrumentation
 ==========================
 
-This shows how to use ``opentelemetry-exporter-prometheus`` to automatically generate prometheus metrics.
+This shows how to use ``opentelemetry-exporter-prometheus`` to automatically generate Prometheus metrics.
 
 The source files of these examples are available :scm_web:`here <docs/examples/prometheus-grafana/>`.
 

--- a/docs/examples/metrics/prometheus-grafana/README.rst
+++ b/docs/examples/metrics/prometheus-grafana/README.rst
@@ -33,7 +33,7 @@ Execution
     $ python ./prometheus-monitor.py
     $ Server is running at http://localhost:8000
 
-Now you can visit `localhost:8000/metrics <http://localhost:8000/metrics>` to see prometheus metrics. 
+Now you can visit `localhost:8000/metrics <http://localhost:8000/metrics>` to see Prometheus metrics. 
 You should see something like:
 
 .. code-block::

--- a/docs/examples/metrics/prometheus-grafana/README.rst
+++ b/docs/examples/metrics/prometheus-grafana/README.rst
@@ -60,4 +60,4 @@ You should see something like:
     # TYPE MyAppPrefix_my_counter_total counter
     MyAppPrefix_my_counter_total 964.0
  
-`MyAppPrefix_my_counter_total` is the custom counter created in the application with the custom prefix `MyAppPrefix`.
+``MyAppPrefix_my_counter_total`` is the custom counter created in the application with the custom prefix ``MyAppPrefix``.

--- a/docs/examples/metrics/prometheus-grafana/README.rst
+++ b/docs/examples/metrics/prometheus-grafana/README.rst
@@ -1,0 +1,63 @@
+Prometheus Instrumentation
+==========================
+
+This shows how to use ``opentelemetry-exporter-prometheus`` to automatically generate prometheus metrics.
+
+The source files of these examples are available :scm_web:`here <docs/examples/prometheus-grafana/>`.
+
+Preparation
+-----------
+
+This example will be executed in a separate virtual environment:
+
+.. code-block::
+
+    $ mkdir prometheus_auto_instrumentation
+    $ virtualenv prometheus_auto_instrumentation
+    $ source prometheus_auto_instrumentation/bin/activate
+
+
+Installation
+------------
+
+.. code-block::
+
+    $ pip install -r requirements.txt
+
+
+Execution
+---------
+
+.. code-block::
+
+    $ python ./prometheus-monitor.py
+    $ Server is running at http://localhost:8000
+
+Now you can visit `localhost:8000/metrics <http://localhost:8000/metrics>` to see prometheus metrics. 
+You should see something like:
+
+.. code-block::
+
+    # HELP python_gc_objects_collected_total Objects collected during gc
+    # TYPE python_gc_objects_collected_total counter
+    python_gc_objects_collected_total{generation="0"} 320.0
+    python_gc_objects_collected_total{generation="1"} 58.0
+    python_gc_objects_collected_total{generation="2"} 0.0
+    # HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
+    # TYPE python_gc_objects_uncollectable_total counter
+    python_gc_objects_uncollectable_total{generation="0"} 0.0
+    python_gc_objects_uncollectable_total{generation="1"} 0.0
+    python_gc_objects_uncollectable_total{generation="2"} 0.0
+    # HELP python_gc_collections_total Number of times this generation was collected
+    # TYPE python_gc_collections_total counter
+    python_gc_collections_total{generation="0"} 61.0
+    python_gc_collections_total{generation="1"} 5.0
+    python_gc_collections_total{generation="2"} 0.0
+    # HELP python_info Python platform information
+    # TYPE python_info gauge
+    python_info{implementation="CPython",major="3",minor="8",patchlevel="5",version="3.8.5"} 1.0
+    # HELP MyAppPrefix_my_counter_total 
+    # TYPE MyAppPrefix_my_counter_total counter
+    MyAppPrefix_my_counter_total 964.0
+ 
+`MyAppPrefix_my_counter_total` is the custom counter created in the application with the custom prefix `MyAppPrefix`.

--- a/docs/examples/metrics/prometheus-grafana/prometheus-monitor.py
+++ b/docs/examples/metrics/prometheus-grafana/prometheus-monitor.py
@@ -18,6 +18,8 @@ meter = get_meter_provider().get_meter("view-name-change", "0.1.2")
 
 my_counter = meter.create_counter("my.counter")
 
+print("Server is running at http://localhost:8000")
+
 while 1:
     my_counter.add(random.randint(1, 10))
     time.sleep(random.random())


### PR DESCRIPTION
# Description

I noticed that several of the examples didn't link to their source code on github even though others did. To be consistent I added a link to the example in the README.rst files.

While working on this I also noticed that there was an example for prometheus but no entry in the Read The Docs generated, so I added one following the same style as the other pages.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation

# How Has This Been Tested?
generated documentation locally and inspected the html files. I checked all the links and make sure they were pointing to correct github example page.
