### PR TITLE
sdk: tighten ReadableSpan.attributes to non-Optional Mapping (#4569)

### DIFF
--- a/.changelog/5183.changed
+++ b/.changelog/5183.changed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: tighten `ReadableSpan.attributes` return type to non-Optional `Mapping`

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -495,7 +495,7 @@ class ReadableSpan:
         return self._status
 
     @property
-    def attributes(self) -> types.Attributes:
+    def attributes(self) -> Mapping[str, types.AttributeValue]:
         return MappingProxyType(self._attributes or {})
 
     @property

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -484,7 +484,7 @@ class ReadableSpan:
         return self._status
 
     @property
-    def attributes(self) -> types.Attributes:
+    def attributes(self) -> Mapping[str, types.AttributeValue]:
         return MappingProxyType(self._attributes or {})
 
     @property


### PR DESCRIPTION
# Description

`ReadableSpan.attributes` is annotated as `types.Attributes`, which resolves to `Optional[Mapping[str, AttributeValue]]`. The implementation always returns `MappingProxyType(self._attributes or {})` - the `or {}` fallback ensures we never return None at runtime.

Pyright / Pylance flags `Object of type "None" is not subscriptable` on `span.attributes["key"]`, forcing `assert span.attributes is not None` boilerplate at every call site.

This PR tightens the return annotation on `ReadableSpan.attributes` to the non-Optional `Mapping[str, types.AttributeValue]`. Implementation unchanged. `Mapping` is already imported in the file.

Scope:
- `ReadableSpan.attributes` only. Inherited by `Span` and `_Span`, no further changes needed.
- `Event.attributes` and `Link.attributes` return `self._attributes` directly (which can be None) and stay Optional.
- `types.Attributes` global alias is unchanged for the same reason.

Per the comment thread on #4569 from @exekis and @tekumara, the implementation has never returned None from `ReadableSpan.attributes`, so this is type-system tightening rather than a behaviour change. Technically a breaking change for any caller explicitly handling None on the return; in practice there shouldn't be any.

Fixes #4569

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- patched file parses cleanly via `python -m ast`
- existing call sites are unchanged, only the return-type annotation is narrower
- have not run the project test suite locally; happy to chase a green CI here if anything trips

## Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

## Checklist:

- [x] Followed the [style guidelines](https://github.com/open-telemetry/opentelemetry-python/blob/main/CONTRIBUTING.md) of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated