### PR TITLE
Preserve random trace ID flag for child spans

### DIFF
--- a/.changelog/5241.fixed
+++ b/.changelog/5241.fixed
@@ -1,0 +1,1 @@
+Preserve the random trace ID flag when creating child spans.

--- a/.changelog/5241.fixed
+++ b/.changelog/5241.fixed
@@ -1,1 +1,1 @@
-Preserve the random trace ID flag when creating child spans.
+Preserve the random trace ID flag when creating child spans instead of always setting the random trace id bit depending on the available trace id generator.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -1225,7 +1225,12 @@ class Tracer(trace_api.Tracer):
             else trace_api.TraceFlags(trace_api.TraceFlags.DEFAULT)
         )
 
-        if self.id_generator.is_trace_id_random():
+        if parent_span_context is None:
+            random_trace_id = self.id_generator.is_trace_id_random()
+        else:
+            random_trace_id = parent_span_context.trace_flags.random_trace_id
+
+        if random_trace_id:
             trace_flags = trace_api.TraceFlags(
                 trace_flags | trace_api.TraceFlags.RANDOM_TRACE_ID
             )

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -517,6 +517,35 @@ class TestSpanCreation(unittest.TestCase):
             self.assertIs(trace_api.get_current_span(), root)
             self.assertIsNotNone(child.end_time)
 
+    def test_start_span_preserves_parent_random_trace_id_flag(self):
+        tracer = new_tracer()
+
+        for parent_trace_flags in (
+            trace_api.TraceFlags(trace_api.TraceFlags.SAMPLED),
+            trace_api.TraceFlags(
+                trace_api.TraceFlags.SAMPLED
+                | trace_api.TraceFlags.RANDOM_TRACE_ID
+            ),
+        ):
+            with self.subTest(parent_trace_flags=parent_trace_flags):
+                parent_context = trace_api.SpanContext(
+                    trace_id=0x000000000000000000000000DEADBEEF,
+                    span_id=0x00000000DEADBEF0,
+                    is_remote=True,
+                    trace_flags=parent_trace_flags,
+                )
+                context = trace_api.set_span_in_context(
+                    trace_api.NonRecordingSpan(parent_context)
+                )
+
+                child = tracer.start_span("child", context)
+                child_trace_flags = child.get_span_context().trace_flags
+
+                self.assertEqual(
+                    parent_trace_flags.random_trace_id,
+                    child_trace_flags.random_trace_id,
+                )
+
     def test_start_as_current_span_implicit(self):
         tracer = new_tracer()
 


### PR DESCRIPTION
Fixes #5240

## Summary
- Set the W3C `random-trace-id` flag from the configured ID generator only when this tracer generates a new root trace ID.
- Preserve the parent `random-trace-id` bit when creating child spans that continue an existing trace ID.
- Added regression coverage for child spans from remote parent contexts with the random bit unset and set.
- Added the towncrier changelog fragment for this trace propagation fix.

## Why
The 1.42.0 random trace ID support consults the ID generator for every new span. That makes child spans advertise `RANDOM_TRACE_ID` even when they continue a trace ID inherited from an incoming parent that did not set the bit.

## Testing
- Ran: local issue reproduction before and after the fix; remote parent flags `0x01` changed from child flags `0x03` to child flags `0x01`
- Ran: `python3 -m pytest opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_start_span_preserves_parent_random_trace_id_flag` - passed
- Ran: `python3 -m pytest opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_start_span_implicit opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_start_span_explicit opentelemetry-sdk/tests/trace/test_trace.py::TestSpanCreation::test_start_span_preserves_parent_random_trace_id_flag` - passed
- Ran: `python3 -m ruff check opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py opentelemetry-sdk/tests/trace/test_trace.py` - passed
- Ran: `python3 -m py_compile opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py opentelemetry-sdk/tests/trace/test_trace.py` - passed

## Notes
- Full `python3 -m pytest opentelemetry-sdk/tests/trace/test_trace.py` ran `107 passed` and failed only `TestTracer.test_shutdown` in this shell because `shutil.which("python")` returned `None`; this environment has `python3` but no `python` executable on `PATH`.
- The full-file run also showed the separate `SelectableGroups` warning tracked by #5231.
