### PR TITLE
docs: add missing modules to Sphinx autodoc configuration

### DIFF
--- a/docs/api/_events.rst
+++ b/docs/api/_events.rst
@@ -1,0 +1,10 @@
+opentelemetry._events package
+=============================
+
+Module contents
+---------------
+
+.. automodule:: opentelemetry._events
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -14,6 +14,7 @@ For the concrete implementation of these interfaces, see the
 .. toctree::
     :maxdepth: 1
 
+    _events
     _logs
     baggage
     context

--- a/docs/api/propagators.b3.rst
+++ b/docs/api/propagators.b3.rst
@@ -1,0 +1,7 @@
+opentelemetry.propagators.b3
+============================
+
+.. automodule:: opentelemetry.propagators.b3
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/propagators.jaeger.rst
+++ b/docs/api/propagators.jaeger.rst
@@ -1,0 +1,7 @@
+opentelemetry.propagators.jaeger
+================================
+
+.. automodule:: opentelemetry.propagators.jaeger
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/propagators.rst
+++ b/docs/api/propagators.rst
@@ -8,3 +8,5 @@ Subpackages
 
    propagators.textmap
    propagators.composite
+   propagators.b3
+   propagators.jaeger

--- a/docs/api/trace.propagation.rst
+++ b/docs/api/trace.propagation.rst
@@ -1,0 +1,7 @@
+opentelemetry.trace.propagation
+================================
+
+.. automodule:: opentelemetry.trace.propagation
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/trace.rst
+++ b/docs/api/trace.rst
@@ -8,6 +8,7 @@ Submodules
 
    trace.status
    trace.span
+   trace.propagation
 
 Module contents
 ---------------

--- a/docs/sdk/_logs.export.rst
+++ b/docs/sdk/_logs.export.rst
@@ -1,0 +1,7 @@
+opentelemetry.sdk._logs.export
+==============================
+
+.. automodule:: opentelemetry.sdk._logs.export
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/sdk/_logs.rst
+++ b/docs/sdk/_logs.rst
@@ -1,6 +1,16 @@
 opentelemetry.sdk._logs package
 ===============================
 
+Submodules
+----------
+
+.. toctree::
+
+   _logs.export
+
+Module contents
+---------------
+
 .. automodule:: opentelemetry.sdk._logs
     :members:
     :undoc-members:


### PR DESCRIPTION
# Description

Several public Python modules were not wired into the Sphinx documentation build, meaning their classes, functions, and docstrings did not appear on ReadTheDocs. This PR adds the missing RST files and updates existing toctrees so these modules are included in the generated API documentation.

Fixes #2573

## Changes

**New RST files (API):**
- `docs/api/_events.rst` — `opentelemetry._events` (EventLogger, EventLoggerProvider, etc.)
- `docs/api/trace.propagation.rst` — `opentelemetry.trace.propagation` (`set_span_in_context`, `get_current_span`)
- `docs/api/propagators.b3.rst` — `opentelemetry.propagators.b3` (B3 propagator)
- `docs/api/propagators.jaeger.rst` — `opentelemetry.propagators.jaeger` (Jaeger propagator)

**New RST files (SDK):**
- `docs/sdk/_logs.export.rst` — `opentelemetry.sdk._logs.export` (BatchLogRecordProcessor, ConsoleLogExporter, etc.)

**Updated toctrees:**
- `docs/api/index.rst` — added `_events`
- `docs/api/trace.rst` — added `trace.propagation`
- `docs/api/propagators.rst` — added `propagators.b3` and `propagators.jaeger`
- `docs/sdk/_logs.rst` — added `_logs.export` submodule section

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

- Verified that each new RST file uses the correct `automodule` directive pointing to the corresponding Python module
- Confirmed that `autodoc_default_options` in `docs/conf.py` already sets `:members:`, `:undoc-members:`, and `:show-inheritance:` globally, so the explicit flags in new RST files are consistent with the project convention

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated