### PR TITLE
fix(exporter/otlp): support non-standard types as attribute values and log body

### DIFF
--- a/.changelog/5210.fixed
+++ b/.changelog/5210.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-exporter-otlp-proto-common`, `opentelemetry-exporter-otlp-json-common`: support non-standard attribute value types (e.g. `pathlib.Path`) by coercing to string

--- a/.changelog/5210.fixed
+++ b/.changelog/5210.fixed
@@ -1,1 +1,0 @@
-`opentelemetry-exporter-otlp-proto-common`, `opentelemetry-exporter-otlp-json-common`: support non-standard attribute value types (e.g. `pathlib.Path`) by coercing to string

--- a/.changelog/5239.fixed
+++ b/.changelog/5239.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-exporter-otlp-proto-common`, `opentelemetry-exporter-otlp-json-common`: support non-standard attribute value types (e.g. `pathlib.Path`) by coercing to string

--- a/exporter/opentelemetry-exporter-otlp-json-common/src/opentelemetry/exporter/otlp/json/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-json-common/src/opentelemetry/exporter/otlp/json/common/_internal/__init__.py
@@ -87,6 +87,11 @@ def _encode_value(value: Any, allow_null: bool = False) -> JSONAnyValue | None:
     # whitelisted; stringify as a best-effort fallback so telemetry is not silently lost.
     # None is excluded — it must be handled via allow_null=True at the call site.
     if value is not None:
+        _logger.error(
+            "Invalid type %s for OTLP value; encoding as string. "
+            "This is a bug in the instrumentation.",
+            type(value),
+        )
         # pylint: disable=broad-exception-caught
         try:
             return JSONAnyValue(string_value=str(value))

--- a/exporter/opentelemetry-exporter-otlp-json-common/src/opentelemetry/exporter/otlp/json/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-json-common/src/opentelemetry/exporter/otlp/json/common/_internal/__init__.py
@@ -83,6 +83,15 @@ def _encode_value(value: Any, allow_null: bool = False) -> JSONAnyValue | None:
                 ]
             )
         )
+    # Third-party instrumentation can inject arbitrary types that cannot be exhaustively
+    # whitelisted; stringify as a best-effort fallback so telemetry is not silently lost.
+    # None is excluded — it must be handled via allow_null=True at the call site.
+    if value is not None:
+        # pylint: disable=broad-exception-caught
+        try:
+            return JSONAnyValue(string_value=str(value))
+        except Exception:
+            pass
     raise TypeError(f"Invalid type {type(value)} of value {value}")
 
 

--- a/exporter/opentelemetry-exporter-otlp-json-common/tests/test_common_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-json-common/tests/test_common_encoder.py
@@ -336,9 +336,7 @@ class TestCommonEncoder(unittest.TestCase):  # pylint: disable=too-many-public-m
             result = _encode_value(path)
         self.assertEqual(result, JSONAnyValue(string_value=str(path)))
         self.assertEqual(result.to_dict(), {"stringValue": str(path)})
-        self.assertTrue(
-            any("Invalid type" in msg for msg in log_cm.output)
-        )
+        self.assertTrue(any("Invalid type" in msg for msg in log_cm.output))
 
     def test_encode_attributes_pathlib_path(self):
         path = Path("/models/my-model")
@@ -363,6 +361,4 @@ class TestCommonEncoder(unittest.TestCase):  # pylint: disable=too-many-public-m
         ) as log_cm:
             with self.assertRaises((TypeError, Exception)):
                 _encode_value(_Unstringable())
-        self.assertTrue(
-            any("Invalid type" in msg for msg in log_cm.output)
-        )
+        self.assertTrue(any("Invalid type" in msg for msg in log_cm.output))

--- a/exporter/opentelemetry-exporter-otlp-json-common/tests/test_common_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-json-common/tests/test_common_encoder.py
@@ -36,7 +36,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 
 
-class TestCommonEncoder(unittest.TestCase):
+class TestCommonEncoder(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def test_encode_value(self):
         cases = [
             (
@@ -329,18 +329,20 @@ class TestCommonEncoder(unittest.TestCase):
         self.assertEqual(result.to_dict(), {})
 
     def test_encode_value_pathlib_path(self):
-        result = _encode_value(Path("/models/my-model"))
-        self.assertEqual(result, JSONAnyValue(string_value="/models/my-model"))
-        self.assertEqual(result.to_dict(), {"stringValue": "/models/my-model"})
+        path = Path("/models/my-model")
+        result = _encode_value(path)
+        self.assertEqual(result, JSONAnyValue(string_value=str(path)))
+        self.assertEqual(result.to_dict(), {"stringValue": str(path)})
 
     def test_encode_attributes_pathlib_path(self):
-        result = _encode_attributes({"model_path": Path("/models/my-model")})
+        path = Path("/models/my-model")
+        result = _encode_attributes({"model_path": path})
         self.assertEqual(
             result,
             [
                 JSONKeyValue(
                     key="model_path",
-                    value=JSONAnyValue(string_value="/models/my-model"),
+                    value=JSONAnyValue(string_value=str(path)),
                 )
             ],
         )

--- a/exporter/opentelemetry-exporter-otlp-json-common/tests/test_common_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-json-common/tests/test_common_encoder.py
@@ -330,9 +330,15 @@ class TestCommonEncoder(unittest.TestCase):  # pylint: disable=too-many-public-m
 
     def test_encode_value_pathlib_path(self):
         path = Path("/models/my-model")
-        result = _encode_value(path)
+        with self.assertLogs(
+            "opentelemetry.exporter.otlp.json.common._internal", level=ERROR
+        ) as log_cm:
+            result = _encode_value(path)
         self.assertEqual(result, JSONAnyValue(string_value=str(path)))
         self.assertEqual(result.to_dict(), {"stringValue": str(path)})
+        self.assertTrue(
+            any("Invalid type" in msg for msg in log_cm.output)
+        )
 
     def test_encode_attributes_pathlib_path(self):
         path = Path("/models/my-model")
@@ -352,5 +358,11 @@ class TestCommonEncoder(unittest.TestCase):  # pylint: disable=too-many-public-m
             def __str__(self):
                 raise RuntimeError("cannot convert")
 
-        with self.assertRaises((TypeError, Exception)):
-            _encode_value(_Unstringable())
+        with self.assertLogs(
+            "opentelemetry.exporter.otlp.json.common._internal", level=ERROR
+        ) as log_cm:
+            with self.assertRaises((TypeError, Exception)):
+                _encode_value(_Unstringable())
+        self.assertTrue(
+            any("Invalid type" in msg for msg in log_cm.output)
+        )

--- a/exporter/opentelemetry-exporter-otlp-json-common/tests/test_common_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-json-common/tests/test_common_encoder.py
@@ -6,6 +6,7 @@
 import base64
 import unittest
 from logging import ERROR
+from pathlib import Path
 
 from opentelemetry.exporter.otlp.json.common._internal import (
     _encode_array,
@@ -326,3 +327,28 @@ class TestCommonEncoder(unittest.TestCase):
         result = _encode_instrumentation_scope(None)
         self.assertEqual(result, JSONInstrumentationScope())
         self.assertEqual(result.to_dict(), {})
+
+    def test_encode_value_pathlib_path(self):
+        result = _encode_value(Path("/models/my-model"))
+        self.assertEqual(result, JSONAnyValue(string_value="/models/my-model"))
+        self.assertEqual(result.to_dict(), {"stringValue": "/models/my-model"})
+
+    def test_encode_attributes_pathlib_path(self):
+        result = _encode_attributes({"model_path": Path("/models/my-model")})
+        self.assertEqual(
+            result,
+            [
+                JSONKeyValue(
+                    key="model_path",
+                    value=JSONAnyValue(string_value="/models/my-model"),
+                )
+            ],
+        )
+
+    def test_encode_value_unstringable_type_raises(self):
+        class _Unstringable:
+            def __str__(self):
+                raise RuntimeError("cannot convert")
+
+        with self.assertRaises((TypeError, Exception)):
+            _encode_value(_Unstringable())

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -83,6 +83,11 @@ def _encode_value(value: Any, allow_null: bool = False) -> PB2AnyValue | None:
     # whitelisted; stringify as a best-effort fallback so telemetry is not silently lost.
     # None is excluded — it must be handled via allow_null=True at the call site.
     if value is not None:
+        _logger.error(
+            "Invalid type %s for OTLP value; encoding as string. "
+            "This is a bug in the instrumentation.",
+            type(value),
+        )
         # pylint: disable=broad-exception-caught
         try:
             return PB2AnyValue(string_value=str(value))

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -79,6 +79,15 @@ def _encode_value(value: Any, allow_null: bool = False) -> PB2AnyValue | None:
                 ]
             )
         )
+    # Third-party instrumentation can inject arbitrary types that cannot be exhaustively
+    # whitelisted; stringify as a best-effort fallback so telemetry is not silently lost.
+    # None is excluded — it must be handled via allow_null=True at the call site.
+    if value is not None:
+        # pylint: disable=broad-exception-caught
+        try:
+            return PB2AnyValue(string_value=str(value))
+        except Exception:
+            pass
     raise Exception(f"Invalid type {type(value)} of value {value}")
 
 

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_attribute_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_attribute_encoder.py
@@ -115,8 +115,14 @@ class TestOTLPAttributeEncoder(unittest.TestCase):
 
     def test_encode_value_pathlib_path(self):
         path = Path("/models/my-model")
-        result = _encode_value(path)
+        with self.assertLogs(
+            "opentelemetry.exporter.otlp.proto.common._internal", level=ERROR
+        ) as log_cm:
+            result = _encode_value(path)
         self.assertEqual(result, PB2AnyValue(string_value=str(path)))
+        self.assertTrue(
+            any("Invalid type" in msg for msg in log_cm.output)
+        )
 
     def test_encode_attributes_pathlib_path(self):
         path = Path("/models/my-model")
@@ -136,5 +142,11 @@ class TestOTLPAttributeEncoder(unittest.TestCase):
             def __str__(self):
                 raise RuntimeError("cannot convert")
 
-        with self.assertRaises(Exception):
-            _encode_value(_Unstringable())
+        with self.assertLogs(
+            "opentelemetry.exporter.otlp.proto.common._internal", level=ERROR
+        ) as log_cm:
+            with self.assertRaises(Exception):
+                _encode_value(_Unstringable())
+        self.assertTrue(
+            any("Invalid type" in msg for msg in log_cm.output)
+        )

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_attribute_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_attribute_encoder.py
@@ -3,9 +3,11 @@
 
 import unittest
 from logging import ERROR
+from pathlib import Path
 
 from opentelemetry.exporter.otlp.proto.common._internal import (
     _encode_attributes,
+    _encode_value,
 )
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue as PB2AnyValue
 from opentelemetry.proto.common.v1.common_pb2 import (
@@ -110,3 +112,27 @@ class TestOTLPAttributeEncoder(unittest.TestCase):
                 PB2KeyValue(key="b", value=PB2AnyValue(int_value=2)),
             ],
         )
+
+    def test_encode_value_pathlib_path(self):
+        result = _encode_value(Path("/models/my-model"))
+        self.assertEqual(result, PB2AnyValue(string_value="/models/my-model"))
+
+    def test_encode_attributes_pathlib_path(self):
+        result = _encode_attributes({"model_path": Path("/models/my-model")})
+        self.assertEqual(
+            result,
+            [
+                PB2KeyValue(
+                    key="model_path",
+                    value=PB2AnyValue(string_value="/models/my-model"),
+                )
+            ],
+        )
+
+    def test_encode_value_unstringable_type_raises(self):
+        class _Unstringable:
+            def __str__(self):
+                raise RuntimeError("cannot convert")
+
+        with self.assertRaises(Exception):
+            _encode_value(_Unstringable())

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_attribute_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_attribute_encoder.py
@@ -120,9 +120,7 @@ class TestOTLPAttributeEncoder(unittest.TestCase):
         ) as log_cm:
             result = _encode_value(path)
         self.assertEqual(result, PB2AnyValue(string_value=str(path)))
-        self.assertTrue(
-            any("Invalid type" in msg for msg in log_cm.output)
-        )
+        self.assertTrue(any("Invalid type" in msg for msg in log_cm.output))
 
     def test_encode_attributes_pathlib_path(self):
         path = Path("/models/my-model")
@@ -147,6 +145,4 @@ class TestOTLPAttributeEncoder(unittest.TestCase):
         ) as log_cm:
             with self.assertRaises(Exception):
                 _encode_value(_Unstringable())
-        self.assertTrue(
-            any("Invalid type" in msg for msg in log_cm.output)
-        )
+        self.assertTrue(any("Invalid type" in msg for msg in log_cm.output))

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_attribute_encoder.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_attribute_encoder.py
@@ -114,17 +114,19 @@ class TestOTLPAttributeEncoder(unittest.TestCase):
         )
 
     def test_encode_value_pathlib_path(self):
-        result = _encode_value(Path("/models/my-model"))
-        self.assertEqual(result, PB2AnyValue(string_value="/models/my-model"))
+        path = Path("/models/my-model")
+        result = _encode_value(path)
+        self.assertEqual(result, PB2AnyValue(string_value=str(path)))
 
     def test_encode_attributes_pathlib_path(self):
-        result = _encode_attributes({"model_path": Path("/models/my-model")})
+        path = Path("/models/my-model")
+        result = _encode_attributes({"model_path": path})
         self.assertEqual(
             result,
             [
                 PB2KeyValue(
                     key="model_path",
-                    value=PB2AnyValue(string_value="/models/my-model"),
+                    value=PB2AnyValue(string_value=str(path)),
                 )
             ],
         )


### PR DESCRIPTION
## Description

Passing a `pathlib.Path` (or any other type outside the OTLP `AnyValue` spec) as a span/log attribute value or log body caused the OTLP exporter to crash:

```
Exception: Invalid type <class 'pathlib.PosixPath'> of value /path/to/something
```

Both the proto-common and json-common OTLP encoders (`_encode_value()`) had no fallback for unrecognised types. This PR adds a `str()` best-effort fallback before raising, so non-standard types are encoded as their string representation instead of crashing the exporter. If `str()` itself raises, the original exception propagates unchanged.

The fix mirrors the existing `_clean_extended_attribute_value()` behaviour in the SDK and is applied consistently across both encoder implementations.

Fixes #5210.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New tests added to both encoder test suites.
- Existing `None`-handling tests (`allow_null=True/False`) and list-with-`None` error paths all pass unchanged.

## Does This PR Require a Contrib Repo Change?

- [x] No.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated