### PR TITLE
Prometheus exporter: Add default aggregation config option

### DIFF
--- a/.changelog/5249.added
+++ b/.changelog/5249.added
@@ -1,0 +1,1 @@
+`opentelemetry-exporter-prometheus`: add `default_aggregation` to `PrometheusMetricReader`

--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
@@ -94,6 +94,7 @@ from opentelemetry.sdk.metrics.export import (
     MetricsData,
     Sum,
 )
+from opentelemetry.sdk.metrics.view import Aggregation
 from opentelemetry.semconv._incubating.attributes.otel_attributes import (
     OtelComponentTypeValues,
 )
@@ -129,6 +130,7 @@ class PrometheusMetricReader(MetricReader):
         prefix: str = "",
         *,
         registry: CollectorRegistry = REGISTRY,
+        default_aggregation: dict[type, Aggregation] | None = None,
     ) -> None:
         super().__init__(
             preferred_temporality={
@@ -139,6 +141,7 @@ class PrometheusMetricReader(MetricReader):
                 ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
                 ObservableGauge: AggregationTemporality.CUMULATIVE,
             },
+            preferred_aggregation=default_aggregation,
             otel_component_type=OtelComponentTypeValues.PROMETHEUS_HTTP_TEXT_METRIC_EXPORTER,
         )
         self._collector = _CustomCollector(

--- a/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py
@@ -17,7 +17,7 @@ from opentelemetry.exporter.prometheus import (
     _CustomCollector,
 )
 from opentelemetry.metrics import NoOpMeterProvider
-from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics import Counter, MeterProvider
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
     Histogram,
@@ -27,6 +27,7 @@ from opentelemetry.sdk.metrics.export import (
     ResourceMetrics,
     ScopeMetrics,
 )
+from opentelemetry.sdk.metrics.view import DropAggregation
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.test.metrictestutil import (
     _generate_gauge,
@@ -88,6 +89,25 @@ class TestPrometheusMetricReader(TestCase):  # pylint: disable=too-many-public-m
         with self._registry_register_patch:
             _ = PrometheusMetricReader()
             self.assertTrue(self._mock_registry_register.called)
+
+    def test_constructor_default_aggregation(self):
+        custom_registry = CollectorRegistry()
+        metric_reader = PrometheusMetricReader(
+            disable_target_info=True,
+            registry=custom_registry,
+            default_aggregation={Counter: DropAggregation()},
+        )
+        provider = MeterProvider(metric_readers=[metric_reader])
+
+        meter = provider.get_meter("getting-started", "0.1.2")
+        counter = meter.create_counter("counter")
+        counter.add(1)
+
+        self.assertEqual(
+            generate_latest(custom_registry).decode("utf-8"),
+            "", # DropAggregation drops all measurements, so no metrics are exported
+        )
+        provider.shutdown()
 
     def test_shutdown(self):
         with patch(


### PR DESCRIPTION
# Description

Add `default_aggregation` to `PrometheusMetricReader`, allowing the Prometheus exporter to configure the MetricReader default aggregation as a function of instrument kind.
This follows the Prometheus exporter spec section being stabilized in open-telemetry/opentelemetry-specification#5113.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


- [x] `uv run tox -e py312-test-opentelemetry-exporter-prometheus -- exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py::TestPrometheusMetricReader::test_constructor_default_aggregation`
- [x] `uv run ruff check exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py exporter/opentelemetry-exporter-prometheus/tests/test_prometheus_exporter.py`


# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated

--- 

Disclaimer: This PR was assisted by LLMs