### PR TITLE
fix(trace): Fix TraceState vendor-id length validation to match W3C spec

### DIFF
--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -21,7 +21,7 @@ from opentelemetry.util import types
 
 _KEY_FORMAT = (
     r"[a-z][_0-9a-z\-\*\/]{0,255}|"
-    r"[a-z0-9][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}"
+    r"[a-z0-9][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,14}"
 )
 _KEY_PATTERN = re.compile(_KEY_FORMAT)
 


### PR DESCRIPTION
## Summary

The W3C Trace Context spec defines vendor-id as `lcalpha 0*14( key-chars )`, allowing up to 15 characters.

The previous regex `{0,13}` only allowed 14 characters. This PR fixes the vendor-id length validation to match the W3C spec.

Fixes #5136.