### PR TITLE
weaver live check: send weaver logs to tmp file instead of pipe to avoid overflow

### DIFF
--- a/.changelog/5208.fixed
+++ b/.changelog/5208.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-test-utils`: fix weaver live check hanging when weaver log output fills the pipe buffer

--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/weaver_live_check.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/weaver_live_check.py
@@ -457,8 +457,8 @@ class WeaverLiveCheck:
             def _read(path: str | None) -> str:
                 if path is None or not os.path.exists(path):
                     return ""
-                with open(path, "rb") as f:
-                    return f.read().decode(errors="replace")
+                with open(path, "rb") as fp:
+                    return fp.read().decode(errors="replace")
 
             return f"{_read(self._stdout_path)}\n{_read(self._stderr_path)}"
         except Exception as exc:  # pylint: disable=broad-except

--- a/tests/opentelemetry-test-utils/src/opentelemetry/test/weaver_live_check.py
+++ b/tests/opentelemetry-test-utils/src/opentelemetry/test/weaver_live_check.py
@@ -8,7 +8,9 @@ import os
 import shutil
 import socket
 import subprocess
+import tempfile
 from collections import defaultdict
+from collections.abc import Sequence
 from itertools import chain
 from typing import Any
 
@@ -244,7 +246,15 @@ class WeaverLiveCheck:
         inactivity_timeout: int = 30,
         otlp_port: int = 0,
         admin_port: int = 0,
+        extra_args: Sequence[str] | None = None,
     ):
+        """Build the ``weaver registry live-check`` command.
+
+        ``extra_args`` is appended verbatim to the weaver command after the
+        managed flags (``--registry``, ``--otlp-grpc-port``, etc.) and lets
+        callers pass additional weaver options — for example ``["--quiet"]``
+        or ``["--skip-policies"]`` — without subclassing.
+        """
         weaver_bin = shutil.which("weaver")
         if not weaver_bin:
             raise RuntimeError(
@@ -257,6 +267,8 @@ class WeaverLiveCheck:
         self._ready = False
         self._stopped = False
         self._process: subprocess.Popen[bytes] | None = None
+        self._stdout_path: str | None = None
+        self._stderr_path: str | None = None
 
         command = [
             weaver_bin,
@@ -281,6 +293,9 @@ class WeaverLiveCheck:
 
         command += ["--registry", registry]
 
+        if extra_args:
+            command.extend(extra_args)
+
         self._command = command
         logger.debug("Weaver command: %s", command)
 
@@ -294,11 +309,22 @@ class WeaverLiveCheck:
 
     def start(self) -> "WeaverLiveCheck":
         logger.debug("Starting WeaverLiveCheck process...")
-        self._process = subprocess.Popen(  # pylint: disable=consider-using-with
-            self._command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        # Redirect weaver's stdout/stderr to tempfiles
+        stdout_fd, self._stdout_path = tempfile.mkstemp(
+            prefix="weaver-stdout-", suffix=".log"
         )
+        stderr_fd, self._stderr_path = tempfile.mkstemp(
+            prefix="weaver-stderr-", suffix=".log"
+        )
+        try:
+            self._process = subprocess.Popen(  # pylint: disable=consider-using-with
+                self._command,
+                stdout=stdout_fd,
+                stderr=stderr_fd,
+            )
+        finally:
+            os.close(stdout_fd)
+            os.close(stderr_fd)
         try:
             self._wait_for_ready()
             self._ready = True
@@ -423,8 +449,18 @@ class WeaverLiveCheck:
         try:
             if self._process.poll() is None:
                 self._process.kill()
-            out, err = self._process.communicate()
-            return f"{out.decode()}\n{err.decode()}"
+            try:
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+            def _read(path: str | None) -> str:
+                if path is None or not os.path.exists(path):
+                    return ""
+                with open(path, "rb") as f:
+                    return f.read().decode(errors="replace")
+
+            return f"{_read(self._stdout_path)}\n{_read(self._stderr_path)}"
         except Exception as exc:  # pylint: disable=broad-except
             logger.error("Could not get weaver logs: %s", exc)
             return None
@@ -442,7 +478,6 @@ class WeaverLiveCheck:
             if self._ready:
                 try:
                     self._do_stop(timeout=30)
-                    return  # process already exited cleanly
                 except Exception as exc:  # pylint: disable=broad-except
                     logger.debug("Error stopping weaver during close: %s", exc)
         if self._process and self._process.poll() is None:
@@ -451,3 +486,11 @@ class WeaverLiveCheck:
                 self._process.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 self._process.kill()
+        for path in (self._stdout_path, self._stderr_path):
+            if path is not None:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+        self._stdout_path = None
+        self._stderr_path = None

--- a/tests/opentelemetry-test-utils/tests/test_weaver_live_check.py
+++ b/tests/opentelemetry-test-utils/tests/test_weaver_live_check.py
@@ -142,6 +142,21 @@ class TestSDKInitLiveCheck(unittest.TestCase):
             )
         )
 
+    def test_extra_args_are_appended_to_command(self):
+        """`extra_args` are appended verbatim and weaver still runs cleanly."""
+        with WeaverLiveCheck(
+            registry=_REGISTRY_DIR, extra_args=["--quiet"]
+        ) as weaver:
+            self.assertIn("--quiet", weaver._command)
+            provider = _make_provider(weaver.otlp_endpoint)
+            with provider.get_tracer("test-tracer").start_as_current_span(
+                "test-span"
+            ):
+                pass
+            provider.force_flush()
+            report = weaver.end_and_check()
+        self.assertIsInstance(report, LiveCheckReport)
+
     def test_report_span_statistics(self):
         """The full report exposes span counts and individual span samples."""
         with WeaverLiveCheck(registry=_REGISTRY_DIR) as weaver:
@@ -162,3 +177,44 @@ class TestSDKInitLiveCheck(unittest.TestCase):
             any(s["name"] == "test-span" for s in span_samples),
             f"Expected 'test-span' in samples, got: {[s['name'] for s in span_samples]}",
         )
+
+
+@unittest.skipUnless(
+    _HAS_GRPC,
+    "grpc exporter not installed",
+)
+@unittest.skipUnless(
+    shutil.which("weaver") is not None,
+    "weaver binary not found on PATH — install from https://github.com/open-telemetry/weaver/releases",
+)
+class TestOutputCapture(unittest.TestCase):
+    """weaver's stdout/stderr is captured to tempfiles, not PIPE, so large
+    diagnostic output can't deadlock the subprocess."""
+
+    def test_tempfiles_cleaned_up_on_close(self):
+        weaver = WeaverLiveCheck(registry=_REGISTRY_DIR)
+        weaver.start()
+        stdout_path = weaver._stdout_path
+        stderr_path = weaver._stderr_path
+        self.assertIsNotNone(stdout_path)
+        self.assertIsNotNone(stderr_path)
+        self.assertTrue(os.path.exists(stdout_path))
+        self.assertTrue(os.path.exists(stderr_path))
+        weaver.close()
+        self.assertFalse(os.path.exists(stdout_path))
+        self.assertFalse(os.path.exists(stderr_path))
+
+    def test_does_not_deadlock_on_large_diagnostic_output(self):
+        """`--debug --debug` makes weaver dump trace logs that exceed the 64KB
+        PIPE buffer; with tempfile capture the subprocess still exits cleanly."""
+        with WeaverLiveCheck(
+            registry=_REGISTRY_DIR, extra_args=["--debug", "--debug"]
+        ) as weaver:
+            provider = _make_provider(weaver.otlp_endpoint)
+            with provider.get_tracer("test-tracer").start_as_current_span(
+                "test-span"
+            ):
+                pass
+            provider.force_flush()
+            report = weaver.end()
+        self.assertIsInstance(report, LiveCheckReport)

--- a/tests/opentelemetry-test-utils/tests/test_weaver_live_check.py
+++ b/tests/opentelemetry-test-utils/tests/test_weaver_live_check.py
@@ -142,21 +142,6 @@ class TestSDKInitLiveCheck(unittest.TestCase):
             )
         )
 
-    def test_extra_args_are_appended_to_command(self):
-        """`extra_args` are appended verbatim and weaver still runs cleanly."""
-        with WeaverLiveCheck(
-            registry=_REGISTRY_DIR, extra_args=["--quiet"]
-        ) as weaver:
-            self.assertIn("--quiet", weaver._command)
-            provider = _make_provider(weaver.otlp_endpoint)
-            with provider.get_tracer("test-tracer").start_as_current_span(
-                "test-span"
-            ):
-                pass
-            provider.force_flush()
-            report = weaver.end_and_check()
-        self.assertIsInstance(report, LiveCheckReport)
-
     def test_report_span_statistics(self):
         """The full report exposes span counts and individual span samples."""
         with WeaverLiveCheck(registry=_REGISTRY_DIR) as weaver:
@@ -190,19 +175,6 @@ class TestSDKInitLiveCheck(unittest.TestCase):
 class TestOutputCapture(unittest.TestCase):
     """weaver's stdout/stderr is captured to tempfiles, not PIPE, so large
     diagnostic output can't deadlock the subprocess."""
-
-    def test_tempfiles_cleaned_up_on_close(self):
-        weaver = WeaverLiveCheck(registry=_REGISTRY_DIR)
-        weaver.start()
-        stdout_path = weaver._stdout_path
-        stderr_path = weaver._stderr_path
-        self.assertIsNotNone(stdout_path)
-        self.assertIsNotNone(stderr_path)
-        self.assertTrue(os.path.exists(stdout_path))
-        self.assertTrue(os.path.exists(stderr_path))
-        weaver.close()
-        self.assertFalse(os.path.exists(stdout_path))
-        self.assertFalse(os.path.exists(stderr_path))
 
     def test_does_not_deadlock_on_large_diagnostic_output(self):
         """`--debug --debug` makes weaver dump trace logs that exceed the 64KB


### PR DESCRIPTION
weaver can report enough warnings to fill 64kb limit on pipes and cause process to deadlock.

switching to temp files.

Also adding argument to pass extra cli params