### PR TITLE
docs: add :members: to opentelemetry.propagate documentation

### DIFF
--- a/docs/api/propagate.rst
+++ b/docs/api/propagate.rst
@@ -5,3 +5,6 @@ Module contents
 ---------------
 
 .. automodule:: opentelemetry.propagate
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
## Summary

Fixes #2573 - Some documentation not built into sphinx docs

The `opentelemetry.propagate` module exports `extract()`, `inject()`, `get_global_textmap()`, and `set_global_textmap()` functions, but the sphinx docs were not including them because the `automodule` directive lacked the `:members:` flag.


## Changes

In `docs/api/propagate.rst`:
- Added `:members:` to the `automodule` directive so that module-level functions are documented
- Added `:undoc-members:` and `:show-inheritance:` for completeness

Before:
```rst
.. automodule:: opentelemetry.propagate
```

After:
```rst
.. automodule:: opentelemetry.propagate
    :members:
    :undoc-members:
    :show-inheritance:
```

Fixes #2573