### PR TITLE
fix(sdk): regenerate service.instance.id post-fork in MeterProvider and TracerProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `opentelemetry-sdk`: Add `service.instance.id` to default resource so every process gets a unique instance identity at startup
+  ([#5000](https://github.com/open-telemetry/opentelemetry-python/pull/5000))
+- `opentelemetry-sdk`: Regenerate `service.instance.id` post-fork in `MeterProvider` and `TracerProvider` to ensure distinct resource identities across prefork workers
+  ([#5000](https://github.com/open-telemetry/opentelemetry-python/pull/5000))
 - `opentelemetry-sdk`: Add file configuration support with YAML/JSON loading, environment variable substitution, and schema validation against the vendored OTel config JSON schema
   ([#4898](https://github.com/open-telemetry/opentelemetry-python/pull/4898))
 - Fix intermittent CI failures in `getting-started` and `tracecontext` jobs caused by GitHub git CDN SHA propagation lag by installing contrib packages from the already-checked-out local copy instead of a second git clone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-sdk`: Add `service.instance.id` to default resource so every process gets a unique instance identity at startup
   ([#5000](https://github.com/open-telemetry/opentelemetry-python/pull/5000))
-- `opentelemetry-sdk`: Regenerate `service.instance.id` post-fork in `MeterProvider` and `TracerProvider` to ensure distinct resource identities across prefork workers
+- `opentelemetry-sdk`: Regenerate a single shared `service.instance.id` post-fork, applied to every registered `MeterProvider` and `TracerProvider` (including providers created after the fork), so prefork workers get distinct but cross-signal-consistent resource identities
   ([#5000](https://github.com/open-telemetry/opentelemetry-python/pull/5000))
 - `opentelemetry-sdk`: Add file configuration support with YAML/JSON loading, environment variable substitution, and schema validation against the vendored OTel config JSON schema
   ([#4898](https://github.com/open-telemetry/opentelemetry-python/pull/4898))

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/_fork.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/_fork.py
@@ -1,0 +1,98 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared post-fork handling of ``service.instance.id`` for SDK providers.
+
+When a prefork server (gunicorn, uWSGI, ...) forks worker processes, every
+worker inherits the same :class:`~opentelemetry.sdk.resources.Resource` -
+including the same ``service.instance.id`` - from the master process. Exporting
+telemetry from several workers under one identity collides in the backend
+(last-write-wins instead of correct aggregation).
+
+This module owns a *single* :func:`os.register_at_fork` hook and a registry of
+providers. After a fork, **one** fresh ``service.instance.id`` is generated and
+applied to *every* registered provider, so all signals (metrics and traces) in
+a given worker share the same, unique instance id. Providers created *after* the
+fork adopt the same id at construction time via :func:`register_provider`.
+"""
+
+from __future__ import annotations
+
+import os
+import weakref
+from threading import Lock
+from typing import Optional, Protocol, runtime_checkable
+from uuid import uuid4
+
+from opentelemetry.sdk.resources import SERVICE_INSTANCE_ID, Resource
+
+
+@runtime_checkable
+class _ForkAwareProvider(Protocol):
+    def _reset_service_instance_id(self, service_instance_id: str) -> None: ...
+
+
+_lock = Lock()
+# WeakSet so providers that go out of scope are dropped automatically, matching
+# the WeakMethod/WeakSet pattern used elsewhere in the SDK for fork hooks.
+_providers: "weakref.WeakSet[_ForkAwareProvider]" = weakref.WeakSet()
+# The instance id for the current process generation. ``None`` until the first
+# fork, so providers in a never-forked process keep the id already present in
+# their resource (the one from the default resource detector).
+_service_instance_id: Optional[str] = None
+
+
+def reset_service_instance_id(resource: Resource, service_instance_id: str) -> Resource:
+    """Return ``resource`` with ``service.instance.id`` replaced.
+
+    All other resource attributes are preserved via :meth:`Resource.merge`.
+    """
+    return resource.merge(Resource({SERVICE_INSTANCE_ID: service_instance_id}))
+
+
+def register_provider(provider: _ForkAwareProvider) -> None:
+    """Register ``provider`` so it is refreshed on the next fork.
+
+    If the current process is already a forked child (i.e. a fork happened
+    before this provider was created), the provider immediately adopts the
+    child's shared instance id so late-created providers stay consistent with
+    the ones that existed at fork time.
+    """
+    with _lock:
+        _providers.add(provider)
+        service_instance_id = _service_instance_id
+    if service_instance_id is not None:
+        provider._reset_service_instance_id(service_instance_id)
+
+
+def _after_in_child() -> None:
+    # ``_lock`` is held across the fork (acquired in ``before``), so we own
+    # exclusive access to the registry here and release it once done.
+    global _service_instance_id  # noqa: PLW0603
+    service_instance_id = str(uuid4())
+    _service_instance_id = service_instance_id
+    providers = list(_providers)
+    _lock.release()
+    for provider in providers:
+        provider._reset_service_instance_id(service_instance_id)
+
+
+if hasattr(os, "register_at_fork"):
+    # Acquiring ``_lock`` in ``before`` guarantees no other thread holds it
+    # while we fork, avoiding a deadlock in the single-threaded child.
+    os.register_at_fork(
+        before=_lock.acquire,
+        after_in_parent=_lock.release,
+        after_in_child=_after_in_child,
+    )

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import weakref
 from atexit import register, unregister
 from logging import getLogger
@@ -19,6 +20,7 @@ from os import environ
 from threading import Lock
 from time import time_ns
 from typing import Optional, Sequence
+from uuid import uuid4
 
 # This kind of import is needed to avoid Sphinx errors.
 import opentelemetry.sdk.metrics
@@ -456,6 +458,12 @@ class MeterProvider(APIMeterProvider):
         self._shutdown_once = Once()
         self._shutdown = False
 
+        if hasattr(os, "register_at_fork"):
+            weak_reinit = weakref.WeakMethod(self._at_fork_reinit)
+            os.register_at_fork(
+                after_in_child=lambda: weak_reinit()()  # pylint: disable=unnecessary-lambda
+            )
+
         for metric_reader in self._sdk_config.metric_readers:
             with self._all_metric_readers_lock:
                 if metric_reader in self._all_metric_readers:
@@ -470,6 +478,22 @@ class MeterProvider(APIMeterProvider):
             metric_reader._set_collect_callback(
                 self._measurement_consumer.collect
             )
+
+    def _at_fork_reinit(self) -> None:
+        """Update the resource with a new unique service.instance.id after a fork.
+
+        When gunicorn (or any other prefork server) forks workers, all workers
+        inherit the same Resource, including the same service.instance.id. This
+        causes metric collisions in backends like Datadog where multiple workers
+        exporting with the same resource identity result in last-write-wins
+        instead of correct aggregation.
+
+        This hook runs post-fork in each worker and replaces service.instance.id
+        with a fresh UUID, ensuring each worker is a distinct instance.
+        """
+        self._sdk_config.resource = self._sdk_config.resource.merge(
+            Resource({"service.instance.id": str(uuid4())})
+        )
 
     def force_flush(self, timeout_millis: float = 10_000) -> bool:
         deadline_ns = time_ns() + timeout_millis * 10**6

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import weakref
 from atexit import register, unregister
 from logging import getLogger
@@ -20,7 +19,6 @@ from os import environ
 from threading import Lock
 from time import time_ns
 from typing import Optional, Sequence
-from uuid import uuid4
 
 # This kind of import is needed to avoid Sphinx errors.
 import opentelemetry.sdk.metrics
@@ -36,6 +34,7 @@ from opentelemetry.metrics import (
 )
 from opentelemetry.metrics import UpDownCounter as APIUpDownCounter
 from opentelemetry.metrics import _Gauge as APIGauge
+from opentelemetry.sdk._shared_internal import _fork
 from opentelemetry.sdk.environment_variables import (
     OTEL_METRICS_EXEMPLAR_FILTER,
     OTEL_SDK_DISABLED,
@@ -458,11 +457,10 @@ class MeterProvider(APIMeterProvider):
         self._shutdown_once = Once()
         self._shutdown = False
 
-        if hasattr(os, "register_at_fork"):
-            weak_reinit = weakref.WeakMethod(self._at_fork_reinit)
-            os.register_at_fork(
-                after_in_child=lambda: weak_reinit()()  # pylint: disable=unnecessary-lambda
-            )
+        # Register with the shared fork hook so every provider in a forked
+        # worker gets the same fresh service.instance.id (see
+        # opentelemetry.sdk._shared_internal._fork).
+        _fork.register_provider(self)
 
         for metric_reader in self._sdk_config.metric_readers:
             with self._all_metric_readers_lock:
@@ -479,20 +477,17 @@ class MeterProvider(APIMeterProvider):
                 self._measurement_consumer.collect
             )
 
-    def _at_fork_reinit(self) -> None:
-        """Update the resource with a new unique service.instance.id after a fork.
+    def _reset_service_instance_id(self, service_instance_id: str) -> None:
+        """Apply a post-fork ``service.instance.id`` shared across providers.
 
-        When gunicorn (or any other prefork server) forks workers, all workers
-        inherit the same Resource, including the same service.instance.id. This
-        causes metric collisions in backends like Datadog where multiple workers
-        exporting with the same resource identity result in last-write-wins
-        instead of correct aggregation.
-
-        This hook runs post-fork in each worker and replaces service.instance.id
-        with a fresh UUID, ensuring each worker is a distinct instance.
+        Called by the shared fork hook (see
+        ``opentelemetry.sdk._shared_internal._fork``) in each forked worker so
+        that metrics and traces report the same, unique instance id without
+        colliding with sibling workers. All other resource attributes are
+        preserved.
         """
-        self._sdk_config.resource = self._sdk_config.resource.merge(
-            Resource({"service.instance.id": str(uuid4())})
+        self._sdk_config.resource = _fork.reset_service_instance_id(
+            self._sdk_config.resource, service_instance_id
         )
 
     def force_flush(self, timeout_millis: float = 10_000) -> bool:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -72,6 +72,7 @@ from os import environ
 from types import ModuleType
 from typing import List, Optional, Set, cast
 from urllib import parse
+from uuid import uuid4
 
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk.environment_variables import (
@@ -323,6 +324,7 @@ _DEFAULT_RESOURCE = Resource(
         TELEMETRY_SDK_LANGUAGE: "python",
         TELEMETRY_SDK_NAME: "opentelemetry",
         TELEMETRY_SDK_VERSION: _OPENTELEMETRY_SDK_VERSION,
+        SERVICE_INSTANCE_ID: str(uuid4()),
     }
 )
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -42,6 +42,7 @@ from typing import (
     Type,
     Union,
 )
+from uuid import uuid4
 from warnings import filterwarnings
 
 from typing_extensions import deprecated
@@ -1364,6 +1365,28 @@ class TracerProvider(trace_api.TracerProvider):
 
         self._tracer_configurator = (
             _tracer_configurator or _default_tracer_configurator
+        )
+
+        if hasattr(os, "register_at_fork"):
+            weak_reinit = weakref.WeakMethod(self._at_fork_reinit)
+            os.register_at_fork(
+                after_in_child=lambda: weak_reinit()()  # pylint: disable=unnecessary-lambda
+            )
+
+    def _at_fork_reinit(self) -> None:
+        """Update the resource with a new unique service.instance.id after a fork.
+
+        When gunicorn (or any other prefork server) forks workers, all workers
+        inherit the same Resource, including the same service.instance.id. This
+        causes metric collisions in backends like Datadog where multiple workers
+        exporting with the same resource identity result in last-write-wins
+        instead of correct aggregation.
+
+        This hook runs post-fork in each worker and replaces service.instance.id
+        with a fresh UUID, ensuring each worker is a distinct instance.
+        """
+        self._resource = self._resource.merge(
+            Resource({"service.instance.id": str(uuid4())})
         )
 
     def _set_tracer_configurator(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -42,7 +42,6 @@ from typing import (
     Type,
     Union,
 )
-from uuid import uuid4
 from warnings import filterwarnings
 
 from typing_extensions import deprecated
@@ -52,6 +51,7 @@ from opentelemetry import metrics as metrics_api
 from opentelemetry import trace as trace_api
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk import util
+from opentelemetry.sdk._shared_internal import _fork
 from opentelemetry.sdk.environment_variables import (
     OTEL_ATTRIBUTE_COUNT_LIMIT,
     OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT,
@@ -1367,26 +1367,22 @@ class TracerProvider(trace_api.TracerProvider):
             _tracer_configurator or _default_tracer_configurator
         )
 
-        if hasattr(os, "register_at_fork"):
-            weak_reinit = weakref.WeakMethod(self._at_fork_reinit)
-            os.register_at_fork(
-                after_in_child=lambda: weak_reinit()()  # pylint: disable=unnecessary-lambda
-            )
+        # Register with the shared fork hook so every provider in a forked
+        # worker gets the same fresh service.instance.id (see
+        # opentelemetry.sdk._shared_internal._fork).
+        _fork.register_provider(self)
 
-    def _at_fork_reinit(self) -> None:
-        """Update the resource with a new unique service.instance.id after a fork.
+    def _reset_service_instance_id(self, service_instance_id: str) -> None:
+        """Apply a post-fork ``service.instance.id`` shared across providers.
 
-        When gunicorn (or any other prefork server) forks workers, all workers
-        inherit the same Resource, including the same service.instance.id. This
-        causes metric collisions in backends like Datadog where multiple workers
-        exporting with the same resource identity result in last-write-wins
-        instead of correct aggregation.
-
-        This hook runs post-fork in each worker and replaces service.instance.id
-        with a fresh UUID, ensuring each worker is a distinct instance.
+        Called by the shared fork hook (see
+        ``opentelemetry.sdk._shared_internal._fork``) in each forked worker so
+        that metrics and traces report the same, unique instance id without
+        colliding with sibling workers. All other resource attributes are
+        preserved.
         """
-        self._resource = self._resource.merge(
-            Resource({"service.instance.id": str(uuid4())})
+        self._resource = _fork.reset_service_instance_id(
+            self._resource, service_instance_id
         )
 
     def _set_tracer_configurator(

--- a/opentelemetry-sdk/tests/metrics/test_meter_provider_fork.py
+++ b/opentelemetry-sdk/tests/metrics/test_meter_provider_fork.py
@@ -1,0 +1,125 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=protected-access
+
+import multiprocessing
+import os
+import unittest
+from platform import system
+
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.resources import Resource
+
+_fork_ctx = (
+    multiprocessing.get_context("fork") if system() != "Windows" else None
+)
+
+
+@unittest.skipUnless(
+    hasattr(os, "fork"),
+    "needs *nix",
+)
+class TestMeterProviderFork(unittest.TestCase):
+    def test_at_fork_reinit_changes_service_instance_id(self):
+        """_at_fork_reinit should assign a new service.instance.id."""
+        resource = Resource({"service.instance.id": "original-id"})
+        provider = MeterProvider(resource=resource)
+
+        original_id = provider._sdk_config.resource.attributes.get(
+            "service.instance.id"
+        )
+        self.assertEqual(original_id, "original-id")
+
+        provider._at_fork_reinit()
+
+        new_id = provider._sdk_config.resource.attributes.get(
+            "service.instance.id"
+        )
+        self.assertNotEqual(new_id, "original-id")
+        self.assertIsNotNone(new_id)
+
+    def test_at_fork_reinit_preserves_other_resource_attributes(self):
+        """_at_fork_reinit should not affect other resource attributes."""
+        resource = Resource(
+            {
+                "service.name": "my-service",
+                "service.instance.id": "original-id",
+                "deployment.environment": "production",
+            }
+        )
+        provider = MeterProvider(resource=resource)
+
+        provider._at_fork_reinit()
+
+        attrs = provider._sdk_config.resource.attributes
+        self.assertEqual(attrs.get("service.name"), "my-service")
+        self.assertEqual(attrs.get("deployment.environment"), "production")
+
+    def test_fork_produces_unique_service_instance_ids(self):
+        """Each forked worker should get a distinct service.instance.id."""
+        provider = MeterProvider()
+
+        parent_id = provider._sdk_config.resource.attributes.get(
+            "service.instance.id"
+        )
+        self.assertIsNotNone(parent_id)
+
+        def child(conn):
+            child_id = provider._sdk_config.resource.attributes.get(
+                "service.instance.id"
+            )
+            conn.send(child_id)
+            conn.close()
+
+        parent_conn, child_conn = _fork_ctx.Pipe()
+        process = _fork_ctx.Process(target=child, args=(child_conn,))
+        process.start()
+        child_id = parent_conn.recv()
+        process.join()
+
+        # Child should have a different service.instance.id than parent
+        self.assertNotEqual(parent_id, child_id)
+        self.assertIsNotNone(child_id)
+
+    def test_multiple_forks_produce_unique_service_instance_ids(self):
+        """Each of N forked workers should have a distinct service.instance.id."""
+        provider = MeterProvider()
+
+        def child(conn):
+            child_id = provider._sdk_config.resource.attributes.get(
+                "service.instance.id"
+            )
+            conn.send(child_id)
+            conn.close()
+
+        ids = set()
+        processes = []
+        conns = []
+
+        for _ in range(4):
+            parent_conn, child_conn = _fork_ctx.Pipe()
+            process = _fork_ctx.Process(target=child, args=(child_conn,))
+            processes.append(process)
+            conns.append(parent_conn)
+            process.start()
+
+        for conn in conns:
+            ids.add(conn.recv())
+
+        for process in processes:
+            process.join()
+
+        # All 4 workers should have distinct IDs
+        self.assertEqual(len(ids), 4)

--- a/opentelemetry-sdk/tests/metrics/test_meter_provider_fork.py
+++ b/opentelemetry-sdk/tests/metrics/test_meter_provider_fork.py
@@ -32,8 +32,8 @@ _fork_ctx = (
     "needs *nix",
 )
 class TestMeterProviderFork(unittest.TestCase):
-    def test_at_fork_reinit_changes_service_instance_id(self):
-        """_at_fork_reinit should assign a new service.instance.id."""
+    def test_reset_service_instance_id_changes_service_instance_id(self):
+        """_reset_service_instance_id should assign the given service.instance.id."""
         resource = Resource({"service.instance.id": "original-id"})
         provider = MeterProvider(resource=resource)
 
@@ -42,16 +42,17 @@ class TestMeterProviderFork(unittest.TestCase):
         )
         self.assertEqual(original_id, "original-id")
 
-        provider._at_fork_reinit()
+        provider._reset_service_instance_id("new-id")
 
         new_id = provider._sdk_config.resource.attributes.get(
             "service.instance.id"
         )
-        self.assertNotEqual(new_id, "original-id")
-        self.assertIsNotNone(new_id)
+        self.assertEqual(new_id, "new-id")
 
-    def test_at_fork_reinit_preserves_other_resource_attributes(self):
-        """_at_fork_reinit should not affect other resource attributes."""
+    def test_reset_service_instance_id_preserves_other_resource_attributes(
+        self,
+    ):
+        """_reset_service_instance_id should not affect other resource attributes."""
         resource = Resource(
             {
                 "service.name": "my-service",
@@ -61,7 +62,7 @@ class TestMeterProviderFork(unittest.TestCase):
         )
         provider = MeterProvider(resource=resource)
 
-        provider._at_fork_reinit()
+        provider._reset_service_instance_id("new-id")
 
         attrs = provider._sdk_config.resource.attributes
         self.assertEqual(attrs.get("service.name"), "my-service")

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -45,6 +45,7 @@ from opentelemetry.sdk.resources import (
     PROCESS_RUNTIME_DESCRIPTION,
     PROCESS_RUNTIME_NAME,
     PROCESS_RUNTIME_VERSION,
+    SERVICE_INSTANCE_ID,
     SERVICE_NAME,
     TELEMETRY_SDK_LANGUAGE,
     TELEMETRY_SDK_NAME,
@@ -88,6 +89,9 @@ class TestResources(unittest.TestCase):
             TELEMETRY_SDK_LANGUAGE: "python",
             TELEMETRY_SDK_VERSION: _OPENTELEMETRY_SDK_VERSION,
             SERVICE_NAME: "unknown_service",
+            SERVICE_INSTANCE_ID: _DEFAULT_RESOURCE.attributes[
+                SERVICE_INSTANCE_ID
+            ],
         }
 
         resource = Resource.create(attributes)
@@ -211,6 +215,9 @@ class TestResources(unittest.TestCase):
             TELEMETRY_SDK_LANGUAGE: "python",
             TELEMETRY_SDK_VERSION: _OPENTELEMETRY_SDK_VERSION,
             SERVICE_NAME: "unknown_service",
+            SERVICE_INSTANCE_ID: _DEFAULT_RESOURCE.attributes[
+                SERVICE_INSTANCE_ID
+            ],
         }
 
         attributes_copy = attributes.copy()

--- a/opentelemetry-sdk/tests/test_fork_service_instance_id.py
+++ b/opentelemetry-sdk/tests/test_fork_service_instance_id.py
@@ -1,0 +1,93 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=protected-access
+
+import multiprocessing
+import os
+import unittest
+from platform import system
+
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.resources import SERVICE_INSTANCE_ID
+from opentelemetry.sdk.trace import TracerProvider
+
+_fork_ctx = (
+    multiprocessing.get_context("fork") if system() != "Windows" else None
+)
+
+
+def _instance_id(provider):
+    resource = (
+        provider._sdk_config.resource
+        if isinstance(provider, MeterProvider)
+        else provider._resource
+    )
+    return resource.attributes.get(SERVICE_INSTANCE_ID)
+
+
+@unittest.skipUnless(hasattr(os, "fork"), "needs *nix")
+class TestForkServiceInstanceId(unittest.TestCase):
+    def test_meter_and_tracer_share_instance_id_after_fork(self):
+        """Both providers must report the SAME, fresh id in a forked worker."""
+        meter_provider = MeterProvider()
+        tracer_provider = TracerProvider()
+
+        parent_id = _instance_id(meter_provider)
+        # Before forking, both providers already share the default id.
+        self.assertEqual(parent_id, _instance_id(tracer_provider))
+
+        def child(conn):
+            conn.send(
+                (
+                    _instance_id(meter_provider),
+                    _instance_id(tracer_provider),
+                )
+            )
+            conn.close()
+
+        parent_conn, child_conn = _fork_ctx.Pipe()
+        process = _fork_ctx.Process(target=child, args=(child_conn,))
+        process.start()
+        child_meter_id, child_tracer_id = parent_conn.recv()
+        process.join()
+
+        # Same id across signals, unique at the instance level.
+        self.assertEqual(child_meter_id, child_tracer_id)
+        self.assertNotEqual(child_meter_id, parent_id)
+
+    def test_provider_created_after_fork_adopts_child_id(self):
+        """A provider built post-fork must adopt the child's shared id."""
+        meter_provider = MeterProvider()
+        parent_id = _instance_id(meter_provider)
+
+        def child(conn):
+            # Created only in the child, after the fork hook has run.
+            late_tracer_provider = TracerProvider()
+            conn.send(
+                (
+                    _instance_id(meter_provider),
+                    _instance_id(late_tracer_provider),
+                )
+            )
+            conn.close()
+
+        parent_conn, child_conn = _fork_ctx.Pipe()
+        process = _fork_ctx.Process(target=child, args=(child_conn,))
+        process.start()
+        forked_meter_id, late_tracer_id = parent_conn.recv()
+        process.join()
+
+        self.assertEqual(forked_meter_id, late_tracer_id)
+        self.assertNotEqual(late_tracer_id, parent_id)

--- a/opentelemetry-sdk/tests/trace/test_tracer_provider_fork.py
+++ b/opentelemetry-sdk/tests/trace/test_tracer_provider_fork.py
@@ -1,0 +1,113 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=protected-access
+
+import multiprocessing
+import os
+import unittest
+from platform import system
+
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+
+_fork_ctx = (
+    multiprocessing.get_context("fork") if system() != "Windows" else None
+)
+
+
+@unittest.skipUnless(
+    hasattr(os, "fork"),
+    "needs *nix",
+)
+class TestTracerProviderFork(unittest.TestCase):
+    def test_at_fork_reinit_changes_service_instance_id(self):
+        """_at_fork_reinit should assign a new service.instance.id."""
+        resource = Resource({"service.instance.id": "original-id"})
+        provider = TracerProvider(resource=resource)
+
+        original_id = provider._resource.attributes.get("service.instance.id")
+        self.assertEqual(original_id, "original-id")
+
+        provider._at_fork_reinit()
+
+        new_id = provider._resource.attributes.get("service.instance.id")
+        self.assertNotEqual(new_id, "original-id")
+        self.assertIsNotNone(new_id)
+
+    def test_at_fork_reinit_preserves_other_resource_attributes(self):
+        """_at_fork_reinit should not affect other resource attributes."""
+        resource = Resource(
+            {
+                "service.name": "my-service",
+                "service.instance.id": "original-id",
+                "deployment.environment": "production",
+            }
+        )
+        provider = TracerProvider(resource=resource)
+
+        provider._at_fork_reinit()
+
+        attrs = provider._resource.attributes
+        self.assertEqual(attrs.get("service.name"), "my-service")
+        self.assertEqual(attrs.get("deployment.environment"), "production")
+
+    def test_fork_produces_unique_service_instance_ids(self):
+        """Each forked worker should get a distinct service.instance.id."""
+        provider = TracerProvider()
+
+        parent_id = provider._resource.attributes.get("service.instance.id")
+        self.assertIsNotNone(parent_id)
+
+        def child(conn):
+            child_id = provider._resource.attributes.get("service.instance.id")
+            conn.send(child_id)
+            conn.close()
+
+        parent_conn, child_conn = _fork_ctx.Pipe()
+        process = _fork_ctx.Process(target=child, args=(child_conn,))
+        process.start()
+        child_id = parent_conn.recv()
+        process.join()
+
+        self.assertNotEqual(parent_id, child_id)
+        self.assertIsNotNone(child_id)
+
+    def test_multiple_forks_produce_unique_service_instance_ids(self):
+        """Each of N forked workers should have a distinct service.instance.id."""
+        provider = TracerProvider()
+
+        def child(conn):
+            child_id = provider._resource.attributes.get("service.instance.id")
+            conn.send(child_id)
+            conn.close()
+
+        ids = set()
+        processes = []
+        conns = []
+
+        for _ in range(4):
+            parent_conn, child_conn = _fork_ctx.Pipe()
+            process = _fork_ctx.Process(target=child, args=(child_conn,))
+            processes.append(process)
+            conns.append(parent_conn)
+            process.start()
+
+        for conn in conns:
+            ids.add(conn.recv())
+
+        for process in processes:
+            process.join()
+
+        self.assertEqual(len(ids), 4)

--- a/opentelemetry-sdk/tests/trace/test_tracer_provider_fork.py
+++ b/opentelemetry-sdk/tests/trace/test_tracer_provider_fork.py
@@ -32,22 +32,23 @@ _fork_ctx = (
     "needs *nix",
 )
 class TestTracerProviderFork(unittest.TestCase):
-    def test_at_fork_reinit_changes_service_instance_id(self):
-        """_at_fork_reinit should assign a new service.instance.id."""
+    def test_reset_service_instance_id_changes_service_instance_id(self):
+        """_reset_service_instance_id should assign the given service.instance.id."""
         resource = Resource({"service.instance.id": "original-id"})
         provider = TracerProvider(resource=resource)
 
         original_id = provider._resource.attributes.get("service.instance.id")
         self.assertEqual(original_id, "original-id")
 
-        provider._at_fork_reinit()
+        provider._reset_service_instance_id("new-id")
 
         new_id = provider._resource.attributes.get("service.instance.id")
-        self.assertNotEqual(new_id, "original-id")
-        self.assertIsNotNone(new_id)
+        self.assertEqual(new_id, "new-id")
 
-    def test_at_fork_reinit_preserves_other_resource_attributes(self):
-        """_at_fork_reinit should not affect other resource attributes."""
+    def test_reset_service_instance_id_preserves_other_resource_attributes(
+        self,
+    ):
+        """_reset_service_instance_id should not affect other resource attributes."""
         resource = Resource(
             {
                 "service.name": "my-service",
@@ -57,7 +58,7 @@ class TestTracerProviderFork(unittest.TestCase):
         )
         provider = TracerProvider(resource=resource)
 
-        provider._at_fork_reinit()
+        provider._reset_service_instance_id("new-id")
 
         attrs = provider._resource.attributes
         self.assertEqual(attrs.get("service.name"), "my-service")


### PR DESCRIPTION
# Description

When a prefork server (e.g. gunicorn) forks workers, all workers inherit the same `Resource` from the master process — including the same `service.instance.id`. The SDK already restarts background threads post-fork (`PeriodicExportingMetricReader`, `BatchSpanProcessor`) but never updates the resource identity. This causes metric and trace collisions in OTLP backends where multiple workers exporting with the same resource identity result in incorrect aggregation (last-write-wins) instead of correct summation.

This PR registers an `os.register_at_fork(after_in_child=...)` hook on both `MeterProvider` and `TracerProvider` that replaces `service.instance.id` with a fresh UUID in each forked worker. All other resource attributes are preserved via `Resource.merge()`. `WeakMethod` is used for the hook reference, consistent with the existing pattern in `PeriodicExportingMetricReader` and `BatchSpanProcessor`.


Fixes #4390 
Related: https://github.com/open-telemetry/opentelemetry-python/issues/3885

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Two new test files covering both providers:

* `tests/metrics/test_meter_provider_fork.py`
* `tests/trace/test_tracer_provider_fork.py`

Each covers:
`_at_fork_reinit` assigns a new `service.instance.id`
Other resource attributes are preserved

A real fork() produces a distinct ID in the child vs the parent
4 concurrent forks each produce a unique ID

Run with:
`pytest opentelemetry-sdk/tests/metrics/test_meter_provider_fork.py`
`pytest opentelemetry-sdk/tests/trace/test_tracer_provider_fork.py`

- [x] Unit tests (fork-based, *nix only)


# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
