### PR TITLE
Add _common submodules to OTLP exporter docs (Fixes #2573)

### DIFF
--- a/docs/exporter/otlp/otlp.rst
+++ b/docs/exporter/otlp/otlp.rst
@@ -8,19 +8,34 @@ OpenTelemetry OTLP Exporters
 opentelemetry.exporter.otlp.proto.http
 ---------------------------------------
 
+.. toctree::
+    :maxdepth: 1
+
 .. automodule:: opentelemetry.exporter.otlp.proto.http
     :members:
     :undoc-members:
     :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.http.trace_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.http.metric_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.http._log_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 opentelemetry.exporter.otlp.proto.grpc
 ---------------------------------------
+
+.. toctree::
+    :maxdepth: 1
 
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc
     :members:
@@ -28,7 +43,16 @@ opentelemetry.exporter.otlp.proto.grpc
     :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc.trace_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc.metric_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc._log_exporter
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/exporter/otlp/otlp.rst
+++ b/docs/exporter/otlp/otlp.rst
@@ -16,6 +16,11 @@ opentelemetry.exporter.otlp.proto.http
     :undoc-members:
     :show-inheritance:
 
+.. automodule:: opentelemetry.exporter.otlp.proto.http._common
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. automodule:: opentelemetry.exporter.otlp.proto.http.trace_exporter
     :members:
     :undoc-members:
@@ -38,6 +43,11 @@ opentelemetry.exporter.otlp.proto.grpc
     :maxdepth: 1
 
 .. automodule:: opentelemetry.exporter.otlp.proto.grpc
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: opentelemetry.exporter.otlp.proto.grpc._common
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
## Summary

Fixes #2573.

Adds `:automodule:` entries for the `_common` submodules in both the HTTP and gRPC OTLP exporter documentation, so that all exported modules are documented in the Sphinx docs.

## Changes

In `docs/exporter/otlp/otlp.rst`:
- Added documentation for `opentelemetry.exporter.otlp.proto.http._common`
- Added documentation for `opentelemetry.exporter.otlp.proto.grpc._common`

Both now include the standard `:members:`, `:undoc-members:`, and `:show-inheritance:` directives.