### PR TITLE
opentelemetry-sdk: inline the method `_clean_attribute_value`

### DIFF
--- a/.changelog/5275.changed
+++ b/.changelog/5275.changed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: inline the method `_clean_attribute_value`

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -65,7 +65,7 @@ def _clean_attribute(
             except UnicodeDecodeError:
                 _logger.warning("Byte attribute could not be decoded.")
                 return None
-        elif max_len is not None and isinstance(value, str):
+        if max_len is not None and isinstance(value, str):
             value = value[:max_len]
         return value
 
@@ -81,7 +81,7 @@ def _clean_attribute(
                     _logger.warning("Byte attribute could not be decoded.")
                     cleaned_seq.append(None)
                     continue
-            elif max_len is not None and isinstance(element, str):
+            if max_len is not None and isinstance(element, str):
                 element = element[:max_len]
             elif element is None:
                 cleaned_seq.append(None)

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -83,7 +83,7 @@ def _clean_attribute(
                     continue
             elif max_len is not None and isinstance(element, str):
                 element = element[:max_len]
-            elif element == None:
+            elif element is None:
                 cleaned_seq.append(None)
                 continue
 

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -58,17 +58,30 @@ def _clean_attribute(
         return None
 
     if isinstance(value, _VALID_ATTR_VALUE_TYPES):
-        return _clean_attribute_value(value, max_len)
+        if isinstance(value, bytes):
+            try:
+                value = value.decode()
+            except UnicodeDecodeError:
+                _logger.warning("Byte attribute could not be decoded.")
+                return None
+        elif max_len is not None and isinstance(value, str):
+            value = value[:max_len]
+        return value
 
     if isinstance(value, Sequence):
         sequence_first_valid_type = None
         cleaned_seq = []
 
         for element in value:
-            element = _clean_attribute_value(element, max_len)  # type: ignore
-            if element is None:
-                cleaned_seq.append(element)
-                continue
+            if isinstance(element, bytes):
+                try:
+                    element = element.decode()
+                except UnicodeDecodeError:
+                    _logger.warning("Byte attribute could not be decoded.")
+                    cleaned_seq.append(None)
+                    continue
+            elif max_len is not None and isinstance(element, str):
+                element = element[:max_len]
 
             element_type = type(element)
             # Reject attribute value if sequence contains a value with an incompatible type.
@@ -212,24 +225,6 @@ def _clean_extended_attribute(
     except TypeError as exception:
         _logger.warning("Attribute %s: %s", key, exception)
         return None
-
-
-def _clean_attribute_value(
-    value: types.AttributeValue, limit: int | None
-) -> types.AttributeValue | None:
-    if value is None:
-        return None
-
-    if isinstance(value, bytes):
-        try:
-            value = value.decode()
-        except UnicodeDecodeError:
-            _logger.warning("Byte attribute could not be decoded.")
-            return None
-
-    if limit is not None and isinstance(value, str):
-        value = value[:limit]
-    return value
 
 
 class BoundedAttributes(MutableMapping):  # type: ignore

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -34,6 +34,7 @@ def _type_name(t):
 
 _logger = logging.getLogger(__name__)
 
+
 # pylint: disable=too-many-return-statements
 # pylint: disable=too-many-branches
 def _clean_attribute(

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -34,7 +34,8 @@ def _type_name(t):
 
 _logger = logging.getLogger(__name__)
 
-
+# pylint: disable=too-many-return-statements
+# pylint: disable=too-many-branches
 def _clean_attribute(
     key: str, value: types.AttributeValue, max_len: int | None
 ) -> types.AttributeValue | tuple[str | int | float, ...] | None:

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -83,6 +83,9 @@ def _clean_attribute(
                     continue
             elif max_len is not None and isinstance(element, str):
                 element = element[:max_len]
+            elif element == None:
+                cleaned_seq.append(None)
+                continue
 
             element_type = type(element)
             # Reject attribute value if sequence contains a value with an incompatible type.

--- a/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
@@ -104,6 +104,34 @@ def test_set_attribute(benchmark, num_attrs):
     benchmark(benchmark_set_attribute)
 
 
+@pytest.mark.parametrize(
+    "attr_type,value",
+    [
+        ("bool", True),
+        ("int", 42),
+        ("float", 3.14),
+        ("str", "hello world"),
+        ("bytes", b"hello world"),
+        ("seq_bool", (True, False, True)),
+        ("seq_int", (1, 2, 3, 4, 5)),
+        ("seq_float", (1.1, 2.2, 3.3)),
+        ("seq_str", ("a", "b", "c", "d", "e")),
+        ("seq_bytes", (b"a", b"b", b"c")),
+    ],
+)
+def test_set_attribute_types(benchmark, attr_type, value):
+    attrs = {f"key{i}": value for i in range(128)}
+
+    def benchmark_set_attribute():
+        for _ in range(5_000):
+            span = tracer.start_span("benchmarkedSpan")
+            for key, val in attrs.items():
+                span.set_attribute(key, val)
+            span.end()
+
+    benchmark(benchmark_set_attribute)
+
+
 def test_simple_start_as_current_span(benchmark):
     def benchmark_start_as_current_span():
         with tracer.start_as_current_span(


### PR DESCRIPTION
# Description

This removes an if statement to check if the value is None and embeds the method inline to remove the need for that check. A second check for None is removed in the loop through the Sequence type.

Note to reviewers: I bumped the number of spans in the benchmark test to 5000 to get a more consistent result, it doesn't have to stay here, let me know if you'd like it removed.

Follow up to https://github.com/open-telemetry/opentelemetry-python/pull/5274, can rebase after it's merged (if it merges) or without it if reviewers would prefer.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran the following:
    
```
 pytest opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py::test_set_attribute_types \
      --benchmark-min-rounds=10 --benchmark-columns=mean,median,ops
 ```
    
 And got these results for the different types:
    
| type      | Before (ms) | After (ms) | Δ     |
|-----------|------------|-----------|------|
| bool      |       204.1 |      197.3 |  -3%  |
| str       |       211.9 |      203.9 |  -4%  |
| int       |       221.3 |      213.5 |  -4%  |
| bytes     |       226.5 |      216.8 |  -4%  |
| float     |       227.3 |      222.1 |  -2%  |
| seq_bool  |       488.3 |      453.7 |  -7%  |
| seq_bytes |       513.7 |      471.7 |  -8%  |
| seq_float |       539.6 |      508.4 |  -6%  |
| seq_str   |       594.3 |      537.0 | -10%  |
| seq_int   |       636.0 |      576.3 |  -9%  |

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Benchmark tests have been added
- [ ] Documentation has been updated
