### PR TITLE
Fix type checking for built in metric exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4676](https://github.com/open-telemetry/opentelemetry-python/pull/4676))
 - [BREAKING] Rename several classes from Log to LogRecord
   ([#4647](https://github.com/open-telemetry/opentelemetry-python/pull/4647))
+- Fix type checking for built in metric exporters
+  ([#4820](https://github.com/open-telemetry/opentelemetry-python/pull/4820))
   
   **Migration Guide:**
   

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
@@ -145,7 +145,7 @@ class ConsoleMetricExporter(MetricExporter):
         self,
         out: IO = stdout,
         formatter: Callable[
-            ["opentelemetry.sdk.metrics.export.MetricsData"], str
+            [MetricsData], str
         ] = lambda metrics_data: metrics_data.to_json() + linesep,
         preferred_temporality: dict[type, AggregationTemporality]
         | None = None,
@@ -362,7 +362,7 @@ class MetricReader(ABC):
     @abstractmethod
     def _receive_metrics(
         self,
-        metrics_data: "opentelemetry.sdk.metrics.export.MetricsData",
+        metrics_data: MetricsData,
         timeout_millis: float = 10_000,
         **kwargs,
     ) -> None:
@@ -406,13 +406,11 @@ class InMemoryMetricReader(MetricReader):
             preferred_aggregation=preferred_aggregation,
         )
         self._lock = RLock()
-        self._metrics_data: "opentelemetry.sdk.metrics.export.MetricsData" = (
-            None
-        )
+        self._metrics_data: MetricsData = None
 
     def get_metrics_data(
         self,
-    ) -> Optional["opentelemetry.sdk.metrics.export.MetricsData"]:
+    ) -> Optional[MetricsData]:
         """Reads and returns current metrics from the SDK"""
         with self._lock:
             self.collect()
@@ -422,7 +420,7 @@ class InMemoryMetricReader(MetricReader):
 
     def _receive_metrics(
         self,
-        metrics_data: "opentelemetry.sdk.metrics.export.MetricsData",
+        metrics_data: MetricsData,
         timeout_millis: float = 10_000,
         **kwargs,
     ) -> None:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/export/__init__.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 
-from opentelemetry.sdk.metrics._internal.export import (
+from opentelemetry.sdk.metrics._internal.aggregation import (
     AggregationTemporality,
+)
+from opentelemetry.sdk.metrics._internal.export import (
     ConsoleMetricExporter,
     InMemoryMetricReader,
     MetricExporter,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -63,7 +63,7 @@ class SpanExporter:
 
     def export(
         self, spans: typing.Sequence[ReadableSpan]
-    ) -> "SpanExportResult":
+    ) -> "SpanExportResult":  # pyright: ignore[reportReturnType]
         """Exports a batch of telemetry data.
 
         Args:
@@ -79,7 +79,7 @@ class SpanExporter:
         Called when the SDK is shut down.
         """
 
-    def force_flush(self, timeout_millis: int = 30000) -> bool:
+    def force_flush(self, timeout_millis: int = 30000) -> bool:  # pyright: ignore[reportReturnType]
         """Hint to ensure that the export of any spans the exporter has received
         prior to the call to ForceFlush SHOULD be completed as soon as possible, preferably
         before returning from this method.
@@ -102,7 +102,7 @@ class SimpleSpanProcessor(SpanProcessor):
         pass
 
     def on_end(self, span: ReadableSpan) -> None:
-        if not span.context.trace_flags.sampled:
+        if not (span.context and span.context.trace_flags.sampled):
             return
         token = attach(set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
         try:
@@ -188,7 +188,7 @@ class BatchSpanProcessor(SpanProcessor):
         pass
 
     def on_end(self, span: ReadableSpan) -> None:
-        if not span.context.trace_flags.sampled:
+        if not (span.context and span.context.trace_flags.sampled):
             return
         self._batch_processor.emit(span)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,11 +111,8 @@ include = [
 exclude = [
   "opentelemetry-sdk/tests",
   "opentelemetry-sdk/src/opentelemetry/sdk/_events",
-  "opentelemetry-sdk/src/opentelemetry/sdk/error_handler",
-  "opentelemetry-sdk/src/opentelemetry/sdk/metrics",
-  "opentelemetry-sdk/src/opentelemetry/sdk/trace/export",
+  "opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/",
   "opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py",
-  "opentelemetry-sdk/src/opentelemetry/sdk/util",
   "opentelemetry-sdk/benchmarks",
   "exporter/opentelemetry-exporter-otlp-proto-grpc/tests",
 ]


### PR DESCRIPTION
# Description

This fixes errors about unknown type for users using `InMemoryMetricExporter` and `ConsoleMetricExporter`. Also removed a bunch of paths from pyright excludes to expand type checking coverage

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Enabled pyright on this file

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
