### PR TITLE
Config inner sdk logger

### DIFF
--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -41,6 +41,7 @@ from typing import Any, Optional, cast
 
 from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.environment_variables import _OTEL_PYTHON_LOGGER_PROVIDER
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.trace.span import TraceFlags
 from opentelemetry.util._once import Once
 from opentelemetry.util._providers import _load_provider
@@ -159,6 +160,7 @@ class LoggerProvider(ABC):
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
         attributes: Optional[Attributes] = None,
+        instrumentation_scope: Optional[InstrumentationScope] = None,
     ) -> Logger:
         """Returns a `Logger` for use by the given instrumentation library.
 
@@ -274,6 +276,7 @@ def get_logger(
     logger_provider: Optional[LoggerProvider] = None,
     schema_url: Optional[str] = None,
     attributes: Optional[Attributes] = None,
+    instrumentation_scope: Optional[InstrumentationScope] = None,
 ) -> "Logger":
     """Returns a `Logger` for use within a python process.
 
@@ -284,9 +287,17 @@ def get_logger(
     """
     if logger_provider is None:
         logger_provider = get_logger_provider()
+    if isinstance(logger_provider, NoOpLoggerProvider):
+        return NoOpLogger(
+            instrumenting_module_name,
+            version=instrumenting_library_version,
+            schema_url=schema_url,
+            attributes=attributes,
+        )
     return logger_provider.get_logger(
         instrumenting_module_name,
         instrumenting_library_version,
         schema_url,
         attributes,
+        instrumentation_scope,
     )

--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -41,7 +41,6 @@ from typing import Any, Optional, cast
 
 from opentelemetry._logs.severity import SeverityNumber
 from opentelemetry.environment_variables import _OTEL_PYTHON_LOGGER_PROVIDER
-from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.trace.span import TraceFlags
 from opentelemetry.util._once import Once
 from opentelemetry.util._providers import _load_provider
@@ -121,11 +120,13 @@ class ProxyLogger(Logger):
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
         attributes: Optional[Attributes] = None,
+        instrumentation_scope: Optional[Any] = None,
     ):
         self._name = name
         self._version = version
         self._schema_url = schema_url
         self._attributes = attributes
+        self._instrumentation_scope = instrumentation_scope
         self._real_logger: Optional[Logger] = None
         self._noop_logger = NoOpLogger(name)
 
@@ -135,11 +136,20 @@ class ProxyLogger(Logger):
             return self._real_logger
 
         if _LOGGER_PROVIDER:
+            if self._instrumentation_scope is None:
+                self._real_logger = _LOGGER_PROVIDER.get_logger(
+                    self._name,
+                    self._version,
+                    self._schema_url,
+                    self._attributes,
+                )
+                return self._real_logger
             self._real_logger = _LOGGER_PROVIDER.get_logger(
                 self._name,
                 self._version,
                 self._schema_url,
                 self._attributes,
+                self._instrumentation_scope,
             )
             return self._real_logger
         return self._noop_logger
@@ -160,7 +170,7 @@ class LoggerProvider(ABC):
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
         attributes: Optional[Attributes] = None,
-        instrumentation_scope: Optional[InstrumentationScope] = None,
+        instrumentation_scope: Optional[Any] = None,
     ) -> Logger:
         """Returns a `Logger` for use by the given instrumentation library.
 
@@ -199,8 +209,10 @@ class NoOpLoggerProvider(LoggerProvider):
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
         attributes: Optional[Attributes] = None,
+        instrumentation_scope: Optional[Any] = None,
     ) -> Logger:
         """Returns a NoOpLogger."""
+        _ = instrumentation_scope
         return NoOpLogger(
             name, version=version, schema_url=schema_url, attributes=attributes
         )
@@ -213,19 +225,29 @@ class ProxyLoggerProvider(LoggerProvider):
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
         attributes: Optional[Attributes] = None,
+        instrumentation_scope: Optional[Any] = None,
     ) -> Logger:
         if _LOGGER_PROVIDER:
+            if instrumentation_scope is None:
+                return _LOGGER_PROVIDER.get_logger(
+                    name,
+                    version=version,
+                    schema_url=schema_url,
+                    attributes=attributes,
+                )
             return _LOGGER_PROVIDER.get_logger(
                 name,
                 version=version,
                 schema_url=schema_url,
                 attributes=attributes,
+                instrumentation_scope=instrumentation_scope,
             )
         return ProxyLogger(
             name,
             version=version,
             schema_url=schema_url,
             attributes=attributes,
+            instrumentation_scope=instrumentation_scope,
         )
 
 
@@ -276,7 +298,7 @@ def get_logger(
     logger_provider: Optional[LoggerProvider] = None,
     schema_url: Optional[str] = None,
     attributes: Optional[Attributes] = None,
-    instrumentation_scope: Optional[InstrumentationScope] = None,
+    instrumentation_scope: Optional[Any] = None,
 ) -> "Logger":
     """Returns a `Logger` for use within a python process.
 
@@ -287,12 +309,12 @@ def get_logger(
     """
     if logger_provider is None:
         logger_provider = get_logger_provider()
-    if isinstance(logger_provider, NoOpLoggerProvider):
-        return NoOpLogger(
+    if instrumentation_scope is None:
+        return logger_provider.get_logger(
             instrumenting_module_name,
-            version=instrumenting_library_version,
-            schema_url=schema_url,
-            attributes=attributes,
+            instrumenting_library_version,
+            schema_url,
+            attributes,
         )
     return logger_provider.get_logger(
         instrumenting_module_name,

--- a/opentelemetry-api/tests/logs/test_proxy.py
+++ b/opentelemetry-api/tests/logs/test_proxy.py
@@ -22,7 +22,23 @@ from opentelemetry.test.globals_test import LoggingGlobalsTest
 from opentelemetry.util.types import Attributes
 
 
-class TestProvider(_logs.NoOpLoggerProvider):
+class LoggerProviderTest(_logs.NoOpLoggerProvider):
+    def __init__(self):
+        self.instrumentation_scope = None
+
+    def get_logger(
+        self,
+        name: str,
+        version: typing.Optional[str] = None,
+        schema_url: typing.Optional[str] = None,
+        attributes: typing.Optional[Attributes] = None,
+        instrumentation_scope: typing.Optional[typing.Any] = None,
+    ) -> _logs.Logger:
+        self.instrumentation_scope = instrumentation_scope
+        return LoggerTest(name)
+
+
+class OldSignatureLoggerProvider(_logs.NoOpLoggerProvider):
     def get_logger(
         self,
         name: str,
@@ -49,10 +65,10 @@ class TestProxy(LoggingGlobalsTest, unittest.TestCase):
         self.assertIsInstance(logger, _logs_internal.ProxyLogger)
 
         # set a real provider
-        _logs.set_logger_provider(TestProvider())
+        _logs.set_logger_provider(LoggerProviderTest())
 
         # get_logger_provider() now returns the real provider
-        self.assertIsInstance(_logs.get_logger_provider(), TestProvider)
+        self.assertIsInstance(_logs.get_logger_provider(), LoggerProviderTest)
 
         # logger provider now returns real instance
         self.assertIsInstance(
@@ -62,3 +78,34 @@ class TestProxy(LoggingGlobalsTest, unittest.TestCase):
         # references to the old provider still work but return real logger now
         real_logger = provider.get_logger("proxy-test")
         self.assertIsInstance(real_logger, LoggerTest)
+
+    def test_proxy_logger_instrumentation_scope(self):
+        provider = _logs.get_logger_provider()
+        instrumentation_scope = object()
+
+        logger = provider.get_logger(
+            "proxy-test", instrumentation_scope=instrumentation_scope
+        )
+
+        logger_provider = LoggerProviderTest()
+        _logs.set_logger_provider(logger_provider)
+
+        self.assertIsInstance(logger._logger, LoggerTest)
+        self.assertIs(
+            logger_provider.instrumentation_scope, instrumentation_scope
+        )
+
+    def test_proxy_logger_works_with_old_signature_provider(self):
+        provider = _logs.get_logger_provider()
+        logger = provider.get_logger("proxy-test")
+
+        _logs.set_logger_provider(OldSignatureLoggerProvider())
+
+        self.assertIsInstance(logger._logger, LoggerTest)
+
+    def test_get_logger_works_with_old_signature_provider(self):
+        logger_provider = OldSignatureLoggerProvider()
+
+        logger = _logs.get_logger("proxy-test", logger_provider=logger_provider)
+
+        self.assertIsInstance(logger, LoggerTest)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -468,11 +468,14 @@ class LoggingHandler(logging.Handler):
         self,
         level=logging.NOTSET,
         logger_provider=None,
+        instrumentation_scope=None,
     ) -> None:
         super().__init__(level=level)
         self._logger_provider = logger_provider or get_logger_provider()
         self._logger = get_logger(
-            __name__, logger_provider=self._logger_provider
+            __name__,
+            logger_provider=self._logger_provider,
+            instrumentation_scope=instrumentation_scope,
         )
 
     @staticmethod
@@ -648,6 +651,7 @@ class LoggerProvider(APILoggerProvider):
         version: Optional[str] = None,
         schema_url: Optional[str] = None,
         attributes: Optional[Attributes] = None,
+        instrumentation_scope: Optional[InstrumentationScope] = None,
     ) -> Logger:
         if self._disabled:
             _logger.warning("SDK is disabled.")
@@ -656,6 +660,17 @@ class LoggerProvider(APILoggerProvider):
                 version=version,
                 schema_url=schema_url,
                 attributes=attributes,
+            )
+        if instrumentation_scope:
+            return Logger(
+                self._resource,
+                self._multi_log_record_processor,
+                InstrumentationScope(
+                    instrumentation_scope.name,
+                    instrumentation_scope.version,
+                    instrumentation_scope.schema_url,
+                    instrumentation_scope.attributes,
+                ),
             )
         return Logger(
             self._resource,

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -72,6 +72,37 @@ class TestSimpleLogRecordProcessor(unittest.TestCase):
             warning_log_record.severity_number, SeverityNumber.WARN
         )
 
+    def test_simple_log_record_processor_instrumentation_scope(self):
+        exporter = InMemoryLogExporter()
+        logger_provider = LoggerProvider()
+        instrumentation_scope = InstrumentationScope(
+            "custom_name",
+            "custom_version",
+            "custom_schema_url",
+            {"custom_key": "custom_value"},
+        )
+
+        logger_provider.add_log_record_processor(
+            SimpleLogRecordProcessor(exporter)
+        )
+
+        logger = logging.getLogger("custom_instrumentation_scope")
+        logger.propagate = False
+        logger.addHandler(
+            LoggingHandler(
+                logger_provider=logger_provider,
+                instrumentation_scope=instrumentation_scope,
+            )
+        )
+
+        logger.warning("Something is wrong")
+        finished_logs = exporter.get_finished_logs()
+
+        self.assertEqual(len(finished_logs), 1)
+        self.assertEqual(
+            finished_logs[0].instrumentation_scope, instrumentation_scope
+        )
+
     def test_simple_log_record_processor_custom_level(self):
         exporter = InMemoryLogExporter()
         logger_provider = LoggerProvider()

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -24,6 +24,7 @@ from opentelemetry.sdk._logs._internal import (
 )
 from opentelemetry.sdk.environment_variables import OTEL_SDK_DISABLED
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 
 
 class TestLoggerProvider(unittest.TestCase):
@@ -65,6 +66,37 @@ class TestLoggerProvider(unittest.TestCase):
         )
         self.assertEqual(
             logger._instrumentation_scope.attributes, {"key": "value"}
+        )
+
+    def test_get_logger_instrumentation(self):
+        """
+        `LoggerProvider.get_logger` arguments are used to create an
+        `InstrumentationScope` object on the created `Logger`.
+        """
+        instruments = {
+            "name": "instrument_name",
+            "version": "instrument_version",
+            "schema_url": "instrument_schema_url",
+            "attributes": {"instrument_key": "instrument_value"},
+        }
+        logger = LoggerProvider().get_logger(
+            "name",
+            version="version",
+            schema_url="schema_url",
+            attributes={"key": "value"},
+            instrumentation_scope=InstrumentationScope(**instruments),
+        )
+
+        self.assertEqual(logger._instrumentation_scope.name, "instrument_name")
+        self.assertEqual(
+            logger._instrumentation_scope.version, "instrument_version"
+        )
+        self.assertEqual(
+            logger._instrumentation_scope.schema_url, "instrument_schema_url"
+        )
+        self.assertEqual(
+            logger._instrumentation_scope.attributes,
+            {"instrument_key": "instrument_value"},
         )
 
     @patch.dict("os.environ", {OTEL_SDK_DISABLED: "true"})

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -68,36 +68,26 @@ class TestLoggerProvider(unittest.TestCase):
             logger._instrumentation_scope.attributes, {"key": "value"}
         )
 
-    def test_get_logger_instrumentation(self):
+    def test_get_logger_with_instrumentation_scope(self):
         """
-        `LoggerProvider.get_logger` arguments are used to create an
+        `LoggerProvider.get_logger` uses an explicitly provided
         `InstrumentationScope` object on the created `Logger`.
         """
-        instruments = {
-            "name": "instrument_name",
-            "version": "instrument_version",
-            "schema_url": "instrument_schema_url",
-            "attributes": {"instrument_key": "instrument_value"},
-        }
+        instrumentation_scope = InstrumentationScope(
+            "instrument_name",
+            "instrument_version",
+            "instrument_schema_url",
+            {"instrument_key": "instrument_value"},
+        )
         logger = LoggerProvider().get_logger(
             "name",
             version="version",
             schema_url="schema_url",
             attributes={"key": "value"},
-            instrumentation_scope=InstrumentationScope(**instruments),
+            instrumentation_scope=instrumentation_scope,
         )
 
-        self.assertEqual(logger._instrumentation_scope.name, "instrument_name")
-        self.assertEqual(
-            logger._instrumentation_scope.version, "instrument_version"
-        )
-        self.assertEqual(
-            logger._instrumentation_scope.schema_url, "instrument_schema_url"
-        )
-        self.assertEqual(
-            logger._instrumentation_scope.attributes,
-            {"instrument_key": "instrument_value"},
-        )
+        self.assertEqual(logger._instrumentation_scope, instrumentation_scope)
 
     @patch.dict("os.environ", {OTEL_SDK_DISABLED: "true"})
     def test_get_logger_with_sdk_disabled(self):


### PR DESCRIPTION
# Description

Add a way to configure the `InstrumentationScope` used by the SDK logger created internally by `LoggingHandler`.

`LoggingHandler` previously always created its inner logger with `__name__`, an empty version, and an empty schema URL. This change allows callers to provide an explicit instrumentation scope while preserving compatibility with existing logger providers.

Fixes #4060

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added unit coverage for `LoggerProvider.get_logger` with an explicit instrumentation scope.
- [x] Added unit coverage for `LoggingHandler` to verify exported `LogData` uses the provided instrumentation scope.
- [x] Added API proxy compatibility coverage for old-style logger providers that do not accept the new argument.

Reproduced with:

```bash
.tox/py312-test-opentelemetry-api/bin/pytest opentelemetry-api/tests/logs/test_proxy.py -q
.tox/py312-test-opentelemetry-sdk/bin/pytest opentelemetry-sdk/tests/logs/test_logs.py opentelemetry-sdk/tests/logs/test_export.py -q
git diff --check
```

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
