### PR TITLE
fix(api): avoid SelectableGroups.values() DeprecationWarning on Python 3.10/3.11

### DIFF
--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -9,6 +9,7 @@ It also normalizes minor differences across python versions 3.10+. References to
 
 - https://github.com/open-telemetry/opentelemetry-python/pull/4735
 - https://github.com/open-telemetry/opentelemetry-python/pull/5203
+- https://github.com/open-telemetry/opentelemetry-python/issues/5231
 """
 
 from functools import cache
@@ -28,7 +29,16 @@ from typing import Any
 def _as_entry_points(eps: Any) -> EntryPoints:
     if isinstance(eps, EntryPoints):
         return eps
-    # Handle Python 3.10 SelectableGroups (dict-like)
+    # On Python 3.10 and 3.11, entry_points() returns a SelectableGroups
+    # object whose dict interface is deprecated and emits a DeprecationWarning
+    # when iterated via .values().  The correct way to flatten the groups is
+    # to call .select() without filters, which returns a flat EntryPoints list
+    # without triggering the deprecation warning.
+    # See: https://github.com/open-telemetry/opentelemetry-python/issues/5231
+    if hasattr(eps, "select"):
+        return eps.select()
+    # Fallback for any other dict-like structure (should not be reached in
+    # practice but kept for robustness).
     return EntryPoints(ep for group_eps in eps.values() for ep in group_eps)
 
 


### PR DESCRIPTION
Fixes #5231.

## Problem

`opentelemetry-api` v1.42.0 introduced `_as_entry_points()` in `_importlib_metadata.py` (via #5203) to normalise the return value of `importlib.metadata.entry_points()` across Python versions. On Python 3.10 and 3.11, `entry_points()` returns a `SelectableGroups` object whose **dict interface is deprecated**. The current implementation iterates it via `.values()`, which unconditionally emits:

```
DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
```

Projects that run CI with `-W error` (warnings-as-errors) — which is common best practice — see this as an import-time error, breaking their test suites after upgrading from v1.41.1 to v1.42.0.

```sh
# Reproduces the error:
uv run --isolated -p 3.11 --with opentelemetry-api==1.42.0 python -W error -c 'import opentelemetry.context'
```

## Root cause

In `_as_entry_points()`:

```python
# Before (triggers DeprecationWarning on 3.10/3.11)
return EntryPoints(ep for group_eps in eps.values() for ep in group_eps)
```

## Fix

Prefer `.select()` (called without filters) over `.values()`, which is the officially documented migration path for the `SelectableGroups` dict interface. Both `SelectableGroups` (3.10/3.11) and the newer `EntryPoints` (3.12+) expose `.select()`, so a `hasattr` guard cleanly handles both cases without relying on isinstance checks against a private type:

```python
# After (no warning on any Python version)
if hasattr(eps, "select"):
    return eps.select()
return EntryPoints(ep for group_eps in eps.values() for ep in group_eps)
```

## Testing

```sh
# Should exit 0 after this fix (currently exits non-zero on 1.42.0):
uv run --isolated -p 3.10 --with opentelemetry-api python -W error -c 'import opentelemetry.context'
uv run --isolated -p 3.11 --with opentelemetry-api python -W error -c 'import opentelemetry.context'
uv run --isolated -p 3.12 --with opentelemetry-api python -W error -c 'import opentelemetry.context'
```