### PR TITLE
Add missing :members: to OTLP exporter RST submodules (fix #2786)

### DIFF
--- a/docs/exporter/otlp/otlp.rst
+++ b/docs/exporter/otlp/otlp.rst
@@ -8,19 +8,34 @@ OpenTelemetry OTLP Exporters
 opentelemetry.exporter.otlp.proto.http
 ---------------------------------------
 
+.. toctree::
+    :maxdepth: 1
+
 .. automodule:: opentelemetry.exporter.otlp.proto.http
     :members:
     :undoc-members:
     :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.http.trace_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.http.metric_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.http._log_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 opentelemetry.exporter.otlp.proto.grpc
 ---------------------------------------
+
+.. toctree::
+    :maxdepth: 1
 
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc
     :members:
@@ -28,7 +43,16 @@ opentelemetry.exporter.otlp.proto.grpc
     :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc.trace_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc.metric_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc._log_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
## Summary

Fixes open-telemetry/opentelemetry-python#2786.

The OTLP exporter RST file had `automodule` directives for `trace_exporter`, `metric_exporter`, and `_log_exporter` submodules (in both grpc and http) that were missing the `:members:`, `:undoc-members:`, and `:show-inheritance:` options. As a result, the API documentation for these submodules was not being generated.

This change adds these options to all four missing submodule directives per section (grpc and http), matching the pattern used for the parent module directives.