### PR TITLE
opentelemetry-sdk: add ServiceInstanceIdResourceDetector for populating service.instance.id

### DIFF
--- a/.changelog/5259.added
+++ b/.changelog/5259.added
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: add `ServiceInstanceIdResourceDetector` for populating `service.instance.id`

--- a/opentelemetry-sdk/pyproject.toml
+++ b/opentelemetry-sdk/pyproject.toml
@@ -74,6 +74,7 @@ otel = "opentelemetry.sdk.resources:OTELResourceDetector"
 process = "opentelemetry.sdk.resources:ProcessResourceDetector"
 os = "opentelemetry.sdk.resources:OsResourceDetector"
 host = "opentelemetry.sdk.resources:_HostResourceDetector"
+service_instance = "opentelemetry.sdk.resources:ServiceInstanceIdResourceDetector"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-sdk"

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -56,6 +56,7 @@ import platform
 import socket
 import sys
 import typing
+import uuid
 from collections.abc import Sequence
 from json import dumps
 from os import environ
@@ -460,6 +461,21 @@ class _HostResourceDetector(ResourceDetector):  # type: ignore[reportUnusedClass
                 HOST_ARCH: platform.machine(),
             }
         )
+
+
+class ServiceInstanceIdResourceDetector(ResourceDetector):
+    """Detects service.instance.id as a random UUID v4.
+
+    Per the OpenTelemetry specification, SDKs SHOULD generate a random v1/v4
+    UUID for service.instance.id to uniquely identify each service instance.
+    """
+
+    def __init__(self, raise_on_error: bool = False) -> None:
+        super().__init__(raise_on_error)
+        self._instance_id = str(uuid.uuid4())
+
+    def detect(self) -> "Resource":
+        return Resource({SERVICE_INSTANCE_ID: self._instance_id})
 
 
 def _build_resource_detectors() -> list["ResourceDetector"]:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -496,12 +496,14 @@ class ServiceInstanceIdResourceDetector(ResourceDetector):
 def _build_resource_detectors() -> list["ResourceDetector"]:
     """Returns the ordered list of resource detectors to use for Resource.create.
 
-    Fast path: if no extra detectors are configured, returns only
-    OTELResourceDetector without scanning entry_points.
+    Fast path: if no extra detectors are configured, returns only the two
+    built-in detectors without scanning entry_points.
 
-    "otel" (OTELResourceDetector) defaults to last position so that
-    OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME take highest merge priority,
-    but an explicit position in OTEL_EXPERIMENTAL_RESOURCE_DETECTORS is respected.
+    "service_instance" (ServiceInstanceIdResourceDetector) and "otel"
+    (OTELResourceDetector) are always appended as defaults. "otel" is last so
+    that OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME take highest merge
+    priority, but an explicit position in OTEL_EXPERIMENTAL_RESOURCE_DETECTORS
+    is respected for either name.
     """
     detector_names: list[str] = list(
         dict.fromkeys(
@@ -512,13 +514,13 @@ def _build_resource_detectors() -> list["ResourceDetector"]:
                 ).split(",")
                 if name.strip()
             ]
-            + ["otel"]
+            + ["service_instance", "otel"]
         )
     )
 
-    # Fast path: only the built-in "otel" detector — no entry_points scan needed.
-    if detector_names == ["otel"]:
-        return [OTELResourceDetector()]
+    # Fast path: only the two built-in detectors — no entry_points scan needed.
+    if detector_names == ["service_instance", "otel"]:
+        return [ServiceInstanceIdResourceDetector(), OTELResourceDetector()]
 
     # pylint: disable=import-outside-toplevel
     from opentelemetry.util._importlib_metadata import (  # noqa: PLC0415

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -55,6 +55,7 @@ import os
 import platform
 import socket
 import sys
+import threading
 import typing
 import uuid
 from collections.abc import Sequence
@@ -279,6 +280,11 @@ _DEFAULT_RESOURCE = Resource(
 )
 
 
+_service_instance_id: str | None = None
+_service_instance_id_pid: int | None = None
+_service_instance_id_lock = threading.Lock()
+
+
 class ResourceDetector(abc.ABC):
     def __init__(self, raise_on_error: bool = False) -> None:
         self.raise_on_error = raise_on_error
@@ -468,14 +474,23 @@ class ServiceInstanceIdResourceDetector(ResourceDetector):
 
     Per the OpenTelemetry specification, SDKs SHOULD generate a random v1/v4
     UUID for service.instance.id to uniquely identify each service instance.
+    The ID is shared across all detector instances within the same process and
+    regenerated automatically when the process PID changes (e.g. after a fork).
     """
 
-    def __init__(self, raise_on_error: bool = False) -> None:
-        super().__init__(raise_on_error)
-        self._instance_id = str(uuid.uuid4())
-
     def detect(self) -> "Resource":
-        return Resource({SERVICE_INSTANCE_ID: self._instance_id})
+        # pylint: disable-next=global-statement
+        global _service_instance_id, _service_instance_id_pid
+        with _service_instance_id_lock:
+            current_pid = os.getpid()
+            if (
+                _service_instance_id is None
+                or _service_instance_id_pid != current_pid
+            ):
+                _service_instance_id = str(uuid.uuid4())
+                _service_instance_id_pid = current_pid
+            instance_id = _service_instance_id
+        return Resource({SERVICE_INSTANCE_ID: instance_id})
 
 
 def _build_resource_detectors() -> list["ResourceDetector"]:

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -66,6 +66,11 @@ except ImportError:
 class TestResources(unittest.TestCase):
     def setUp(self) -> None:
         environ[OTEL_RESOURCE_ATTRIBUTES] = ""
+        self._service_instance_id = (
+            ServiceInstanceIdResourceDetector()
+            .detect()
+            .attributes[SERVICE_INSTANCE_ID]
+        )
 
     def tearDown(self) -> None:
         environ.pop(OTEL_RESOURCE_ATTRIBUTES)
@@ -86,6 +91,7 @@ class TestResources(unittest.TestCase):
             TELEMETRY_SDK_NAME: "opentelemetry",
             TELEMETRY_SDK_LANGUAGE: "python",
             TELEMETRY_SDK_VERSION: _OPENTELEMETRY_SDK_VERSION,
+            SERVICE_INSTANCE_ID: self._service_instance_id,
             SERVICE_NAME: "unknown_service",
         }
 
@@ -112,40 +118,30 @@ class TestResources(unittest.TestCase):
         resource = Resource.get_empty()
         self.assertEqual(resource, _EMPTY_RESOURCE)
 
-        resource = Resource.create(None)
-        self.assertEqual(
-            resource,
-            _DEFAULT_RESOURCE.merge(
-                Resource({SERVICE_NAME: "unknown_service"}, "")
-            ),
+        expected_default = _DEFAULT_RESOURCE.merge(
+            Resource(
+                {
+                    SERVICE_INSTANCE_ID: self._service_instance_id,
+                    SERVICE_NAME: "unknown_service",
+                },
+                "",
+            )
         )
+
+        resource = Resource.create(None)
+        self.assertEqual(resource, expected_default)
         self.assertEqual(resource.schema_url, "")
 
         resource = Resource.create(None, None)
-        self.assertEqual(
-            resource,
-            _DEFAULT_RESOURCE.merge(
-                Resource({SERVICE_NAME: "unknown_service"}, "")
-            ),
-        )
+        self.assertEqual(resource, expected_default)
         self.assertEqual(resource.schema_url, "")
 
         resource = Resource.create({})
-        self.assertEqual(
-            resource,
-            _DEFAULT_RESOURCE.merge(
-                Resource({SERVICE_NAME: "unknown_service"}, "")
-            ),
-        )
+        self.assertEqual(resource, expected_default)
         self.assertEqual(resource.schema_url, "")
 
         resource = Resource.create({}, None)
-        self.assertEqual(
-            resource,
-            _DEFAULT_RESOURCE.merge(
-                Resource({SERVICE_NAME: "unknown_service"}, "")
-            ),
-        )
+        self.assertEqual(resource, expected_default)
         self.assertEqual(resource.schema_url, "")
 
     def test_resource_merge(self):
@@ -209,6 +205,7 @@ class TestResources(unittest.TestCase):
             TELEMETRY_SDK_NAME: "opentelemetry",
             TELEMETRY_SDK_LANGUAGE: "python",
             TELEMETRY_SDK_VERSION: _OPENTELEMETRY_SDK_VERSION,
+            SERVICE_INSTANCE_ID: self._service_instance_id,
             SERVICE_NAME: "unknown_service",
         }
 
@@ -264,7 +261,13 @@ class TestResources(unittest.TestCase):
         self.assertEqual(
             aggregated_resources,
             _DEFAULT_RESOURCE.merge(
-                Resource({SERVICE_NAME: "unknown_service"}, "")
+                Resource(
+                    {
+                        SERVICE_INSTANCE_ID: self._service_instance_id,
+                        SERVICE_NAME: "unknown_service",
+                    },
+                    "",
+                )
             ),
         )
 
@@ -315,7 +318,13 @@ class TestResources(unittest.TestCase):
                 [resource_detector1, resource_detector2, resource_detector3]
             ),
             _DEFAULT_RESOURCE.merge(
-                Resource({SERVICE_NAME: "unknown_service"}, "")
+                Resource(
+                    {
+                        SERVICE_INSTANCE_ID: self._service_instance_id,
+                        SERVICE_NAME: "unknown_service",
+                    },
+                    "",
+                )
             ).merge(
                 Resource(
                     {
@@ -358,7 +367,13 @@ class TestResources(unittest.TestCase):
         self.assertEqual(
             get_aggregated_resources([resource_detector1, resource_detector2]),
             _DEFAULT_RESOURCE.merge(
-                Resource({SERVICE_NAME: "unknown_service"}, "")
+                Resource(
+                    {
+                        SERVICE_INSTANCE_ID: self._service_instance_id,
+                        SERVICE_NAME: "unknown_service",
+                    },
+                    "",
+                )
             ).merge(
                 Resource(
                     {"key1": "value1", "key2": "value2", "key3": "value3"},
@@ -372,7 +387,13 @@ class TestResources(unittest.TestCase):
                     [resource_detector2, resource_detector3]
                 ),
                 _DEFAULT_RESOURCE.merge(
-                    Resource({SERVICE_NAME: "unknown_service"}, "")
+                    Resource(
+                        {
+                            SERVICE_INSTANCE_ID: self._service_instance_id,
+                            SERVICE_NAME: "unknown_service",
+                        },
+                        "",
+                    )
                 ).merge(
                     Resource({"key2": "value2", "key3": "value3"}, "url1")
                 ),
@@ -390,7 +411,13 @@ class TestResources(unittest.TestCase):
                     ]
                 ),
                 _DEFAULT_RESOURCE.merge(
-                    Resource({SERVICE_NAME: "unknown_service"}, "")
+                    Resource(
+                        {
+                            SERVICE_INSTANCE_ID: self._service_instance_id,
+                            SERVICE_NAME: "unknown_service",
+                        },
+                        "",
+                    )
                 ).merge(
                     Resource(
                         {
@@ -414,7 +441,13 @@ class TestResources(unittest.TestCase):
             self.assertEqual(
                 get_aggregated_resources([resource_detector]),
                 _DEFAULT_RESOURCE.merge(
-                    Resource({SERVICE_NAME: "unknown_service"}, "")
+                    Resource(
+                        {
+                            SERVICE_INSTANCE_ID: self._service_instance_id,
+                            SERVICE_NAME: "unknown_service",
+                        },
+                        "",
+                    )
                 ),
             )
 
@@ -434,7 +467,13 @@ class TestResources(unittest.TestCase):
         self.assertEqual(
             get_aggregated_resources([resource_detector]),
             _DEFAULT_RESOURCE.merge(
-                Resource({SERVICE_NAME: "unknown_service"}, "")
+                Resource(
+                    {
+                        SERVICE_INSTANCE_ID: self._service_instance_id,
+                        SERVICE_NAME: "unknown_service",
+                    },
+                    "",
+                )
             ),
         )
         mock_logger.warning.assert_called_with(

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -1036,20 +1036,14 @@ from opentelemetry.sdk.resources import ServiceInstanceIdResourceDetector, SERVI
 
 parent_id = ServiceInstanceIdResourceDetector().detect().attributes[SERVICE_INSTANCE_ID]
 
-r_fd, w_fd = os.pipe()
 pid = os.fork()
 if not pid:
-    os.close(r_fd)
     child_id = ServiceInstanceIdResourceDetector().detect().attributes[SERVICE_INSTANCE_ID]
-    with os.fdopen(w_fd, "w") as w:
-        w.write(child_id)
+    print(f"child:{child_id}", flush=True)
     os._exit(0)
 else:
-    os.close(w_fd)
-    with os.fdopen(r_fd, "r") as r:
-        child_id = r.read()
     os.waitpid(pid, 0)
-    print(f"{parent_id}:{child_id}")
+    print(f"parent:{parent_id}", flush=True)
 """
         result = subprocess.run(
             [sys.executable, "-c", script],
@@ -1057,7 +1051,10 @@ else:
             text=True,
             check=True,
         )
-        parent_id, child_id = result.stdout.strip().split(":")
+        ids = dict(
+            line.split(":", 1) for line in result.stdout.strip().splitlines()
+        )
+        parent_id, child_id = ids["parent"], ids["child"]
         self.assertNotEqual(parent_id, child_id)
         self.assertEqual(uuid.UUID(parent_id).version, 4)
         self.assertEqual(uuid.UUID(child_id).version, 4)

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -34,6 +34,7 @@ from opentelemetry.sdk.resources import (
     PROCESS_RUNTIME_DESCRIPTION,
     PROCESS_RUNTIME_NAME,
     PROCESS_RUNTIME_VERSION,
+    SERVICE_INSTANCE_ID,
     SERVICE_NAME,
     TELEMETRY_SDK_LANGUAGE,
     TELEMETRY_SDK_NAME,
@@ -43,6 +44,7 @@ from opentelemetry.sdk.resources import (
     ProcessResourceDetector,
     Resource,
     ResourceDetector,
+    ServiceInstanceIdResourceDetector,
     _HostResourceDetector,
     get_aggregated_resources,
 )
@@ -912,3 +914,40 @@ class TestHostResourceDetector(unittest.TestCase):
             resource.attributes["telemetry.sdk.language"], "python"
         )
         self.assertIn(HOST_NAME, resource.attributes)
+
+
+class TestServiceInstanceIdResourceDetector(unittest.TestCase):
+    def test_detect_value_is_valid_uuid4(self):
+        detector = ServiceInstanceIdResourceDetector()
+        value = detector.detect().attributes[SERVICE_INSTANCE_ID]
+        parsed = uuid.UUID(value)
+        self.assertEqual(parsed.version, 4)
+
+    def test_detect_stable_within_instance(self):
+        detector = ServiceInstanceIdResourceDetector()
+        id1 = detector.detect().attributes[SERVICE_INSTANCE_ID]
+        id2 = detector.detect().attributes[SERVICE_INSTANCE_ID]
+        self.assertEqual(id1, id2)
+
+    def test_detect_unique_across_instances(self):
+        id1 = (
+            ServiceInstanceIdResourceDetector()
+            .detect()
+            .attributes[SERVICE_INSTANCE_ID]
+        )
+        id2 = (
+            ServiceInstanceIdResourceDetector()
+            .detect()
+            .attributes[SERVICE_INSTANCE_ID]
+        )
+        self.assertNotEqual(id1, id2)
+
+    @patch.dict(
+        environ,
+        {OTEL_EXPERIMENTAL_RESOURCE_DETECTORS: "service_instance"},
+        clear=True,
+    )
+    def test_resource_detector_entry_points_service_instance(self):
+        resource = Resource.create()
+        self.assertIn(SERVICE_INSTANCE_ID, resource.attributes)
+        uuid.UUID(resource.attributes[SERVICE_INSTANCE_ID])

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -1,6 +1,10 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=too-many-lines
+
 import os
+import subprocess
 import sys
 import unittest
 import uuid
@@ -10,6 +14,7 @@ from os import environ
 from unittest.mock import Mock, patch
 from urllib import parse
 
+import opentelemetry.sdk.resources as _resources_module
 from opentelemetry.sdk.environment_variables import (
     OTEL_EXPERIMENTAL_RESOURCE_DETECTORS,
 )
@@ -916,20 +921,35 @@ class TestHostResourceDetector(unittest.TestCase):
         self.assertIn(HOST_NAME, resource.attributes)
 
 
+# pylint: disable=protected-access
 class TestServiceInstanceIdResourceDetector(unittest.TestCase):
+    def setUp(self) -> None:
+        self._orig_instance_id = _resources_module._service_instance_id
+        self._orig_instance_pid = _resources_module._service_instance_id_pid
+
+    def tearDown(self) -> None:
+        _resources_module._service_instance_id = self._orig_instance_id
+        _resources_module._service_instance_id_pid = self._orig_instance_pid
+
     def test_detect_value_is_valid_uuid4(self):
+        _resources_module._service_instance_id = None
+        _resources_module._service_instance_id_pid = None
         detector = ServiceInstanceIdResourceDetector()
         value = detector.detect().attributes[SERVICE_INSTANCE_ID]
         parsed = uuid.UUID(value)
         self.assertEqual(parsed.version, 4)
 
     def test_detect_stable_within_instance(self):
+        _resources_module._service_instance_id = None
+        _resources_module._service_instance_id_pid = None
         detector = ServiceInstanceIdResourceDetector()
         id1 = detector.detect().attributes[SERVICE_INSTANCE_ID]
         id2 = detector.detect().attributes[SERVICE_INSTANCE_ID]
         self.assertEqual(id1, id2)
 
-    def test_detect_unique_across_instances(self):
+    def test_detect_shared_across_instances(self):
+        _resources_module._service_instance_id = None
+        _resources_module._service_instance_id_pid = None
         id1 = (
             ServiceInstanceIdResourceDetector()
             .detect()
@@ -940,7 +960,68 @@ class TestServiceInstanceIdResourceDetector(unittest.TestCase):
             .detect()
             .attributes[SERVICE_INSTANCE_ID]
         )
-        self.assertNotEqual(id1, id2)
+        self.assertEqual(id1, id2)
+
+    def test_detect_pid_change_generates_new_id(self):
+        _resources_module._service_instance_id = "old-id"
+        _resources_module._service_instance_id_pid = os.getpid() - 1
+        new_id = (
+            ServiceInstanceIdResourceDetector()
+            .detect()
+            .attributes[SERVICE_INSTANCE_ID]
+        )
+        self.assertNotEqual(new_id, "old-id")
+        self.assertEqual(
+            _resources_module._service_instance_id_pid, os.getpid()
+        )
+        uuid.UUID(new_id)
+
+    def test_detect_pid_unchanged_returns_same_id(self):
+        known_id = "known-stable-id"
+        _resources_module._service_instance_id = known_id
+        _resources_module._service_instance_id_pid = os.getpid()
+        result = (
+            ServiceInstanceIdResourceDetector()
+            .detect()
+            .attributes[SERVICE_INSTANCE_ID]
+        )
+        self.assertEqual(result, known_id)
+
+    @unittest.skipUnless(hasattr(os, "fork"), "requires os.fork")
+    def test_detect_fork_generates_new_id(self):
+        script = """\
+import os
+import sys
+
+from opentelemetry.sdk.resources import ServiceInstanceIdResourceDetector, SERVICE_INSTANCE_ID
+
+parent_id = ServiceInstanceIdResourceDetector().detect().attributes[SERVICE_INSTANCE_ID]
+
+r_fd, w_fd = os.pipe()
+pid = os.fork()
+if not pid:
+    os.close(r_fd)
+    child_id = ServiceInstanceIdResourceDetector().detect().attributes[SERVICE_INSTANCE_ID]
+    with os.fdopen(w_fd, "w") as w:
+        w.write(child_id)
+    os._exit(0)
+else:
+    os.close(w_fd)
+    with os.fdopen(r_fd, "r") as r:
+        child_id = r.read()
+    os.waitpid(pid, 0)
+    print(f"{parent_id}:{child_id}")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        parent_id, child_id = result.stdout.strip().split(":")
+        self.assertNotEqual(parent_id, child_id)
+        self.assertEqual(uuid.UUID(parent_id).version, 4)
+        self.assertEqual(uuid.UUID(child_id).version, 4)
 
     @patch.dict(
         environ,

--- a/tests/opentelemetry-test-utils/tests/testdata/registry/attributes.yaml
+++ b/tests/opentelemetry-test-utils/tests/testdata/registry/attributes.yaml
@@ -5,6 +5,11 @@ groups:
     type: attribute_group
     brief: Minimal registry for WeaverLiveCheck self-tests.
     attributes:
+      - id: service.instance.id
+        type: string
+        brief: The unique identifier of the service instance.
+        stability: stable
+        examples: ["my-k8s-pod-deployment-1"]
       - id: service.name
         type: string
         brief: The name of the service.


### PR DESCRIPTION
# Description

Creates a new `ServiceInstanceIdResourceDetector` for populating the `service.instance.id` resource attribute with a unique v4 UUID per the OTel spec: 

> Implementations, such as SDKs, are recommended to generate a random Version 1 or Version 4 [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID, but are free to use an inherent unique ID as the source of this value if stability is desirable. In that case, the ID SHOULD be used as source of a UUID Version 5 and SHOULD use the following UUID as the namespace: 4d63009a-8d0f-11ee-aad7-4c796ed8e320.

Fixes #5257

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```bash
uv run tox -e py314-test-opentelemetry-sdk
```

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
