### PR TITLE
feat: implement on ending in span processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `opentelemetry-exporter-credential-provider-gcp` as an optional dependency to `opentelemetry-exporter-otlp-proto-grpc` 
   and `opentelemetry-exporter-otlp-proto-http` 
   ([#4760](https://github.com/open-telemetry/opentelemetry-python/pull/4760))
+- feat: implement on ending in span processor
+  ([#4775](https://github.com/open-telemetry/opentelemetry-python/pull/4775))
 - semantic-conventions: Bump to 1.38.0
   ([#4791](https://github.com/open-telemetry/opentelemetry-python/pull/4791))
 - [BREAKING] Remove LogData and extend SDK LogRecord to have instrumentation scope

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -101,6 +101,9 @@ class SimpleSpanProcessor(SpanProcessor):
     ) -> None:
         pass
 
+    def _on_ending(self, span: Span) -> None:
+        pass
+
     def on_end(self, span: ReadableSpan) -> None:
         if not (span.context and span.context.trace_flags.sampled):
             return
@@ -185,6 +188,9 @@ class BatchSpanProcessor(SpanProcessor):
     def on_start(
         self, span: Span, parent_context: Context | None = None
     ) -> None:
+        pass
+
+    def _on_ending(self, span: Span) -> None:
         pass
 
     def on_end(self, span: ReadableSpan) -> None:


### PR DESCRIPTION
# Description

[SpanProcessor.onEnding() Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#onending)

This PR serves to implement the in-development feature `onEnding` for the span processor. This will allow users to make modifications to the span before it becomes immutable when `onEnd` is reached.

Also updated SimpleSpanProcessor and BatchSpanProcessor to explicitly implement and `pass` the `_on_ending` method

Loosely following implementation in Java repo: https://github.com/open-telemetry/opentelemetry-java/pull/6367

Fixes: N/A

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Callout: Maintained previous unit test that validated span processor behaviour without `onEnding`
- Added a unit test to ensure onEnding is called in the correct order (in between `onStart` and `onEnd`)
- Added new unit tests to ensure onEnding is called appropriately (once per `Span.End()`)

# Does This PR Require a Contrib Repo Change?

No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
