### PR TITLE
docs: clarify unit for OTEL_EXPORTER_OTLP_TIMEOUT default

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
@@ -334,8 +334,8 @@ OTEL_EXPORTER_OTLP_TIMEOUT = "OTEL_EXPORTER_OTLP_TIMEOUT"
 """
 .. envvar:: OTEL_EXPORTER_OTLP_TIMEOUT
 
-The :envvar:`OTEL_EXPORTER_OTLP_TIMEOUT` is the maximum time (in seconds) the OTLP exporter will wait for each batch export.
-Default: 10 (seconds)
+The :envvar:`OTEL_EXPORTER_OTLP_TIMEOUT` is the maximum time the OTLP exporter will wait for each batch export.
+Default: 10000
 """
 
 OTEL_EXPORTER_OTLP_ENDPOINT = "OTEL_EXPORTER_OTLP_ENDPOINT"


### PR DESCRIPTION
# Description

Clarify the unit for the documented default value of `OTEL_EXPORTER_OTLP_TIMEOUT` in the SDK environment variables docs.

The current docs show `Default: 10` without stating the unit, which can lead to operators misinterpreting the value (e.g., 10ms vs 10s). This PR updates only the default line to make the unit explicit while keeping the surrounding wording consistent with existing env var docs.

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/4858

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Built the docs locally with Sphinx

Repro steps:

- `python -m pip install -r docs-requirements.txt`
- `cd docs && python -m sphinx -b html -D master_doc=sdk/environment_variables . _build/html_envvars`

# Does This PR Require a Contrib Repo Change?

- [x] Yes. - Link to PR:
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated (not needed for docs-only clarification)
- [ ] Unit tests have been added (not applicable)
- [x] Documentation has been updated
