### PR TITLE
docs: expose API metrics members in Sphinx

### DIFF
--- a/docs/api/metrics.rst
+++ b/docs/api/metrics.rst
@@ -8,3 +8,6 @@ Module contents
 ---------------
 
 .. automodule:: opentelemetry.metrics
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
## Summary
- add Sphinx member directives to `docs/api/metrics.rst`
- expose the `opentelemetry.metrics` API members on the generated docs page
- keep the change narrowly scoped to the smaller remaining docs gap from #2573

## Validation
- `python3 -m tox -e docs`
  - build now reaches and writes `api/metrics.html`, and the generated page contains API symbols such as `Counter`, `Histogram`, `Meter`, `NoOpMeter`, and `ObservableCounter`
  - the full docs job still fails in this environment on a pre-existing Sphinx warning: `<unknown>:1:py:class reference target not found: Token`

Refs #2573
