### PR TITLE
semconv: use X | Y union annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4907](https://github.com/open-telemetry/opentelemetry-python/issues/4907))
 - Drop Python 3.9 support
   ([#5076](https://github.com/open-telemetry/opentelemetry-python/pull/5076))
+- `opentelemetry-semantic-conventions`: use `X | Y` union annotation
+  ([#5096](https://github.com/open-telemetry/opentelemetry-python/pull/5096))
 
 
 ## Version 1.41.0/0.62b0 (2026-04-09)

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/container_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/container_metrics.py
@@ -13,15 +13,8 @@
 # limitations under the License.
 
 
-from typing import (
-    Callable,
-    Final,
-    Generator,
-    Iterable,
-    Optional,
-    Sequence,
-    Union,
-)
+from collections.abc import Callable, Generator, Iterable, Sequence
+from typing import Final
 
 from opentelemetry.metrics import (
     CallbackOptions,
@@ -33,10 +26,10 @@ from opentelemetry.metrics import (
 )
 
 # pylint: disable=invalid-name
-CallbackT = Union[
-    Callable[[CallbackOptions], Iterable[Observation]],
-    Generator[Iterable[Observation], CallbackOptions, None],
-]
+CallbackT = (
+    Callable[[CallbackOptions], Iterable[Observation]]
+    | Generator[Iterable[Observation], CallbackOptions, None]
+)
 
 CONTAINER_CPU_TIME: Final = "container.cpu.time"
 """
@@ -66,7 +59,7 @@ Note: CPU usage of the specific container on all available CPU cores, averaged o
 
 
 def create_container_cpu_usage(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Container's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"""
     return meter.create_observable_gauge(
@@ -284,7 +277,7 @@ The actual accuracy would depend on the instrumentation and operating system.
 
 
 def create_container_uptime(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The time the container has been running"""
     return meter.create_observable_gauge(

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/cpu_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/cpu_metrics.py
@@ -13,15 +13,8 @@
 # limitations under the License.
 
 
-from typing import (
-    Callable,
-    Final,
-    Generator,
-    Iterable,
-    Optional,
-    Sequence,
-    Union,
-)
+from collections.abc import Callable, Generator, Iterable, Sequence
+from typing import Final
 
 from opentelemetry.metrics import (
     CallbackOptions,
@@ -32,10 +25,10 @@ from opentelemetry.metrics import (
 )
 
 # pylint: disable=invalid-name
-CallbackT = Union[
-    Callable[[CallbackOptions], Iterable[Observation]],
-    Generator[Iterable[Observation], CallbackOptions, None],
-]
+CallbackT = (
+    Callable[[CallbackOptions], Iterable[Observation]]
+    | Generator[Iterable[Observation], CallbackOptions, None]
+)
 
 CPU_FREQUENCY: Final = "cpu.frequency"
 """
@@ -44,7 +37,7 @@ Deprecated: Replaced by `system.cpu.frequency`.
 
 
 def create_cpu_frequency(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Deprecated. Use `system.cpu.frequency` instead"""
     return meter.create_observable_gauge(
@@ -77,7 +70,7 @@ Deprecated: Replaced by `system.cpu.utilization`.
 
 
 def create_cpu_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Deprecated. Use `system.cpu.utilization` instead"""
     return meter.create_observable_gauge(

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/hw_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/hw_metrics.py
@@ -13,15 +13,8 @@
 # limitations under the License.
 
 
-from typing import (
-    Callable,
-    Final,
-    Generator,
-    Iterable,
-    Optional,
-    Sequence,
-    Union,
-)
+from collections.abc import Callable, Generator, Iterable, Sequence
+from typing import Final
 
 from opentelemetry.metrics import (
     CallbackOptions,
@@ -33,10 +26,10 @@ from opentelemetry.metrics import (
 )
 
 # pylint: disable=invalid-name
-CallbackT = Union[
-    Callable[[CallbackOptions], Iterable[Observation]],
-    Generator[Iterable[Observation], CallbackOptions, None],
-]
+CallbackT = (
+    Callable[[CallbackOptions], Iterable[Observation]]
+    | Generator[Iterable[Observation], CallbackOptions, None]
+)
 
 HW_BATTERY_CHARGE: Final = "hw.battery.charge"
 """
@@ -47,7 +40,7 @@ Unit: 1
 
 
 def create_hw_battery_charge(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Remaining fraction of battery charge"""
     return meter.create_observable_gauge(
@@ -67,7 +60,7 @@ Unit: 1
 
 
 def create_hw_battery_charge_limit(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Lower limit of battery charge fraction to ensure proper operation"""
     return meter.create_observable_gauge(
@@ -87,7 +80,7 @@ Unit: s
 
 
 def create_hw_battery_time_left(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Time left before battery is completely charged or discharged"""
     return meter.create_observable_gauge(
@@ -107,7 +100,7 @@ Unit: Hz
 
 
 def create_hw_cpu_speed(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """CPU current frequency"""
     return meter.create_observable_gauge(
@@ -127,7 +120,7 @@ Unit: Hz
 
 
 def create_hw_cpu_speed_limit(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """CPU maximum frequency"""
     return meter.create_observable_gauge(
@@ -181,7 +174,7 @@ Unit: rpm
 
 
 def create_hw_fan_speed(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Fan speed in revolutions per minute"""
     return meter.create_observable_gauge(
@@ -201,7 +194,7 @@ Unit: rpm
 
 
 def create_hw_fan_speed_limit(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Speed limit in rpm"""
     return meter.create_observable_gauge(
@@ -221,7 +214,7 @@ Unit: 1
 
 
 def create_hw_fan_speed_ratio(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Fan speed expressed as a fraction of its maximum speed"""
     return meter.create_observable_gauge(
@@ -292,7 +285,7 @@ Unit: 1
 
 
 def create_hw_gpu_memory_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Fraction of GPU memory used"""
     return meter.create_observable_gauge(
@@ -312,7 +305,7 @@ Unit: 1
 
 
 def create_hw_gpu_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Fraction of time spent in a specific task"""
     return meter.create_observable_gauge(
@@ -332,7 +325,7 @@ Unit: Cel
 
 
 def create_hw_host_ambient_temperature(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Ambient (external) temperature of the physical host"""
     return meter.create_observable_gauge(
@@ -370,7 +363,7 @@ Unit: Cel
 
 
 def create_hw_host_heating_margin(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning threshold on one of the internal sensors"""
     return meter.create_observable_gauge(
@@ -391,7 +384,7 @@ Note: The overall energy usage of a host MUST be reported using the specific `hw
 
 
 def create_hw_host_power(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred)"""
     return meter.create_observable_gauge(
@@ -445,7 +438,7 @@ Unit: 1
 
 
 def create_hw_logical_disk_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Logical disk space utilization as a fraction"""
     return meter.create_observable_gauge(
@@ -499,7 +492,7 @@ Unit: 1
 
 
 def create_hw_network_bandwidth_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Utilization of the network bandwidth as a fraction"""
     return meter.create_observable_gauge(
@@ -572,7 +565,7 @@ Unit: 1
 
 
 def create_hw_physical_disk_endurance_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Endurance remaining for this SSD disk"""
     return meter.create_observable_gauge(
@@ -609,7 +602,7 @@ Unit: 1
 
 
 def create_hw_physical_disk_smart(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Value of the corresponding [S.M.A.R.T.](https://wikipedia.org/wiki/S.M.A.R.T.) (Self-Monitoring, Analysis, and Reporting Technology) attribute"""
     return meter.create_observable_gauge(
@@ -630,7 +623,7 @@ Note: It is recommended to report `hw.energy` instead of `hw.power` when possibl
 
 
 def create_hw_power(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Instantaneous power consumed by the component"""
     return meter.create_observable_gauge(
@@ -684,7 +677,7 @@ Unit: 1
 
 
 def create_hw_power_supply_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Utilization of the power supply as a fraction of its maximum output"""
     return meter.create_observable_gauge(
@@ -739,7 +732,7 @@ Unit: Cel
 
 
 def create_hw_temperature(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Temperature in degrees Celsius"""
     return meter.create_observable_gauge(
@@ -759,7 +752,7 @@ Unit: Cel
 
 
 def create_hw_temperature_limit(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Temperature limit in degrees Celsius"""
     return meter.create_observable_gauge(
@@ -779,7 +772,7 @@ Unit: V
 
 
 def create_hw_voltage(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Voltage measured by the sensor"""
     return meter.create_observable_gauge(
@@ -799,7 +792,7 @@ Unit: V
 
 
 def create_hw_voltage_limit(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Voltage limit in Volts"""
     return meter.create_observable_gauge(
@@ -819,7 +812,7 @@ Unit: V
 
 
 def create_hw_voltage_nominal(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Nominal (expected) voltage"""
     return meter.create_observable_gauge(

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/k8s_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/k8s_metrics.py
@@ -13,15 +13,8 @@
 # limitations under the License.
 
 
-from typing import (
-    Callable,
-    Final,
-    Generator,
-    Iterable,
-    Optional,
-    Sequence,
-    Union,
-)
+from collections.abc import Callable, Generator, Iterable, Sequence
+from typing import Final
 
 from opentelemetry.metrics import (
     CallbackOptions,
@@ -33,10 +26,10 @@ from opentelemetry.metrics import (
 )
 
 # pylint: disable=invalid-name
-CallbackT = Union[
-    Callable[[CallbackOptions], Iterable[Observation]],
-    Generator[Iterable[Observation], CallbackOptions, None],
-]
+CallbackT = (
+    Callable[[CallbackOptions], Iterable[Observation]]
+    | Generator[Iterable[Observation], CallbackOptions, None]
+)
 
 K8S_CONTAINER_CPU_LIMIT: Final = "k8s.container.cpu.limit"
 """
@@ -68,7 +61,7 @@ Note: The value range is [0.0,1.0]. A value of 1.0 means the container is using 
 
 
 def create_k8s_container_cpu_limit_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The ratio of container CPU usage to its CPU limit"""
     return meter.create_observable_gauge(
@@ -108,7 +101,7 @@ Unit: 1
 
 
 def create_k8s_container_cpu_request_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The ratio of container CPU usage to its CPU request"""
     return meter.create_observable_gauge(
@@ -624,7 +617,7 @@ the `k8s.container.name` attribute MUST be set to identify the specific containe
 
 
 def create_k8s_hpa_metric_target_cpu_average_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Target average utilization, in percentage, for CPU resource in HPA config"""
     return meter.create_observable_gauge(
@@ -650,7 +643,7 @@ the `k8s.container.name` attribute MUST be set to identify the specific containe
 
 
 def create_k8s_hpa_metric_target_cpu_average_value(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Target average value for CPU resource in HPA config"""
     return meter.create_observable_gauge(
@@ -674,7 +667,7 @@ the `k8s.container.name` attribute MUST be set to identify the specific containe
 
 
 def create_k8s_hpa_metric_target_cpu_value(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Target value for CPU resource in HPA config"""
     return meter.create_observable_gauge(
@@ -1090,7 +1083,7 @@ Note: CPU usage of the specific Node on all available CPU cores, averaged over t
 
 
 def create_k8s_node_cpu_usage(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"""
     return meter.create_observable_gauge(
@@ -1271,7 +1264,7 @@ Note: Total memory usage of the Node.
 
 
 def create_k8s_node_memory_usage(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Memory usage of the Node"""
     return meter.create_observable_gauge(
@@ -1363,7 +1356,7 @@ The actual accuracy would depend on the instrumentation and operating system.
 
 
 def create_k8s_node_uptime(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The time the Node has been running"""
     return meter.create_observable_gauge(
@@ -1402,7 +1395,7 @@ Note: CPU usage of the specific Pod on all available CPU cores, averaged over th
 
 
 def create_k8s_pod_cpu_usage(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Pod's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"""
     return meter.create_observable_gauge(
@@ -1545,7 +1538,7 @@ Note: Total memory usage of the Pod.
 
 
 def create_k8s_pod_memory_usage(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Memory usage of the Pod"""
     return meter.create_observable_gauge(
@@ -1658,7 +1651,7 @@ The actual accuracy would depend on the instrumentation and operating system.
 
 
 def create_k8s_pod_uptime(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The time the Pod has been running"""
     return meter.create_observable_gauge(
@@ -2508,7 +2501,7 @@ The `k8s.service.publish_not_ready_addresses` resource attribute indicates this 
 
 
 def create_k8s_service_endpoint_count(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Number of endpoints for a service by condition and address type"""
     return meter.create_observable_gauge(
@@ -2542,7 +2535,7 @@ guarantee that the load balancer is healthy.
 
 
 def create_k8s_service_load_balancer_ingress_count(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Number of load balancer ingress points (external IPs/hostnames) assigned to the service"""
     return meter.create_observable_gauge(

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/process_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/process_metrics.py
@@ -13,15 +13,8 @@
 # limitations under the License.
 
 
-from typing import (
-    Callable,
-    Final,
-    Generator,
-    Iterable,
-    Optional,
-    Sequence,
-    Union,
-)
+from collections.abc import Callable, Generator, Iterable, Sequence
+from typing import Final
 
 from opentelemetry.metrics import (
     CallbackOptions,
@@ -33,10 +26,10 @@ from opentelemetry.metrics import (
 )
 
 # pylint: disable=invalid-name
-CallbackT = Union[
-    Callable[[CallbackOptions], Iterable[Observation]],
-    Generator[Iterable[Observation], CallbackOptions, None],
-]
+CallbackT = (
+    Callable[[CallbackOptions], Iterable[Observation]]
+    | Generator[Iterable[Observation], CallbackOptions, None]
+)
 
 PROCESS_CONTEXT_SWITCHES: Final = "process.context_switches"
 """
@@ -81,7 +74,7 @@ Unit: 1
 
 
 def create_process_cpu_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process"""
     return meter.create_observable_gauge(
@@ -241,7 +234,7 @@ The actual accuracy would depend on the instrumentation and operating system.
 
 
 def create_process_uptime(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The time the process has been running"""
     return meter.create_observable_gauge(

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/system_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/system_metrics.py
@@ -13,15 +13,8 @@
 # limitations under the License.
 
 
-from typing import (
-    Callable,
-    Final,
-    Generator,
-    Iterable,
-    Optional,
-    Sequence,
-    Union,
-)
+from collections.abc import Callable, Generator, Iterable, Sequence
+from typing import Final
 
 from opentelemetry.metrics import (
     CallbackOptions,
@@ -33,10 +26,10 @@ from opentelemetry.metrics import (
 )
 
 # pylint: disable=invalid-name
-CallbackT = Union[
-    Callable[[CallbackOptions], Iterable[Observation]],
-    Generator[Iterable[Observation], CallbackOptions, None],
-]
+CallbackT = (
+    Callable[[CallbackOptions], Iterable[Observation]]
+    | Generator[Iterable[Observation], CallbackOptions, None]
+)
 
 SYSTEM_CPU_FREQUENCY: Final = "system.cpu.frequency"
 """
@@ -47,7 +40,7 @@ Unit: Hz
 
 
 def create_system_cpu_frequency(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Operating frequency of the logical CPU in Hertz"""
     return meter.create_observable_gauge(
@@ -120,7 +113,7 @@ Unit: 1
 
 
 def create_system_cpu_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """For each logical CPU, the utilization is calculated as the change in cumulative CPU time (cpu.time) over a measurement interval, divided by the elapsed time"""
     return meter.create_observable_gauge(
@@ -288,7 +281,7 @@ Unit: 1
 
 
 def create_system_filesystem_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Fraction of filesystem bytes used"""
     return meter.create_observable_gauge(
@@ -448,7 +441,7 @@ Unit: 1
 
 
 def create_system_memory_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Percentage of memory bytes in use"""
     return meter.create_observable_gauge(
@@ -659,7 +652,7 @@ Unit: 1
 
 
 def create_system_paging_utilization(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Swap (unix) or pagefile (windows) utilization"""
     return meter.create_observable_gauge(
@@ -715,7 +708,7 @@ The actual accuracy would depend on the instrumentation and operating system.
 
 
 def create_system_uptime(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The time the system has been running"""
     return meter.create_observable_gauge(

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/vcs_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/vcs_metrics.py
@@ -13,15 +13,8 @@
 # limitations under the License.
 
 
-from typing import (
-    Callable,
-    Final,
-    Generator,
-    Iterable,
-    Optional,
-    Sequence,
-    Union,
-)
+from collections.abc import Callable, Generator, Iterable, Sequence
+from typing import Final
 
 from opentelemetry.metrics import (
     CallbackOptions,
@@ -32,10 +25,10 @@ from opentelemetry.metrics import (
 )
 
 # pylint: disable=invalid-name
-CallbackT = Union[
-    Callable[[CallbackOptions], Iterable[Observation]],
-    Generator[Iterable[Observation], CallbackOptions, None],
-]
+CallbackT = (
+    Callable[[CallbackOptions], Iterable[Observation]]
+    | Generator[Iterable[Observation], CallbackOptions, None]
+)
 
 VCS_CHANGE_COUNT: Final = "vcs.change.count"
 """
@@ -63,7 +56,7 @@ Unit: s
 
 
 def create_vcs_change_duration(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The time duration a change (pull request/merge request/changelist) has been in a given state"""
     return meter.create_observable_gauge(
@@ -83,7 +76,7 @@ Unit: s
 
 
 def create_vcs_change_time_to_approval(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The amount of time since its creation it took a change (pull request/merge request/changelist) to get the first approval"""
     return meter.create_observable_gauge(
@@ -103,7 +96,7 @@ Unit: s
 
 
 def create_vcs_change_time_to_merge(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The amount of time since its creation it took a change (pull request/merge request/changelist) to get merged into the target(base) ref"""
     return meter.create_observable_gauge(
@@ -123,7 +116,7 @@ Unit: {contributor}
 
 
 def create_vcs_contributor_count(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The number of unique contributors to a repository"""
     return meter.create_observable_gauge(
@@ -163,7 +156,7 @@ If number of lines added/removed should be calculated from the start of time, th
 
 
 def create_vcs_ref_lines_delta(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The number of lines added/removed in a ref (branch) relative to the ref from the `vcs.ref.base.name` attribute"""
     return meter.create_observable_gauge(
@@ -185,7 +178,7 @@ instrumentation SHOULD report two measurements: 3 and 2 (both positive numbers) 
 
 
 def create_vcs_ref_revisions_delta(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute"""
     return meter.create_observable_gauge(
@@ -205,7 +198,7 @@ Unit: s
 
 
 def create_vcs_ref_time(
-    meter: Meter, callbacks: Optional[Sequence[CallbackT]]
+    meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
     """Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch`"""
     return meter.create_observable_gauge(

--- a/scripts/semconv/templates/registry/semantic_metrics.j2
+++ b/scripts/semconv/templates/registry/semantic_metrics.j2
@@ -50,14 +50,14 @@ from opentelemetry.metrics import {{i | map_text("py_instrument_to_type")}}
     {%- endfor-%}
 
     {%- if ctx.metrics | selectattr("instrument", "equalto", "gauge") | list | count > 0 %}
-from typing import Callable, Generator, Iterable, Optional, Sequence, Union
+from collections.abc import Callable, Generator, Iterable, Sequence
 from opentelemetry.metrics import CallbackOptions, ObservableGauge, Observation
 
 # pylint: disable=invalid-name
-CallbackT = Union[
-    Callable[[CallbackOptions], Iterable[Observation]],
-    Generator[Iterable[Observation], CallbackOptions, None],
-]
+CallbackT = (
+    Callable[[CallbackOptions], Iterable[Observation]]
+    | Generator[Iterable[Observation], CallbackOptions, None]
+)
     {%- endif %}
 
   {%- endif -%}
@@ -76,7 +76,7 @@ from typing import Final
 {% if ctx.filter == "any" %}
 {% set metric_name = metric.metric_name | replace(".", "_") %}
 {%- if metric.instrument == "gauge" %}
-def create_{{ metric_name }}(meter: Meter, callbacks: Optional[Sequence[CallbackT]]) -> {{metric.instrument | map_text("py_instrument_to_type")}}:
+def create_{{ metric_name }}(meter: Meter, callbacks: Sequence[CallbackT] | None) -> {{metric.instrument | map_text("py_instrument_to_type")}}:
 {%- else %}
 def create_{{ metric_name }}(meter: Meter) -> {{metric.instrument | map_text("py_instrument_to_type")}}:
 {%- endif %}

--- a/tox.ini
+++ b/tox.ini
@@ -261,7 +261,6 @@ commands =
   coverage: {toxinidir}/scripts/coverage.sh
 
 [testenv:spellcheck]
-basepython: python3
 recreate = True
 deps =
   codespell==2.2.6
@@ -270,7 +269,6 @@ commands =
   codespell
 
 [testenv:docs]
-basepython: python3
 recreate = True
 deps =
   -c {toxinidir}/dev-requirements.txt
@@ -377,7 +375,6 @@ commands =
   sh -c "find {toxinidir} -name \*.sh | xargs shellcheck --severity=warning"
 
 [testenv:typecheck]
-basepython: python3
 deps =
   -c {toxinidir}/dev-requirements.txt
   pyright
@@ -400,7 +397,6 @@ commands =
   pyright
 
 [testenv:{precommit,ruff}]
-basepython: python3
 deps =
   -c {toxinidir}/dev-requirements.txt
   pre-commit


### PR DESCRIPTION
# Description

Now all packages require `python>=3.10`, I updated the semconv package to use X | Y union annotation. Ideally, we should enable the ruff rule `UP` across the whole repo, but there are many changes, and I would like to split them into small PRs.

Validated with: `ruff check opentelemetry-semantic-conventions --extend-select UP`: All checks passed!

