### PR TITLE
proto: relax protobuf upper bound to <8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#4907](https://github.com/open-telemetry/opentelemetry-python/issues/4907))
 - Drop Python 3.9 support
   ([#5076](https://github.com/open-telemetry/opentelemetry-python/pull/5076))
+- `opentelemetry-proto`: relax protobuf upper bound from `<7.0` to `<8.0` to unblock adoption of protobuf 7.x (CVE-2026-8994)
+  ([#5099](https://github.com/open-telemetry/opentelemetry-python/issues/5099))
 
 
 ## Version 1.41.0/0.62b0 (2026-04-09)

--- a/opentelemetry-proto/pyproject.toml
+++ b/opentelemetry-proto/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "protobuf>=5.0, < 7.0",
+  "protobuf>=5.0, < 8.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
# Description

Relax the `protobuf` upper bound in `opentelemetry-proto` from `<7.0` to `<8.0` so downstream users of `opentelemetry-exporter-otlp` (and its proto-grpc / proto-common / proto-http variants) can adopt `protobuf>=7.0`.

Protobuf 7.0 contains the fix for **CVE-2026-8994** (CVSS 7.58) — a DoS in `google.protobuf.json_format.ParseDict()` where a malicious payload can bypass input validation. The current `<7.0` cap blocks users from picking up that fix without pinning around OTel constraints.

This mirrors the prior bump pattern in #4620 (`<6.0` → `<7.0`). `googleapis-common-protos` already allows `protobuf <8.0.0`, so it is not a blocker.

Fixes #5099

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Installed the package against `protobuf==7.34.1` and confirmed `opentelemetry.proto.*_pb2` modules import and serialize/deserialize cleanly (wire format is stable across 5.x → 7.x).
- [x] Installed the package against `protobuf==5.29.5` (existing `test-requirements.oldest.txt`) to confirm the lower bound still resolves.

CI coverage (tox) exercises the proto package against the existing pinned protobuf in `test-requirements.txt`; no generated code changes, so existing unit tests are unaffected.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

This PR only relaxes a dependency specifier in `opentelemetry-proto/pyproject.toml`. No shared config files, CODEOWNERS, scripts copied to contrib, or public interfaces change.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added — N/A (dependency specifier change, no behavioral change in generated or library code)
- [ ] Documentation has been updated — N/A