### PR TITLE
Remove importlib-metadata dependency

### DIFF
--- a/.changelog/3234.removed
+++ b/.changelog/3234.removed
@@ -1,0 +1,1 @@
+`opentelemetry-api`: remove third-party importlib-metadata in favor of standard library since Python >= 3.10 is now required

--- a/codegen/opentelemetry-codegen-json/test-requirements.txt
+++ b/codegen/opentelemetry-codegen-json/test-requirements.txt
@@ -1,4 +1,3 @@
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.5.0
@@ -6,7 +5,6 @@ protobuf==6.31.1
 pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.12.0
-zipp==3.19.2
 grpcio==1.78.0
 grpcio-tools==1.78.0
 -e codegen/opentelemetry-codegen-json

--- a/docs/getting_started/tests/requirements.txt
+++ b/docs/getting_started/tests/requirements.txt
@@ -5,7 +5,6 @@ charset-normalizer==2.0.12
 click==8.1.7
 Flask==2.3.3
 idna==3.7
-importlib-metadata==6.8.0
 iniconfig==2.0.0
 itsdangerous==2.1.2
 Jinja2==3.1.5
@@ -20,7 +19,6 @@ typing_extensions==4.12.0
 urllib3==1.26.19
 Werkzeug==3.0.6
 wrapt==1.15.0
-zipp==3.19.2
 -e opentelemetry-semantic-conventions
 -e opentelemetry-proto
 -e exporter/opentelemetry-exporter-otlp-proto-common

--- a/exporter/opentelemetry-exporter-opencensus/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-opencensus/test-requirements.txt
@@ -1,6 +1,5 @@
 asgiref==3.7.2
 grpcio==1.75.1
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 opencensus-proto==0.1.0
 packaging==24.0
@@ -11,7 +10,6 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.12.0
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e tests/opentelemetry-test-utils

--- a/exporter/opentelemetry-exporter-otlp-json-common/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-otlp-json-common/test-requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
@@ -9,7 +8,6 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.12.0
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions

--- a/exporter/opentelemetry-exporter-otlp-proto-common/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/test-requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
@@ -9,7 +8,6 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.12.0
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.latest.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.latest.txt
@@ -33,6 +33,10 @@ asgiref==3.7.2
     # via
     #   -c dev-requirements.txt
     #   opentelemetry-test-utils
+certifi==2026.4.22
+    # via requests
+charset-normalizer==3.4.7
+    # via requests
 colorama==0.4.6
     # via
     #   -r exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.in
@@ -43,8 +47,8 @@ googleapis-common-protos==1.74.0
     # via opentelemetry-exporter-otlp-proto-grpc
 grpcio==1.80.0
     # via opentelemetry-exporter-otlp-proto-grpc
-importlib-metadata==8.7.1
-    # via opentelemetry-api
+idna==3.14
+    # via requests
 iniconfig==2.3.0
     # via
     #   -r exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.in
@@ -66,6 +70,10 @@ pytest==7.4.4
     # via
     #   -c dev-requirements.txt
     #   -r exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.in
+requests==2.32.3
+    # via
+    #   -c dev-requirements.txt
+    #   opentelemetry-test-utils
 tomli==2.4.1 ; python_full_version < '3.11'
     # via pytest
 typing-extensions==4.15.0
@@ -77,5 +85,5 @@ typing-extensions==4.15.0
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-zipp==3.23.0
-    # via importlib-metadata
+urllib3==2.7.0
+    # via requests

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.oldest.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.oldest.txt
@@ -33,6 +33,10 @@ asgiref==3.7.2
     # via
     #   -c dev-requirements.txt
     #   opentelemetry-test-utils
+certifi==2017.4.17
+    # via requests
+charset-normalizer==2.0.0
+    # via requests
 colorama==0.4.6
     # via
     #   -r exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.in
@@ -47,8 +51,8 @@ grpcio==1.66.2 ; python_full_version == '3.13.*'
     # via opentelemetry-exporter-otlp-proto-grpc
 grpcio==1.75.1 ; python_full_version >= '3.14'
     # via opentelemetry-exporter-otlp-proto-grpc
-importlib-metadata==6.0.0
-    # via opentelemetry-api
+idna==2.5
+    # via requests
 iniconfig==2.0.0
     # via
     #   -r exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.in
@@ -70,6 +74,10 @@ pytest==7.4.4
     # via
     #   -c dev-requirements.txt
     #   -r exporter/opentelemetry-exporter-otlp-proto-grpc/test-requirements.in
+requests==2.32.3
+    # via
+    #   -c dev-requirements.txt
+    #   opentelemetry-test-utils
 tomli==1.0.0 ; python_full_version < '3.11'
     # via pytest
 typing-extensions==4.6.0 ; python_full_version < '3.14'
@@ -86,5 +94,5 @@ typing-extensions==4.12.0 ; python_full_version >= '3.14'
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-zipp==0.5.0
-    # via importlib-metadata
+urllib3==1.21.1
+    # via requests

--- a/exporter/opentelemetry-exporter-otlp-proto-http/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/test-requirements.txt
@@ -3,7 +3,6 @@ certifi==2024.7.4
 charset-normalizer==3.3.2
 googleapis-common-protos==1.70.0
 idna==3.7
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
@@ -17,7 +16,6 @@ tomli==2.0.1
 typing_extensions==4.12.0
 urllib3==2.2.2
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e tests/opentelemetry-test-utils
 -e exporter/opentelemetry-exporter-otlp-proto-common

--- a/exporter/opentelemetry-exporter-otlp/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-otlp/test-requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
@@ -8,7 +7,6 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.12.0
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e tests/opentelemetry-test-utils
 -e exporter/opentelemetry-exporter-otlp-proto-common

--- a/exporter/opentelemetry-exporter-prometheus/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-prometheus/test-requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
@@ -9,7 +8,6 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e tests/opentelemetry-test-utils

--- a/exporter/opentelemetry-exporter-zipkin-json/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-zipkin-json/test-requirements.txt
@@ -2,7 +2,6 @@ asgiref==3.7.2
 certifi==2024.7.4
 charset-normalizer==3.3.2
 idna==3.7
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
@@ -13,7 +12,6 @@ tomli==2.0.1
 typing_extensions==4.10.0
 urllib3==2.2.2
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/test-requirements.txt
@@ -2,7 +2,6 @@ asgiref==3.7.2
 certifi==2024.7.4
 charset-normalizer==3.3.2
 idna==3.7
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
@@ -14,7 +13,6 @@ tomli==2.0.1
 typing_extensions==4.10.0
 urllib3==2.2.2
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e exporter/opentelemetry-exporter-zipkin-json
 -e opentelemetry-sdk

--- a/exporter/opentelemetry-exporter-zipkin/test-requirements.txt
+++ b/exporter/opentelemetry-exporter-zipkin/test-requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
@@ -8,7 +7,6 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e exporter/opentelemetry-exporter-zipkin-json
 -e exporter/opentelemetry-exporter-zipkin-proto-http

--- a/opentelemetry-api/pyproject.toml
+++ b/opentelemetry-api/pyproject.toml
@@ -26,9 +26,6 @@ classifiers = [
 ]
 dependencies = [
     "typing-extensions >= 4.5.0",
-    # FIXME This should be able to be removed after 3.12 is released if there is a reliable API
-    # in importlib.metadata.
-    "importlib-metadata >= 6.0, < 8.8.0",
 ]
 dynamic = [
     "version",

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -11,13 +11,20 @@ from importlib.metadata import (
     requires,
     version,
 )
+from importlib.metadata import entry_points as original_entry_points
+from typing import Any
+
+
+def _as_entry_points(eps: Any) -> EntryPoints:
+    if isinstance(eps, EntryPoints):
+        return eps
+    # Handle Python 3.10 SelectableGroups (dict-like)
+    return EntryPoints(ep for group_eps in eps.values() for ep in group_eps)
 
 
 @cache
 def _all_entry_points_cached() -> EntryPoints:
-    return EntryPoints(
-        ep for dist in distributions() for ep in dist.entry_points
-    )
+    return _as_entry_points(original_entry_points())
 
 
 def entry_points(**params) -> EntryPoints:

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -2,11 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import cache
-
-# FIXME: Use importlib.metadata (not importlib_metadata)
-# when support for 3.11 is dropped if the rest of
-# the supported versions at that time have the same API.
-from importlib_metadata import (  # type: ignore
+from importlib.metadata import (
     Distribution,
     EntryPoint,
     EntryPoints,
@@ -15,21 +11,19 @@ from importlib_metadata import (  # type: ignore
     requires,
     version,
 )
-from importlib_metadata import (
-    entry_points as original_entry_points,
-)
 
 
 @cache
-def _original_entry_points_cached():
-    return original_entry_points()
+def _all_entry_points_cached() -> EntryPoints:
+    return EntryPoints(
+        ep for dist in distributions() for ep in dist.entry_points
+    )
 
 
 def entry_points(**params) -> EntryPoints:
-    """Replacement for importlib_metadata.entry_points that caches getting all the entry points.
-
-    That part can be very slow, and OTel uses this function many times."""
-    return _original_entry_points_cached().select(**params)
+    if not params:
+        return _all_entry_points_cached()
+    return _all_entry_points_cached().select(**params)
 
 
 __all__ = [

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -1,6 +1,16 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+"""
+Caching and compatibility wrapper for standard library ``importlib.metadata``.
+
+This module caches ``entry_points()`` to avoid reloading entry points from disk on every call.
+It also normalizes minor differences across python versions 3.10+. References to issues:
+
+- https://github.com/open-telemetry/opentelemetry-python/pull/4735
+- https://github.com/open-telemetry/opentelemetry-python/pull/5203
+"""
+
 from functools import cache
 from importlib.metadata import (
     Distribution,
@@ -23,12 +33,12 @@ def _as_entry_points(eps: Any) -> EntryPoints:
 
 
 @cache
-def _all_entry_points_cached() -> EntryPoints:
+def _original_entry_points_cached() -> EntryPoints:
     return _as_entry_points(original_entry_points())
 
 
 def entry_points(**params) -> EntryPoints:
-    return _all_entry_points_cached().select(**params)
+    return _original_entry_points_cached().select(**params)
 
 
 __all__ = [

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -28,8 +28,6 @@ def _all_entry_points_cached() -> EntryPoints:
 
 
 def entry_points(**params) -> EntryPoints:
-    if not params:
-        return _all_entry_points_cached()
     return _all_entry_points_cached().select(**params)
 
 

--- a/opentelemetry-api/test-requirements.txt
+++ b/opentelemetry-api/test-requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-importlib-metadata==8.7.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0

--- a/opentelemetry-api/tests/util/test__importlib_metadata.py
+++ b/opentelemetry-api/tests/util/test__importlib_metadata.py
@@ -103,6 +103,12 @@ class TestEntryPoints(TestCase):
         self.assertIsInstance(version("opentelemetry-api"), str)
 
     def test_as_entry_points_selectable_groups_compat(self):
+        """Test that _as_entry_points correctly normalizes dict-like SelectableGroups
+        (returned by importlib.metadata.entry_points() in Python 3.10) into EntryPoints.
+
+        On Python 3.11+, entry_points() returns EntryPoints directly, which is
+        handled by the fast-path in _as_entry_points.
+        """
         ep1 = EntryPoint(name="foo", value="bar:baz", group="gp")
         ep2 = EntryPoint(name="foo2", value="bar2:baz2", group="gp")
         selectable_groups = {"gp": [ep1, ep2]}

--- a/opentelemetry-api/tests/util/test__importlib_metadata.py
+++ b/opentelemetry-api/tests/util/test__importlib_metadata.py
@@ -7,6 +7,7 @@ from opentelemetry.metrics import MeterProvider
 from opentelemetry.util._importlib_metadata import (
     EntryPoint,
     EntryPoints,
+    _as_entry_points,
     version,
 )
 from opentelemetry.util._importlib_metadata import (
@@ -100,3 +101,13 @@ class TestEntryPoints(TestCase):
         self.assertEqual(len(entry_points), 0)
 
         self.assertIsInstance(version("opentelemetry-api"), str)
+
+    def test_as_entry_points_selectable_groups_compat(self):
+        ep1 = EntryPoint(name="foo", value="bar:baz", group="gp")
+        ep2 = EntryPoint(name="foo2", value="bar2:baz2", group="gp")
+        selectable_groups = {"gp": [ep1, ep2]}
+
+        normalized = _as_entry_points(selectable_groups)
+        self.assertIsInstance(normalized, EntryPoints)
+        self.assertEqual(len(normalized), 2)
+        self.assertEqual(list(normalized), [ep1, ep2])

--- a/opentelemetry-sdk/test-requirements.txt
+++ b/opentelemetry-sdk/test-requirements.txt
@@ -1,6 +1,5 @@
 asgiref==3.7.2
 flaky==3.7.0
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0

--- a/opentelemetry-semantic-conventions/test-requirements.txt
+++ b/opentelemetry-semantic-conventions/test-requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0

--- a/propagator/opentelemetry-propagator-b3/test-requirements.txt
+++ b/propagator/opentelemetry-propagator-b3/test-requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
@@ -8,7 +7,6 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions

--- a/propagator/opentelemetry-propagator-jaeger/test-requirements.txt
+++ b/propagator/opentelemetry-propagator-jaeger/test-requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
@@ -8,7 +7,6 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions

--- a/shim/opentelemetry-opencensus-shim/test-requirements.txt
+++ b/shim/opentelemetry-opencensus-shim/test-requirements.txt
@@ -7,7 +7,6 @@ google-auth==2.28.1
 googleapis-common-protos==1.63.2
 grpcio==1.75.1
 idna==3.7
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 opencensus==0.11.1
 opencensus-context==0.1.3
@@ -26,7 +25,6 @@ tomli==2.0.1
 typing_extensions==4.12.0
 urllib3==2.2.2
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e tests/opentelemetry-test-utils

--- a/shim/opentelemetry-opentracing-shim/test-requirements.txt
+++ b/shim/opentelemetry-opentracing-shim/test-requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 opentracing==2.4.0
 packaging==24.0
@@ -9,7 +8,6 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.10.0
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e tests/opentelemetry-test-utils

--- a/tests/opentelemetry-test-utils/test-requirements.txt
+++ b/tests/opentelemetry-test-utils/test-requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.7.2
-importlib-metadata==6.11.0
 iniconfig==2.0.0
 packaging==24.0
 pluggy==1.6.0
@@ -8,7 +7,6 @@ pytest==7.4.4
 tomli==2.0.1
 typing_extensions==4.12.0
 wrapt==1.16.0
-zipp==3.19.2
 -e opentelemetry-api
 -e opentelemetry-sdk
 -e opentelemetry-semantic-conventions

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ members = [
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
@@ -40,7 +40,7 @@ wheels = [
 [[package]]
 name = "anyio"
 version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
@@ -54,7 +54,7 @@ wheels = [
 [[package]]
 name = "argcomplete"
 version = "3.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
@@ -63,7 +63,7 @@ wheels = [
 [[package]]
 name = "asgiref"
 version = "3.11.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -75,7 +75,7 @@ wheels = [
 [[package]]
 name = "attrs"
 version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
@@ -84,7 +84,7 @@ wheels = [
 [[package]]
 name = "black"
 version = "26.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "click" },
     { name = "mypy-extensions" },
@@ -128,7 +128,7 @@ wheels = [
 [[package]]
 name = "cachetools"
 version = "7.0.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/dd/57fe3fdb6e65b25a5987fd2cdc7e22db0aef508b91634d2e57d22928d41b/cachetools-7.0.5.tar.gz", hash = "sha256:0cd042c24377200c1dcd225f8b7b12b0ca53cc2c961b43757e774ebe190fd990", size = 37367, upload-time = "2026-03-09T20:51:29.451Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/f3/39cf3367b8107baa44f861dc802cbf16263c945b62d8265d36034fc07bea/cachetools-7.0.5-py3-none-any.whl", hash = "sha256:46bc8ebefbe485407621d0a4264b23c080cedd913921bad7ac3ed2f26c183114", size = 13918, upload-time = "2026-03-09T20:51:27.33Z" },
@@ -137,7 +137,7 @@ wheels = [
 [[package]]
 name = "certifi"
 version = "2026.2.25"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
@@ -146,7 +146,7 @@ wheels = [
 [[package]]
 name = "cffi"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
@@ -228,7 +228,7 @@ wheels = [
 [[package]]
 name = "cfgv"
 version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
@@ -237,7 +237,7 @@ wheels = [
 [[package]]
 name = "charset-normalizer"
 version = "3.4.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
@@ -342,7 +342,7 @@ wheels = [
 [[package]]
 name = "click"
 version = "8.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -354,7 +354,7 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
@@ -363,7 +363,7 @@ wheels = [
 [[package]]
 name = "cryptography"
 version = "46.0.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -423,7 +423,7 @@ wheels = [
 [[package]]
 name = "datamodel-code-generator"
 version = "0.56.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "argcomplete" },
     { name = "black" },
@@ -451,7 +451,7 @@ ruff = [
 [[package]]
 name = "distlib"
 version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
@@ -460,7 +460,7 @@ wheels = [
 [[package]]
 name = "exceptiongroup"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -472,7 +472,7 @@ wheels = [
 [[package]]
 name = "filelock"
 version = "3.25.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
@@ -481,7 +481,7 @@ wheels = [
 [[package]]
 name = "genson"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cf/2303c8ad276dcf5ee2ad6cf69c4338fd86ef0f471a5207b069adf7a393cf/genson-1.3.0.tar.gz", hash = "sha256:e02db9ac2e3fd29e65b5286f7135762e2cd8a986537c075b06fc5f1517308e37", size = 34919, upload-time = "2024-05-15T22:08:49.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/5c/e226de133afd8bb267ec27eead9ae3d784b95b39a287ed404caab39a5f50/genson-1.3.0-py3-none-any.whl", hash = "sha256:468feccd00274cc7e4c09e84b08704270ba8d95232aa280f65b986139cec67f7", size = 21470, upload-time = "2024-05-15T22:08:47.056Z" },
@@ -490,7 +490,7 @@ wheels = [
 [[package]]
 name = "google-auth"
 version = "2.49.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
@@ -503,7 +503,7 @@ wheels = [
 [[package]]
 name = "googleapis-common-protos"
 version = "1.74.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -515,7 +515,7 @@ wheels = [
 [[package]]
 name = "grpcio"
 version = "1.80.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -576,7 +576,7 @@ wheels = [
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
@@ -585,7 +585,7 @@ wheels = [
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
@@ -598,7 +598,7 @@ wheels = [
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
@@ -613,7 +613,7 @@ wheels = [
 [[package]]
 name = "identify"
 version = "2.6.18"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/c4/7fb4db12296cdb11893d61c92048fe617ee853f8523b9b296ac03b43757e/identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd", size = 99580, upload-time = "2026-03-15T18:39:50.319Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737", size = 99394, upload-time = "2026-03-15T18:39:48.915Z" },
@@ -622,28 +622,16 @@ wheels = [
 [[package]]
 name = "idna"
 version = "3.11"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
-]
-
-[[package]]
 name = "inflect"
 version = "7.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "more-itertools" },
     { name = "typeguard" },
@@ -656,7 +644,7 @@ wheels = [
 [[package]]
 name = "isort"
 version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
@@ -665,7 +653,7 @@ wheels = [
 [[package]]
 name = "jinja2"
 version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -677,7 +665,7 @@ wheels = [
 [[package]]
 name = "jsonschema"
 version = "4.26.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "attrs" },
     { name = "jsonschema-specifications" },
@@ -692,7 +680,7 @@ wheels = [
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "referencing" },
 ]
@@ -704,7 +692,7 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
@@ -789,7 +777,7 @@ wheels = [
 [[package]]
 name = "more-itertools"
 version = "11.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
@@ -798,7 +786,7 @@ wheels = [
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
@@ -807,7 +795,7 @@ wheels = [
 [[package]]
 name = "nodeenv"
 version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
@@ -817,15 +805,11 @@ wheels = [
 name = "opentelemetry-api"
 source = { editable = "opentelemetry-api" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "importlib-metadata", specifier = ">=6.0,<8.8.0" },
-    { name = "typing-extensions", specifier = ">=4.5.0" },
-]
+requires-dist = [{ name = "typing-extensions", specifier = ">=4.5.0" }]
 
 [[package]]
 name = "opentelemetry-codegen-json"
@@ -845,7 +829,7 @@ requires-dist = [
 [[package]]
 name = "opentelemetry-exporter-credential-provider-gcp"
 version = "0.62b0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "google-auth" },
     { name = "grpcio" },
@@ -1148,7 +1132,7 @@ requires-dist = [
 [[package]]
 name = "packaging"
 version = "26.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
@@ -1157,7 +1141,7 @@ wheels = [
 [[package]]
 name = "pathspec"
 version = "1.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
@@ -1166,7 +1150,7 @@ wheels = [
 [[package]]
 name = "platformdirs"
 version = "4.9.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
@@ -1175,7 +1159,7 @@ wheels = [
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -1184,7 +1168,7 @@ wheels = [
 [[package]]
 name = "pre-commit"
 version = "4.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "cfgv" },
     { name = "identify" },
@@ -1200,7 +1184,7 @@ wheels = [
 [[package]]
 name = "prometheus-client"
 version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
@@ -1209,7 +1193,7 @@ wheels = [
 [[package]]
 name = "protobuf"
 version = "6.33.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
@@ -1224,7 +1208,7 @@ wheels = [
 [[package]]
 name = "pyasn1"
 version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
@@ -1233,7 +1217,7 @@ wheels = [
 [[package]]
 name = "pyasn1-modules"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "pyasn1" },
 ]
@@ -1245,7 +1229,7 @@ wheels = [
 [[package]]
 name = "pycparser"
 version = "3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
@@ -1254,7 +1238,7 @@ wheels = [
 [[package]]
 name = "pydantic"
 version = "2.12.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
@@ -1269,7 +1253,7 @@ wheels = [
 [[package]]
 name = "pydantic-core"
 version = "2.41.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -1387,7 +1371,7 @@ wheels = [
 [[package]]
 name = "pyproject-api"
 version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "packaging" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -1400,7 +1384,7 @@ wheels = [
 [[package]]
 name = "python-discovery"
 version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
@@ -1413,7 +1397,7 @@ wheels = [
 [[package]]
 name = "pytokens"
 version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
@@ -1452,7 +1436,7 @@ wheels = [
 [[package]]
 name = "pyyaml"
 version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
@@ -1516,7 +1500,7 @@ wheels = [
 [[package]]
 name = "referencing"
 version = "0.37.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
@@ -1530,7 +1514,7 @@ wheels = [
 [[package]]
 name = "requests"
 version = "2.33.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -1545,7 +1529,7 @@ wheels = [
 [[package]]
 name = "rpds-py"
 version = "0.30.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
@@ -1667,7 +1651,7 @@ wheels = [
 [[package]]
 name = "ruff"
 version = "0.15.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
@@ -1692,7 +1676,7 @@ wheels = [
 [[package]]
 name = "tomli"
 version = "2.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
@@ -1746,7 +1730,7 @@ wheels = [
 [[package]]
 name = "tomli-w"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
@@ -1755,7 +1739,7 @@ wheels = [
 [[package]]
 name = "towncrier"
 version = "25.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "click" },
     { name = "jinja2" },
@@ -1769,7 +1753,7 @@ wheels = [
 [[package]]
 name = "tox"
 version = "4.52.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "cachetools" },
     { name = "colorama" },
@@ -1792,7 +1776,7 @@ wheels = [
 [[package]]
 name = "tox-uv"
 version = "1.35.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "tox-uv-bare" },
     { name = "uv" },
@@ -1804,7 +1788,7 @@ wheels = [
 [[package]]
 name = "tox-uv-bare"
 version = "1.35.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "packaging" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -1818,7 +1802,7 @@ wheels = [
 [[package]]
 name = "typeguard"
 version = "4.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -1830,7 +1814,7 @@ wheels = [
 [[package]]
 name = "types-protobuf"
 version = "7.34.1.20260408"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/b1/4521e68c2cc17703d80eb42796751345376dd4c706f84007ef5e7c707774/types_protobuf-7.34.1.20260408.tar.gz", hash = "sha256:e2c0a0430e08c75b52671a6f0035abfdcc791aad12af16274282de1b721758ab", size = 68835, upload-time = "2026-04-08T04:26:43.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/b5/0bc9874d89c58fb0ce851e150055ce732d254dbb10b06becbc7635d0d635/types_protobuf-7.34.1.20260408-py3-none-any.whl", hash = "sha256:ebbcd4e27b145aef6a59bc0cb6c013b3528151c1ba5e7f7337aeee355d276a5e", size = 86012, upload-time = "2026-04-08T04:26:42.566Z" },
@@ -1839,7 +1823,7 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
@@ -1848,7 +1832,7 @@ wheels = [
 [[package]]
 name = "typing-inspection"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -1860,7 +1844,7 @@ wheels = [
 [[package]]
 name = "urllib3"
 version = "2.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
@@ -1869,7 +1853,7 @@ wheels = [
 [[package]]
 name = "uv"
 version = "0.11.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/dd/f3/8aceeab67ea69805293ab290e7ca8cc1b61a064d28b8a35c76d8eba063dd/uv-0.11.6.tar.gz", hash = "sha256:e3b21b7e80024c95ff339fcd147ac6fc3dd98d3613c9d45d3a1f4fd1057f127b", size = 4073298, upload-time = "2026-04-09T12:09:01.738Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/fe/4b61a3d5ad9d02e8a4405026ccd43593d7044598e0fa47d892d4dafe44c9/uv-0.11.6-py3-none-linux_armv6l.whl", hash = "sha256:ada04dcf89ddea5b69d27ac9cdc5ef575a82f90a209a1392e930de504b2321d6", size = 23780079, upload-time = "2026-04-09T12:08:56.609Z" },
@@ -1895,7 +1879,7 @@ wheels = [
 [[package]]
 name = "virtualenv"
 version = "21.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
@@ -1906,13 +1890,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/97/c5/aff062c66b42e2183201a7ace10c6b2e959a9a16525c8e8ca8e59410d27a/virtualenv-21.2.1.tar.gz", hash = "sha256:b66ffe81301766c0d5e2208fc3576652c59d44e7b731fc5f5ed701c9b537fa78", size = 5844770, upload-time = "2026-04-09T18:47:11.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/0e/f083a76cb590e60dff3868779558eefefb8dfb7c9ed020babc7aa014ccbf/virtualenv-21.2.1-py3-none-any.whl", hash = "sha256:bd16b49c53562b28cf1a3ad2f36edb805ad71301dee70ddc449e5c88a9f919a2", size = 5828326, upload-time = "2026-04-09T18:47:09.331Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
# Description

Fixes https://github.com/open-telemetry/opentelemetry-python/issues/3234

Remove the importlib-metadata dependency in favor of the standard library's `importlib.metadata`. Since Python >= 3.10 is now required (#5076), `importlib.metadata` is stable enough and available across all supported versions.

Adds a compatibility wrapper in `opentelemetry-api` for Python < 3.12 to handle entry point loading differences when called with no arguments (SelectableGroups vs EntryPoints), avoiding DeprecationWarning and ensuring uniform behavior.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Existing tests pass

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
