### PR TITLE
fix: correct create_tracer() example to pass TracerProvider instead of Tracer

### DIFF
--- a/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
+++ b/shim/opentelemetry-opentracing-shim/src/opentelemetry/shim/opentracing_shim/__init__.py
@@ -35,11 +35,8 @@ following example::
     # Define which OpenTelemetry Tracer provider implementation to use.
     trace.set_tracer_provider(TracerProvider())
 
-    # Create an OpenTelemetry Tracer.
-    otel_tracer = trace.get_tracer(__name__)
-
     # Create an OpenTracing shim.
-    shim = create_tracer(otel_tracer)
+    shim = create_tracer(trace.get_tracer_provider())
 
     with shim.start_active_span("ProcessHTTPRequest"):
         print("Processing HTTP request")


### PR DESCRIPTION
## Summary
The docstring example in the OpenTracing shim incorrectly creates a `Tracer` object and passes it to `create_tracer()`, but `create_tracer()` expects a `TracerProvider`. Following the example causes an `AttributeError: 'Tracer' object has no attribute 'get_tracer'`.

## Changes
Updated the example to pass `trace.get_tracer_provider()` directly to `create_tracer()`, removing the unnecessary intermediate `otel_tracer` variable.

Before:
```python
otel_tracer = trace.get_tracer(__name__)
shim = create_tracer(otel_tracer)  # Wrong: passes Tracer
```

After:
```python
shim = create_tracer(trace.get_tracer_provider())  # Correct: passes TracerProvider
```

Closes #5072

Assisted-by: GLM 5.1