### PR TITLE
opentelemetry-sdk: remove copy on span instantiation

### DIFF
--- a/.changelog/5272.changed
+++ b/.changelog/5272.changed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: remove unnecessary `copy` in Span creation

--- a/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
@@ -45,6 +45,17 @@ def test_simple_start_span(benchmark):
     benchmark(benchmark_start_span)
 
 
+@pytest.mark.parametrize("num_attrs", [0, 1, 10, 50, 128])
+def test_start_span_with_attributes(benchmark, num_attrs):
+    attrs = {f"key{i}": f"value{i}" for i in range(num_attrs)}
+
+    def benchmark_start_span():
+        span = tracer.start_span("benchmarkedSpan", attributes=attrs)
+        span.end()
+
+    benchmark(benchmark_start_span)
+
+
 # pylint: disable=protected-access,redefined-outer-name
 def test_simple_start_span_with_tracer_configurator_rules(
     benchmark, num_tracer_configurator_rules

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -1256,7 +1256,7 @@ class Tracer(trace_api.Tracer):
                 parent=parent_span_context,
                 sampler=self.sampler,
                 resource=self.resource,
-                attributes=sampling_result.attributes.copy(),
+                attributes=sampling_result.attributes,
                 span_processor=self.span_processor,
                 kind=kind,
                 links=links,


### PR DESCRIPTION
# Description

The copy isn't necessary as the init method of the BoundedAttributes (inside the span's init method) already iterates through and copies all the attributes in a new Dict. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran some benchmarks before and after the change with:

```
pytest opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py::test_start_span_with_attributes \
      --memray --trace-python-allocators --benchmark-disable -v
```
    
The following table shows the before and after change savings:
    
| attrs | Before (KiB) | After (KiB) | Saved (KiB) |
|------:|-------------:|------------:|------------:|
| 0     | 7.5          | 7.3         | 0.2         |
| 1     | 8.3          | 8.1         | 0.2         |
| 10    | 11.3         | 11.3        | 0.0         |
| 50    | 15.8         | 14.3        | 1.5         |
| 128   | 28.0         | 24.8        | 3.2         |

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Benchmark tests have been added
- [ ] Documentation has been updated
