### PR TITLE
opentelemetry-test-utils: don't install grpc in test requirements on PyPy 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2983,31 +2983,6 @@ jobs:
       - name: Run tests
         run: tox -e py314-test-opentelemetry-test-utils -- -ra
 
-  py314t-test-opentelemetry-test-utils_ubuntu-latest:
-    name: opentelemetry-test-utils 3.14t Ubuntu
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
-
-      - name: Install weaver
-        run: |
-          WEAVER_URL="https://github.com/open-telemetry/weaver/releases/download/${{ env.WEAVER_VERSION }}/weaver-x86_64-unknown-linux-gnu.tar.xz"
-          curl -sSL "$WEAVER_URL" | tar -xJ -C /tmp weaver-x86_64-unknown-linux-gnu/weaver
-          sudo mv /tmp/weaver-x86_64-unknown-linux-gnu/weaver /usr/local/bin/weaver
-
-      - name: Set up Python 3.14t
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.14t"
-
-      - name: Install tox
-        run: pip install tox-uv
-
-      - name: Run tests
-        run: tox -e py314t-test-opentelemetry-test-utils -- -ra
-
   pypy3-test-opentelemetry-test-utils_ubuntu-latest:
     name: opentelemetry-test-utils pypy-3.10 Ubuntu
     runs-on: ubuntu-latest
@@ -6259,27 +6234,6 @@ jobs:
 
       - name: Run tests
         run: tox -e py314-test-opentelemetry-test-utils -- -ra
-
-  py314t-test-opentelemetry-test-utils_windows-latest:
-    name: opentelemetry-test-utils 3.14t Windows
-    runs-on: windows-latest
-    timeout-minutes: 30
-    steps:
-      - name: Configure git to support long filenames
-        run: git config --system core.longpaths true
-      - name: Checkout repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.14t
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.14t"
-
-      - name: Install tox
-        run: pip install tox-uv
-
-      - name: Run tests
-        run: tox -e py314t-test-opentelemetry-test-utils -- -ra
 
   pypy3-test-opentelemetry-test-utils_windows-latest:
     name: opentelemetry-test-utils pypy-3.10 Windows

--- a/tests/opentelemetry-test-utils/test-requirements.txt
+++ b/tests/opentelemetry-test-utils/test-requirements.txt
@@ -13,9 +13,9 @@ zipp==3.19.2
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions
 -e tests/opentelemetry-test-utils
-# these are required for weaver integration tests, we're running that only on linux
+# these are required for weaver integration tests, we're running that only on linux / CPython
 # because of lack of support for gRPC on Windows in some cases.
 # note: tox does not support PEP 508 markers on `-e` editable installs, so these are installed non-editable
-./opentelemetry-proto ; sys_platform != 'win32'
-./exporter/opentelemetry-exporter-otlp-proto-common ; sys_platform != 'win32'
-./exporter/opentelemetry-exporter-otlp-proto-grpc ; sys_platform != 'win32'
+./opentelemetry-proto ; sys_platform != 'win32' and platform_python_implementation != 'PyPy'
+./exporter/opentelemetry-exporter-otlp-proto-common ; sys_platform != 'win32' and platform_python_implementation != 'PyPy'
+./exporter/opentelemetry-exporter-otlp-proto-grpc ; sys_platform != 'win32' and platform_python_implementation != 'PyPy'

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ envlist =
     pypy3-test-opentelemetry-propagator-jaeger
     lint-opentelemetry-propagator-jaeger
 
-    py3{10,11,12,13,14,14t}-test-opentelemetry-test-utils
+    py3{10,11,12,13,14}-test-opentelemetry-test-utils
     pypy3-test-opentelemetry-test-utils
     lint-opentelemetry-test-utils
 

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,7 @@ envlist =
     pypy3-test-opentelemetry-propagator-jaeger
     lint-opentelemetry-propagator-jaeger
 
+    ; skip py314t until grpc gets wheels for it or we stop using grpc exporter in weaver tests
     py3{10,11,12,13,14}-test-opentelemetry-test-utils
     pypy3-test-opentelemetry-test-utils
     lint-opentelemetry-test-utils


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Since it takes ages and they are flaky there.

Failure run https://github.com/open-telemetry/opentelemetry-python/actions/runs/24895670265/job/72899682215?pr=5121

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
