### PR TITLE
opentelemetry-sdk: remove generator in the accessor for links/events

### DIFF
--- a/.changelog/5287.changed
+++ b/.changelog/5287.changed
@@ -1,0 +1,1 @@
+opentelemetry-sdk: remove generator in the accessor for links/events

--- a/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
@@ -168,12 +168,12 @@ _link_context = SpanContext(
 def test_read_events(benchmark, num_events):
     provider = TracerProvider(sampler=sampling.DEFAULT_ON)
     provider.add_span_processor(_EventsReadingProcessor())
-    t = provider.get_tracer("bench")
+    tp = provider.get_tracer("bench")
 
     def benchmark_read_events():
-        span = t.start_span("benchmarkedSpan")
-        for i in range(num_events):
-            span.add_event(f"event{i}", {"k": "v"})
+        span = tp.start_span("benchmarkedSpan")
+        for event in range(num_events):
+            span.add_event(f"event{event}", {"k": "v"})
         span.end()
 
     benchmark(benchmark_read_events)
@@ -183,10 +183,10 @@ def test_read_events(benchmark, num_events):
 def test_read_links(benchmark, num_links):
     provider = TracerProvider(sampler=sampling.DEFAULT_ON)
     provider.add_span_processor(_LinksReadingProcessor())
-    t = provider.get_tracer("bench")
+    tp = provider.get_tracer("bench")
 
     def benchmark_read_links():
-        span = t.start_span("benchmarkedSpan")
+        span = tp.start_span("benchmarkedSpan")
         for _ in range(num_links):
             span.add_link(_link_context)
         span.end()

--- a/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
@@ -7,6 +7,8 @@ import pytest
 
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import (
+    ReadableSpan,
+    SpanProcessor,
     TracerProvider,
     _default_tracer_configurator,
     _RuleBasedTracerConfigurator,
@@ -14,6 +16,7 @@ from opentelemetry.sdk.trace import (
     sampling,
 )
 from opentelemetry.sdk.util.instrumentation import _scope_name_matches_glob
+from opentelemetry.trace import SpanContext, TraceFlags
 
 tracer_provider = TracerProvider(
     sampler=sampling.DEFAULT_ON,
@@ -141,3 +144,51 @@ def test_simple_start_as_current_span(benchmark):
             span.add_event("benchmarkEvent")
 
     benchmark(benchmark_start_as_current_span)
+
+
+class _EventsReadingProcessor(SpanProcessor):
+    def on_end(self, span: ReadableSpan) -> None:
+        _ = span.events
+
+
+class _LinksReadingProcessor(SpanProcessor):
+    def on_end(self, span: ReadableSpan) -> None:
+        _ = span.links
+
+
+_link_context = SpanContext(
+    trace_id=0x000000000000000000000000DEADBEEF,
+    span_id=0x00000000DEADBEF0,
+    is_remote=True,
+    trace_flags=TraceFlags(TraceFlags.SAMPLED),
+)
+
+
+@pytest.mark.parametrize("num_events", [1, 10, 50, 128])
+def test_read_events(benchmark, num_events):
+    provider = TracerProvider(sampler=sampling.DEFAULT_ON)
+    provider.add_span_processor(_EventsReadingProcessor())
+    t = provider.get_tracer("bench")
+
+    def benchmark_read_events():
+        span = t.start_span("benchmarkedSpan")
+        for i in range(num_events):
+            span.add_event(f"event{i}", {"k": "v"})
+        span.end()
+
+    benchmark(benchmark_read_events)
+
+
+@pytest.mark.parametrize("num_links", [1, 10, 50, 128])
+def test_read_links(benchmark, num_links):
+    provider = TracerProvider(sampler=sampling.DEFAULT_ON)
+    provider.add_span_processor(_LinksReadingProcessor())
+    t = provider.get_tracer("bench")
+
+    def benchmark_read_links():
+        span = t.start_span("benchmarkedSpan")
+        for _ in range(num_links):
+            span.add_link(_link_context)
+        span.end()
+
+    benchmark(benchmark_read_links)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -497,11 +497,11 @@ class ReadableSpan:
 
     @property
     def events(self) -> Sequence[Event]:
-        return tuple(event for event in self._events)
+        return tuple(self._events)
 
     @property
     def links(self) -> Sequence[trace_api.Link]:
-        return tuple(link for link in self._links)
+        return tuple(self._links)
 
     @property
     def resource(self) -> Resource:


### PR DESCRIPTION
# Description

A small performance improvement that doesn't impact anything else. 

## Type of change

Please delete options that are not relevant.

- [x] Small improvement

# How Has This Been Tested?

The results from running the trace benchmarks with the added tests show a median improvement over 10 runs:

| Test | Before (ns) | After (ns) | Improvement |
|---|---|---|---|
| `test_read_events[1]` | 6,351.2 | 6,029.5 | +5.1% |
| `test_read_events[10]` | 17,303.1 | 16,521.3 | +4.5% |
| `test_read_events[50]` | 64,633.7 | 61,815.9 | +4.4% |
| `test_read_events[128]` | 155,636.7 | 149,841.7 | +3.7% |
| `test_read_links[1]` | 5,866.8 | 5,464.1 | +6.9% |
| `test_read_links[10]` | 12,995.7 | 12,350.7 | +5.0% |
| `test_read_links[50]` | 43,593.6 | 42,135.1 | +3.3% |
| `test_read_links[128]` | 106,932.7 | 99,705.2 | +6.8% |


# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Benchmark tests have been added
