### PR TITLE
Add CC users for benchmark performance alert comments

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -42,3 +42,4 @@ jobs:
         # Alert with a commit comment on possible performance regression
         alert-threshold: '200%'
         comment-on-alert: true
+        alert-comment-cc-users: "@open-telemetry/python-approvers,@open-telemetry/python-maintainers"


### PR DESCRIPTION
Reference: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#alert-comment-cc-users-optional 