### PR TITLE
opentelemetry-api: remove unnecessary copy in iterator

### DIFF
--- a/.changelog/5288.changed
+++ b/.changelog/5288.changed
@@ -1,0 +1,1 @@
+opentelemetry-api: remove unnecessary copy in iterator

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -309,7 +309,7 @@ class BoundedAttributes(MutableMapping):  # type: ignore
 
     def __iter__(self):  # type: ignore
         with self._lock:
-            return iter(self._dict.copy())  # type: ignore
+            return iter(list(self._dict))  # type: ignore
 
     def __len__(self) -> int:
         return len(self._dict)

--- a/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
@@ -1,10 +1,12 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import tracemalloc
 from functools import lru_cache
 
 import pytest
 
+from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import (
     ReadableSpan,
@@ -192,3 +194,24 @@ def test_read_links(benchmark, num_links):
         span.end()
 
     benchmark(benchmark_read_links)
+
+
+@pytest.mark.parametrize("num_attrs", [1, 10, 50, 128])
+def test_bounded_attribute_iterator(benchmark, num_attrs):
+    attrs = BoundedAttributes(
+        attributes={f"key{i}": f"value{i}" for i in range(num_attrs)}
+    )
+
+    peaks = []
+    for _ in range(200):
+        tracemalloc.start()
+        list(attrs)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peaks.append(peak)
+    benchmark.extra_info["mean_alloc_bytes"] = sum(peaks) / len(peaks)
+
+    def benchmark_iter():
+        list(attrs)
+
+    benchmark(benchmark_iter)


### PR DESCRIPTION
# Description

The list of keys should be all that's needed for the iterator on a Mapping. Will rebase after https://github.com/open-telemetry/opentelemetry-python/pull/5287

## Type of change

Please delete options that are not relevant.

- [x] Small improvement

# How Has This Been Tested?

Ran benchmarks and got the following comparison:

Attrs | CPU Before (ns) | CPU After (ns) | CPU Δ | Mem Before (B) | Mem After (B) | Mem Δ
-- | -- | -- | -- | -- | -- | --
1 | 90.0 | 90.8 | +0.8% | 120 | 96 | -20.0%
10 | 131.1 | 134.0 | +2.2% | 208 | 160 | -23.1%
50 | 324.4 | 287.2 | -11.5% | 1,520 | 480 | -68.4%
128 | 656.3 | 594.0 | -9.5% | 3,264 | 1,088 | -66.7%

<br class="Apple-interchange-newline">

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Benchmark tests have been added
- [ ] Documentation has been updated
