### PR TITLE
opentelemetry-api: fix SelectableGroups deprecation warning

### DIFF
--- a/.changelog/5250.fixed
+++ b/.changelog/5250.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-api`: fix SelectableGroups deprecation warning

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -11,6 +11,7 @@ It also normalizes minor differences across python versions 3.10+. References to
 - https://github.com/open-telemetry/opentelemetry-python/pull/5203
 """
 
+import itertools
 from functools import cache
 from importlib.metadata import (
     Distribution,
@@ -28,8 +29,15 @@ from typing import Any
 def _as_entry_points(eps: Any) -> EntryPoints:
     if isinstance(eps, EntryPoints):
         return eps
-    # Handle Python 3.10 SelectableGroups (dict-like)
-    return EntryPoints(ep for group_eps in eps.values() for ep in group_eps)
+    # Python 3.10 entry_points() returns a dict-like SelectableGroups object.
+    # Use dict.values() instead of eps.values() to avoid the DeprecationWarning
+    # that SelectableGroups raises when calling .values().
+    if isinstance(eps, dict):
+        return EntryPoints(itertools.chain.from_iterable(dict.values(eps)))
+    # Fallback for all other types
+    return EntryPoints(
+        ep for group in eps.groups for ep in eps.select(group=group)
+    )
 
 
 @cache

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -27,14 +27,16 @@ from typing import Any
 
 
 def _as_entry_points(eps: Any) -> EntryPoints:
+    # Python versions greater than 3.11 return EntryPoints.
     if isinstance(eps, EntryPoints):
         return eps
-    # Python 3.10 entry_points() returns a dict-like SelectableGroups object.
+    # In Python 3.10 and 3.11 entry_points() returns
+    # a dict-like SelectableGroups object.
     # Use dict.values() instead of eps.values() to avoid the DeprecationWarning
     # that SelectableGroups raises when calling .values().
     if isinstance(eps, dict):
         return EntryPoints(itertools.chain.from_iterable(dict.values(eps)))
-    # Fallback for all other types
+    # This case should be unreachable, but is included as a fallback.
     return EntryPoints(
         ep for group in eps.groups for ep in eps.select(group=group)
     )

--- a/opentelemetry-api/tests/util/test__importlib_metadata.py
+++ b/opentelemetry-api/tests/util/test__importlib_metadata.py
@@ -1,7 +1,15 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import unittest
+import warnings
 from unittest import TestCase
+
+try:
+    # pylint: disable-next=no-name-in-module
+    from importlib.metadata import SelectableGroups as _SelectableGroups
+except ImportError:
+    _SelectableGroups = None
 
 from opentelemetry.metrics import MeterProvider
 from opentelemetry.util._importlib_metadata import (
@@ -114,6 +122,24 @@ class TestEntryPoints(TestCase):
         selectable_groups = {"gp": [ep1, ep2]}
 
         normalized = _as_entry_points(selectable_groups)
+        self.assertIsInstance(normalized, EntryPoints)
+        self.assertEqual(len(normalized), 2)
+        self.assertEqual(list(normalized), [ep1, ep2])
+
+    @unittest.skipIf(
+        _SelectableGroups is None,
+        "SelectableGroups not available on this Python version",
+    )
+    def test_as_entry_points_selectable_groups_no_deprecation_warning(self):
+        ep1 = EntryPoint(name="foo", value="bar:baz", group="gp")
+        ep2 = EntryPoint(name="foo2", value="bar2:baz2", group="gp")
+
+        sg = _SelectableGroups({"gp": [ep1, ep2]})  # type: ignore
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            normalized = _as_entry_points(sg)
+
         self.assertIsInstance(normalized, EntryPoints)
         self.assertEqual(len(normalized), 2)
         self.assertEqual(list(normalized), [ep1, ep2])


### PR DESCRIPTION
# Description

Fixes bug where deprecation warnings are raised when calling `_as_entry_points` on Python versions 3.10/3.11. 

Fixes #5231

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```bash
uv run tox -e py310-test-opentelemetry-api
```

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
