### PR TITLE
ci: increase stale action operations-per-run to 500

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,4 +33,5 @@ jobs:
             This PR has been closed due to inactivity. Please reopen if you would
             like to continue working on it.
           exempt-pr-labels: "hold,WIP,blocked by spec,do not merge"
+          # TODO: Revert back to default of 30 after we have cleared the backlog of stale PRs.
           operations-per-run: 500


### PR DESCRIPTION
## Summary

The stale action defaults to 30 operations per run. With ~88 open PRs many of which qualify as stale, at 30/day it would take several days to catch up. This increases the limit to 500 so it processes all qualifying PRs in a single run.

Assisted-by: Claude Sonnet 4.6