### PR TITLE
Fix OTLP gRPC log exporter request wrapper and timeout precedence

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
@@ -100,7 +100,7 @@ class OTLPLogExporter(
             insecure=insecure,
             credentials=credentials,
             headers=headers or environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS),
-            timeout=timeout or environ_timeout,
+            timeout=timeout if timeout is not None else environ_timeout,
             compression=compression,
             stub=LogsServiceStub,
             result=LogRecordExportResult,
@@ -110,7 +110,7 @@ class OTLPLogExporter(
     def _translate_data(
         self, data: Sequence[ReadableLogRecord]
     ) -> ExportLogsServiceRequest:
-        return encode_logs(data)
+        return ExportLogsServiceRequest(resource_logs=encode_logs(data))
 
     def export(  # type: ignore [reportIncompatibleMethodOverride]
         self,


### PR DESCRIPTION
# Description

This commit fixes a critical bug in the `OTLPLogExporter` where `_translate_data` was returning raw `ResourceLogs` instead of wrapping them in the expected `ExportLogsServiceRequest` envelope. This previously caused gRPC export calls to fail with a type error.

Additionally, this fixes a logic flaw in `__init__` regarding the `timeout` argument. It changes the assignment to check `if timeout is not None`, ensuring that an explicit `timeout=0` is respected rather than being overridden by environment variables.

Fixes #4814

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual Verification: Created a script to initialize `OTLPLogExporter` and verify that `_translate_data` now correctly returns an instance of `ExportLogsServiceRequest` instead of a raw list.
- [x] Manual Verification: Verified that initializing `OTLPLogExporter(timeout=0)` results in the instance having a `timeout` of `0`, whereas previously it defaulted to `None` or the environment variable.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated