### PR TITLE
attributes: fix AttributeError on Python 3.9 with typing generics

### DIFF
--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -24,6 +24,19 @@ from opentelemetry.util import types
 # bytes are accepted as a user supplied value for attributes but
 # decoded to strings internally.
 _VALID_ATTR_VALUE_TYPES = (bool, str, bytes, int, float)
+
+
+def _type_name(t: type) -> str:
+    """Return a human-readable name for a type.
+
+    ``typing`` generics (e.g. ``Mapping``, ``Sequence``) do not expose
+    ``__name__`` on Python 3.9, only ``_name``.  Falling back to
+    ``repr`` ensures we always produce a readable string regardless of
+    the Python version or the origin of the type.
+    """
+    return getattr(t, "__name__", None) or getattr(t, "_name", None) or repr(t)
+
+
 # AnyValue possible values
 _VALID_ANY_VALUE_TYPES = (
     type(None),
@@ -84,7 +97,7 @@ def _clean_attribute(
                     element_type.__name__,
                     key,
                     [
-                        valid_type.__name__
+                        _type_name(valid_type)
                         for valid_type in _VALID_ATTR_VALUE_TYPES
                     ],
                 )
@@ -114,7 +127,7 @@ def _clean_attribute(
         "sequence of those types",
         type(value).__name__,
         key,
-        [valid_type.__name__ for valid_type in _VALID_ATTR_VALUE_TYPES],
+        [_type_name(valid_type) for valid_type in _VALID_ATTR_VALUE_TYPES],
     )
     return None
 
@@ -191,7 +204,7 @@ def _clean_extended_attribute_value(  # pylint: disable=too-many-branches
     except Exception:
         raise TypeError(
             f"Invalid type {type(value).__name__} for attribute value. "
-            f"Expected one of {[valid_type.__name__ for valid_type in _VALID_ANY_VALUE_TYPES]} or a "
+            f"Expected one of {[_type_name(valid_type) for valid_type in _VALID_ANY_VALUE_TYPES]} or a "
             "sequence of those types",
         )
 

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -22,6 +22,8 @@ from opentelemetry.attributes import (
     BoundedAttributes,
     _clean_attribute,
     _clean_extended_attribute,
+    _clean_extended_attribute_value,
+    _type_name,
 )
 
 
@@ -348,3 +350,45 @@ class TestBoundedAttributes(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             bdict_copy["invalid"] = "invalid"
+
+
+class TestTypeNameHelper(unittest.TestCase):
+    """Regression tests for _type_name.
+
+    On Python 3.9, ``typing`` generics such as ``Mapping`` and ``Sequence``
+    expose ``_name`` but not ``__name__``.  Accessing ``__name__`` directly
+    raises ``AttributeError``, which masked the real ``TypeError`` when an
+    invalid attribute value was passed (issue #4821).
+    """
+
+    def test_concrete_type_returns_name(self):
+        self.assertEqual(_type_name(int), "int")
+        self.assertEqual(_type_name(str), "str")
+        self.assertEqual(_type_name(bool), "bool")
+
+    def test_typing_generic_does_not_raise(self):
+        from typing import Mapping, Sequence
+
+        # Must not raise AttributeError on any Python version
+        self.assertIsInstance(_type_name(Sequence), str)
+        self.assertIsInstance(_type_name(Mapping), str)
+        self.assertTrue(len(_type_name(Sequence)) > 0)
+        self.assertTrue(len(_type_name(Mapping)) > 0)
+
+    def test_invalid_extended_attribute_raises_type_error_not_attribute_error(
+        self,
+    ):
+        """When str(value) also fails, the raised exception must be TypeError
+        (with a message listing valid types), not AttributeError from accessing
+        ``__name__`` on typing generics such as ``Mapping`` / ``Sequence``.
+        This is the regression from issue #4821 on Python 3.9."""
+
+        class Unstringable:
+            def __str__(self):
+                raise ValueError("cannot stringify")
+
+        with self.assertRaises(TypeError) as ctx:
+            _clean_extended_attribute_value(Unstringable(), None)
+
+        self.assertNotIsInstance(ctx.exception, AttributeError)
+        self.assertIn("Invalid type", str(ctx.exception))


### PR DESCRIPTION
Fixes #4821

## Problem

On Python 3.9, `typing` generics such as `Mapping` and `Sequence` expose `_name` but **not** `__name__`. When an invalid attribute value is passed (e.g. an arbitrary object whose `str()` also fails), the code attempts to build an error message using a list comprehension over `_VALID_ANY_VALUE_TYPES`:

```python
[valid_type.__name__ for valid_type in _VALID_ANY_VALUE_TYPES]
```

Because `_VALID_ANY_VALUE_TYPES` contains `Mapping` and `Sequence` from `typing`, this raises `AttributeError: __name__` on Python 3.9, completely hiding the intended `TypeError`.

## Solution

Introduce a `_type_name(t)` helper that resolves a type's name safely:

```python
def _type_name(t: type) -> str:
    return getattr(t, "__name__", None) or getattr(t, "_name", None) or repr(t)
```

Replace all direct `.__name__` accesses on type objects from `_VALID_ATTR_VALUE_TYPES` and `_VALID_ANY_VALUE_TYPES` with this helper. Accesses on `type(value)` (i.e. concrete runtime types) are always safe and left unchanged.

## Testing

Added `TestTypeNameHelper` with three cases:
- Concrete types return their `__name__` correctly
- `typing.Mapping` / `typing.Sequence` do not raise on any Python version
- Passing an unstringable object raises `TypeError` (not `AttributeError`) with a message containing `"Invalid type"`