### PR TITLE
misc: use stdlib "importlib.metadata" on Python >= 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#5088](https://github.com/open-telemetry/opentelemetry-python/pull/5088))
 - ci: wait for tracecontext server readiness instead of a fixed sleep in `scripts/tracecontext-integration-test.sh`
   ([#5149](https://github.com/open-telemetry/opentelemetry-python/pull/5149))
+- `opentelemetry-api`: use stdlib `importlib.metadata` on Python >= 3.12
+  ([#5156](https://github.com/open-telemetry/opentelemetry-python/pull/5156))
 
 ## Version 1.41.0/0.62b0 (2026-04-09)
 

--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -26,9 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "typing-extensions >= 4.5.0",
-    # FIXME This should be able to be removed after 3.12 is released if there is a reliable API
-    # in importlib.metadata.
-    "importlib-metadata >= 6.0, < 8.8.0",
+    "importlib-metadata >= 6.0, < 8.8.0; python_version < '3.12'",
 ]
 dynamic = [
     "version",

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -12,23 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from functools import cache
 
-# FIXME: Use importlib.metadata (not importlib_metadata)
-# when support for 3.11 is dropped if the rest of
-# the supported versions at that time have the same API.
-from importlib_metadata import (  # type: ignore
-    Distribution,
-    EntryPoint,
-    EntryPoints,
-    PackageNotFoundError,
-    distributions,
-    requires,
-    version,
-)
-from importlib_metadata import (
-    entry_points as original_entry_points,
-)
+if sys.version_info >= (3, 12):
+    from importlib.metadata import (
+        Distribution,
+        EntryPoint,
+        EntryPoints,
+        PackageNotFoundError,
+        distributions,
+        requires,
+        version,
+    )
+    from importlib.metadata import (
+        entry_points as original_entry_points,
+    )
+else:
+    from importlib_metadata import (
+        Distribution,
+        EntryPoint,
+        EntryPoints,
+        PackageNotFoundError,
+        distributions,
+        requires,
+        version,
+    )
+    from importlib_metadata import (
+        entry_points as original_entry_points,
+    )
 
 
 @cache

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107 }
 wheels = [
@@ -816,13 +816,13 @@ wheels = [
 name = "opentelemetry-api"
 source = { editable = "opentelemetry-api" }
 dependencies = [
-    { name = "importlib-metadata" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
     { name = "typing-extensions" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "importlib-metadata", specifier = ">=6.0,<8.8.0" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'", specifier = ">=6.0,<8.8.0" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
 


### PR DESCRIPTION
# Description

Switches to using the standard library's `importlib.metadata` module for Python versions 3.12 and above, eliminating the `importlib_metadata` dependency for Python 3.12 and above.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```bash
uv run tox -e py314-test-opentelemetry-sdk
uv run tox -e py310-test-opentelemetry-sdk
```

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Documentation has been updated
