### PR TITLE
ci: Enable GitHub Merge Queue support

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+  merge_group:
 
 permissions:
   contents: read
@@ -17,6 +18,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     if: |
+      github.event_name != 'merge_group' &&
       !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')
       && github.actor != 'otelbot[bot]'
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,13 +13,23 @@ on:
       - '**/*.rst'
       - '.github/workflows/check-links.yml'
       - '.github/workflows/check_links_config.json'
+  merge_group:
+    paths:
+      - '**/*.md'
+      - '**/*.rst'
+      - '.github/workflows/check-links.yml'
+      - '.github/workflows/check_links_config.json'
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
   cancel-in-progress: true
+
+env:
+  # Diff against merge group SHAs in queue, or PR base branch otherwise
+  DIFF_RANGE: ${{ github.event_name == 'merge_group' && format('{0}...{1}', github.event.merge_group.base_sha, github.event.merge_group.head_sha) || format('origin/{0}...HEAD', github.base_ref) }}
 
 jobs:
   check-links:
@@ -53,14 +63,14 @@ jobs:
             ${{ steps.changed-files.outputs.all_changed_files }} \
             || { echo "Check that anchor links are lowercase"; exit 1; }
 
-      - name: Check new links only on pull requests
-        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request'
+      - name: Check new links only on pull requests and merge groups
+        if: steps.changed-files.outputs.any_changed == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
         run: |
           # Extract URLs only from added lines in the diff to avoid
           # rate limiting when checking all links in large files like
           # CHANGELOG.md. Only new/changed links are checked on PRs;
           # pushes to main still check all links in changed files.
-          git diff "origin/${{ github.base_ref }}...HEAD" -- \
+          git diff "$DIFF_RANGE" -- \
             ${{ steps.changed-files.outputs.all_changed_files }} \
             | grep '^+' | grep -v '^+++' \
             | grep -oP 'https?://[^\s\)\]\"'"'"'`>]+' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches:
     - 'main'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -98,7 +98,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: |
-      github.event.pull_request.user.login != 'otelbot[bot]' && github.event_name == 'pull_request'
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'otelbot[bot]')
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4

--- a/.github/workflows/templates/ci.yml.j2
+++ b/.github/workflows/templates/ci.yml.j2
@@ -8,6 +8,7 @@ on:
     branches:
     - 'main'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/templates/misc.yml.j2
+++ b/.github/workflows/templates/misc.yml.j2
@@ -46,7 +46,9 @@ jobs:
     {%- endif %}
     {%- if job_data == "docs" %}
     if: |
-      github.event.pull_request.user.login != 'otelbot[bot]' && github.event_name == 'pull_request'
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'otelbot[bot]')
     {%- endif %}
     steps:
       - name: Checkout repo @ SHA - ${% raw %}{{ github.sha }}{% endraw %}


### PR DESCRIPTION
# Description

Part of https://github.com/open-telemetry/community/issues/3436

For merge queues, we need to trigger github actions on `merge_group` events as mentioned [in the docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions). This updates workflows so they will trigger.

**The "changelog" and "public API" checks are skipped, because they rely on checking the PR labels which aren't provided in the `merge_group` event.**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this so far in a fork with merge queues enabled. I was able to merge my PRs through the queue 
<img width="1115" height="698" alt="Screenshot 2026-05-14 at 5 29 38 PM" src="https://github.com/user-attachments/assets/f3c7d846-78ba-4cd4-8b29-5502fbcdaa4c" />

# Does This PR Require a Contrib Repo Change?

Not directly, but I will make the same change there.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
