### PR TITLE
opentelemetry-api: avoid SelectableGroups dict API

### DIFF
--- a/.changelog/5234.fixed
+++ b/.changelog/5234.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-api`: avoid deprecated `SelectableGroups` dict access.

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -28,6 +28,8 @@ from typing import Any
 def _as_entry_points(eps: Any) -> EntryPoints:
     if isinstance(eps, EntryPoints):
         return eps
+    if hasattr(eps, "select"):
+        return eps.select()
     # Handle Python 3.10 SelectableGroups (dict-like)
     return EntryPoints(ep for group_eps in eps.values() for ep in group_eps)
 

--- a/opentelemetry-api/tests/util/test__importlib_metadata.py
+++ b/opentelemetry-api/tests/util/test__importlib_metadata.py
@@ -117,3 +117,18 @@ class TestEntryPoints(TestCase):
         self.assertIsInstance(normalized, EntryPoints)
         self.assertEqual(len(normalized), 2)
         self.assertEqual(list(normalized), [ep1, ep2])
+
+    def test_as_entry_points_uses_selectable_groups_select(self):
+        """Test that SelectableGroups are normalized without the deprecated dict API."""
+        entry_point = EntryPoint(name="foo", value="bar:baz", group="gp")
+
+        class SelectableGroups:
+            def select(self):
+                return EntryPoints([entry_point])
+
+            def values(self):
+                raise AssertionError("deprecated dict interface used")
+
+        normalized = _as_entry_points(SelectableGroups())
+        self.assertIsInstance(normalized, EntryPoints)
+        self.assertEqual(list(normalized), [entry_point])


### PR DESCRIPTION
# Description

Fixes #5231.

Normalize `importlib.metadata` `SelectableGroups` through `select()` instead of the deprecated dict-style interface. This preserves the existing cached all-entry-points behavior while avoiding the Python 3.10/3.11 `SelectableGroups dict interface is deprecated` warning path.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `git diff --check`
- [x] `git diff --cached --check`

Not run locally.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated

The PR is draft until the first remote checks are available.