### PR TITLE
Implement partial success logging in OTLP exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- OTLP exporters now log partial success responses at `debug` level when `OTEL_LOG_LEVEL` is set to `debug` or `verbose`.
+- OTLP exporters now log partial success responses.
   ([#4805](https://github.com/open-telemetry/opentelemetry-python/pull/4805))
 - docs: Added sqlcommenter example
   ([#4734](https://github.com/open-telemetry/opentelemetry-python/pull/4734))

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+
 from os import environ
 from typing import Dict, Literal, Optional, Sequence, Tuple, Union
 from typing import Sequence as TypingSequence
@@ -112,11 +112,6 @@ class OTLPLogExporter(
         self, data: Sequence[ReadableLogRecord]
     ) -> ExportLogsServiceRequest:
         return encode_logs(data)
-
-    def _log_partial_success(self, partial_success):
-        # Override that skips the "logging" module due to the possibility
-        # of circular logic (logging -> OTLP logs export).
-        sys.stderr.write(f"Partial success:\n{partial_success}\n")
 
     def export(  # type: ignore [reportIncompatibleMethodOverride]
         self,

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -374,12 +374,9 @@ class OTLPExporterMixin(
     ) -> ExportServiceRequestT:
         pass
 
-    def _log_partial_success(self, partial_success):
-        logger.debug("Partial success:\n%s", partial_success)
-
     def _process_response(self, response):
         if response.HasField("partial_success"):
-            self._log_partial_success(response.partial_success)
+            logger.debug("Partial success:\n%s", response.partial_success)
 
     def _export(
         self,

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/logs/test_otlp_logs_exporter.py
@@ -15,7 +15,6 @@
 # pylint: disable=too-many-lines
 
 import time
-from io import StringIO
 from os.path import dirname
 from unittest import TestCase
 from unittest.mock import Mock, patch
@@ -29,9 +28,7 @@ from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
     OTLPLogExporter,
 )
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
-    ExportLogsPartialSuccess,
     ExportLogsServiceRequest,
-    ExportLogsServiceResponse,
 )
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
 from opentelemetry.proto.common.v1.common_pb2 import (
@@ -318,26 +315,6 @@ class TestOTLPLogExporter(TestCase):
             .get("logRecords")
         )
         return log_records
-
-    @patch("sys.stderr", new_callable=StringIO)
-    def test_partial_success_recorded_directly_to_stderr(self, mock_stderr):
-        # pylint: disable=protected-access
-        exporter = OTLPLogExporter()
-        exporter._client = Mock()
-        exporter._client.Export.return_value = ExportLogsServiceResponse(
-            partial_success=ExportLogsPartialSuccess(
-                rejected_log_records=1,
-                error_message="Log record dropped",
-            )
-        )
-
-        exporter.export([self.log_data_1])
-
-        self.assertIn("Partial success:\n", mock_stderr.getvalue())
-        self.assertIn("rejected_log_records: 1\n", mock_stderr.getvalue())
-        self.assertIn(
-            'error_message: "Log record dropped"\n', mock_stderr.getvalue()
-        )
 
     def test_exported_log_without_trace_id(self):
         log_records = self.export_log_and_deserialize(self.log_data_4)


### PR DESCRIPTION
# Log partial success

Partial successes during OTLP export is now logged.

Fixes #4803

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [?] This change requires a documentation update

# How Has This Been Tested?

Added new unit tests covering the relevant cases.

# Does This PR Require a Contrib Repo Change?

- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [X] Unit tests have been added
- [] Documentation has been updated - _unsure what to update_