### PR TITLE
opentelemetry-sdk: make SynchronousMeasurementConsumer collect deadline test more robust

### DIFF
--- a/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
+++ b/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
@@ -156,8 +156,9 @@ class TestSynchronousMeasurementConsumer(TestCase):
         "opentelemetry.sdk.metrics._internal."
         "measurement_consumer.CallbackOptions"
     )
+    @patch("opentelemetry.sdk.metrics._internal.measurement_consumer.time_ns")
     def test_collect_deadline(
-        self, mock_callback_options, MockMetricReaderStorage
+        self, mock_time_ns, mock_callback_options, MockMetricReaderStorage
     ):
         reader_mock = Mock()
         reader_storage_mock = Mock()
@@ -171,16 +172,22 @@ class TestSynchronousMeasurementConsumer(TestCase):
             )
         )
 
-        def sleep_1(*args, **kwargs):
-            sleep(1)
-            return []
+        consumer.register_asynchronous_instrument(
+            Mock(**{"callback.return_value": []})
+        )
+        consumer.register_asynchronous_instrument(
+            Mock(**{"callback.return_value": []})
+        )
 
-        consumer.register_asynchronous_instrument(
-            Mock(**{"callback.side_effect": sleep_1})
-        )
-        consumer.register_asynchronous_instrument(
-            Mock(**{"callback.side_effect": sleep_1})
-        )
+        # collect start, first remaining_time, post-first callback,
+        # second remaining_time, post-second callback
+        mock_time_ns.side_effect = [
+            0,
+            0,
+            int(1e9),
+            int(1e9),
+            int(2e9),
+        ]
 
         consumer.collect(reader_mock)
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Instead of sleeping mock time_ns so that we can exercise the path more deterministically. Hopefully it'll help on platforms were time is not so precise like PyPy / windows.

Assisted-by: Copilot

Fixes #5067

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
