### PR TITLE
opentelemetry-proto-json: update to use opentelemetry-proto v1.10.0

### DIFF
--- a/.changelog/5224.added
+++ b/.changelog/5224.added
@@ -1,0 +1,1 @@
+`opentelemetry-proto-json`: update to use opentelemetry-proto v1.10.0

--- a/codegen/opentelemetry-codegen-json/src/opentelemetry/codegen/json/generator.py
+++ b/codegen/opentelemetry-codegen-json/src/opentelemetry/codegen/json/generator.py
@@ -296,18 +296,7 @@ class OtlpJsonGenerator:
         writer.comment(
             [
                 "Copyright The OpenTelemetry Authors",
-                "",
-                'Licensed under the Apache License, Version 2.0 (the "License");',
-                "you may not use this file except in compliance with the License.",
-                "You may obtain a copy of the License at",
-                "",
-                "    http://www.apache.org/licenses/LICENSE-2.0",
-                "",
-                "Unless required by applicable law or agreed to in writing, software",
-                'distributed under the License is distributed on an "AS IS" BASIS,',
-                "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
-                "See the License for the specific language governing permissions and",
-                "limitations under the License.",
+                "SPDX-License-Identifier: Apache-2.0",
             ]
         )
         writer.blank_line()

--- a/opentelemetry-proto-json/README.rst
+++ b/opentelemetry-proto-json/README.rst
@@ -6,9 +6,9 @@ OpenTelemetry Python Proto JSON
 .. |pypi| image:: https://badge.fury.io/py/opentelemetry-proto-json.svg
    :target: https://pypi.org/project/opentelemetry-proto-json/
 
-This library contains the generated code for OpenTelemetry protobuf data model with JSON encoding support. The code in the current package was generated using the v1.9.0 release_ of opentelemetry-proto and includes definitions for the OpenTelemetry JSON Protobuf encoding specification.
+This library contains the generated code for OpenTelemetry protobuf data model with JSON encoding support. The code in the current package was generated using the v1.10.0 release_ of opentelemetry-proto and includes definitions for the OpenTelemetry JSON Protobuf encoding specification.
 
-.. _release: https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.9.0
+.. _release: https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.10.0
 
 Installation
 ------------
@@ -21,11 +21,11 @@ Code Generation
 ---------------
 
 These files were generated automatically using the custom protoc plugin opentelemetry-codegen-json_ from code in opentelemetry-proto_.
-To regenerate the code, run ``../scripts/proto_codegen_json.sh``.
+To regenerate the code, run ``uv run ./scripts/proto_codegen_json.sh`` from the project root.
 
 To build against a new release or specific commit of opentelemetry-proto_,
 update the ``PROTO_REPO_BRANCH_OR_COMMIT`` variable in
-``../scripts/proto_codegen_json.sh``. Then run the script and commit the changes
+``./scripts/proto_codegen_json.sh``. Then run the script and commit the changes
 as well as any fixes needed in the OTLP exporter.
 
 .. _opentelemetry-codegen-json: https://github.com/open-telemetry/opentelemetry-python/tree/main/codegen/opentelemetry-codegen-json

--- a/opentelemetry-proto-json/src/opentelemetry/proto_json/_json_codec.py
+++ b/opentelemetry-proto-json/src/opentelemetry/proto_json/_json_codec.py
@@ -38,14 +38,14 @@ class JsonMessage(abc.ABC):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls: type[M], data: typing.Union[str, bytes]) -> M:
+    def from_json(cls: type[M], data: str | bytes) -> M:
         """
         Deserialize from a JSON string or bytes.
         """
         return cls.from_dict(json.loads(data))
 
 
-def encode_hex(value: typing.Optional[bytes]) -> str:
+def encode_hex(value: bytes | None) -> str:
     """
     Encode bytes as hex string.
 
@@ -57,7 +57,7 @@ def encode_hex(value: typing.Optional[bytes]) -> str:
     return value.hex() if value else ""
 
 
-def encode_base64(value: typing.Optional[bytes]) -> str:
+def encode_base64(value: bytes | None) -> str:
     """
     Encode bytes as base64 string.
     Standard Proto3 JSON mapping for bytes.
@@ -83,7 +83,7 @@ def encode_int64(value: int) -> str:
     return str(value)
 
 
-def encode_float(value: float) -> typing.Union[float, str]:
+def encode_float(value: float) -> float | str:
     """
     Encode float/double values.
 
@@ -100,7 +100,7 @@ def encode_float(value: float) -> typing.Union[float, str]:
 
 
 def encode_repeated(
-    values: typing.Optional[list[T]],
+    values: list[T] | None,
     map_fn: typing.Callable[[T], typing.Any],
 ) -> list[typing.Any]:
     """
@@ -115,7 +115,7 @@ def encode_repeated(
     return [map_fn(v) for v in values] if values else []
 
 
-def decode_hex(value: typing.Optional[str], field_name: str) -> bytes:
+def decode_hex(value: str | None, field_name: str) -> bytes:
     """
     Decode hex string to bytes.
 
@@ -136,7 +136,7 @@ def decode_hex(value: typing.Optional[str], field_name: str) -> bytes:
         ) from None
 
 
-def decode_base64(value: typing.Optional[str], field_name: str) -> bytes:
+def decode_base64(value: str | None, field_name: str) -> bytes:
     """
     Decode base64 string to bytes.
 
@@ -157,9 +157,7 @@ def decode_base64(value: typing.Optional[str], field_name: str) -> bytes:
         ) from None
 
 
-def decode_int64(
-    value: typing.Optional[typing.Union[int, str]], field_name: str
-) -> int:
+def decode_int64(value: int | str | None, field_name: str) -> int:
     """
     Parse int64 from number or string.
 
@@ -180,9 +178,7 @@ def decode_int64(
         ) from None
 
 
-def decode_float(
-    value: typing.Optional[typing.Union[float, int, str]], field_name: str
-) -> float:
+def decode_float(value: float | int | str | None, field_name: str) -> float:
     """
     Parse float/double from number or string, handling special values.
 
@@ -210,7 +206,7 @@ def decode_float(
 
 
 def decode_repeated(
-    values: typing.Optional[list[typing.Any]],
+    values: list[typing.Any] | None,
     item_parser: typing.Callable[[typing.Any], T],
     field_name: str,
 ) -> list[T]:
@@ -232,7 +228,7 @@ def decode_repeated(
 
 def validate_type(
     value: typing.Any,
-    expected_types: typing.Union[type, tuple[type, ...]],
+    expected_types: type | tuple[type, ...],
     field_name: str,
 ) -> None:
     """

--- a/opentelemetry-proto-json/src/opentelemetry/proto_json/common/v1/common.py
+++ b/opentelemetry-proto-json/src/opentelemetry/proto_json/common/v1/common.py
@@ -30,6 +30,7 @@ class AnyValue(opentelemetry.proto_json._json_codec.JsonMessage):
     array_value: typing.Optional[ArrayValue] = None
     kvlist_value: typing.Optional[KeyValueList] = None
     bytes_value: typing.Optional[builtins.bytes] = None
+    string_value_strindex: typing.Optional[builtins.int] = None
 
     def to_dict(self) -> builtins.dict[builtins.str, typing.Any]:
         """
@@ -39,7 +40,9 @@ class AnyValue(opentelemetry.proto_json._json_codec.JsonMessage):
             Dictionary representation following OTLP JSON encoding
         """
         _result = {}
-        if self.bytes_value is not None:
+        if self.string_value_strindex is not None:
+            _result["stringValueStrindex"] = self.string_value_strindex
+        elif self.bytes_value is not None:
             _result["bytesValue"] = opentelemetry.proto_json._json_codec.encode_base64(self.bytes_value)
         elif self.kvlist_value is not None:
             _result["kvlistValue"] = self.kvlist_value.to_dict()
@@ -69,7 +72,10 @@ class AnyValue(opentelemetry.proto_json._json_codec.JsonMessage):
         opentelemetry.proto_json._json_codec.validate_type(data, builtins.dict, "data")
         _args = {}
 
-        if (_value := data.get("bytesValue")) is not None:
+        if (_value := data.get("stringValueStrindex")) is not None:
+            opentelemetry.proto_json._json_codec.validate_type(_value, builtins.int, "string_value_strindex")
+            _args["string_value_strindex"] = _value
+        elif (_value := data.get("bytesValue")) is not None:
             _args["bytes_value"] = opentelemetry.proto_json._json_codec.decode_base64(_value, "bytes_value")
         elif (_value := data.get("kvlistValue")) is not None:
             _args["kvlist_value"] = KeyValueList.from_dict(_value)
@@ -180,6 +186,7 @@ class KeyValue(opentelemetry.proto_json._json_codec.JsonMessage):
 
     key: typing.Optional[builtins.str] = ""
     value: typing.Optional[AnyValue] = None
+    key_strindex: typing.Optional[builtins.int] = 0
 
     def to_dict(self) -> builtins.dict[builtins.str, typing.Any]:
         """
@@ -193,6 +200,8 @@ class KeyValue(opentelemetry.proto_json._json_codec.JsonMessage):
             _result["key"] = self.key
         if self.value:
             _result["value"] = self.value.to_dict()
+        if self.key_strindex:
+            _result["keyStrindex"] = self.key_strindex
         return _result
 
     @builtins.classmethod
@@ -214,6 +223,9 @@ class KeyValue(opentelemetry.proto_json._json_codec.JsonMessage):
             _args["key"] = _value
         if (_value := data.get("value")) is not None:
             _args["value"] = AnyValue.from_dict(_value)
+        if (_value := data.get("keyStrindex")) is not None:
+            opentelemetry.proto_json._json_codec.validate_type(_value, builtins.int, "key_strindex")
+            _args["key_strindex"] = _value
 
         return cls(**_args)
 

--- a/opentelemetry-proto-json/src/opentelemetry/proto_json/profiles/v1development/profiles.py
+++ b/opentelemetry-proto-json/src/opentelemetry/proto_json/profiles/v1development/profiles.py
@@ -434,9 +434,9 @@ class Sample(opentelemetry.proto_json._json_codec.JsonMessage):
     """
 
     stack_index: typing.Optional[builtins.int] = 0
-    values: builtins.list[builtins.int] = dataclasses.field(default_factory=builtins.list)
     attribute_indices: builtins.list[builtins.int] = dataclasses.field(default_factory=builtins.list)
     link_index: typing.Optional[builtins.int] = 0
+    values: builtins.list[builtins.int] = dataclasses.field(default_factory=builtins.list)
     timestamps_unix_nano: builtins.list[builtins.int] = dataclasses.field(default_factory=builtins.list)
 
     def to_dict(self) -> builtins.dict[builtins.str, typing.Any]:
@@ -449,12 +449,12 @@ class Sample(opentelemetry.proto_json._json_codec.JsonMessage):
         _result = {}
         if self.stack_index:
             _result["stackIndex"] = self.stack_index
-        if self.values:
-            _result["values"] = opentelemetry.proto_json._json_codec.encode_repeated(self.values, lambda _v: opentelemetry.proto_json._json_codec.encode_int64(_v))
         if self.attribute_indices:
             _result["attributeIndices"] = self.attribute_indices
         if self.link_index:
             _result["linkIndex"] = self.link_index
+        if self.values:
+            _result["values"] = opentelemetry.proto_json._json_codec.encode_repeated(self.values, lambda _v: opentelemetry.proto_json._json_codec.encode_int64(_v))
         if self.timestamps_unix_nano:
             _result["timestampsUnixNano"] = opentelemetry.proto_json._json_codec.encode_repeated(self.timestamps_unix_nano, lambda _v: opentelemetry.proto_json._json_codec.encode_int64(_v))
         return _result
@@ -476,13 +476,13 @@ class Sample(opentelemetry.proto_json._json_codec.JsonMessage):
         if (_value := data.get("stackIndex")) is not None:
             opentelemetry.proto_json._json_codec.validate_type(_value, builtins.int, "stack_index")
             _args["stack_index"] = _value
-        if (_value := data.get("values")) is not None:
-            _args["values"] = opentelemetry.proto_json._json_codec.decode_repeated(_value, lambda _v: opentelemetry.proto_json._json_codec.decode_int64(_v, "values"), "values")
         if (_value := data.get("attributeIndices")) is not None:
             _args["attribute_indices"] = opentelemetry.proto_json._json_codec.decode_repeated(_value, lambda _v: _v, "attribute_indices")
         if (_value := data.get("linkIndex")) is not None:
             opentelemetry.proto_json._json_codec.validate_type(_value, builtins.int, "link_index")
             _args["link_index"] = _value
+        if (_value := data.get("values")) is not None:
+            _args["values"] = opentelemetry.proto_json._json_codec.decode_repeated(_value, lambda _v: opentelemetry.proto_json._json_codec.decode_int64(_v, "values"), "values")
         if (_value := data.get("timestampsUnixNano")) is not None:
             _args["timestamps_unix_nano"] = opentelemetry.proto_json._json_codec.decode_repeated(_value, lambda _v: opentelemetry.proto_json._json_codec.decode_int64(_v, "timestamps_unix_nano"), "timestamps_unix_nano")
 

--- a/scripts/proto_codegen_json.sh
+++ b/scripts/proto_codegen_json.sh
@@ -12,7 +12,7 @@
 #   PROTO_REPO_DIR - the path to an existing checkout of the opentelemetry-proto repo
 
 # Pinned commit/branch/tag for the current version used in opentelemetry-proto python package.
-PROTO_REPO_BRANCH_OR_COMMIT="v1.9.0"
+PROTO_REPO_BRANCH_OR_COMMIT="v1.10.0"
 
 set -e
 


### PR DESCRIPTION
# Description

Updates `opentelemetry-proto-json` to use v1.10.0 of `opentelemetry-proto`. I have also tweaked the `README.rst` with updated command information based on a small issue encountered during code generation. The codegen package has also been updated to utilize the new header format. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tox

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Documentation has been updated
