### PR TITLE
ci: automatically add new PRs to OTel project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,10 +1,6 @@
 name: Add to project
 
 on:
-  issues:
-    types:
-      - opened
-      - transferred
   pull_request_target:
     # SECURITY NOTE: pull_request_target runs in the base repo context and has access to
     # secrets, even for PRs from forks. This is intentional — pull_request does NOT have
@@ -17,6 +13,7 @@ on:
     # reassessing the security implications.
     types:
       - opened
+      - ready_for_review
 
 permissions:
   contents: read
@@ -24,6 +21,8 @@ permissions:
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
+    # Skip draft PRs; ready_for_review will trigger when they are published
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: otelbot-token


### PR DESCRIPTION
## Description

Adds a GHA workflow that automatically adds non-draft PRs to the [shared OTel Python project board](https://github.com/orgs/open-telemetry/projects/88) when opened or when a draft is marked ready for review.

Uses the existing `otelbot` GitHub App (already used for backport automation) with the official `actions/add-to-project` action.

**Scope:** PRs only (not issues). Adding issues automatically would increase noise given the current high PR count. This can be revisited once the stale/close cadence has settled (~14–28 days).

**Draft PRs:** Draft PRs are excluded. When a draft is converted to ready for review, the `ready_for_review` event triggers and adds it to the board at that point.

## Security: `pull_request_target` trigger

This workflow uses `pull_request_target` rather than `pull_request`. This is an intentional choice with security implications that reviewers should be aware of:

**Why `pull_request_target`:** The `pull_request` trigger does not have access to repository secrets when the PR originates from a fork. Since the workflow needs to authenticate as otelbot to call the GitHub Projects API, it requires secrets — hence `pull_request_target`.

**The risk:** `pull_request_target` runs in the base repository context and has access to secrets, even for PRs from forks.

**The mitigation:** This workflow contains **no `actions/checkout` step**. It never executes any code from the fork — it only uses the event payload (a PR node ID) to make a single GitHub API call. The comments in the workflow file explicitly warn future maintainers not to add a checkout step without reassessing security.

This is the standard recommended pattern for project automation bots (labelers, project boards, etc.) in GitHub's own documentation.

## Prerequisites for org admins

Before this workflow will function after merge, an org admin must grant otelbot the Projects permission (if not already done):

- [ ] Org admin grants otelbot **"Projects: read/write"** permission at https://github.com/organizations/open-telemetry/settings/apps/otelbot

Assisted-by: Claude Sonnet 4.6