### PR TITLE
refactor(prometheus): simplify _CustomCollector by replacing deque with Optional[MetricsData]

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
@@ -51,7 +51,6 @@ API
 ---
 """
 
-from collections import deque
 from collections.abc import Iterable, Sequence
 from itertools import chain
 from json import dumps
@@ -172,14 +171,14 @@ class _CustomCollector:
 
     def __init__(self, disable_target_info: bool = False, prefix: str = ""):
         self._callback = None
-        self._metrics_datas: deque[MetricsData] = deque()
+        self._metrics_data: MetricsData | None = None
         self._disable_target_info = disable_target_info
         self._target_info = None
         self._prefix = prefix
 
     def add_metrics_data(self, metrics_data: MetricsData) -> None:
         """Add metrics to Prometheus data"""
-        self._metrics_datas.append(metrics_data)
+        self._metrics_data = metrics_data
 
     def collect(self) -> Iterable[PrometheusMetric]:
         """Collect fetches the metrics from OpenTelemetry
@@ -190,29 +189,29 @@ class _CustomCollector:
         if self._callback is not None:
             self._callback()
 
+        metrics_data = self._metrics_data
+        self._metrics_data = None
+
+        if metrics_data is None:
+            return
+
         metric_family_id_metric_family = {}
 
-        if len(self._metrics_datas):
-            if not self._disable_target_info:
-                if self._target_info is None:
-                    attributes: Attributes = {}
-                    for res in self._metrics_datas[0].resource_metrics:
-                        attributes = {**attributes, **res.resource.attributes}
+        if not self._disable_target_info:
+            if self._target_info is None:
+                attributes: Attributes = {}
+                for res in metrics_data.resource_metrics:
+                    attributes = {**attributes, **res.resource.attributes}
 
-                    self._target_info = self._create_info_metric(
-                        _TARGET_INFO_NAME, _TARGET_INFO_DESCRIPTION, attributes
-                    )
-                metric_family_id_metric_family[_TARGET_INFO_NAME] = (
-                    self._target_info
+                self._target_info = self._create_info_metric(
+                    _TARGET_INFO_NAME, _TARGET_INFO_DESCRIPTION, attributes
                 )
+            metric_family_id_metric_family[_TARGET_INFO_NAME] = self._target_info
 
-        while self._metrics_datas:
-            self._translate_to_prometheus(
-                self._metrics_datas.popleft(), metric_family_id_metric_family
-            )
+        self._translate_to_prometheus(metrics_data, metric_family_id_metric_family)
 
-            if metric_family_id_metric_family:
-                yield from metric_family_id_metric_family.values()
+        if metric_family_id_metric_family:
+            yield from metric_family_id_metric_family.values()
 
     # pylint: disable=too-many-locals,too-many-branches
     def _translate_to_prometheus(


### PR DESCRIPTION
## Summary

Fixes #2500 (referenced in PR #2321 discussion).

The internal `_CustomCollector` used a `deque[MetricsData]` to buffer metric data between the `_receive_metrics → add_metrics_data` call and the Prometheus `collect()` scrape. In practice the deque holds at most one item per scrape cycle because `_callback()` triggers exactly one `_receive_metrics` invocation before `collect()` drains the queue.

This PR simplifies the flow:
- Replace `deque[MetricsData]` with `MetricsData | None`
- `add_metrics_data` assigns directly instead of appending
- `collect()` reads and clears the single field, replacing the `while … popleft()` loop
- Remove the now-unused `from collections import deque` import

This also fixes a latent correctness issue: with the deque, if `add_metrics_data` were called multiple times between scrapes, `collect()` would yield duplicate metric family entries (because `metric_family_id_metric_family` accumulated across the loop but was yielded inside the loop).

## Before

```
collect() → callback() → _receive_metrics() → add_metrics_data() → deque.append()
         → while deque: popleft() → translate → yield (inside loop, potential duplicates)
```

## After

```
collect() → callback() → _receive_metrics() → add_metrics_data() → self._metrics_data = …
         → translate single MetricsData → yield once
```

## Test plan

- [ ] Existing Prometheus exporter tests pass
- [ ] Manual scrape endpoint returns correct metrics
- [ ] No metrics emitted when no data collected (metrics_data is None)