### PR TITLE
fix: Drop JAEGER related environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `opentelemetry-sdk`: Remove unused Jaeger-related environment variables (`OTEL_EXPORTER_JAEGER_*`) since the Jaeger exporter was removed in 1.22.0
+  ([#4918](https://github.com/open-telemetry/opentelemetry-python/issues/4918))
 - `opentelemetry-sdk`: Clarify timeout units in environment variable documentation
   ([#4906](https://github.com/open-telemetry/opentelemetry-python/pull/4906))
 - `opentelemetry-exporter-otlp-proto-grpc`: Fix re-initialization of gRPC channel on UNAVAILABLE error

--- a/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py
@@ -205,52 +205,6 @@ The :envvar:`OTEL_SPAN_LINK_COUNT_LIMIT` represents the maximum allowed span lin
 Default: 128
 """
 
-OTEL_EXPORTER_JAEGER_AGENT_HOST = "OTEL_EXPORTER_JAEGER_AGENT_HOST"
-"""
-.. envvar:: OTEL_EXPORTER_JAEGER_AGENT_HOST
-
-The :envvar:`OTEL_EXPORTER_JAEGER_AGENT_HOST` represents the hostname for the Jaeger agent.
-Default: "localhost"
-"""
-
-OTEL_EXPORTER_JAEGER_AGENT_PORT = "OTEL_EXPORTER_JAEGER_AGENT_PORT"
-"""
-.. envvar:: OTEL_EXPORTER_JAEGER_AGENT_PORT
-
-The :envvar:`OTEL_EXPORTER_JAEGER_AGENT_PORT` represents the port for the Jaeger agent.
-Default: 6831
-"""
-
-OTEL_EXPORTER_JAEGER_ENDPOINT = "OTEL_EXPORTER_JAEGER_ENDPOINT"
-"""
-.. envvar:: OTEL_EXPORTER_JAEGER_ENDPOINT
-
-The :envvar:`OTEL_EXPORTER_JAEGER_ENDPOINT` represents the HTTP endpoint for Jaeger traces.
-Default: "http://localhost:14250"
-"""
-
-OTEL_EXPORTER_JAEGER_USER = "OTEL_EXPORTER_JAEGER_USER"
-"""
-.. envvar:: OTEL_EXPORTER_JAEGER_USER
-
-The :envvar:`OTEL_EXPORTER_JAEGER_USER` represents the username to be used for HTTP basic authentication.
-"""
-
-OTEL_EXPORTER_JAEGER_PASSWORD = "OTEL_EXPORTER_JAEGER_PASSWORD"
-"""
-.. envvar:: OTEL_EXPORTER_JAEGER_PASSWORD
-
-The :envvar:`OTEL_EXPORTER_JAEGER_PASSWORD` represents the password to be used for HTTP basic authentication.
-"""
-
-OTEL_EXPORTER_JAEGER_TIMEOUT = "OTEL_EXPORTER_JAEGER_TIMEOUT"
-"""
-.. envvar:: OTEL_EXPORTER_JAEGER_TIMEOUT
-
-Maximum time (in seconds) the Jaeger exporter will wait for each batch export.
-Default: 10
-"""
-
 OTEL_EXPORTER_ZIPKIN_ENDPOINT = "OTEL_EXPORTER_ZIPKIN_ENDPOINT"
 """
 .. envvar:: OTEL_EXPORTER_ZIPKIN_ENDPOINT
@@ -731,24 +685,6 @@ wait for each batch export for logs.
 Default: 10
 """
 
-OTEL_EXPORTER_JAEGER_CERTIFICATE = "OTEL_EXPORTER_JAEGER_CERTIFICATE"
-"""
-.. envvar:: OTEL_EXPORTER_JAEGER_CERTIFICATE
-
-The :envvar:`OTEL_EXPORTER_JAEGER_CERTIFICATE` stores the path to the certificate file for
-TLS credentials of gRPC client for Jaeger. Should only be used for a secure connection with Jaeger.
-"""
-
-OTEL_EXPORTER_JAEGER_AGENT_SPLIT_OVERSIZED_BATCHES = (
-    "OTEL_EXPORTER_JAEGER_AGENT_SPLIT_OVERSIZED_BATCHES"
-)
-"""
-.. envvar:: OTEL_EXPORTER_JAEGER_AGENT_SPLIT_OVERSIZED_BATCHES
-
-The :envvar:`OTEL_EXPORTER_JAEGER_AGENT_SPLIT_OVERSIZED_BATCHES` is a boolean flag to determine whether
-to split a large span batch to admire the udp packet size limit.
-"""
-
 OTEL_SERVICE_NAME = "OTEL_SERVICE_NAME"
 """
 .. envvar:: OTEL_SERVICE_NAME
@@ -796,13 +732,6 @@ on the basis of instrument kind. The valid (case-insensitive) values are:
 Use ``CUMULATIVE`` aggregation temporality for ``UpDownCounter`` and ``Asynchronous UpDownCounter``.
 ``LOWMEMORY``: Use ``DELTA`` aggregation temporality for ``Counter`` and ``Histogram``.
 Use ``CUMULATIVE`` aggregation temporality for ``UpDownCounter``, ``AsynchronousCounter`` and ``Asynchronous UpDownCounter``.
-"""
-
-OTEL_EXPORTER_JAEGER_GRPC_INSECURE = "OTEL_EXPORTER_JAEGER_GRPC_INSECURE"
-"""
-.. envvar:: OTEL_EXPORTER_JAEGER_GRPC_INSECURE
-
-The :envvar:`OTEL_EXPORTER_JAEGER_GRPC_INSECURE` is a boolean flag to True if collector has no encryption or authentication.
 """
 
 OTEL_METRIC_EXPORT_INTERVAL = "OTEL_METRIC_EXPORT_INTERVAL"


### PR DESCRIPTION
## Summary

Addresses #4918.

Done. Here's a summary of what was changed and why:

## Summary

**Issue:** OTEL_EXPORTER_JAEGER_* environment variables were still defined in the SDK despite the Jaeger exporter being removed in v1.22.0 (December 2023).

**Changes made:**

1. **`opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py`** — Removed 9 unused Jaeger environment variable definitions (71 lines total):
   - `OTEL_EXPORTER_JAEGER_AGENT_HOST`
   - `OTEL_EXPORTER_JAEGER_AGENT_PORT`
   - `OTEL_EXPORTER_J

## Changes

```
1a57191 fix: drop unused Jaeger-related environment variables (#4918)
 CHANGELOG.md                                       |  2 +
 .../sdk/environment_variables/__init__.py          | 71 ----------------------
 2 files changed, 2 insertions(+), 71 deletions(-)

```
