### PR TITLE
chore: enable ruff flake8-comprehensions (C4) rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#5096](https://github.com/open-telemetry/opentelemetry-python/pull/5096))
 - Add WeaverLiveCheck test util
   ([#5088](https://github.com/open-telemetry/opentelemetry-python/pull/5088))
+- Enable ruff `flake8-comprehensions` (C4) rules and fix violations across the codebase
+  ([#5107](https://github.com/open-telemetry/opentelemetry-python/pull/5107))
 
 ## Version 1.41.0/0.62b0 (2026-04-09)
 

--- a/codegen/opentelemetry-codegen-json/src/opentelemetry/codegen/json/generator.py
+++ b/codegen/opentelemetry-codegen-json/src/opentelemetry/codegen/json/generator.py
@@ -386,10 +386,10 @@ class OtlpJsonGenerator:
         Returns:
             Set of import statement strings
         """
-        return set(
+        return {
             "import " + self._get_module_path(dep_file)
             for dep_file in self._file_dependencies.get(proto_file, [])
-        )
+        }
 
     def _generate_enums_for_file(
         self,

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -342,7 +342,7 @@ class OTLPExporterMixin(
         elif isinstance(self._headers, dict):
             self._headers = tuple(self._headers.items())
         if self._headers is None:
-            self._headers = tuple()
+            self._headers = ()
 
         if channel_options:
             # merge the default channel options with the one passed as parameter

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -34,12 +34,8 @@ def get_dict_as_key(labels):
     """Converts a dict to be used as a unique key"""
     return tuple(
         sorted(
-            map(
-                lambda kv: (
-                    (kv[0], tuple(kv[1])) if isinstance(kv[1], list) else kv
-                ),
-                labels.items(),
-            )
+            (kv[0], tuple(kv[1])) if isinstance(kv[1], list) else kv
+            for kv in labels.items()
         )
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ select = [
   "F",   # pyflakes
   "E",   # pycodestyle errors
   "W",   # pycodestyle warnings
+  "C4",  # flake8-comprehensions
   "PLC", # pylint convention
   "PLE", # pylint error
   "Q",   # flake8-quotes

--- a/shim/opentelemetry-opentracing-shim/tests/testbed/testcase.py
+++ b/shim/opentelemetry-opentracing-shim/tests/testbed/testcase.py
@@ -43,4 +43,4 @@ class OpenTelemetryTestCase(unittest.TestCase):
         self.assertNotEqual(ctxA.span_id, ctxB.span_id)
 
     def assertNamesEqual(self, spans, names):
-        self.assertEqual(list(map(lambda x: x.name, spans)), names)
+        self.assertEqual([x.name for x in spans], names)


### PR DESCRIPTION
# Description

Enable the `C4` ([flake8-comprehensions](https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4)) rule set in ruff and fix all existing violations.

Fixes addressed:

| Rule | Description | File |
|------|-------------|------|
| C401 | Use set comprehension instead of `set(generator)` | `codegen/.../generator.py` |
| C408 | Use tuple literal `()` instead of `tuple()` | `exporter/.../exporter.py` |
| C417 | Use generator expression instead of `map(lambda)` | `opentelemetry-sdk/.../util/__init__.py` |
| C417 | Use list comprehension instead of `map(lambda)` | `shim/.../testcase.py` |

Addresses #4227

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Ran `ruff check .` with the new `C4` rule enabled - all checks pass
- [x] Changes are mechanical rewrites that preserve identical runtime behavior

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated