### PR TITLE
fix(shim): Map OpenTracing span.kind tag to OTel SpanKind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#5091](https://github.com/open-telemetry/opentelemetry-python/pull/5091))
 - `opentelemetry-sdk`: Add `create_logger_provider`/`configure_logger_provider` to declarative file configuration, enabling LoggerProvider instantiation from config files without reading env vars
   ([#4990](https://github.com/open-telemetry/opentelemetry-python/pull/4990))
+- `opentelemetry-opentracing-shim`: Map OpenTracing `span.kind` tag to the corresponding OpenTelemetry `SpanKind`, including support for `internal` kind
+  ([#5080](https://github.com/open-telemetry/opentelemetry-python/pull/5080))
 - `opentelemetry-sdk`: Add `service` resource detector support to declarative file configuration via `detection_development.detectors[].service`
   ([#5003](https://github.com/open-telemetry/opentelemetry-python/pull/5003))
 - logs: add exception support to Logger emit and LogRecord attributes

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
@@ -117,6 +117,7 @@ from opentelemetry.trace import (
     INVALID_SPAN_CONTEXT,
     Link,
     NonRecordingSpan,
+    SpanKind,
     TracerProvider,
     get_current_span,
     set_span_in_context,
@@ -667,6 +668,16 @@ class TracerShim(Tracer):
 
         parent_span_context = set_span_in_context(parent)
 
+        # Extract span.kind from OpenTracing tags and map to OTel SpanKind.
+        # The span.kind tag is removed from tags as it is not a regular
+        # attribute but controls the span's kind in OpenTelemetry.
+        kind = SpanKind.INTERNAL
+        if tags is not None and "span.kind" in tags:
+            mapped_kind = util.opentracing_kind_to_otel_kind(tags["span.kind"])
+            if mapped_kind is not None:
+                kind = mapped_kind
+            del tags["span.kind"]
+
         # The OpenTracing API expects time values to be `float` values which
         # represent the number of seconds since the epoch. OpenTelemetry
         # represents time values as nanoseconds since the epoch.
@@ -677,6 +688,7 @@ class TracerShim(Tracer):
         span = self._otel_tracer.start_span(
             operation_name,
             context=parent_span_context,
+            kind=kind,
             links=valid_links,
             attributes=tags,
             start_time=start_time_ns,

--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/util.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/util.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from opentelemetry.trace import SpanKind
+
 # A default event name to be used for logging events when a better event name
 # can't be derived from the event's key-value pairs.
 DEFAULT_EVENT_NAME = "log"
@@ -52,3 +54,21 @@ def event_name_from_kv(key_values):
         return DEFAULT_EVENT_NAME
 
     return key_values["event"]
+
+
+_OPENTRACING_TO_OTEL_KIND = {
+    "client": SpanKind.CLIENT,
+    "server": SpanKind.SERVER,
+    "producer": SpanKind.PRODUCER,
+    "consumer": SpanKind.CONSUMER,
+    "internal": SpanKind.INTERNAL,
+}
+
+
+def opentracing_kind_to_otel_kind(opentracing_kind):
+    """Maps an OpenTracing span.kind tag value to the corresponding
+    OpenTelemetry SpanKind.
+
+    Returns None if the kind is not recognized.
+    """
+    return _OPENTRACING_TO_OTEL_KIND.get(opentracing_kind)

--- a/shim/opentelemetry-opentracing-shim/tests/test_shim.py
+++ b/shim/opentelemetry-opentracing-shim/tests/test_shim.py
@@ -35,6 +35,7 @@ from opentelemetry.test.mock_textmap import (
     MockTextMapPropagator,
     NOOPTextMapPropagator,
 )
+from opentelemetry.trace import SpanKind
 
 
 class TestShim(TestCase):
@@ -642,6 +643,34 @@ class TestShim(TestCase):
 
         # Verify no span is active.
         self.assertIsNone(self.shim.active_span)
+
+    def test_span_kind_from_tags(self):
+        """Test that span.kind OpenTracing tag is mapped to OTel SpanKind."""
+        test_cases = [
+            ({"span.kind": "consumer"}, SpanKind.CONSUMER),
+            ({"span.kind": "producer"}, SpanKind.PRODUCER),
+            ({"span.kind": "client"}, SpanKind.CLIENT),
+            ({"span.kind": "server"}, SpanKind.SERVER),
+            ({"span.kind": "unknown_kind"}, SpanKind.INTERNAL),
+            ({"other_tag": "value"}, SpanKind.INTERNAL),
+            (None, SpanKind.INTERNAL),
+        ]
+
+        for tags, expected_kind in test_cases:
+            with self.subTest(tags=tags, expected_kind=expected_kind):
+                with self.shim.start_active_span(
+                    "TestSpanKind", tags=tags
+                ) as scope:
+                    self.assertEqual(scope.span.unwrap().kind, expected_kind)
+
+    def test_span_kind_tag_removed_from_attributes(self):
+        """Test that span.kind tag is removed from span attributes after extraction."""
+        with self.shim.start_active_span(
+            "TestSpanKind", tags={"span.kind": "client", "other": "value"}
+        ) as scope:
+            self.assertEqual(scope.span.unwrap().kind, SpanKind.CLIENT)
+            self.assertNotIn("span.kind", scope.span.unwrap().attributes)
+            self.assertEqual(scope.span.unwrap().attributes["other"], "value")
 
     def test_mixed_mode(self):
         """Test that span parent-child relationship is kept between

--- a/shim/opentelemetry-opentracing-shim/tests/test_util.py
+++ b/shim/opentelemetry-opentracing-shim/tests/test_util.py
@@ -18,9 +18,11 @@ from unittest import TestCase
 from opentelemetry.shim.opentracing_shim.util import (
     DEFAULT_EVENT_NAME,
     event_name_from_kv,
+    opentracing_kind_to_otel_kind,
     time_seconds_from_ns,
     time_seconds_to_ns,
 )
+from opentelemetry.trace import SpanKind
 
 
 class TestUtil(TestCase):
@@ -53,6 +55,26 @@ class TestUtil(TestCase):
         result = time_seconds_from_ns(time_nanoseconds)
 
         self.assertEqual(result, time_nanoseconds / 1e9)
+
+    def test_opentracing_kind_to_otel_kind(self):
+        """Test mapping of OpenTracing kind tags to OTel SpanKind."""
+        test_cases = {
+            "client": SpanKind.CLIENT,
+            "server": SpanKind.SERVER,
+            "producer": SpanKind.PRODUCER,
+            "consumer": SpanKind.CONSUMER,
+            "internal": SpanKind.INTERNAL,
+            "unknown": None,
+            "": None,
+        }
+        for opentracing_kind, expected in test_cases.items():
+            with self.subTest(
+                opentracing_kind=opentracing_kind, expected=expected
+            ):
+                self.assertEqual(
+                    opentracing_kind_to_otel_kind(opentracing_kind),
+                    expected,
+                )
 
     def test_time_conversion_precision(self):
         """Verify time conversion from seconds to nanoseconds and vice versa is


### PR DESCRIPTION
# Description

The OpenTracing compatibility shim ignores the `span.kind` tag when creating spans via `TracerShim.start_span()`. All spans default to `SpanKind.INTERNAL` regardless of the OpenTracing `span.kind` value (`client`, `server`, `producer`, `consumer`). This breaks interoperability for users migrating from OpenTracing to OpenTelemetry, as span kind is critical for trace visualization and backend processing.

This PR extracts `span.kind` from the tags dict before span creation, maps it to the corresponding `SpanKind` enum value (including `internal`), passes it as the `kind=` parameter, and **removes** `span.kind` from the tags so it does not appear as a duplicate attribute — it is a semantic control tag, not a regular user attribute.

> **Note:** A previous attempt in #4953 was auto-closed by the stale bot (no activity for 28 days). This PR differs in two key ways:
> 1. It **removes** `span.kind` from span attributes after extraction, preventing duplication (the previous PR preserved it as an attribute).
> 2. The mapping logic is separated into a **testable helper function** in `util.py` with dedicated unit tests.

Fixes #2549

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

All existing shim tests plus new test cases pass:

```
pytest shim/opentelemetry-opentracing-shim/tests/ -v
```

- [x] `test_span_kind_from_tags` — 7 sub-tests covering all four OpenTracing kinds + unknown + absent + None
- [x] `test_span_kind_tag_removed_from_attributes` — verifies `span.kind` is removed from attributes while other tags are preserved
- [x] `test_opentracing_kind_to_otel_kind` — 7 sub-tests for the `util.py` helper (all five valid kinds + unknown + empty)

61 tests passed, 0 failures.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated