### PR TITLE
Bump semconv to 1.41.1

### DIFF
--- a/.changelog/5200.changed
+++ b/.changelog/5200.changed
@@ -1,0 +1,1 @@
+`opentelemetry-semantic-conventions`: Bump semantic conventions to 1.41.1, this changes the metrics name of `K8S_CONTAINER_CPU_LIMIT_UTILIZATION` and `K8S_CONTAINER_CPU_REQUEST_UTILIZATION`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#5151](https://github.com/open-telemetry/opentelemetry-python/pull/5151))
 - `opentelemetry-api`, `opentelemetry-sdk`: add support for 'random-trace-id' flags in W3C traceparent header trace flags. Implementations of `IdGenerator` that do randomly generate the 56 least significant bits, should also implement a `is_trace_id_random` methods that returns `True`.
   ([#4854](https://github.com/open-telemetry/opentelemetry-python/pull/4854))
+- `opentelemetry-semantic-conventions`: Bump semantic conventions to 1.41.0, this changes the metrics name of `K8S_CONTAINER_CPU_LIMIT_UTILIZATION` and `K8S_CONTAINER_CPU_REQUEST_UTILIZATION`.
+  ([#5200](https://github.com/open-telemetry/opentelemetry-python/pull/5200))
 
 ## Version 1.41.0/0.62b0 (2026-04-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#5151](https://github.com/open-telemetry/opentelemetry-python/pull/5151))
 - `opentelemetry-api`, `opentelemetry-sdk`: add support for 'random-trace-id' flags in W3C traceparent header trace flags. Implementations of `IdGenerator` that do randomly generate the 56 least significant bits, should also implement a `is_trace_id_random` methods that returns `True`.
   ([#4854](https://github.com/open-telemetry/opentelemetry-python/pull/4854))
-- `opentelemetry-semantic-conventions`: Bump semantic conventions to 1.41.0, this changes the metrics name of `K8S_CONTAINER_CPU_LIMIT_UTILIZATION` and `K8S_CONTAINER_CPU_REQUEST_UTILIZATION`.
+- `opentelemetry-semantic-conventions`: Bump semantic conventions to 1.41.1, this changes the metrics name of `K8S_CONTAINER_CPU_LIMIT_UTILIZATION` and `K8S_CONTAINER_CPU_REQUEST_UTILIZATION`.
   ([#5200](https://github.com/open-telemetry/opentelemetry-python/pull/5200))
 
 ## Version 1.41.0/0.62b0 (2026-04-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#5151](https://github.com/open-telemetry/opentelemetry-python/pull/5151))
 - `opentelemetry-api`, `opentelemetry-sdk`: add support for 'random-trace-id' flags in W3C traceparent header trace flags. Implementations of `IdGenerator` that do randomly generate the 56 least significant bits, should also implement a `is_trace_id_random` methods that returns `True`.
   ([#4854](https://github.com/open-telemetry/opentelemetry-python/pull/4854))
-- `opentelemetry-semantic-conventions`: Bump semantic conventions to 1.41.1, this changes the metrics name of `K8S_CONTAINER_CPU_LIMIT_UTILIZATION` and `K8S_CONTAINER_CPU_REQUEST_UTILIZATION`.
-  ([#5200](https://github.com/open-telemetry/opentelemetry-python/pull/5200))
 
 ## Version 1.41.0/0.62b0 (2026-04-09)
 

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/aws_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/aws_attributes.py
@@ -198,7 +198,7 @@ Note: This may be different from `cloud.resource_id` if an alias is involved.
 
 AWS_LAMBDA_RESOURCE_MAPPING_ID: Final = "aws.lambda.resource_mapping.id"
 """
-The UUID of the [AWS Lambda EvenSource Mapping](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html). An event source is mapped to a lambda function. It's contents are read by Lambda and used to trigger a function. This isn't available in the lambda execution context or the lambda runtime environtment. This is going to be populated by the AWS SDK for each language when that UUID is present. Some of these operations are Create/Delete/Get/List/Update EventSourceMapping.
+The UUID of the [AWS Lambda EvenSource Mapping](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html). An event source is mapped to a lambda function. It's contents are read by Lambda and used to trigger a function. This isn't available in the lambda execution context or the lambda runtime environment. This is going to be populated by the AWS SDK for each language when that UUID is present. Some of these operations are Create/Delete/Get/List/Update EventSourceMapping.
 """
 
 AWS_LOG_GROUP_ARNS: Final = "aws.log.group.arns"
@@ -301,7 +301,7 @@ This applies in particular to the following operations:
 
 AWS_SECRETSMANAGER_SECRET_ARN: Final = "aws.secretsmanager.secret.arn"
 """
-The ARN of the Secret stored in the Secrets Mangger.
+The ARN of the Secret stored in the Secrets Manager.
 """
 
 AWS_SNS_TOPIC_ARN: Final = "aws.sns.topic.arn"

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/cicd_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/cicd_attributes.py
@@ -42,6 +42,7 @@ The human readable name of a task within a pipeline. Task here most closely alig
 CICD_PIPELINE_TASK_RUN_ID: Final = "cicd.pipeline.task.run.id"
 """
 The unique identifier of a task run within a pipeline.
+Note: For a given pipeline run and task, the `cicd.pipeline.task.run.id` MUST be unique within that run. For the same task across different runs of the same pipeline, the `cicd.pipeline.task.run.id` MAY remain the same, enabling correlation of `cicd.pipeline.task.run.result` values across multiple pipeline runs.
 """
 
 CICD_PIPELINE_TASK_RUN_RESULT: Final = "cicd.pipeline.task.run.result"

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/container_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/container_attributes.py
@@ -91,7 +91,7 @@ Deprecated: Replaced by `container.runtime.name`.
 
 CONTAINER_RUNTIME_DESCRIPTION: Final = "container.runtime.description"
 """
-A description about the runtime which could include, for example details about the CRI/API version being used or other customisations.
+A description about the runtime which could include, for example details about the CRI/API version being used or other customizations.
 """
 
 CONTAINER_RUNTIME_NAME: Final = "container.runtime.name"

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/deployment_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/deployment_attributes.py
@@ -4,6 +4,8 @@
 from enum import Enum
 from typing import Final
 
+from typing_extensions import deprecated
+
 DEPLOYMENT_ENVIRONMENT: Final = "deployment.environment"
 """
 Deprecated: Replaced by `deployment.environment.name`.
@@ -11,14 +13,7 @@ Deprecated: Replaced by `deployment.environment.name`.
 
 DEPLOYMENT_ENVIRONMENT_NAME: Final = "deployment.environment.name"
 """
-Name of the [deployment environment](https://wikipedia.org/wiki/Deployment_environment) (aka deployment tier).
-Note: `deployment.environment.name` does not affect the uniqueness constraints defined through
-the `service.namespace`, `service.name` and `service.instance.id` resource attributes.
-This implies that resources carrying the following attribute combinations MUST be
-considered to be identifying the same service:
-
-- `service.name=frontend`, `deployment.environment.name=production`
-- `service.name=frontend`, `deployment.environment.name=staging`.
+Deprecated in favor of stable :py:const:`opentelemetry.semconv.attributes.deployment_attributes.DEPLOYMENT_ENVIRONMENT_NAME`.
 """
 
 DEPLOYMENT_ID: Final = "deployment.id"
@@ -35,6 +30,20 @@ DEPLOYMENT_STATUS: Final = "deployment.status"
 """
 The status of the deployment.
 """
+
+
+@deprecated(
+    "Deprecated in favor of stable :py:const:`opentelemetry.semconv.attributes.deployment_attributes.DeploymentEnvironmentNameValues`."
+)
+class DeploymentEnvironmentNameValues(Enum):
+    PRODUCTION = "production"
+    """Deprecated in favor of stable :py:const:`opentelemetry.semconv.attributes.deployment_attributes.DeploymentEnvironmentNameValues.PRODUCTION`."""
+    STAGING = "staging"
+    """Deprecated in favor of stable :py:const:`opentelemetry.semconv.attributes.deployment_attributes.DeploymentEnvironmentNameValues.STAGING`."""
+    TEST = "test"
+    """Deprecated in favor of stable :py:const:`opentelemetry.semconv.attributes.deployment_attributes.DeploymentEnvironmentNameValues.TEST`."""
+    DEVELOPMENT = "development"
+    """Deprecated in favor of stable :py:const:`opentelemetry.semconv.attributes.deployment_attributes.DeploymentEnvironmentNameValues.DEVELOPMENT`."""
 
 
 class DeploymentStatusValues(Enum):

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/gen_ai_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/gen_ai_attributes.py
@@ -232,6 +232,11 @@ GEN_AI_REQUEST_STOP_SEQUENCES: Final = "gen_ai.request.stop_sequences"
 List of sequences that the model will use to stop generating further tokens.
 """
 
+GEN_AI_REQUEST_STREAM: Final = "gen_ai.request.stream"
+"""
+Indicates whether the GenAI request was made in streaming mode.
+"""
+
 GEN_AI_REQUEST_TEMPERATURE: Final = "gen_ai.request.temperature"
 """
 The temperature setting for the GenAI request.
@@ -260,6 +265,13 @@ The unique identifier for the completion.
 GEN_AI_RESPONSE_MODEL: Final = "gen_ai.response.model"
 """
 The name of the model that generated the response.
+"""
+
+GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK: Final = (
+    "gen_ai.response.time_to_first_chunk"
+)
+"""
+Time to first chunk in a streaming response, measured from request issuance, in seconds. The value is measured from when the client issues the generation request to when the first chunk is received in the response stream.
 """
 
 GEN_AI_RETRIEVAL_DOCUMENTS: Final = "gen_ai.retrieval.documents"
@@ -345,16 +357,16 @@ deserialize it to an object. When recorded on spans, it MAY be recorded as a JSO
 
 GEN_AI_TOOL_DEFINITIONS: Final = "gen_ai.tool.definitions"
 """
-The list of source system tool definitions available to the GenAI agent or model.
-Note: The value of this attribute matches source system tool definition format.
+The list of tool definitions available to the GenAI agent or model.
+Note: Instrumentations MUST follow [Tool Definitions JSON Schema](/docs/gen-ai/gen-ai-tool-definitions.json).
 
-It's expected to be an array of objects where each object represents a tool definition. In case a serialized string is available
-to the instrumentation, the instrumentation SHOULD do the best effort to
-deserialize it to an array. When recorded on spans, it MAY be recorded as a JSON string if structured format is not supported and SHOULD be recorded in structured form otherwise.
+When the attribute is recorded on events, it MUST be recorded in structured
+form. When recorded on spans, it MAY be recorded as a JSON string if structured
+format is not supported and SHOULD be recorded in structured form otherwise.
 
 Since this attribute could be large, it's NOT RECOMMENDED to populate
-it by default. Instrumentations MAY provide a way to enable
-populating this attribute.
+non-required properties by default. Instrumentations MAY provide a way
+to enable populating optional properties.
 """
 
 GEN_AI_TOOL_DESCRIPTION: Final = "gen_ai.tool.description"
@@ -417,6 +429,20 @@ GEN_AI_USAGE_PROMPT_TOKENS: Final = "gen_ai.usage.prompt_tokens"
 Deprecated: Replaced by `gen_ai.usage.input_tokens`.
 """
 
+GEN_AI_USAGE_REASONING_OUTPUT_TOKENS: Final = (
+    "gen_ai.usage.reasoning.output_tokens"
+)
+"""
+The number of output tokens used for reasoning (e.g. chain-of-thought, extended thinking).
+Note: The value SHOULD be included in `gen_ai.usage.output_tokens`.
+"""
+
+GEN_AI_WORKFLOW_NAME: Final = "gen_ai.workflow.name"
+"""
+Human-readable name of the GenAI workflow provided by the application.
+Note: This attribute can be populated in different frameworks eg: name of the first chain in LangChain OR name of the crew in CrewAI.
+"""
+
 
 @deprecated(
     "The attribute gen_ai.openai.request.response_format is deprecated - Replaced by `gen_ai.output.type`"
@@ -457,6 +483,8 @@ class GenAiOperationNameValues(Enum):
     """Invoke GenAI agent."""
     EXECUTE_TOOL = "execute_tool"
     """Execute a tool."""
+    INVOKE_WORKFLOW = "invoke_workflow"
+    """Invoke GenAI workflow."""
 
 
 class GenAiOutputTypeValues(Enum):
@@ -486,7 +514,7 @@ class GenAiProviderNameValues(Enum):
     AZURE_AI_INFERENCE = "azure.ai.inference"
     """Azure AI Inference."""
     AZURE_AI_OPENAI = "azure.ai.openai"
-    """[Azure OpenAI](https://azure.microsoft.com/products/ai-services/openai-service/)."""
+    """[Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)."""
     IBM_WATSONX_AI = "ibm.watsonx.ai"
     """[IBM Watsonx AI](https://www.ibm.com/products/watsonx-ai)."""
     AWS_BEDROCK = "aws.bedrock"

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/graphql_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/graphql_attributes.py
@@ -7,7 +7,7 @@ from typing import Final
 GRAPHQL_DOCUMENT: Final = "graphql.document"
 """
 The GraphQL document being executed.
-Note: The value may be sanitized to exclude sensitive information.
+Note: If instrumentation can reliably identify and redact sensitive information it SHOULD do it.
 """
 
 GRAPHQL_OPERATION_NAME: Final = "graphql.operation.name"

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/hw_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/hw_attributes.py
@@ -6,7 +6,7 @@ from typing import Final
 
 HW_BATTERY_CAPACITY: Final = "hw.battery.capacity"
 """
-Design capacity in Watts-hours or Amper-hours.
+Design capacity in Watts-hours or Ampere-hours.
 """
 
 HW_BATTERY_CHEMISTRY: Final = "hw.battery.chemistry"

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/k8s_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/k8s_attributes.py
@@ -314,9 +314,109 @@ K8S_NODE_NAME: Final = "k8s.node.name"
 The name of the Node.
 """
 
+K8S_NODE_SYSTEM_CONTAINER_NAME: Final = "k8s.node.system_container.name"
+"""
+The name of the system container running on the K8s Node.
+"""
+
 K8S_NODE_UID: Final = "k8s.node.uid"
 """
 The UID of the Node.
+"""
+
+K8S_PERSISTENTVOLUME_ANNOTATION_TEMPLATE: Final = (
+    "k8s.persistentvolume.annotation"
+)
+"""
+The annotation placed on the PersistentVolume, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
+Note: Examples:
+
+- An annotation `pv.kubernetes.io/provisioned-by` with value `kubernetes.io/aws-ebs` SHOULD be recorded as
+  the `k8s.persistentvolume.annotation.pv.kubernetes.io/provisioned-by` attribute with value `"kubernetes.io/aws-ebs"`.
+- An annotation `data` with empty string value SHOULD be recorded as
+  the `k8s.persistentvolume.annotation.data` attribute with value `""`.
+"""
+
+K8S_PERSISTENTVOLUME_LABEL_TEMPLATE: Final = "k8s.persistentvolume.label"
+"""
+The label placed on the PersistentVolume, the `<key>` being the label name, the value being the label value, even if the value is empty.
+Note: Examples:
+
+- A label `type` with value `ssd` SHOULD be recorded as
+  the `k8s.persistentvolume.label.type` attribute with value `"ssd"`.
+- A label `data` with empty string value SHOULD be recorded as
+  the `k8s.persistentvolume.label.data` attribute with value `""`.
+"""
+
+K8S_PERSISTENTVOLUME_NAME: Final = "k8s.persistentvolume.name"
+"""
+The name of the PersistentVolume.
+"""
+
+K8S_PERSISTENTVOLUME_RECLAIM_POLICY: Final = (
+    "k8s.persistentvolume.reclaim_policy"
+)
+"""
+The reclaim policy of the PersistentVolume.
+Note: This attribute aligns with the `persistentVolumeReclaimPolicy` field of the
+[K8s PersistentVolumeSpec](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/#PersistentVolumeSpec).
+"""
+
+K8S_PERSISTENTVOLUME_STATUS_PHASE: Final = "k8s.persistentvolume.status.phase"
+"""
+The phase of the PersistentVolume.
+Note: This attribute aligns with the `phase` field of the
+[K8s PersistentVolumeStatus](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/#PersistentVolumeStatus).
+"""
+
+K8S_PERSISTENTVOLUME_UID: Final = "k8s.persistentvolume.uid"
+"""
+The UID of the PersistentVolume.
+"""
+
+K8S_PERSISTENTVOLUMECLAIM_ANNOTATION_TEMPLATE: Final = (
+    "k8s.persistentvolumeclaim.annotation"
+)
+"""
+The annotation placed on the PersistentVolumeClaim, the `<key>` being the annotation name, the value being the annotation value, even if the value is empty.
+Note: Examples:
+
+- An annotation `volume.beta.kubernetes.io/storage-provisioner` with value `kubernetes.io/aws-ebs` SHOULD be recorded as
+  the `k8s.persistentvolumeclaim.annotation.volume.beta.kubernetes.io/storage-provisioner` attribute with value `"kubernetes.io/aws-ebs"`.
+- An annotation `data` with empty string value SHOULD be recorded as
+  the `k8s.persistentvolumeclaim.annotation.data` attribute with value `""`.
+"""
+
+K8S_PERSISTENTVOLUMECLAIM_LABEL_TEMPLATE: Final = (
+    "k8s.persistentvolumeclaim.label"
+)
+"""
+The label placed on the PersistentVolumeClaim, the `<key>` being the label name, the value being the label value, even if the value is empty.
+Note: Examples:
+
+- A label `app` with value `my-app` SHOULD be recorded as
+  the `k8s.persistentvolumeclaim.label.app` attribute with value `"my-app"`.
+- A label `data` with empty string value SHOULD be recorded as
+  the `k8s.persistentvolumeclaim.label.data` attribute with value `""`.
+"""
+
+K8S_PERSISTENTVOLUMECLAIM_NAME: Final = "k8s.persistentvolumeclaim.name"
+"""
+The name of the PersistentVolumeClaim.
+"""
+
+K8S_PERSISTENTVOLUMECLAIM_STATUS_PHASE: Final = (
+    "k8s.persistentvolumeclaim.status.phase"
+)
+"""
+The phase of the PersistentVolumeClaim.
+Note: This attribute aligns with the `phase` field of the
+[K8s PersistentVolumeClaimStatus](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimStatus).
+"""
+
+K8S_PERSISTENTVOLUMECLAIM_UID: Final = "k8s.persistentvolumeclaim.uid"
+"""
+The UID of the PersistentVolumeClaim.
 """
 
 K8S_POD_ANNOTATION_TEMPLATE: Final = "k8s.pod.annotation"
@@ -669,6 +769,37 @@ class K8sNodeConditionTypeValues(Enum):
     """Pressure exists on the processes—that is, if there are too many processes on the node."""
     NETWORK_UNAVAILABLE = "NetworkUnavailable"
     """The network for the node is not correctly configured."""
+
+
+class K8sPersistentvolumeReclaimPolicyValues(Enum):
+    DELETE = "Delete"
+    """The volume will be deleted when released from its claim."""
+    RECYCLE = "Recycle"
+    """The volume will be recycled (basic scrub) when released from its claim."""
+    RETAIN = "Retain"
+    """The volume will be retained when released from its claim."""
+
+
+class K8sPersistentvolumeStatusPhaseValues(Enum):
+    AVAILABLE = "Available"
+    """The volume is available and not yet bound to a claim."""
+    BOUND = "Bound"
+    """The volume is bound to a claim."""
+    FAILED = "Failed"
+    """The volume has failed its automatic reclamation."""
+    PENDING = "Pending"
+    """The volume is being provisioned."""
+    RELEASED = "Released"
+    """The claim has been deleted but the volume is not yet available."""
+
+
+class K8sPersistentvolumeclaimStatusPhaseValues(Enum):
+    BOUND = "Bound"
+    """The claim is bound to a volume."""
+    LOST = "Lost"
+    """The claim has lost its underlying volume (the volume does not exist anymore)."""
+    PENDING = "Pending"
+    """The claim has not yet been bound to a volume."""
 
 
 class K8sPodStatusPhaseValues(Enum):

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/otel_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/otel_attributes.py
@@ -33,8 +33,7 @@ E.g. for Java the fully qualified classname SHOULD be used in this case.
 
 OTEL_EVENT_NAME: Final = "otel.event.name"
 """
-Identifies the class / type of event.
-Note: This attribute SHOULD be used by non-OTLP exporters when destination does not support `EventName` or equivalent field. This attribute MAY be used by applications using existing logging libraries so that it can be used to set the `EventName` field by Collector or SDK components.
+Deprecated in favor of stable :py:const:`opentelemetry.semconv.attributes.otel_attributes.OTEL_EVENT_NAME`.
 """
 
 OTEL_LIBRARY_NAME: Final = "otel.library.name"

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/process_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/process_attributes.py
@@ -69,7 +69,20 @@ PROCESS_EXECUTABLE_BUILD_ID_HTLHASH: Final = (
     "process.executable.build_id.htlhash"
 )
 """
-Profiling specific build ID for executables. See the OTel specification for Profiles for more information.
+Deterministic build ID for executables.
+Note: GNU and Go build IDs may be stripped or unavailable in some environments
+(e.g., Alpine Linux, Docker images). This attribute provides a deterministic
+build ID computed by hashing the first and last 4096 bytes of the file
+along with its length:
+
+```
+Input   ← Concat(File[:4096], File[-4096:], BigEndianUInt64(Len(File)))
+Digest  ← SHA256(Input)
+BuildID ← Digest[:16]
+```
+
+The result is the first 16 bytes (128 bits) of the SHA256 digest,
+represented as a hex string.
 """
 
 PROCESS_EXECUTABLE_BUILD_ID_PROFILING: Final = (

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/system_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/system_attributes.py
@@ -41,6 +41,13 @@ SYSTEM_FILESYSTEM_TYPE: Final = "system.filesystem.type"
 The filesystem type.
 """
 
+SYSTEM_MEMORY_LINUX_HUGEPAGES_STATE: Final = (
+    "system.memory.linux.hugepages.state"
+)
+"""
+The Linux HugePages memory state.
+"""
+
 SYSTEM_MEMORY_LINUX_SLAB_STATE: Final = "system.memory.linux.slab.state"
 """
 The Linux Slab memory state.
@@ -129,6 +136,13 @@ class SystemFilesystemTypeValues(Enum):
     """hfsplus."""
     EXT4 = "ext4"
     """ext4."""
+
+
+class SystemMemoryLinuxHugepagesStateValues(Enum):
+    FREE = "free"
+    """free."""
+    USED = "used"
+    """used."""
 
 
 class SystemMemoryLinuxSlabStateValues(Enum):

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/telemetry_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/attributes/telemetry_attributes.py
@@ -8,14 +8,12 @@ from typing_extensions import deprecated
 
 TELEMETRY_DISTRO_NAME: Final = "telemetry.distro.name"
 """
-The name of the auto instrumentation agent or distribution, if used.
-Note: Official auto instrumentation agents and distributions SHOULD set the `telemetry.distro.name` attribute to
-a string starting with `opentelemetry-`, e.g. `opentelemetry-java-instrumentation`.
+Deprecated in favor of stable :py:const:`opentelemetry.semconv.attributes.telemetry_attributes.TELEMETRY_DISTRO_NAME`.
 """
 
 TELEMETRY_DISTRO_VERSION: Final = "telemetry.distro.version"
 """
-The version string of the auto instrumentation agent or distribution, if used.
+Deprecated in favor of stable :py:const:`opentelemetry.semconv.attributes.telemetry_attributes.TELEMETRY_DISTRO_VERSION`.
 """
 
 TELEMETRY_SDK_LANGUAGE: Final = "telemetry.sdk.language"

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/container_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/container_metrics.py
@@ -20,6 +20,7 @@ CallbackT = (
     | Generator[Iterable[Observation], CallbackOptions, None]
 )
 
+
 CONTAINER_CPU_TIME: Final = "container.cpu.time"
 """
 Total CPU time consumed

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/cpu_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/cpu_metrics.py
@@ -19,6 +19,7 @@ CallbackT = (
     | Generator[Iterable[Observation], CallbackOptions, None]
 )
 
+
 CPU_FREQUENCY: Final = "cpu.frequency"
 """
 Deprecated: Replaced by `system.cpu.frequency`.

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/gen_ai_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/gen_ai_metrics.py
@@ -23,6 +23,50 @@ def create_gen_ai_client_operation_duration(meter: Meter) -> Histogram:
     )
 
 
+GEN_AI_CLIENT_OPERATION_TIME_PER_OUTPUT_CHUNK: Final = (
+    "gen_ai.client.operation.time_per_output_chunk"
+)
+"""
+Time per output chunk, recorded for each chunk received after the first one, measured as the time elapsed from the end of the previous chunk to the end of the current chunk
+Instrument: histogram
+Unit: s
+Note: This metrics SHOULD be reported for streaming calls and SHOULD NOT be reported otherwise.
+"""
+
+
+def create_gen_ai_client_operation_time_per_output_chunk(
+    meter: Meter,
+) -> Histogram:
+    """Time per output chunk, recorded for each chunk received after the first one, measured as the time elapsed from the end of the previous chunk to the end of the current chunk"""
+    return meter.create_histogram(
+        name=GEN_AI_CLIENT_OPERATION_TIME_PER_OUTPUT_CHUNK,
+        description="Time per output chunk, recorded for each chunk received after the first one, measured as the time elapsed from the end of the previous chunk to the end of the current chunk.",
+        unit="s",
+    )
+
+
+GEN_AI_CLIENT_OPERATION_TIME_TO_FIRST_CHUNK: Final = (
+    "gen_ai.client.operation.time_to_first_chunk"
+)
+"""
+Time to receive the first chunk, measured from when the client issues the generation request to when the first chunk is received in the response stream
+Instrument: histogram
+Unit: s
+Note: This metrics SHOULD be reported for streaming calls and SHOULD NOT be reported otherwise.
+"""
+
+
+def create_gen_ai_client_operation_time_to_first_chunk(
+    meter: Meter,
+) -> Histogram:
+    """Time to receive the first chunk, measured from when the client issues the generation request to when the first chunk is received in the response stream"""
+    return meter.create_histogram(
+        name=GEN_AI_CLIENT_OPERATION_TIME_TO_FIRST_CHUNK,
+        description="Time to receive the first chunk, measured from when the client issues the generation request to when the first chunk is received in the response stream.",
+        unit="s",
+    )
+
+
 GEN_AI_CLIENT_TOKEN_USAGE: Final = "gen_ai.client.token.usage"
 """
 Number of input and output tokens used

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/hw_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/hw_metrics.py
@@ -20,6 +20,7 @@ CallbackT = (
     | Generator[Iterable[Observation], CallbackOptions, None]
 )
 
+
 HW_BATTERY_CHARGE: Final = "hw.battery.charge"
 """
 Remaining fraction of battery charge

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/k8s_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/k8s_metrics.py
@@ -20,6 +20,7 @@ CallbackT = (
     | Generator[Iterable[Observation], CallbackOptions, None]
 )
 
+
 K8S_CONTAINER_CPU_LIMIT: Final = "k8s.container.cpu.limit"
 """
 Deprecated: Replaced by `k8s.container.cpu.limit.desired`.
@@ -105,26 +106,6 @@ def create_k8s_container_cpu_limit_utilization(
     )
 
 
-K8S_CONTAINER_CPU_LIMIT_UTILIZATION: Final = (
-    "k8s.container.cpu.limit_utilization"
-)
-"""
-Deprecated: Replaced by `k8s.container.cpu.limit.utilization`.
-"""
-
-
-def create_k8s_container_cpu_limit_utilization(
-    meter: Meter, callbacks: Sequence[CallbackT] | None
-) -> ObservableGauge:
-    """Deprecated, use `k8s.container.cpu.limit.utilization` instead"""
-    return meter.create_observable_gauge(
-        name=K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
-        callbacks=callbacks,
-        description="Deprecated, use `k8s.container.cpu.limit.utilization` instead.",
-        unit="1",
-    )
-
-
 K8S_CONTAINER_CPU_REQUEST: Final = "k8s.container.cpu.request"
 """
 Deprecated: Replaced by `k8s.container.cpu.request.desired`.
@@ -206,26 +187,6 @@ def create_k8s_container_cpu_request_utilization(
         name=K8S_CONTAINER_CPU_REQUEST_UTILIZATION,
         callbacks=callbacks,
         description="The ratio of container CPU usage to its current CPU request.",
-        unit="1",
-    )
-
-
-K8S_CONTAINER_CPU_REQUEST_UTILIZATION: Final = (
-    "k8s.container.cpu.request_utilization"
-)
-"""
-Deprecated: Replaced by `k8s.container.cpu.request.utilization`.
-"""
-
-
-def create_k8s_container_cpu_request_utilization(
-    meter: Meter, callbacks: Sequence[CallbackT] | None
-) -> ObservableGauge:
-    """Deprecated, use `k8s.container.cpu.request.utilization` instead"""
-    return meter.create_observable_gauge(
-        name=K8S_CONTAINER_CPU_REQUEST_UTILIZATION,
-        callbacks=callbacks,
-        description="Deprecated, use `k8s.container.cpu.request.utilization` instead.",
         unit="1",
     )
 

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/k8s_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/k8s_metrics.py
@@ -22,19 +22,86 @@ CallbackT = (
 
 K8S_CONTAINER_CPU_LIMIT: Final = "k8s.container.cpu.limit"
 """
-Maximum CPU resource limit set for the container
-Instrument: updowncounter
-Unit: {cpu}
-Note: See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
+Deprecated: Replaced by `k8s.container.cpu.limit.desired`.
 """
 
 
 def create_k8s_container_cpu_limit(meter: Meter) -> UpDownCounter:
-    """Maximum CPU resource limit set for the container"""
+    """Deprecated, use `k8s.container.cpu.limit.desired` and `k8s.container.cpu.limit.current` instead"""
     return meter.create_up_down_counter(
         name=K8S_CONTAINER_CPU_LIMIT,
-        description="Maximum CPU resource limit set for the container.",
+        description="Deprecated, use `k8s.container.cpu.limit.desired` and `k8s.container.cpu.limit.current` instead.",
         unit="{cpu}",
+    )
+
+
+K8S_CONTAINER_CPU_LIMIT_CURRENT: Final = "k8s.container.cpu.limit.current"
+"""
+Maximum CPU resource limit currently configured for a running container
+Instrument: updowncounter
+Unit: {cpu}
+Note: This metric aligns with the limit in the
+[`resources`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#resourcerequirements-v1-core) field of
+[K8s ContainerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#containerstatus-v1-core)
+(status.containerStatuses[*].resources). Also see `Actual Resources` in
+<https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/> for more details.
+"""
+
+
+def create_k8s_container_cpu_limit_current(meter: Meter) -> UpDownCounter:
+    """Maximum CPU resource limit currently configured for a running container"""
+    return meter.create_up_down_counter(
+        name=K8S_CONTAINER_CPU_LIMIT_CURRENT,
+        description="Maximum CPU resource limit currently configured for a running container.",
+        unit="{cpu}",
+    )
+
+
+K8S_CONTAINER_CPU_LIMIT_DESIRED: Final = "k8s.container.cpu.limit.desired"
+"""
+Maximum CPU resource limit as defined by the container spec
+Instrument: updowncounter
+Unit: {cpu}
+Note: This metric aligns with the limit in the
+[`resources`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#resourcerequirements-v1-core) field of
+[K8s Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#container-v1-core)
+(spec.containers[*].resources). Also see `Desired Resources` in
+<https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/> for more details.
+"""
+
+
+def create_k8s_container_cpu_limit_desired(meter: Meter) -> UpDownCounter:
+    """Maximum CPU resource limit as defined by the container spec"""
+    return meter.create_up_down_counter(
+        name=K8S_CONTAINER_CPU_LIMIT_DESIRED,
+        description="Maximum CPU resource limit as defined by the container spec.",
+        unit="{cpu}",
+    )
+
+
+K8S_CONTAINER_CPU_LIMIT_UTILIZATION: Final = (
+    "k8s.container.cpu.limit.utilization"
+)
+"""
+The ratio of container CPU usage to its current CPU limit
+Instrument: gauge
+Unit: 1
+Note: The current CPU limit reflects the actual resources applied to the container, as reported by
+[ContainerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#containerstatus-v1-core).
+The value range is [0.0,1.0]. A value of 1.0 means the container is using 100% of its actual CPU limit.
+If the CPU limit is not set, this metric SHOULD NOT be emitted for that container.
+"""
+
+
+def create_k8s_container_cpu_limit_utilization(
+    meter: Meter, callbacks: Sequence[CallbackT] | None
+) -> ObservableGauge:
+    """The ratio of container CPU usage to its current CPU limit"""
+    return meter.create_observable_gauge(
+        name=K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
+        callbacks=callbacks,
+        description="The ratio of container CPU usage to its current CPU limit.",
+        unit="1",
     )
 
 
@@ -42,40 +109,104 @@ K8S_CONTAINER_CPU_LIMIT_UTILIZATION: Final = (
     "k8s.container.cpu.limit_utilization"
 )
 """
-The ratio of container CPU usage to its CPU limit
-Instrument: gauge
-Unit: 1
-Note: The value range is [0.0,1.0]. A value of 1.0 means the container is using 100% of its CPU limit. If the CPU limit is not set, this metric SHOULD NOT be emitted for that container.
+Deprecated: Replaced by `k8s.container.cpu.limit.utilization`.
 """
 
 
 def create_k8s_container_cpu_limit_utilization(
     meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
-    """The ratio of container CPU usage to its CPU limit"""
+    """Deprecated, use `k8s.container.cpu.limit.utilization` instead"""
     return meter.create_observable_gauge(
         name=K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
         callbacks=callbacks,
-        description="The ratio of container CPU usage to its CPU limit.",
+        description="Deprecated, use `k8s.container.cpu.limit.utilization` instead.",
         unit="1",
     )
 
 
 K8S_CONTAINER_CPU_REQUEST: Final = "k8s.container.cpu.request"
 """
-CPU resource requested for the container
-Instrument: updowncounter
-Unit: {cpu}
-Note: See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
+Deprecated: Replaced by `k8s.container.cpu.request.desired`.
 """
 
 
 def create_k8s_container_cpu_request(meter: Meter) -> UpDownCounter:
-    """CPU resource requested for the container"""
+    """Deprecated, use `k8s.container.cpu.request.desired` and `k8s.container.cpu.request.current` instead"""
     return meter.create_up_down_counter(
         name=K8S_CONTAINER_CPU_REQUEST,
-        description="CPU resource requested for the container.",
+        description="Deprecated, use `k8s.container.cpu.request.desired` and `k8s.container.cpu.request.current` instead.",
         unit="{cpu}",
+    )
+
+
+K8S_CONTAINER_CPU_REQUEST_CURRENT: Final = "k8s.container.cpu.request.current"
+"""
+CPU resource requested currently configured for a running container
+Instrument: updowncounter
+Unit: {cpu}
+Note: This metric aligns with the request in the
+[`resources`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#resourcerequirements-v1-core) field of
+[K8s ContainerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#containerstatus-v1-core)
+(status.containerStatuses[*].resources). Also see `Actual Resources` in
+<https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/> for more details.
+"""
+
+
+def create_k8s_container_cpu_request_current(meter: Meter) -> UpDownCounter:
+    """CPU resource requested currently configured for a running container"""
+    return meter.create_up_down_counter(
+        name=K8S_CONTAINER_CPU_REQUEST_CURRENT,
+        description="CPU resource requested currently configured for a running container.",
+        unit="{cpu}",
+    )
+
+
+K8S_CONTAINER_CPU_REQUEST_DESIRED: Final = "k8s.container.cpu.request.desired"
+"""
+CPU resource requested as defined by the container spec
+Instrument: updowncounter
+Unit: {cpu}
+Note: This metric aligns with the request in the
+[`resources`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#resourcerequirements-v1-core) field of
+[K8s Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#container-v1-core)
+(spec.containers[*].resources). Also see `Desired Resources` in
+<https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/> for more details.
+"""
+
+
+def create_k8s_container_cpu_request_desired(meter: Meter) -> UpDownCounter:
+    """CPU resource requested as defined by the container spec"""
+    return meter.create_up_down_counter(
+        name=K8S_CONTAINER_CPU_REQUEST_DESIRED,
+        description="CPU resource requested as defined by the container spec.",
+        unit="{cpu}",
+    )
+
+
+K8S_CONTAINER_CPU_REQUEST_UTILIZATION: Final = (
+    "k8s.container.cpu.request.utilization"
+)
+"""
+The ratio of container CPU usage to its current CPU request
+Instrument: gauge
+Unit: 1
+Note: The current CPU request reflects the request applied to the running container, as reported by
+[ContainerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#containerstatus-v1-core).
+The value range is [0.0,1.0]. A value of 1.0 means the container is using 100% of its actual CPU request.
+If the CPU request is not set, this metric SHOULD NOT be emitted for that container.
+"""
+
+
+def create_k8s_container_cpu_request_utilization(
+    meter: Meter, callbacks: Sequence[CallbackT] | None
+) -> ObservableGauge:
+    """The ratio of container CPU usage to its current CPU request"""
+    return meter.create_observable_gauge(
+        name=K8S_CONTAINER_CPU_REQUEST_UTILIZATION,
+        callbacks=callbacks,
+        description="The ratio of container CPU usage to its current CPU request.",
+        unit="1",
     )
 
 
@@ -83,20 +214,18 @@ K8S_CONTAINER_CPU_REQUEST_UTILIZATION: Final = (
     "k8s.container.cpu.request_utilization"
 )
 """
-The ratio of container CPU usage to its CPU request
-Instrument: gauge
-Unit: 1
+Deprecated: Replaced by `k8s.container.cpu.request.utilization`.
 """
 
 
 def create_k8s_container_cpu_request_utilization(
     meter: Meter, callbacks: Sequence[CallbackT] | None
 ) -> ObservableGauge:
-    """The ratio of container CPU usage to its CPU request"""
+    """Deprecated, use `k8s.container.cpu.request.utilization` instead"""
     return meter.create_observable_gauge(
         name=K8S_CONTAINER_CPU_REQUEST_UTILIZATION,
         callbacks=callbacks,
-        description="The ratio of container CPU usage to its CPU request.",
+        description="Deprecated, use `k8s.container.cpu.request.utilization` instead.",
         unit="1",
     )
 
@@ -147,36 +276,126 @@ def create_k8s_container_ephemeral_storage_request(
 
 K8S_CONTAINER_MEMORY_LIMIT: Final = "k8s.container.memory.limit"
 """
-Maximum memory resource limit set for the container
-Instrument: updowncounter
-Unit: By
-Note: See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
+Deprecated: Replaced by `k8s.container.memory.limit.desired`.
 """
 
 
 def create_k8s_container_memory_limit(meter: Meter) -> UpDownCounter:
-    """Maximum memory resource limit set for the container"""
+    """Deprecated, use `k8s.container.memory.limit.desired` and `k8s.container.memory.limit.current` instead"""
     return meter.create_up_down_counter(
         name=K8S_CONTAINER_MEMORY_LIMIT,
-        description="Maximum memory resource limit set for the container.",
+        description="Deprecated, use `k8s.container.memory.limit.desired` and `k8s.container.memory.limit.current` instead.",
+        unit="By",
+    )
+
+
+K8S_CONTAINER_MEMORY_LIMIT_CURRENT: Final = (
+    "k8s.container.memory.limit.current"
+)
+"""
+Maximum memory resource limit currently configured for a running container
+Instrument: updowncounter
+Unit: By
+Note: This metric aligns with the limit in the
+[`resources`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#resourcerequirements-v1-core) field of
+[K8s ContainerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#containerstatus-v1-core)
+(status.containerStatuses[*].resources). Also see `Actual Resources` in
+<https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/> for more details.
+"""
+
+
+def create_k8s_container_memory_limit_current(meter: Meter) -> UpDownCounter:
+    """Maximum memory resource limit currently configured for a running container"""
+    return meter.create_up_down_counter(
+        name=K8S_CONTAINER_MEMORY_LIMIT_CURRENT,
+        description="Maximum memory resource limit currently configured for a running container.",
+        unit="By",
+    )
+
+
+K8S_CONTAINER_MEMORY_LIMIT_DESIRED: Final = (
+    "k8s.container.memory.limit.desired"
+)
+"""
+Maximum memory resource limit as defined by the container spec
+Instrument: updowncounter
+Unit: By
+Note: This metric aligns with the limit in the
+[`resources`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#resourcerequirements-v1-core) field of
+[K8s Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#container-v1-core)
+(spec.containers[*].resources). Also see `Desired Resources` in
+<https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/> for more details.
+"""
+
+
+def create_k8s_container_memory_limit_desired(meter: Meter) -> UpDownCounter:
+    """Maximum memory resource limit as defined by the container spec"""
+    return meter.create_up_down_counter(
+        name=K8S_CONTAINER_MEMORY_LIMIT_DESIRED,
+        description="Maximum memory resource limit as defined by the container spec.",
         unit="By",
     )
 
 
 K8S_CONTAINER_MEMORY_REQUEST: Final = "k8s.container.memory.request"
 """
-Memory resource requested for the container
-Instrument: updowncounter
-Unit: By
-Note: See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#resourcerequirements-v1-core for details.
+Deprecated: Replaced by `k8s.container.memory.request.desired`.
 """
 
 
 def create_k8s_container_memory_request(meter: Meter) -> UpDownCounter:
-    """Memory resource requested for the container"""
+    """Deprecated, use `k8s.container.memory.request.desired` and `k8s.container.memory.request.current` instead"""
     return meter.create_up_down_counter(
         name=K8S_CONTAINER_MEMORY_REQUEST,
-        description="Memory resource requested for the container.",
+        description="Deprecated, use `k8s.container.memory.request.desired` and `k8s.container.memory.request.current` instead.",
+        unit="By",
+    )
+
+
+K8S_CONTAINER_MEMORY_REQUEST_CURRENT: Final = (
+    "k8s.container.memory.request.current"
+)
+"""
+Memory resource request currently configured for a running container
+Instrument: updowncounter
+Unit: By
+Note: This metric aligns with the request in the
+[`resources`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#resourcerequirements-v1-core) field of
+[K8s ContainerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#containerstatus-v1-core)
+(status.containerStatuses[*].resources). Also see `Actual Resources` in
+<https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/> for more details.
+"""
+
+
+def create_k8s_container_memory_request_current(meter: Meter) -> UpDownCounter:
+    """Memory resource request currently configured for a running container"""
+    return meter.create_up_down_counter(
+        name=K8S_CONTAINER_MEMORY_REQUEST_CURRENT,
+        description="Memory resource request currently configured for a running container.",
+        unit="By",
+    )
+
+
+K8S_CONTAINER_MEMORY_REQUEST_DESIRED: Final = (
+    "k8s.container.memory.request.desired"
+)
+"""
+Memory resource requested as defined by the container spec
+Instrument: updowncounter
+Unit: By
+Note: This metric aligns with the request in the
+[`resources`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#resourcerequirements-v1-core) field of
+[K8s Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#container-v1-core)
+(spec.containers[*].resources). Also see `Desired Resources` in
+<https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/> for more details.
+"""
+
+
+def create_k8s_container_memory_request_desired(meter: Meter) -> UpDownCounter:
+    """Memory resource requested as defined by the container spec"""
+    return meter.create_up_down_counter(
+        name=K8S_CONTAINER_MEMORY_REQUEST_DESIRED,
+        description="Memory resource requested as defined by the container spec.",
         unit="By",
     )
 
@@ -1334,6 +1553,93 @@ def create_k8s_node_pod_allocatable(meter: Meter) -> UpDownCounter:
     )
 
 
+K8S_NODE_SYSTEM_CONTAINER_CPU_TIME: Final = (
+    "k8s.node.system_container.cpu.time"
+)
+"""
+Node's system container CPU time
+Instrument: counter
+Unit: s
+Note: This metric is derived from the [CPUStats.UsageCoreNanoSeconds](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L236) field of the [ContainerStats](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L157C6-L157C20) of [Node.SystemContainers](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L40) of the Kubelet's stats API.
+"""
+
+
+def create_k8s_node_system_container_cpu_time(meter: Meter) -> Counter:
+    """Node's system container CPU time"""
+    return meter.create_counter(
+        name=K8S_NODE_SYSTEM_CONTAINER_CPU_TIME,
+        description="Node's system container CPU time.",
+        unit="s",
+    )
+
+
+K8S_NODE_SYSTEM_CONTAINER_CPU_USAGE: Final = (
+    "k8s.node.system_container.cpu.usage"
+)
+"""
+Node's system container CPU usage, measured in cpus
+Instrument: gauge
+Unit: {cpu}
+Note: This metric is derived from the [CPUStats.UsageNanoCores](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L233) field of the [ContainerStats](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L157C6-L157C20) of [Node.SystemContainers](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L40) of the Kubelet's stats API.
+"""
+
+
+def create_k8s_node_system_container_cpu_usage(
+    meter: Meter, callbacks: Sequence[CallbackT] | None
+) -> ObservableGauge:
+    """Node's system container CPU usage, measured in cpus"""
+    return meter.create_observable_gauge(
+        name=K8S_NODE_SYSTEM_CONTAINER_CPU_USAGE,
+        callbacks=callbacks,
+        description="Node's system container CPU usage, measured in cpus.",
+        unit="{cpu}",
+    )
+
+
+K8S_NODE_SYSTEM_CONTAINER_MEMORY_USAGE: Final = (
+    "k8s.node.system_container.memory.usage"
+)
+"""
+Node's system container memory usage
+Instrument: updowncounter
+Unit: By
+Note: This metric is derived from the [MemoryStats.UsageBytes](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L252) field of the [ContainerStats](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L157C6-L157C20) of [Node.SystemContainers](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L40) of the Kubelet's stats API.
+"""
+
+
+def create_k8s_node_system_container_memory_usage(
+    meter: Meter,
+) -> UpDownCounter:
+    """Node's system container memory usage"""
+    return meter.create_up_down_counter(
+        name=K8S_NODE_SYSTEM_CONTAINER_MEMORY_USAGE,
+        description="Node's system container memory usage.",
+        unit="By",
+    )
+
+
+K8S_NODE_SYSTEM_CONTAINER_MEMORY_WORKING_SET: Final = (
+    "k8s.node.system_container.memory.working_set"
+)
+"""
+The amount of working set memory
+Instrument: updowncounter
+Unit: By
+Note: This metric is derived from the [MemoryStats.WorkingSetBytes](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L256) field of the [ContainerStats](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L157C6-L157C20) of [Node.SystemContainers](https://github.com/kubernetes/kubelet/blob/v0.35.2/pkg/apis/stats/v1alpha1/types.go#L40) of the Kubelet's stats API.
+"""
+
+
+def create_k8s_node_system_container_memory_working_set(
+    meter: Meter,
+) -> UpDownCounter:
+    """The amount of working set memory"""
+    return meter.create_up_down_counter(
+        name=K8S_NODE_SYSTEM_CONTAINER_MEMORY_WORKING_SET,
+        description="The amount of working set memory.",
+        unit="By",
+    )
+
+
 K8S_NODE_UPTIME: Final = "k8s.node.uptime"
 """
 The time the Node has been running
@@ -1353,6 +1659,118 @@ def create_k8s_node_uptime(
         callbacks=callbacks,
         description="The time the Node has been running.",
         unit="s",
+    )
+
+
+K8S_PERSISTENTVOLUME_STATUS_PHASE: Final = "k8s.persistentvolume.status.phase"
+"""
+Number of PersistentVolumes in a given phase
+Instrument: updowncounter
+Unit: {persistentvolume}
+Note: All possible phases should be reported at each interval to avoid gaps in the time series.
+This metric is derived from the `.status.phase` field of the
+[K8s PersistentVolumeStatus](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/#PersistentVolumeStatus).
+"""
+
+
+def create_k8s_persistentvolume_status_phase(meter: Meter) -> UpDownCounter:
+    """Number of PersistentVolumes in a given phase"""
+    return meter.create_up_down_counter(
+        name=K8S_PERSISTENTVOLUME_STATUS_PHASE,
+        description="Number of PersistentVolumes in a given phase.",
+        unit="{persistentvolume}",
+    )
+
+
+K8S_PERSISTENTVOLUME_STORAGE_CAPACITY: Final = (
+    "k8s.persistentvolume.storage.capacity"
+)
+"""
+The storage capacity of the PersistentVolume
+Instrument: updowncounter
+Unit: By
+Note: This metric is derived from the `.spec.capacity.storage` field of the [K8s PersistentVolumeSpec](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/#PersistentVolumeSpec).
+"""
+
+
+def create_k8s_persistentvolume_storage_capacity(
+    meter: Meter,
+) -> UpDownCounter:
+    """The storage capacity of the PersistentVolume"""
+    return meter.create_up_down_counter(
+        name=K8S_PERSISTENTVOLUME_STORAGE_CAPACITY,
+        description="The storage capacity of the PersistentVolume.",
+        unit="By",
+    )
+
+
+K8S_PERSISTENTVOLUMECLAIM_STATUS_PHASE: Final = (
+    "k8s.persistentvolumeclaim.status.phase"
+)
+"""
+Number of PersistentVolumeClaims in a given phase
+Instrument: updowncounter
+Unit: {persistentvolumeclaim}
+Note: All possible phases should be reported at each interval to avoid gaps in the time series.
+This metric is derived from the `.status.phase` field of the
+[K8s PersistentVolumeClaimStatus](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimStatus).
+"""
+
+
+def create_k8s_persistentvolumeclaim_status_phase(
+    meter: Meter,
+) -> UpDownCounter:
+    """Number of PersistentVolumeClaims in a given phase"""
+    return meter.create_up_down_counter(
+        name=K8S_PERSISTENTVOLUMECLAIM_STATUS_PHASE,
+        description="Number of PersistentVolumeClaims in a given phase.",
+        unit="{persistentvolumeclaim}",
+    )
+
+
+K8S_PERSISTENTVOLUMECLAIM_STORAGE_CAPACITY: Final = (
+    "k8s.persistentvolumeclaim.storage.capacity"
+)
+"""
+The actual storage capacity provisioned for the PersistentVolumeClaim
+Instrument: updowncounter
+Unit: By
+Note: Only available when the PVC is bound. May differ from the requested capacity due to provisioner rounding.
+This metric is derived from the `.status.capacity.storage` field of the
+[K8s PersistentVolumeClaimStatus](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimStatus).
+"""
+
+
+def create_k8s_persistentvolumeclaim_storage_capacity(
+    meter: Meter,
+) -> UpDownCounter:
+    """The actual storage capacity provisioned for the PersistentVolumeClaim"""
+    return meter.create_up_down_counter(
+        name=K8S_PERSISTENTVOLUMECLAIM_STORAGE_CAPACITY,
+        description="The actual storage capacity provisioned for the PersistentVolumeClaim.",
+        unit="By",
+    )
+
+
+K8S_PERSISTENTVOLUMECLAIM_STORAGE_REQUEST: Final = (
+    "k8s.persistentvolumeclaim.storage.request"
+)
+"""
+The storage requested by the PersistentVolumeClaim
+Instrument: updowncounter
+Unit: By
+Note: This metric is derived from the `.spec.resources.requests.storage` field of the [K8s PersistentVolumeClaimSpec](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec).
+"""
+
+
+def create_k8s_persistentvolumeclaim_storage_request(
+    meter: Meter,
+) -> UpDownCounter:
+    """The storage requested by the PersistentVolumeClaim"""
+    return meter.create_up_down_counter(
+        name=K8S_PERSISTENTVOLUMECLAIM_STORAGE_REQUEST,
+        description="The storage requested by the PersistentVolumeClaim.",
+        unit="By",
     )
 
 

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/process_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/process_metrics.py
@@ -20,6 +20,7 @@ CallbackT = (
     | Generator[Iterable[Observation], CallbackOptions, None]
 )
 
+
 PROCESS_CONTEXT_SWITCHES: Final = "process.context_switches"
 """
 Number of times the process has been context switched

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/process_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/process_metrics.py
@@ -39,17 +39,17 @@ def create_process_context_switches(meter: Meter) -> Counter:
 
 PROCESS_CPU_TIME: Final = "process.cpu.time"
 """
-Total CPU seconds broken down by different states
+Total CPU seconds broken down by different CPU modes
 Instrument: counter
 Unit: s
 """
 
 
 def create_process_cpu_time(meter: Meter) -> Counter:
-    """Total CPU seconds broken down by different states"""
+    """Total CPU seconds broken down by different CPU modes"""
     return meter.create_counter(
         name=PROCESS_CPU_TIME,
-        description="Total CPU seconds broken down by different states.",
+        description="Total CPU seconds broken down by different CPU modes.",
         unit="s",
     )
 

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/system_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/system_metrics.py
@@ -20,6 +20,7 @@ CallbackT = (
     | Generator[Iterable[Observation], CallbackOptions, None]
 )
 
+
 SYSTEM_CPU_FREQUENCY: Final = "system.cpu.frequency"
 """
 Operating frequency of the logical CPU in Hertz

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/system_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/system_metrics.py
@@ -350,6 +350,135 @@ def create_system_memory_linux_available(meter: Meter) -> UpDownCounter:
     )
 
 
+SYSTEM_MEMORY_LINUX_HUGEPAGES_LIMIT: Final = (
+    "system.memory.linux.hugepages.limit"
+)
+"""
+Total number of hugepages available
+Instrument: updowncounter
+Unit: {page}
+"""
+
+
+def create_system_memory_linux_hugepages_limit(meter: Meter) -> UpDownCounter:
+    """Total number of hugepages available"""
+    return meter.create_up_down_counter(
+        name=SYSTEM_MEMORY_LINUX_HUGEPAGES_LIMIT,
+        description="Total number of hugepages available.",
+        unit="{page}",
+    )
+
+
+SYSTEM_MEMORY_LINUX_HUGEPAGES_PAGE_SIZE: Final = (
+    "system.memory.linux.hugepages.page_size"
+)
+"""
+System hugepage size in bytes
+Instrument: updowncounter
+Unit: By
+"""
+
+
+def create_system_memory_linux_hugepages_page_size(
+    meter: Meter,
+) -> UpDownCounter:
+    """System hugepage size in bytes"""
+    return meter.create_up_down_counter(
+        name=SYSTEM_MEMORY_LINUX_HUGEPAGES_PAGE_SIZE,
+        description="System hugepage size in bytes.",
+        unit="By",
+    )
+
+
+SYSTEM_MEMORY_LINUX_HUGEPAGES_RESERVED: Final = (
+    "system.memory.linux.hugepages.reserved"
+)
+"""
+Number of reserved hugepages
+Instrument: updowncounter
+Unit: {page}
+Note: Hugepages for which a commitment to allocate has been made, but no allocation has yet been made.
+This is reported as a separate metric rather than a `usage` state because reserved pages are already counted in `free` pages.
+They represent a subset of free pages that cannot be used for non-reserved allocations.
+"""
+
+
+def create_system_memory_linux_hugepages_reserved(
+    meter: Meter,
+) -> UpDownCounter:
+    """Number of reserved hugepages"""
+    return meter.create_up_down_counter(
+        name=SYSTEM_MEMORY_LINUX_HUGEPAGES_RESERVED,
+        description="Number of reserved hugepages.",
+        unit="{page}",
+    )
+
+
+SYSTEM_MEMORY_LINUX_HUGEPAGES_SURPLUS: Final = (
+    "system.memory.linux.hugepages.surplus"
+)
+"""
+Number of surplus hugepages
+Instrument: updowncounter
+Unit: {page}
+Note: Overcommitted hugepages beyond the persistent pool.
+This is reported as a separate metric rather than a `usage` state because surplus pages can be in either `used` or `free` state.
+Including them in `usage` would break the convention that `usage` states sum to the `limit`.
+"""
+
+
+def create_system_memory_linux_hugepages_surplus(
+    meter: Meter,
+) -> UpDownCounter:
+    """Number of surplus hugepages"""
+    return meter.create_up_down_counter(
+        name=SYSTEM_MEMORY_LINUX_HUGEPAGES_SURPLUS,
+        description="Number of surplus hugepages.",
+        unit="{page}",
+    )
+
+
+SYSTEM_MEMORY_LINUX_HUGEPAGES_USAGE: Final = (
+    "system.memory.linux.hugepages.usage"
+)
+"""
+Number of hugepages in use by state
+Instrument: updowncounter
+Unit: {page}
+"""
+
+
+def create_system_memory_linux_hugepages_usage(meter: Meter) -> UpDownCounter:
+    """Number of hugepages in use by state"""
+    return meter.create_up_down_counter(
+        name=SYSTEM_MEMORY_LINUX_HUGEPAGES_USAGE,
+        description="Number of hugepages in use by state.",
+        unit="{page}",
+    )
+
+
+SYSTEM_MEMORY_LINUX_HUGEPAGES_UTILIZATION: Final = (
+    "system.memory.linux.hugepages.utilization"
+)
+"""
+Percentage of hugepages in use by state
+Instrument: gauge
+Unit: 1
+"""
+
+
+def create_system_memory_linux_hugepages_utilization(
+    meter: Meter, callbacks: Sequence[CallbackT] | None
+) -> ObservableGauge:
+    """Percentage of hugepages in use by state"""
+    return meter.create_observable_gauge(
+        name=SYSTEM_MEMORY_LINUX_HUGEPAGES_UTILIZATION,
+        callbacks=callbacks,
+        description="Percentage of hugepages in use by state.",
+        unit="1",
+    )
+
+
 SYSTEM_MEMORY_LINUX_SHARED: Final = "system.memory.linux.shared"
 """
 Shared memory used (mostly by tmpfs)

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/vcs_metrics.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/_incubating/metrics/vcs_metrics.py
@@ -19,6 +19,7 @@ CallbackT = (
     | Generator[Iterable[Observation], CallbackOptions, None]
 )
 
+
 VCS_CHANGE_COUNT: Final = "vcs.change.count"
 """
 The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged)

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/deployment_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/deployment_attributes.py
@@ -1,0 +1,28 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from enum import Enum
+from typing import Final
+
+DEPLOYMENT_ENVIRONMENT_NAME: Final = "deployment.environment.name"
+"""
+Name of the [deployment environment](https://wikipedia.org/wiki/Deployment_environment) (aka deployment tier).
+Note: `deployment.environment.name` does not affect the uniqueness constraints defined through
+the `service.namespace`, `service.name` and `service.instance.id` resource attributes.
+This implies that resources carrying the following attribute combinations MUST be
+considered to be identifying the same service:
+
+- `service.name=frontend`, `deployment.environment.name=production`
+- `service.name=frontend`, `deployment.environment.name=staging`.
+"""
+
+
+class DeploymentEnvironmentNameValues(Enum):
+    PRODUCTION = "production"
+    """Production environment."""
+    STAGING = "staging"
+    """Staging environment."""
+    TEST = "test"
+    """Testing environment."""
+    DEVELOPMENT = "development"
+    """Development environment."""

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/error_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/error_attributes.py
@@ -12,6 +12,12 @@ Note: The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
 When `error.type` is set to a type (e.g., an exception type), its
 canonical class name identifying the type within the artifact SHOULD be used.
 
+If the recorded error type is a wrapper that is not meaningful for
+failure classification, instrumentation MAY use the type of the inner
+error instead. For example, in Go, errors created with `fmt.Errorf`
+using `%w` MAY be unwrapped when the wrapper type does not help
+classify the failure.
+
 Instrumentations SHOULD document the list of errors they report.
 
 The cardinality of `error.type` within one instrumentation library SHOULD be low.

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/exception_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/exception_attributes.py
@@ -24,4 +24,9 @@ A stacktrace as a string in the natural representation for the language runtime.
 EXCEPTION_TYPE: Final = "exception.type"
 """
 The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
+Note: If the recorded exception type is a wrapper that is not meaningful for
+failure classification, instrumentation MAY use the type of the inner
+exception instead. For example, in Go, errors created with `fmt.Errorf`
+using `%w` MAY be unwrapped when the wrapper type does not help
+classify the failure.
 """

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/otel_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/otel_attributes.py
@@ -4,6 +4,12 @@
 from enum import Enum
 from typing import Final
 
+OTEL_EVENT_NAME: Final = "otel.event.name"
+"""
+Identifies the class / type of event.
+Note: This attribute SHOULD be used by non-OTLP exporters when destination does not support `EventName` or equivalent field. This attribute MAY be used by applications using existing logging libraries so that it can be used to set the `EventName` field by Collector or SDK components.
+"""
+
 OTEL_SCOPE_NAME: Final = "otel.scope.name"
 """
 The name of the instrumentation scope - (`InstrumentationScope.Name` in OTLP).

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/service_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/service_attributes.py
@@ -37,7 +37,8 @@ port.
 SERVICE_NAME: Final = "service.name"
 """
 Logical name of the service.
-Note: MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+Note: MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with the process executable name, e.g. `unknown_service:bash`. If the process executable name is not available, the value MUST be set to `unknown_service`.
+The process executable name is the name of the process executable, the same value as described by the [`process.executable.name`](process.md) resource attribute.
 """
 
 SERVICE_NAMESPACE: Final = "service.namespace"

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/telemetry_attributes.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/attributes/telemetry_attributes.py
@@ -4,6 +4,18 @@
 from enum import Enum
 from typing import Final
 
+TELEMETRY_DISTRO_NAME: Final = "telemetry.distro.name"
+"""
+The name of the auto instrumentation agent or distribution, if used.
+Note: Official auto instrumentation agents and distributions SHOULD set the `telemetry.distro.name` attribute to
+a string starting with `opentelemetry-`, e.g. `opentelemetry-java-instrumentation`.
+"""
+
+TELEMETRY_DISTRO_VERSION: Final = "telemetry.distro.version"
+"""
+The version string of the auto instrumentation agent or distribution, if used.
+"""
+
 TELEMETRY_SDK_LANGUAGE: Final = "telemetry.sdk.language"
 """
 The language of the telemetry SDK.

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/schemas.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/schemas.py
@@ -94,5 +94,10 @@ class Schemas(Enum):
     The URL of the OpenTelemetry schema version 1.41.0.
     """
 
+    V1_41_1 = "https://opentelemetry.io/schemas/1.41.1"
+    """
+    The URL of the OpenTelemetry schema version 1.41.1.
+    """
+
     # when generating new semantic conventions,
     # make sure to add new versions version here.

--- a/opentelemetry-semantic-conventions/src/opentelemetry/semconv/schemas.py
+++ b/opentelemetry-semantic-conventions/src/opentelemetry/semconv/schemas.py
@@ -89,5 +89,10 @@ class Schemas(Enum):
     The URL of the OpenTelemetry schema version 1.40.0.
     """
 
+    V1_41_0 = "https://opentelemetry.io/schemas/1.41.0"
+    """
+    The URL of the OpenTelemetry schema version 1.41.0.
+    """
+
     # when generating new semantic conventions,
     # make sure to add new versions version here.

--- a/scripts/semconv/generate.sh
+++ b/scripts/semconv/generate.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../.."
 
 # freeze the spec version to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=1.41.0
+SEMCONV_VERSION=1.41.1
 SEMCONV_VERSION_TAG=v$SEMCONV_VERSION
 OTEL_WEAVER_IMG_VERSION=v0.23.0
 INCUBATING_DIR=_incubating

--- a/scripts/semconv/generate.sh
+++ b/scripts/semconv/generate.sh
@@ -5,9 +5,9 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../.."
 
 # freeze the spec version to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=1.40.0
+SEMCONV_VERSION=1.41.0
 SEMCONV_VERSION_TAG=v$SEMCONV_VERSION
-OTEL_WEAVER_IMG_VERSION=v0.21.2
+OTEL_WEAVER_IMG_VERSION=v0.23.0
 INCUBATING_DIR=_incubating
 cd ${SCRIPT_DIR}
 

--- a/scripts/semconv/templates/registry/common.j2
+++ b/scripts/semconv/templates/registry/common.j2
@@ -1,17 +1,6 @@
 {%- macro file_header() -%}
 # Copyright The OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 {% endmacro -%}
 

--- a/scripts/semconv/templates/registry/semantic_attributes.j2
+++ b/scripts/semconv/templates/registry/semantic_attributes.j2
@@ -1,16 +1,5 @@
 # Copyright The OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import Final
 

--- a/scripts/semconv/templates/registry/semantic_metrics.j2
+++ b/scripts/semconv/templates/registry/semantic_metrics.j2
@@ -1,16 +1,5 @@
 # Copyright The OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 {% set file_name = ctx.output + ctx.root_namespace | snake_case ~ "_metrics.py" -%}
 {{- template.set_file_name(file_name) -}}

--- a/scripts/semconv/templates/registry/semantic_metrics.j2
+++ b/scripts/semconv/templates/registry/semantic_metrics.j2
@@ -56,6 +56,7 @@ from typing import Final
 {{ import_instrument_classes(filtered_metrics) }}
 
 {%- for metric in ctx.metrics %}
+{% if metric.metric_name not in ctx.excluded_metrics %}
 {% set const_name = metric.metric_name | screaming_snake_case %}
 {{const_name}}: Final = "{{metric.metric_name}}"
 {%- set doc_string=write_docstring(metric, const_name, "")-%}{%- if doc_string %}
@@ -82,4 +83,5 @@ def create_{{ metric_name }}(meter: Meter) -> {{metric.instrument | map_text("py
     )
     {%- endif -%}
 
+{% endif %}
 {% endfor %}

--- a/scripts/semconv/templates/registry/weaver.yaml
+++ b/scripts/semconv/templates/registry/weaver.yaml
@@ -6,6 +6,9 @@ params:
   # this behavior is fully controlled by jinja templates
   excluded_attributes: ["messaging.client_id"]
 
+  # excluded metrics will be excluded from the generated code in jinja templates
+  excluded_metrics: ["k8s.container.cpu.limit_utilization", "k8s.container.cpu.request_utilization"]
+
   stable_package_name: opentelemetry.semconv
 
 templates:
@@ -35,7 +38,8 @@ templates:
         metrics: .metrics,
         output: $output + "metrics/",
         stable_package_name: $stable_package_name + ".metrics",
-        filter: $filter
+        filter: $filter,
+        excluded_metrics: $excluded_metrics
       })
     application_mode: each
 text_maps:

--- a/scripts/semconv/templates/registry/weaver.yaml
+++ b/scripts/semconv/templates/registry/weaver.yaml
@@ -7,7 +7,7 @@ params:
   excluded_attributes: ["messaging.client_id"]
 
   # excluded metrics will be excluded from the generated code in jinja templates
-  excluded_metrics: ["k8s.container.cpu.limit_utilization", "k8s.container.cpu.request_utilization"]
+  excluded_metrics: []
 
   stable_package_name: opentelemetry.semconv
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

In 1.41.0 we have a clash of different metrics being normalized to the same name, one being a deprecated version of the other. Upstream this has been resolved by skipping the deprecated ones. This introduces a list of excluded metrics to skip these problematic metrics, then dropped in 1.41.1 bump commit since it's already handled on the semconv side. The problematic metrics are from k8s namespace, are in development and have no current users inside OpenTelemetry.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
