### PR TITLE
Config inner sdk logger 

### DIFF
--- a/.changelog/5261.added
+++ b/.changelog/5261.added
@@ -1,0 +1,1 @@
+Added support for configuring the instrumentation scope used by the SDK logger created by `LoggingHandler`.

--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -28,7 +28,7 @@ from abc import ABC, abstractmethod
 from logging import getLogger
 from os import environ
 from time import time_ns
-from typing import cast, overload
+from typing import Any, cast, overload
 
 from typing_extensions import deprecated
 
@@ -227,11 +227,13 @@ class ProxyLogger(Logger):
         version: str | None = None,
         schema_url: str | None = None,
         attributes: _ExtendedAttributes | None = None,
+        instrumentation_scope: Any | None = None,
     ):
         self._name = name
         self._version = version
         self._schema_url = schema_url
         self._attributes = attributes
+        self._instrumentation_scope = instrumentation_scope
         self._real_logger: Logger | None = None
         self._noop_logger = NoOpLogger(name)
 
@@ -241,11 +243,20 @@ class ProxyLogger(Logger):
             return self._real_logger
 
         if _LOGGER_PROVIDER:
+            if self._instrumentation_scope is None:
+                self._real_logger = _LOGGER_PROVIDER.get_logger(
+                    self._name,
+                    self._version,
+                    self._schema_url,
+                    self._attributes,
+                )
+                return self._real_logger
             self._real_logger = _LOGGER_PROVIDER.get_logger(
                 self._name,
                 self._version,
                 self._schema_url,
                 self._attributes,
+                self._instrumentation_scope,
             )
             return self._real_logger
         return self._noop_logger
@@ -313,6 +324,7 @@ class LoggerProvider(ABC):
         version: str | None = None,
         schema_url: str | None = None,
         attributes: _ExtendedAttributes | None = None,
+        instrumentation_scope: Any | None = None,
     ) -> Logger:
         """Returns a `Logger` for use by the given instrumentation library.
 
@@ -352,8 +364,10 @@ class NoOpLoggerProvider(LoggerProvider):
         version: str | None = None,
         schema_url: str | None = None,
         attributes: _ExtendedAttributes | None = None,
+        instrumentation_scope: Any | None = None,
     ) -> Logger:
         """Returns a NoOpLogger."""
+        _ = instrumentation_scope
         return NoOpLogger(
             name, version=version, schema_url=schema_url, attributes=attributes
         )
@@ -366,19 +380,29 @@ class ProxyLoggerProvider(LoggerProvider):
         version: str | None = None,
         schema_url: str | None = None,
         attributes: _ExtendedAttributes | None = None,
+        instrumentation_scope: Any | None = None,
     ) -> Logger:
         if _LOGGER_PROVIDER:
+            if instrumentation_scope is None:
+                return _LOGGER_PROVIDER.get_logger(
+                    name,
+                    version=version,
+                    schema_url=schema_url,
+                    attributes=attributes,
+                )
             return _LOGGER_PROVIDER.get_logger(
                 name,
                 version=version,
                 schema_url=schema_url,
                 attributes=attributes,
+                instrumentation_scope=instrumentation_scope,
             )
         return ProxyLogger(
             name,
             version=version,
             schema_url=schema_url,
             attributes=attributes,
+            instrumentation_scope=instrumentation_scope,
         )
 
 
@@ -429,6 +453,7 @@ def get_logger(
     logger_provider: LoggerProvider | None = None,
     schema_url: str | None = None,
     attributes: _ExtendedAttributes | None = None,
+    instrumentation_scope: Any | None = None,
 ) -> Logger:
     """Returns a `Logger` for use within a python process.
 
@@ -439,9 +464,17 @@ def get_logger(
     """
     if logger_provider is None:
         logger_provider = get_logger_provider()
+    if instrumentation_scope is None:
+        return logger_provider.get_logger(
+            instrumenting_module_name,
+            instrumenting_library_version,
+            schema_url,
+            attributes,
+        )
     return logger_provider.get_logger(
         instrumenting_module_name,
         instrumenting_library_version,
         schema_url,
         attributes,
+        instrumentation_scope,
     )

--- a/opentelemetry-api/tests/logs/test_proxy.py
+++ b/opentelemetry-api/tests/logs/test_proxy.py
@@ -3,6 +3,7 @@
 
 # pylint: disable=W0212,W0222,W0221
 import unittest
+from typing import cast
 from unittest.mock import Mock
 
 import opentelemetry._logs._internal as _logs_internal
@@ -18,7 +19,36 @@ class TestProvider(_logs.NoOpLoggerProvider):
         version: str | None = None,
         schema_url: str | None = None,
         attributes: _ExtendedAttributes | None = None,
+        instrumentation_scope=None,
     ) -> _logs.Logger:
+        _ = instrumentation_scope
+        return LoggerTest(name)
+
+
+class OldSignatureLoggerProvider:
+    def get_logger(  # pylint: disable=no-self-use
+        self,
+        name: str,
+        version: str | None = None,
+        schema_url: str | None = None,
+        attributes: _ExtendedAttributes | None = None,
+    ) -> _logs.Logger:
+        return LoggerTest(name)
+
+
+class LoggerProviderTest(_logs.NoOpLoggerProvider):
+    def __init__(self):
+        self.instrumentation_scope = None
+
+    def get_logger(
+        self,
+        name: str,
+        version: str | None = None,
+        schema_url: str | None = None,
+        attributes: _ExtendedAttributes | None = None,
+        instrumentation_scope=None,
+    ) -> _logs.Logger:
+        self.instrumentation_scope = instrumentation_scope
         return LoggerTest(name)
 
 
@@ -64,6 +94,34 @@ class TestProxy(LoggingGlobalsTest, unittest.TestCase):
         # references to the old provider still work but return real logger now
         real_logger = provider.get_logger("proxy-test")
         self.assertIsInstance(real_logger, LoggerTest)
+
+    def test_proxy_logger_instrumentation_scope(self):
+        provider = _logs.get_logger_provider()
+        instrumentation_scope = object()
+
+        logger = provider.get_logger(
+            "proxy-test", instrumentation_scope=instrumentation_scope
+        )
+
+        logger_provider = LoggerProviderTest()
+        _logs.set_logger_provider(logger_provider)
+
+        proxy_logger = cast(_logs_internal.ProxyLogger, logger)
+        self.assertIsInstance(proxy_logger._logger, LoggerTest)
+        self.assertIs(
+            logger_provider.instrumentation_scope, instrumentation_scope
+        )
+
+    def test_get_logger_works_with_old_signature_provider(self):
+        logger_provider = cast(
+            _logs.LoggerProvider, OldSignatureLoggerProvider()
+        )
+
+        logger = _logs.get_logger(
+            "proxy-test", logger_provider=logger_provider
+        )
+
+        self.assertIsInstance(logger, LoggerTest)
 
     def test_proxy_logger_forwards_record_with_exception(self):
         logger = _logs_internal.ProxyLogger("proxy-test")

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -544,9 +544,11 @@ class LoggingHandler(logging.Handler):
         self,
         level: int = logging.NOTSET,
         logger_provider: APILoggerProvider | None = None,
+        instrumentation_scope: InstrumentationScope | None = None,
     ) -> None:
         super().__init__(level=level)
         self._logger_provider = logger_provider or get_logger_provider()
+        self._instrumentation_scope = instrumentation_scope
 
         warnings.warn(
             "`LoggingHandler` in `opentelemetry-sdk` is deprecated. Use the "
@@ -638,7 +640,11 @@ class LoggingHandler(logging.Handler):
 
         The record is translated to OTel format, and then sent across the pipeline.
         """
-        logger = get_logger(record.name, logger_provider=self._logger_provider)
+        logger = get_logger(
+            record.name,
+            logger_provider=self._logger_provider,
+            instrumentation_scope=self._instrumentation_scope,
+        )
         if not isinstance(logger, NoOpLogger):
             logger.emit(self._translate(record))
 
@@ -856,6 +862,7 @@ class LoggerProvider(APILoggerProvider):
         version: str | None = None,
         schema_url: str | None = None,
         attributes: _ExtendedAttributes | None = None,
+        instrumentation_scope: InstrumentationScope | None = None,
     ) -> APILogger:
         if self._disabled:
             return NoOpLogger(
@@ -864,13 +871,21 @@ class LoggerProvider(APILoggerProvider):
                 schema_url=schema_url,
                 attributes=attributes,
             )
-        logger = (
-            self._get_logger_cached(name, version, schema_url)
-            if attributes is None
-            else self._get_logger_no_cache(
-                name, version, schema_url, attributes
+        if instrumentation_scope is None:
+            logger = (
+                self._get_logger_cached(name, version, schema_url)
+                if attributes is None
+                else self._get_logger_no_cache(
+                    name, version, schema_url, attributes
+                )
             )
-        )
+        else:
+            logger = self._get_logger_no_cache(
+                instrumentation_scope.name,
+                instrumentation_scope.version,
+                instrumentation_scope.schema_url,
+                instrumentation_scope.attributes,
+            )
         with self._active_loggers_lock:
             self._active_loggers.add(logger)
         return logger

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -128,6 +128,37 @@ class TestSimpleLogRecordProcessor(unittest.TestCase):
             finished_logs[0].instrumentation_scope.name, "default_level"
         )
 
+    def test_simple_log_record_processor_instrumentation_scope(self):
+        exporter = InMemoryLogRecordExporter()
+        logger_provider = LoggerProvider()
+        instrumentation_scope = InstrumentationScope(
+            "custom_name",
+            "custom_version",
+            "custom_schema_url",
+            {"custom_key": "custom_value"},
+        )
+
+        logger_provider.add_log_record_processor(
+            SimpleLogRecordProcessor(exporter)
+        )
+
+        logger = logging.getLogger("custom_instrumentation_scope")
+        logger.propagate = False
+        logger.addHandler(
+            LoggingHandler(
+                logger_provider=logger_provider,
+                instrumentation_scope=instrumentation_scope,
+            )
+        )
+
+        logger.warning("Something is wrong")
+        finished_logs = exporter.get_finished_logs()
+
+        self.assertEqual(len(finished_logs), 1)
+        self.assertEqual(
+            finished_logs[0].instrumentation_scope, instrumentation_scope
+        )
+
     def test_simple_log_record_processor_custom_level(self):
         exporter = InMemoryLogRecordExporter()
         logger_provider = LoggerProvider()

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -73,6 +73,27 @@ class TestLoggerProvider(unittest.TestCase):
             logger._instrumentation_scope.attributes, {"key": "value"}
         )
 
+    def test_get_logger_with_instrumentation_scope(self):
+        """
+        `LoggerProvider.get_logger` uses an explicitly provided
+        `InstrumentationScope` object on the created `Logger`.
+        """
+        instrumentation_scope = InstrumentationScope(
+            "instrument_name",
+            "instrument_version",
+            "instrument_schema_url",
+            {"instrument_key": "instrument_value"},
+        )
+        logger = LoggerProvider().get_logger(
+            "name",
+            version="version",
+            schema_url="schema_url",
+            attributes={"key": "value"},
+            instrumentation_scope=instrumentation_scope,
+        )
+
+        self.assertEqual(logger._instrumentation_scope, instrumentation_scope)
+
     @patch.dict("os.environ", {OTEL_SDK_DISABLED: "true"})
     def test_get_logger_with_sdk_disabled(self):
         logger = LoggerProvider().get_logger(Mock())


### PR DESCRIPTION
# Description

Add a way to configure the `InstrumentationScope` used by the SDK logger created internally by `LoggingHandler`.

`LoggingHandler` currently creates SDK loggers internally, so users cannot populate the instrumentation scope values the same way they can when creating tracers or meters directly. This change allows callers to provide an explicit instrumentation scope to `LoggingHandler`.

The default behavior is preserved: when no instrumentation scope is provided, `LoggingHandler` continues to use the logging record name as the logger/scope name. Existing logger providers that do not accept the new optional argument continue to work when the new argument is not supplied.

Fixes #4060

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added unit coverage for `LoggerProvider.get_logger` with an explicit instrumentation scope.
- [x] Added unit coverage for `LoggingHandler` to verify exported `LogData` uses the provided instrumentation scope.
- [x] Added API proxy compatibility coverage for old-style logger providers that do not accept the new argument.
- [x] Rebasing conflicts were avoided by recreating the branch from the latest upstream `main` and reapplying the change.

Reproduced with:

```bash
.tox/py312-test-opentelemetry-api/bin/pytest opentelemetry-api/tests/logs/test_proxy.py -q
.tox/py312-test-opentelemetry-sdk/bin/pytest opentelemetry-sdk/tests/logs/test_logs.py opentelemetry-sdk/tests/logs/test_export.py -q
```

Results:

- API logs proxy tests: 4 passed.
- SDK logs/export tests: 45 passed.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
