### PR TITLE
Fix AttributeError on Python 3.9 when generating invalid attribute error message

### DIFF
--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -190,7 +190,7 @@ def _clean_extended_attribute_value(  # pylint: disable=too-many-branches
     except Exception:
         raise TypeError(
             f"Invalid type {type(value).__name__} for attribute value. "
-            f"Expected one of {[valid_type.__name__ for valid_type in _VALID_ANY_VALUE_TYPES]} or a "
+            f"Expected one of {[getattr(valid_type, '__name__', getattr(valid_type, '_name', None)) for valid_type in _VALID_ANY_VALUE_TYPES]} or a "
             "sequence of those types",
         )
 

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -320,3 +320,25 @@ class TestBoundedAttributes(unittest.TestCase):
         self.assertEqual(
             "<DummyWSGIRequest method=GET path=/example/>", cleaned_value
         )
+
+    def test_invalid_type_error_message(self):
+        """Test that invalid types that cannot be converted to string raise TypeError with proper message.
+
+        This test specifically addresses issue #4821 where on Python 3.9, the error message
+        generation would fail with AttributeError when accessing __name__ on generic types like Mapping.
+        """
+
+        class UnstringifiableObject:
+            """An object that cannot be converted to string."""
+
+            def __str__(self):
+                raise ValueError("Cannot convert to string")
+
+        invalid_value = UnstringifiableObject()
+
+        # Should return None and log warning, not raise AttributeError
+        cleaned_value = _clean_extended_attribute(
+            "test_key", invalid_value, None
+        )
+
+        self.assertIsNone(cleaned_value)


### PR DESCRIPTION
## Summary

Fixes #4821

On Python 3.9, when an invalid attribute value is passed that cannot be converted to a string, the code raises `AttributeError` instead of the intended `TypeError`. This occurs because the error message generation attempts to access `__name__` on all types in `_VALID_ANY_VALUE_TYPES`, but `typing.Mapping` (and other generic types) don't have a `__name__` attribute in Python 3.9.

## Changes

- Updated `_clean_extended_attribute_value()` in [opentelemetry-api/src/opentelemetry/attributes/__init__.py:193](opentelemetry-api/src/opentelemetry/attributes/__init__.py#L193) to use `getattr(valid_type, '__name__', getattr(valid_type, '_name', None))` for safe attribute access
- Added test case `test_invalid_type_error_message()` to verify that invalid types that cannot be stringified return `None` without raising `AttributeError`

## Implementation

The fix follows the suggestion from @xrmx in the issue discussion, using nested `getattr()` calls to:
1. First try to get `__name__` attribute
2. Fall back to `_name` attribute if `__name__` doesn't exist  
3. Return `None` if neither attribute exists

This ensures that the error message generation works correctly across all Python versions, including Python 3.9 where generic types from `typing` module don't have `__name__`.

## Test plan

- Added test case that creates an object which cannot be converted to string
- This triggers the TypeError path where the error message is generated
- On Python 3.9 with the old code, this would fail with AttributeError
- With the fix, it correctly returns None and logs a warning

The CI tests will run this on Python 3.9-3.14 to verify the fix works across all supported versions.