### PR TITLE
remove obsolete dependency on importlib-metadata. All required APIs are already available in PSL importlib.metadata as for python>=3.10

### DIFF
--- a/.changelog/5196.removed
+++ b/.changelog/5196.removed
@@ -1,0 +1,1 @@
+remove obsolete dependency on importlib-metadata. All required APIs are already available in PSL importlib.metadata as for python>=3.10

--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -26,9 +26,6 @@ classifiers = [
 ]
 dependencies = [
     "typing-extensions >= 4.5.0",
-    # FIXME This should be able to be removed after 3.12 is released if there is a reliable API
-    # in importlib.metadata.
-    "importlib-metadata >= 6.0, < 8.8.0",
 ]
 dynamic = [
     "version",

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -2,11 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import cache
-
-# FIXME: Use importlib.metadata (not importlib_metadata)
-# when support for 3.11 is dropped if the rest of
-# the supported versions at that time have the same API.
-from importlib_metadata import (  # type: ignore
+from importlib.metadata import (
     Distribution,
     EntryPoint,
     EntryPoints,
@@ -15,7 +11,7 @@ from importlib_metadata import (  # type: ignore
     requires,
     version,
 )
-from importlib_metadata import (
+from importlib.metadata import (
     entry_points as original_entry_points,
 )
 


### PR DESCRIPTION
remove obsolete dependency on importlib-metadata. All required APIs as available in importlib.metadata as for python>=3.10

# Description

remove obsolete dependency on importlib-metadata. All required APIs as available in importlib.metadata as for python>=3.10
Fixes # (issue)

all types exposed by opentelemetry.util._importlib_metadata are available as of minimum supported python 3.10 std lib

the dependency on importlib-metadata is already falling behind and starting to cause environment solving issues with 3.11+

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The affected module is already tested in opentelemetry-api/tests/util/test__importlib_metadata.py

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.