### PR TITLE
Fix eachdist dependency version matching

### DIFF
--- a/.changelog/5237.fixed
+++ b/.changelog/5237.fixed
@@ -1,0 +1,1 @@
+Prevent release tooling from matching dependency name prefixes.

--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -601,7 +601,7 @@ def update_dependencies(targets, version, packages):
     operators_pattern = "|".join(re.escape(op) for op in operators)
 
     for pkg in packages:
-        search = rf"({basename(pkg)}\s[^,]*)({operators_pattern})(.*\.dev)"
+        search = rf"({basename(pkg)}\s+)({operators_pattern})(.*\.dev)"
         replace = r"\1\2 " + version
         update_files(
             targets,
@@ -618,7 +618,7 @@ def update_patch_dependencies(targets, version, prev_version, packages):
     operators_pattern = "|".join(re.escape(op) for op in operators)
 
     for pkg in packages:
-        search = rf"({basename(pkg)}\s[^,]*?)(\s?({operators_pattern})\s?)(.*{prev_version})"
+        search = rf"({basename(pkg)}\s+)(\s?({operators_pattern})\s?)(.*{prev_version})"
         replace = r"\g<1>\g<2>" + version
         print(f"{search=}\t{replace=}\t{pkg=}")
         update_files(

--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -601,7 +601,7 @@ def update_dependencies(targets, version, packages):
     operators_pattern = "|".join(re.escape(op) for op in operators)
 
     for pkg in packages:
-        search = rf"({basename(pkg)}[^,]*)({operators_pattern})(.*\.dev)"
+        search = rf"({basename(pkg)}\s[^,]*)({operators_pattern})(.*\.dev)"
         replace = r"\1\2 " + version
         update_files(
             targets,
@@ -618,7 +618,7 @@ def update_patch_dependencies(targets, version, prev_version, packages):
     operators_pattern = "|".join(re.escape(op) for op in operators)
 
     for pkg in packages:
-        search = rf"({basename(pkg)}[^,]*?)(\s?({operators_pattern})\s?)(.*{prev_version})"
+        search = rf"({basename(pkg)}\s[^,]*?)(\s?({operators_pattern})\s?)(.*{prev_version})"
         replace = r"\g<1>\g<2>" + version
         print(f"{search=}\t{replace=}\t{pkg=}")
         update_files(


### PR DESCRIPTION
Fixes #5227

## Summary
- Tightened the dependency version replacement regex in `scripts/eachdist.py`.
- Prevented package names that are prefixes of another package, such as `opentelemetry-proto`, from matching `opentelemetry-proto-json`.
- Added the towncrier changelog fragment for this release-tooling fix.

## Why
The release helper matched package name prefixes too broadly, so updating `opentelemetry-proto` could also rewrite dependencies for `opentelemetry-proto-json`.

## Testing
- Ran: targeted Python validation snippet for `update_dependencies` and `update_patch_dependencies` using temporary `pyproject.toml` fixtures - passed
- Ran: `python3 -m py_compile scripts/eachdist.py` - passed

## Notes
- Full tox/precommit not run locally because `uv` and `tox` are not installed in this shell.
