### PR TITLE
Add dev dependency group with tox-uv and pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,3 +127,9 @@ strict = [
   "opentelemetry-sdk/src/opentelemetry/sdk/environment_variables",
   "opentelemetry-sdk/src/opentelemetry/sdk/resources",
 ]
+
+[dependency-groups]
+dev = [
+    "tox-uv",
+    "pre-commit",
+]


### PR DESCRIPTION
This will allow everyone to just run `uv sync` and have tox + pre-commit in the development environment. If I run uv sync, I have to manually install tox and pre-commit again. I added just tox + pre-commit, but we can add other dev-dependencies here as we need