### PR TITLE
Avoid SelectableGroups deprecation warning

### DIFF
--- a/.changelog/5238.fixed
+++ b/.changelog/5238.fixed
@@ -1,0 +1,1 @@
+Avoid import-time deprecation warnings on Python 3.10 and 3.11.

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -11,6 +11,7 @@ It also normalizes minor differences across python versions 3.10+. References to
 - https://github.com/open-telemetry/opentelemetry-python/pull/5203
 """
 
+import warnings
 from functools import cache
 from importlib.metadata import (
     Distribution,
@@ -28,12 +29,14 @@ from typing import Any
 def _as_entry_points(eps: Any) -> EntryPoints:
     if isinstance(eps, EntryPoints):
         return eps
-    if hasattr(eps, "groups") and hasattr(eps, "select"):
-        return EntryPoints(
-            ep for group in eps.groups for ep in eps.select(group=group)
-        )
     # Handle Python 3.10 SelectableGroups (dict-like)
-    return EntryPoints(ep for group_eps in eps.values() for ep in group_eps)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"SelectableGroups dict interface is deprecated\. Use select\.",
+            category=DeprecationWarning,
+        )
+        return EntryPoints(ep for group_eps in eps.values() for ep in group_eps)
 
 
 @cache

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -28,6 +28,10 @@ from typing import Any
 def _as_entry_points(eps: Any) -> EntryPoints:
     if isinstance(eps, EntryPoints):
         return eps
+    if hasattr(eps, "groups") and hasattr(eps, "select"):
+        return EntryPoints(
+            ep for group in eps.groups for ep in eps.select(group=group)
+        )
     # Handle Python 3.10 SelectableGroups (dict-like)
     return EntryPoints(ep for group_eps in eps.values() for ep in group_eps)
 

--- a/opentelemetry-api/tests/util/test__importlib_metadata.py
+++ b/opentelemetry-api/tests/util/test__importlib_metadata.py
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib.metadata
+import warnings
 from unittest import TestCase
 
 from opentelemetry.metrics import MeterProvider
@@ -117,3 +119,23 @@ class TestEntryPoints(TestCase):
         self.assertIsInstance(normalized, EntryPoints)
         self.assertEqual(len(normalized), 2)
         self.assertEqual(list(normalized), [ep1, ep2])
+
+    def test_as_entry_points_selectable_groups_without_warning(self):
+        selectable_groups_class = getattr(
+            importlib.metadata, "SelectableGroups", None
+        )
+        if selectable_groups_class is None:
+            self.skipTest("SelectableGroups is not available")
+
+        ep1 = EntryPoint(name="foo", value="bar:baz", group="gp")
+        ep2 = EntryPoint(name="foo2", value="bar2:baz2", group="gp2")
+        selectable_groups = selectable_groups_class(
+            {"gp": [ep1], "gp2": [ep2]}
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            normalized = _as_entry_points(selectable_groups)
+
+        self.assertIsInstance(normalized, EntryPoints)
+        self.assertCountEqual(normalized, [ep1, ep2])


### PR DESCRIPTION
Fixes #5231

## Summary
- Updated the importlib metadata compatibility wrapper to normalize `SelectableGroups` without using its deprecated dict interface.
- Added regression coverage that treats `DeprecationWarning` as an error while converting `SelectableGroups`.
- Added the towncrier changelog fragment for this API compatibility fix.

## Why
On Python 3.10 and 3.11, `importlib.metadata.entry_points()` can return `SelectableGroups`. Calling its dict-like `values()` emits a `DeprecationWarning`, which breaks users running with warnings as errors when importing `opentelemetry.context`.

## Testing
- Ran: `python3 -m pytest opentelemetry-api/tests/util/test__importlib_metadata.py` - passed
- Ran: `python3 -W error -c 'import opentelemetry.context'` - passed\n- Ran: `python3 -W error -m pytest opentelemetry-api/tests/util/test__importlib_metadata.py` - passed\n- Ran: `python3 -m ruff check opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py opentelemetry-api/tests/util/test__importlib_metadata.py` - passed\n- Ran: `python3 -m py_compile opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py opentelemetry-api/tests/util/test__importlib_metadata.py` - passed\n\n## Notes\n- Full tox/precommit not run locally because `uv` and `tox` are not installed in this shell.\n