### PR TITLE
Add dev dependency group with tox-uv and pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ strict = [
 
 [dependency-groups]
 dev = [
+    "tox",
     "tox-uv>=1",
     "pre-commit",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -474,6 +474,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "tox", version = "4.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "tox", version = "4.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tox-uv", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "tox-uv", version = "1.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
@@ -497,6 +499,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit" },
+    { name = "tox" },
     { name = "tox-uv", specifier = ">=1" },
 ]
 


### PR DESCRIPTION
This will allow everyone to just run uv sync and have tox + pre-commit in the development environment. If I run uv sync, I have to manually install tox and pre-commit again. I added just tox + pre-commit, but we can add other dev-dependencies here as we need