### PR TITLE
fix(ci): stabilize tracecontext job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#5120](https://github.com/open-telemetry/opentelemetry-python/pull/5120))
 - Add WeaverLiveCheck test util
   ([#5088](https://github.com/open-telemetry/opentelemetry-python/pull/5088))
+- ci: wait for tracecontext server readiness instead of a fixed sleep in `scripts/tracecontext-integration-test.sh`
+  ([#5149](https://github.com/open-telemetry/opentelemetry-python/pull/5149))
 
 ## Version 1.41.0/0.62b0 (2026-04-09)
 

--- a/scripts/tracecontext-integration-test.sh
+++ b/scripts/tracecontext-integration-test.sh
@@ -7,15 +7,11 @@ mkdir -p target
 rm -rf ./target/trace-context
 git clone https://github.com/w3c/trace-context ./target/trace-context
 cd ./target/trace-context && git checkout $TRACECONTEXT_GIT_TAG && cd -
-# start example opentelemetry service, which propagates trace-context by 
+# start example opentelemetry service, which propagates trace-context by
 # default.
 python ./tests/w3c_tracecontext_validation_server.py 1>&2 &
 EXAMPLE_SERVER_PID=$!
-# give the app server a little time to start up. Not adding some sort
-# of delay would cause many of the tracecontext tests to fail being
-# unable to connect.
-sleep 1
-onshutdown() 
+onshutdown()
 {
     # send a sigint, to ensure
     # it is caught as a KeyboardInterrupt in the
@@ -23,6 +19,30 @@ onshutdown()
     kill $EXAMPLE_SERVER_PID
 }
 trap onshutdown EXIT
+# Wait for the example server to accept connections on 127.0.0.1:5000
+# before running the W3C tracecontext tests. A fixed `sleep` raced the
+# Flask startup on slow CI runners and produced intermittent connection
+# errors (see issue #5104).
+wait_for_server() {
+    host=127.0.0.1
+    port=5000
+    deadline=$(( $(date +%s) + 30 ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        # Bail out early if the server process died.
+        if ! kill -0 "$EXAMPLE_SERVER_PID" 2>/dev/null; then
+            echo "tracecontext example server exited before becoming ready" >&2
+            return 1
+        fi
+        # Use python so we don't depend on extra tools (nc, curl, etc.).
+        if python -c "import socket,sys; s=socket.socket(); s.settimeout(1); sys.exit(0 if s.connect_ex(('$host', $port)) == 0 else 1)" 2>/dev/null; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    echo "tracecontext example server did not become ready within 30s" >&2
+    return 1
+}
+wait_for_server
 cd ./target/trace-context/test
 
 # The disabled test is not compatible with an optional part of the W3C 


### PR DESCRIPTION
## Why

The `tracecontext` CI job is reported to flake intermittently (#5104). The integration script starts a Flask example server and then waits a hard-coded `sleep 1` before running the W3C tests. On slow runners Flask is not yet listening when the tests start, and pytest fails with connection errors against `127.0.0.1:5000` (per the failed run referenced in the issue: https://github.com/open-telemetry/opentelemetry-python/actions/runs/24451853608/job/71442431200).

The issue author suggested adding readiness logic; this PR does exactly that.

## What

In `scripts/tracecontext-integration-test.sh`:

- Drop the racy `sleep 1`.
- Add a `wait_for_server` function that polls `127.0.0.1:5000` for up to 30s with a 0.5s interval.
- Bail out early (and surface a clear error) if the example server process exits before becoming ready.
- Use Python (already required by the script) for the socket probe so we don't depend on `nc`/`curl` being installed on the runner image.
- Move the `trap onshutdown EXIT` registration before the readiness wait so that a failed readiness probe still cleans up the background server.

No behavior change in the happy path; the only observable difference is faster startup (typically <1s) and deterministic failure messages instead of cryptic connection errors.

## Tested

- The diagnostic in the issue body links a CI run where the failure mode is exactly a connection error against the example server before it is bound to `:5000`. A port-readiness probe is the standard fix for this class of CI race.
- Reviewed the example server (`tests/w3c_tracecontext_validation_server.py`) to confirm it serves on the default Flask port `127.0.0.1:5000`.
- Script remains POSIX `/bin/sh` compatible (no bashisms introduced).

Fixes #5104