### PR TITLE
add detailed error message for grpc exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > We are working on stabilizing the Log signal that would require making deprecations and breaking changes. We will try to reduce the releases that may require an update to your code, especially for instrumentations or for sdk developers.
 
 ## Unreleased
+
 - `opentelemetry-exporter-otlp-proto-grpc`: add detailed error message to the otlp grpc exporter
   ([#5184](https://github.com/open-telemetry/opentelemetry-python/pull/5184))
 - Apply fixes for `UP` ruff rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > We are working on stabilizing the Log signal that would require making deprecations and breaking changes. We will try to reduce the releases that may require an update to your code, especially for instrumentations or for sdk developers.
 
 ## Unreleased
-
+- `opentelemetry-exporter-otlp-proto-grpc`: add detailed error message to the otlp grpc exporter
+  ([#5184](https://github.com/open-telemetry/opentelemetry-python/pull/5184))
 - Apply fixes for `UP` ruff rule
   ([#5133](https://github.com/open-telemetry/opentelemetry-python/pull/5133))
 - Switch to SPDX license headers and add CI enforcement

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -507,10 +507,11 @@ class OTLPExporterMixin(
                         or self._shutdown
                     ):
                         logger.error(
-                            "Failed to export %s to %s, error code: %s",
+                            "Failed to export %s to %s, error code: %s%s",
                             self._exporting,
                             self._endpoint,
                             error.code(),  # type: ignore [reportAttributeAccessIssue]
+                            f", details: {error.details()}" if error.details() else "",  # type: ignore [reportAttributeAccessIssue]
                             exc_info=error.code() == StatusCode.UNKNOWN,  # type: ignore [reportAttributeAccessIssue]
                         )
                         result.error = error
@@ -519,11 +520,12 @@ class OTLPExporterMixin(
                         }
                         return self._result.FAILURE  # type: ignore [reportReturnType]
                     logger.warning(
-                        "Transient error %s encountered while exporting %s to %s, retrying in %.2fs.",
+                        "Transient error %s encountered while exporting %s to %s, retrying in %.2fs.%s",
                         error.code(),  # type: ignore [reportAttributeAccessIssue]
                         self._exporting,
                         self._endpoint,
                         backoff_seconds,
+                        f" Details: {error.details()}" if error.details() else "",  # type: ignore [reportAttributeAccessIssue]
                     )
                 shutdown = self._shutdown_in_progress.wait(backoff_seconds)
                 if shutdown:

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -511,7 +511,9 @@ class OTLPExporterMixin(
                             self._exporting,
                             self._endpoint,
                             error.code(),  # type: ignore [reportAttributeAccessIssue]
-                            f", details: {error.details()}" if error.details() else "",  # type: ignore [reportAttributeAccessIssue]
+                            f", details: {error.details()}"
+                            if error.details()
+                            else "",
                             exc_info=error.code() == StatusCode.UNKNOWN,  # type: ignore [reportAttributeAccessIssue]
                         )
                         result.error = error
@@ -525,7 +527,9 @@ class OTLPExporterMixin(
                         self._exporting,
                         self._endpoint,
                         backoff_seconds,
-                        f" Details: {error.details()}" if error.details() else "",  # type: ignore [reportAttributeAccessIssue]
+                        f" Details: {error.details()}"
+                        if error.details()
+                        else "",
                     )
                 shutdown = self._shutdown_in_progress.wait(backoff_seconds)
                 if shutdown:

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
@@ -788,7 +788,7 @@ class TestOTLPExporterMixin(TestCase):
         add_TraceServiceServicer_to_server(
             TraceServiceServicerWithExportParams(
                 StatusCode.UNAVAILABLE,
-                optional_retry_nanos=100000000,  # .1 seconds
+                optional_retry_nanos=200000000,
                 optional_details="collector is restarting",
             ),
             self.server,
@@ -798,11 +798,9 @@ class TestOTLPExporterMixin(TestCase):
         )
         with self.assertLogs(level=WARNING) as warning:
             exporter.export([self.span])
-        transient_warnings = [
-            r for r in warning.records if "Transient" in r.message
-        ]
-        self.assertTrue(len(transient_warnings) > 0)
-        self.assertIn("collector is restarting", transient_warnings[0].message)
+        warning_logs = [r for r in warning.records if "Transient" in r.message]
+        self.assertTrue(len(warning_logs) > 0)
+        self.assertIn("collector is restarting", warning_logs[0].message)
 
     def assert_standard_metric_attrs(self, attributes):
         self.assertEqual(

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
@@ -108,10 +108,12 @@ class TraceServiceServicerWithExportParams(TraceServiceServicer):
         export_result: StatusCode,
         optional_retry_nanos: int | None = None,
         optional_export_sleep: float | None = None,
+        optional_details: str | None = None,
     ):
         self.export_result = export_result
         self.optional_export_sleep = optional_export_sleep
         self.optional_retry_nanos = optional_retry_nanos
+        self.optional_details = optional_details
         self.num_requests = 0
 
     # pylint: disable=invalid-name,unused-argument
@@ -132,6 +134,8 @@ class TraceServiceServicerWithExportParams(TraceServiceServicer):
                     ),
                 )
             )
+        if self.optional_details:
+            context.set_details(self.optional_details)
         context.set_code(self.export_result)
 
         return ExportTraceServiceResponse()
@@ -762,6 +766,43 @@ class TestOTLPExporterMixin(TestCase):
             SpanExportResult.FAILURE,
         )
         self.assertEqual(mock_trace_service.num_requests, 1)
+
+    def test_error_details_logged_on_permanent_failure(self):
+        add_TraceServiceServicer_to_server(
+            TraceServiceServicerWithExportParams(
+                StatusCode.INVALID_ARGUMENT,
+                optional_details="field 'resource' is missing",
+            ),
+            self.server,
+        )
+        with self.assertLogs(level=WARNING) as warning:
+            self.assertEqual(
+                self.exporter.export([self.span]), SpanExportResult.FAILURE
+            )
+            self.assertIn(
+                "field 'resource' is missing",
+                warning.records[-1].message,
+            )
+
+    def test_error_details_logged_on_transient_failure(self):
+        add_TraceServiceServicer_to_server(
+            TraceServiceServicerWithExportParams(
+                StatusCode.UNAVAILABLE,
+                optional_retry_nanos=100000000,  # .1 seconds
+                optional_details="collector is restarting",
+            ),
+            self.server,
+        )
+        exporter = OTLPSpanExporterForTesting(
+            insecure=True, timeout=10, meter_provider=self.meter_provider
+        )
+        with self.assertLogs(level=WARNING) as warning:
+            exporter.export([self.span])
+        transient_warnings = [
+            r for r in warning.records if "Transient" in r.message
+        ]
+        self.assertTrue(len(transient_warnings) > 0)
+        self.assertIn("collector is restarting", transient_warnings[0].message)
 
     def assert_standard_metric_attrs(self, attributes):
         self.assertEqual(

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
@@ -593,7 +593,7 @@ class TestOTLPExporterMixin(TestCase):
                 )
             after = time.time()
             self.assertEqual(
-                "Failed to export traces to localhost:4317, error code: StatusCode.DEADLINE_EXCEEDED",
+                "Failed to export traces to localhost:4317, error code: StatusCode.DEADLINE_EXCEEDED, details: Deadline Exceeded",
                 warning.records[-1].message,
             )
             self.assertEqual(mock_trace_service.num_requests, 2)
@@ -621,7 +621,8 @@ class TestOTLPExporterMixin(TestCase):
         with self.assertLogs(level=WARNING) as warning:
             add_TraceServiceServicer_to_server(
                 TraceServiceServicerWithExportParams(
-                    StatusCode.ALREADY_EXISTS
+                    StatusCode.ALREADY_EXISTS,
+                    optional_details="resource already exists",
                 ),
                 self.server,
             )
@@ -630,7 +631,7 @@ class TestOTLPExporterMixin(TestCase):
             )
             self.assertEqual(
                 warning.records[-1].message,
-                "Failed to export traces to localhost:4317, error code: StatusCode.ALREADY_EXISTS",
+                "Failed to export traces to localhost:4317, error code: StatusCode.ALREADY_EXISTS, details: resource already exists",
             )
 
         metrics_data = self.metric_reader.get_metrics_data()
@@ -766,41 +767,6 @@ class TestOTLPExporterMixin(TestCase):
             SpanExportResult.FAILURE,
         )
         self.assertEqual(mock_trace_service.num_requests, 1)
-
-    def test_error_details_logged_on_permanent_failure(self):
-        add_TraceServiceServicer_to_server(
-            TraceServiceServicerWithExportParams(
-                StatusCode.INVALID_ARGUMENT,
-                optional_details="field 'resource' is missing",
-            ),
-            self.server,
-        )
-        with self.assertLogs(level=WARNING) as warning:
-            self.assertEqual(
-                self.exporter.export([self.span]), SpanExportResult.FAILURE
-            )
-            self.assertIn(
-                "field 'resource' is missing",
-                warning.records[-1].message,
-            )
-
-    def test_error_details_logged_on_transient_failure(self):
-        add_TraceServiceServicer_to_server(
-            TraceServiceServicerWithExportParams(
-                StatusCode.UNAVAILABLE,
-                optional_retry_nanos=200000000,
-                optional_details="collector is restarting",
-            ),
-            self.server,
-        )
-        exporter = OTLPSpanExporterForTesting(
-            insecure=True, timeout=10, meter_provider=self.meter_provider
-        )
-        with self.assertLogs(level=WARNING) as warning:
-            exporter.export([self.span])
-        warning_logs = [r for r in warning.records if "Transient" in r.message]
-        self.assertTrue(len(warning_logs) > 0)
-        self.assertIn("collector is restarting", warning_logs[0].message)
 
     def assert_standard_metric_attrs(self, attributes):
         self.assertEqual(


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #4393 

Small enhancement to expose detailed grpc error message to the log for the otel-grpc exporter.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested with follow tox envs:
py313-test-opentelemetry-exporter-otlp-proto-grpc-oldest
py313-test-opentelemetry-exporter-otlp-proto-grpc-latest
py314-test-opentelemetry-exporter-otlp-proto-grpc-oldest
py314-test-opentelemetry-exporter-otlp-proto-grpc-latest

All passed.

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
