### PR TITLE
fix: map CRITICAL severity text to FATAL per OTel spec

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -595,7 +595,9 @@ class LoggingHandler(logging.Handler):
         # related to https://github.com/open-telemetry/opentelemetry-python/issues/3548
         # Severity Text = WARN as defined in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#displaying-severity.
         level_name = (
-            "WARN" if record.levelname == "WARNING" else record.levelname
+            "WARN" if record.levelname == "WARNING" else
+            "FATAL" if record.levelname == "CRITICAL" else
+            record.levelname
         )
 
         return LogRecord(


### PR DESCRIPTION
## Summary
Fixes #4984.
**Root cause:** Python's `CRITICAL` log level was mapped to severity text `CRITICAL` instead of `FATAL` as specified in the [OpenTelemetry Logs Data Model specification](https://opentelemetry.io/docs/specs/otel/logs/data-model/#severity-fields).
**Fix:** Updated the severity text mapping so `CRITICAL` maps to `FATAL`.
## Changes
- Updated severity text mapping for CRITICAL level
## Testing
- Verified fix aligns with OTel specification
- Similar to #3548 which fixed WARN mapping