### PR TITLE
Add missing dependency to proto_codegen_json.sh

### DIFF
--- a/opentelemetry-proto-json/README.rst
+++ b/opentelemetry-proto-json/README.rst
@@ -21,11 +21,11 @@ Code Generation
 ---------------
 
 These files were generated automatically using the custom protoc plugin opentelemetry-codegen-json_ from code in opentelemetry-proto_.
-To regenerate the code, run ``uv run ./scripts/proto_codegen_json.sh`` from the project root.
+To regenerate the code, run ``../scripts/proto_codegen_json.sh``.
 
 To build against a new release or specific commit of opentelemetry-proto_,
 update the ``PROTO_REPO_BRANCH_OR_COMMIT`` variable in
-``./scripts/proto_codegen_json.sh``. Then run the script and commit the changes
+``../scripts/proto_codegen_json.sh``. Then run the script and commit the changes
 as well as any fixes needed in the OTLP exporter.
 
 .. _opentelemetry-codegen-json: https://github.com/open-telemetry/opentelemetry-python/tree/main/codegen/opentelemetry-codegen-json

--- a/scripts/proto_codegen_json.sh
+++ b/scripts/proto_codegen_json.sh
@@ -24,6 +24,7 @@ protoc() {
     uvx -c $repo_root/gen-requirements.txt \
         --python 3.12 \
         --from grpcio-tools \
+        --with "$repo_root/codegen/opentelemetry-codegen-json" \
         python -m grpc_tools.protoc "$@"
 }
 


### PR DESCRIPTION
Fixes #5235

We were missing a dependency to run this script, adding it here.

Before adding this dependency:

```
tigre@sandokan:~/github/ocelotl/opentelemetry-python/scripts$ ./proto_codegen_json.sh
libprotoc 26.1
HEAD is now at a895173 Prepare release 1.9.0 (#734)
protoc-gen-otlp_json: program not found or is not executable
Please specify a program using absolute path or make sure the program is available in your PATH system variable
--otlp_json_out: protoc-gen-otlp_json: Plugin failed with status code 1.
```

And the generated files are not updated.

After adding this dependency:

```
tigre@sandokan:~/github/ocelotl/opentelemetry-python/scripts$ ./proto_codegen_json.sh
libprotoc 26.1
HEAD is now at a895173 Prepare release 1.9.0 (#734)
Please update ./opentelemetry-proto-json/README.rst to include the updated version.
```

And the generated files are updated.

This happens because the `protoc-gen-otlp_json` is actually defined in our `opentelemetry-codegen-json` package.