### PR TITLE
document merge queue deadlock workaround and merge order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - contrib
     runs-on: ubuntu-latest
     steps:
+      # Skip alls-green check for post-release version bumps in merge_group.
+      # This avoids a deadlock where core and contrib repos wait for each other's releases.
+      # See RELEASING.md for more details.
       - name: Decide whether the needed jobs succeeded or failed
         if: ${{ !(github.event_name == 'merge_group' && contains(github.event.merge_group.head_commit.message, 'Update version to')) }}
         uses: re-actors/alls-green@release/v1

--- a/.github/workflows/templates/ci.yml.j2
+++ b/.github/workflows/templates/ci.yml.j2
@@ -43,6 +43,9 @@ jobs:
       - contrib
     runs-on: ubuntu-latest
     steps:
+      # Skip alls-green check for post-release version bumps in merge_group.
+      # This avoids a deadlock where core and contrib repos wait for each other's releases.
+      # See RELEASING.md for more details.
       - name: Decide whether the needed jobs succeeded or failed
         if: ${% raw %}{{ !(github.event_name == 'merge_group' && contains(github.event.merge_group.head_commit.message, 'Update version to')) }}{% endraw %}
         uses: re-actors/alls-green@release/v1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,6 +14,7 @@
     * Release builds now should pass.
   * Merge the release PR.
   * Merge the PR to main (this can be done separately from [making the release](#making-the-release))
+    * ⚠️ **Merge `core` first**: To avoid a merge queue deadlock with `contrib`, you must merge the `core` PR to `main` first. We skip `alls-green` in the core merge queue ([ci.yml](https://github.com/open-telemetry/opentelemetry-python/blob/main/.github/workflows/ci.yml)) for this PR, which unblocks `contrib` once merged.
 
 ## Preparing a new patch release
 


### PR DESCRIPTION
# Description

Captures the changes to the post release process with merge queues which was added in fe69b164898ebcaeef4246cebb30ebf255e47d87 (from https://github.com/open-telemetry/opentelemetry-python/pull/5226).

## Type of change

Please delete options that are not relevant.

- [x] Internal docs

# How Has This Been Tested?

n/a

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
