### PR TITLE
opentelemetry-api: suppress SelectableGroups DeprecationWarning on Python 3.10/3.11

### DIFF
--- a/.changelog/5231.fixed
+++ b/.changelog/5231.fixed
@@ -1,0 +1,4 @@
+Suppress ``SelectableGroups`` ``DeprecationWarning`` emitted by
+``importlib.metadata.entry_points()`` on Python 3.10 and 3.11 when
+``opentelemetry.context`` (or any module that calls ``entry_points()``) is
+imported.

--- a/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
+++ b/opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py
@@ -9,8 +9,10 @@ It also normalizes minor differences across python versions 3.10+. References to
 
 - https://github.com/open-telemetry/opentelemetry-python/pull/4735
 - https://github.com/open-telemetry/opentelemetry-python/pull/5203
+- https://github.com/open-telemetry/opentelemetry-python/issues/5231
 """
 
+import warnings
 from functools import cache
 from importlib.metadata import (
     Distribution,
@@ -34,7 +36,19 @@ def _as_entry_points(eps: Any) -> EntryPoints:
 
 @cache
 def _original_entry_points_cached() -> EntryPoints:
-    return _as_entry_points(original_entry_points())
+    # On Python 3.10 and 3.11, calling entry_points() without arguments returns
+    # a SelectableGroups object. Its .values() method emits a DeprecationWarning
+    # ("SelectableGroups dict interface is deprecated. Use select.") that cannot
+    # be avoided while caching all entry points in a single upfront call.
+    # The @cache decorator ensures this path runs only once per interpreter
+    # session, so suppressing the warning here is both safe and targeted.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message="SelectableGroups dict interface is deprecated",
+        )
+        return _as_entry_points(original_entry_points())
 
 
 def entry_points(**params) -> EntryPoints:

--- a/opentelemetry-api/tests/util/test__importlib_metadata.py
+++ b/opentelemetry-api/tests/util/test__importlib_metadata.py
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from unittest import TestCase
 
 from opentelemetry.metrics import MeterProvider
@@ -8,6 +9,7 @@ from opentelemetry.util._importlib_metadata import (
     EntryPoint,
     EntryPoints,
     _as_entry_points,
+    _original_entry_points_cached,
     version,
 )
 from opentelemetry.util._importlib_metadata import (
@@ -101,6 +103,39 @@ class TestEntryPoints(TestCase):
         self.assertEqual(len(entry_points), 0)
 
         self.assertIsInstance(version("opentelemetry-api"), str)
+
+    def test_no_deprecation_warning_from_entry_points(self):
+        """entry_points() must not emit DeprecationWarning on any supported Python version.
+
+        On Python 3.10/3.11, importlib.metadata.entry_points() called without
+        arguments returns a SelectableGroups object.  Accessing its .values()
+        attribute emits ``DeprecationWarning: SelectableGroups dict interface is
+        deprecated. Use select.``, which breaks projects that run their test
+        suites with ``-W error``.  The wrapper in _importlib_metadata.py must
+        suppress that warning before it propagates.
+
+        Regression test for https://github.com/open-telemetry/opentelemetry-python/issues/5231
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            # Clear the cache so the cached path is exercised fresh inside the
+            # catch_warnings context, making the assertion reliable.
+            _original_entry_points_cached.cache_clear()
+            importlib_metadata_entry_points()
+            # Restore cache state for the rest of the test run.
+            _original_entry_points_cached.cache_clear()
+
+        selectable_groups_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and "SelectableGroups" in str(w.message)
+        ]
+        self.assertEqual(
+            selectable_groups_warnings,
+            [],
+            "entry_points() must not emit a SelectableGroups DeprecationWarning",
+        )
 
     def test_as_entry_points_selectable_groups_compat(self):
         """Test that _as_entry_points correctly normalizes dict-like SelectableGroups


### PR DESCRIPTION
## Summary

On Python 3.10 and 3.11, `importlib.metadata.entry_points()` called without arguments returns a [`SelectableGroups`](https://github.com/python/cpython/blob/3.11/Lib/importlib/metadata/__init__.py#L560) object. Accessing its `.values()` method emits:

```
DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
```

This warning propagates to end users any time `opentelemetry.context` (or any module that calls our `entry_points()` wrapper) is imported — particularly painful for projects that run with `-W error`.

## Root cause

In `opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py`, `_original_entry_points_cached()` calls `original_entry_points()` without arguments and passes the result to `_as_entry_points()`. On Python 3.10/3.11, `_as_entry_points()` hits the else-branch and calls `.values()` on the `SelectableGroups` object, which triggers the warning.

## Fix

Wrap the caching call in `_original_entry_points_cached()` with `warnings.catch_warnings()` and `warnings.filterwarnings("ignore", ...)` scoped to the specific `SelectableGroups` message. Because `@cache` ensures this code path runs at most once per interpreter session, the suppression is both targeted and safe — it does not silence unrelated warnings.

## Changes

- `opentelemetry-api/src/opentelemetry/util/_importlib_metadata.py` — add `import warnings`; wrap `_original_entry_points_cached` body with `warnings.catch_warnings()` block
- `opentelemetry-api/tests/util/test__importlib_metadata.py` — add `test_no_deprecation_warning_from_entry_points`: clears the cache, calls `entry_points()` inside `catch_warnings(record=True)`, asserts zero `SelectableGroups` deprecation warnings
- `.changelog/5231.fixed` — towncrier fragment

## Testing

```
tox -e py312-test-opentelemetry-api   # 278 passed
tox -e lint-opentelemetry-api         # pylint 10.00/10
tox -e lint                           # ruff / formatting OK
```

Fixes #5231

Made with [Cursor](https://cursor.com)