### PR TITLE
opentelemetry-sdk: remove unnecessary dict in set_attribute method

### DIFF
--- a/.changelog/5274.changed
+++ b/.changelog/5274.changed
@@ -1,0 +1,1 @@
+opentelemetry-sdk: remove unnecessary dict in set_attribute method

--- a/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
@@ -91,6 +91,19 @@ def test_simple_start_span_with_tracer_configurator_rules(
     )
 
 
+@pytest.mark.parametrize("num_attrs", [1, 10, 50, 128])
+def test_set_attribute(benchmark, num_attrs):
+    attrs = {f"key{i}": f"value{i}" for i in range(num_attrs)}
+
+    def benchmark_set_attribute():
+        span = tracer.start_span("benchmarkedSpan")
+        for key, value in attrs.items():
+            span.set_attribute(key, value)
+        span.end()
+
+    benchmark(benchmark_set_attribute)
+
+
 def test_simple_start_as_current_span(benchmark):
     def benchmark_start_as_current_span():
         with tracer.start_as_current_span(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -895,7 +895,12 @@ class Span(trace_api.Span, ReadableSpan):
                 self._attributes[key] = value
 
     def set_attribute(self, key: str, value: types.AttributeValue) -> None:
-        return self.set_attributes({key: value})
+        with self._lock:
+            if self._end_time is not None:
+                logger.warning("Setting attribute on ended span.")
+                return
+
+            self._attributes[key] = value
 
     @_check_span_ended
     def _add_event(self, event: EventBase) -> None:


### PR DESCRIPTION
# Description

`set_attribute` was unnecessarily creating a dict to set the attribute via `set_attributes`. removed that call and instead put the code from `set_attributes` directly into `set_attribute`. there is a small amount of time saved from doing this, the memory footprint is essentially the same:

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran:

```
pytest opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py::test_set_attribute \
  --memray --trace-python-allocators \
  --benchmark-min-rounds=10 --benchmark-columns=mean,median,ops
```

And got the following results:

| attrs | Before mean (µs) | After mean (µs) | Time saved | Before mem (KiB) | After mem (KiB) | Mem saved | 
|------|-----------------|----------------|-----------|-----------------|----------------|----------|
|     1 |            22.7  |            21.6 |        5%  |            176.8 |           174.6 |      1.2  |
|    10 |            39.9  |            34.4 |       14%  |            356.0 |           408.9 |     -52.9 |
|    50 |           117.6  |            90.4 |       23%  |            190.9 |           240.1 |     -49.2 |
|   128 |           266.3  |           199.3 |       25%  |            115.3 |           139.9 |     -24.6 |

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Benchmark tests have been added
- [ ] Documentation has been updated
