### PR TITLE
chore(deps): bump minimum requests to 2.31 (CVE-2018-18074)

### DIFF
--- a/.changelog/5218.fixed
+++ b/.changelog/5218.fixed
@@ -1,0 +1,1 @@
+Bump minimum `requests` to 2.32 in HTTP/Zipkin exporters to mitigate CVE-2018-18074

--- a/.changelog/5218.fixed
+++ b/.changelog/5218.fixed
@@ -1,1 +1,1 @@
-Bump minimum `requests` to 2.32 in HTTP/Zipkin exporters to mitigate CVE-2018-18074
+Bump minimum `requests` to 2.31 in HTTP/Zipkin exporters to mitigate CVE-2018-18074

--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "opentelemetry-proto == 1.42.0.dev",
   "opentelemetry-sdk ~= 1.42.0.dev",
   "opentelemetry-exporter-otlp-proto-common == 1.42.0.dev",
-  "requests ~= 2.7",
+  "requests ~= 2.32",
   "typing-extensions >= 4.5.0",
 ]
 

--- a/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "opentelemetry-proto == 1.42.0.dev",
   "opentelemetry-sdk ~= 1.42.0.dev",
   "opentelemetry-exporter-otlp-proto-common == 1.42.0.dev",
-  "requests ~= 2.32",
+  "requests ~= 2.31",
   "typing-extensions >= 4.5.0",
 ]
 

--- a/exporter/opentelemetry-exporter-zipkin-json/pyproject.toml
+++ b/exporter/opentelemetry-exporter-zipkin-json/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
   "opentelemetry-api ~= 1.3",
   "opentelemetry-sdk ~= 1.11",
-  "requests ~= 2.7",
+  "requests ~= 2.32",
 ]
 
 [project.entry-points.opentelemetry_traces_exporter]

--- a/exporter/opentelemetry-exporter-zipkin-json/pyproject.toml
+++ b/exporter/opentelemetry-exporter-zipkin-json/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
   "opentelemetry-api ~= 1.3",
   "opentelemetry-sdk ~= 1.11",
-  "requests ~= 2.32",
+  "requests ~= 2.31",
 ]
 
 [project.entry-points.opentelemetry_traces_exporter]

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "opentelemetry-exporter-zipkin-json == 1.42.0.dev",
   "opentelemetry-sdk ~= 1.11",
   "protobuf ~= 3.12",
-  "requests ~= 2.32",
+  "requests ~= 2.31",
 ]
 
 [project.entry-points.opentelemetry_traces_exporter]

--- a/exporter/opentelemetry-exporter-zipkin-proto-http/pyproject.toml
+++ b/exporter/opentelemetry-exporter-zipkin-proto-http/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "opentelemetry-exporter-zipkin-json == 1.42.0.dev",
   "opentelemetry-sdk ~= 1.11",
   "protobuf ~= 3.12",
-  "requests ~= 2.7",
+  "requests ~= 2.32",
 ]
 
 [project.entry-points.opentelemetry_traces_exporter]

--- a/tox.ini
+++ b/tox.ini
@@ -327,7 +327,9 @@ deps =
   # Pinning docker for issue: https://github.com/docker/compose/issues/11309
   docker<7
   docker-compose==1.29.2
-  requests==2.32.3
+  # docker-py < 7's UnixHTTPAdapter overrides only get_connection, which
+  # requests >= 2.32 no longer calls; pin requests below 2.32 here.
+  requests==2.31.0
   ; core packages
   -e {toxinidir}/opentelemetry-api
   -e {toxinidir}/opentelemetry-semantic-conventions

--- a/tox.ini
+++ b/tox.ini
@@ -327,7 +327,7 @@ deps =
   # Pinning docker for issue: https://github.com/docker/compose/issues/11309
   docker<7
   docker-compose==1.29.2
-  requests==2.28.2
+  requests==2.32.3
   ; core packages
   -e {toxinidir}/opentelemetry-api
   -e {toxinidir}/opentelemetry-semantic-conventions

--- a/uv.lock
+++ b/uv.lock
@@ -937,7 +937,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-common", editable = "exporter/opentelemetry-exporter-otlp-proto-common" },
     { name = "opentelemetry-proto", editable = "opentelemetry-proto" },
     { name = "opentelemetry-sdk", editable = "opentelemetry-sdk" },
-    { name = "requests", specifier = "~=2.32" },
+    { name = "requests", specifier = "~=2.31" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
 provides-extras = ["gcp-auth"]
@@ -971,7 +971,7 @@ dependencies = [
 requires-dist = [
     { name = "opentelemetry-api", editable = "opentelemetry-api" },
     { name = "opentelemetry-sdk", editable = "opentelemetry-sdk" },
-    { name = "requests", specifier = "~=2.32" },
+    { name = "requests", specifier = "~=2.31" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -937,7 +937,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-common", editable = "exporter/opentelemetry-exporter-otlp-proto-common" },
     { name = "opentelemetry-proto", editable = "opentelemetry-proto" },
     { name = "opentelemetry-sdk", editable = "opentelemetry-sdk" },
-    { name = "requests", specifier = "~=2.7" },
+    { name = "requests", specifier = "~=2.32" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
 provides-extras = ["gcp-auth"]
@@ -971,7 +971,7 @@ dependencies = [
 requires-dist = [
     { name = "opentelemetry-api", editable = "opentelemetry-api" },
     { name = "opentelemetry-sdk", editable = "opentelemetry-sdk" },
-    { name = "requests", specifier = "~=2.7" },
+    { name = "requests", specifier = "~=2.32" },
 ]
 
 [[package]]
@@ -1513,7 +1513,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "certifi" },
@@ -1521,9 +1521,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

An image scanner for a downstream build depending on the otel-injector triggered on a CVE-2018-18074 alert. Investigation showed the otel-injector depends on an outdated version of the `requests` package as a transitive dependency via this repo (opentelemetry-python).

This PR bump the `requests` dependency floor to `~= 2.31`, for consistency with several existing `requirements.txt` files across this repo for minimum impact and compatibility.

Note that `2.32` was originally tried but found to be incompatible via CI checks on 0e17e3d5539f677b23ddbc904db1714d8cd925f7.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I'm not familiar with this repo, I'm open to guidance on test requirements outside of the standard PR checks, if any.

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [X] Followed the style guidelines of this project
- [X] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
