### PR TITLE
chore: Clean up stale Python 3.10 baseline TODOs

### DIFF
--- a/opentelemetry-api/tests/metrics/test_meter.py
+++ b/opentelemetry-api/tests/metrics/test_meter.py
@@ -4,7 +4,7 @@
 
 from logging import WARNING
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from opentelemetry.metrics import Meter, NoOpMeter
 
@@ -72,9 +72,7 @@ class ChildMeter(Meter):
 
 class TestMeter(TestCase):
     # pylint: disable=no-member
-    # TODO: convert to assertNoLogs instead of mocking logger when 3.10 is baseline
-    @patch("opentelemetry.metrics._internal._logger")
-    def test_repeated_instrument_names(self, logger_mock):
+    def test_repeated_instrument_names(self):
         try:
             test_meter = NoOpMeter("name")
 
@@ -96,18 +94,24 @@ class TestMeter(TestCase):
             "histogram",
             "gauge",
         ]:
-            getattr(test_meter, f"create_{instrument_name}")(instrument_name)
-            logger_mock.warning.assert_not_called()
+            with self.assertNoLogs(
+                "opentelemetry.metrics._internal", level="WARNING"
+            ):
+                getattr(test_meter, f"create_{instrument_name}")(
+                    instrument_name
+                )
 
         for instrument_name in [
             "observable_counter",
             "observable_gauge",
             "observable_up_down_counter",
         ]:
-            getattr(test_meter, f"create_{instrument_name}")(
-                instrument_name, Mock()
-            )
-            logger_mock.warning.assert_not_called()
+            with self.assertNoLogs(
+                "opentelemetry.metrics._internal", level="WARNING"
+            ):
+                getattr(test_meter, f"create_{instrument_name}")(
+                    instrument_name, Mock()
+                )
 
     def test_repeated_instrument_names_with_different_advisory(self):
         try:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -1066,12 +1066,7 @@ class Span(trace_api.Span, ReadableSpan):
         escaped: bool = False,
     ) -> None:
         """Records an exception as a span event."""
-        # TODO: keep only exception as first argument after baseline is 3.10
-        stacktrace = "".join(
-            traceback.format_exception(
-                type(exception), value=exception, tb=exception.__traceback__
-            )
-        )
+        stacktrace = "".join(traceback.format_exception(exception))
         module = type(exception).__module__
         qualname = type(exception).__qualname__
         exception_type = (

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -578,9 +578,7 @@ class TestMeter(TestCase):
     def setUp(self):
         self.meter = Meter(Mock(), Mock())
 
-    # TODO: convert to assertNoLogs instead of mocking logger when 3.10 is baseline
-    @patch("opentelemetry.sdk.metrics._internal._logger")
-    def test_repeated_instrument_names(self, logger_mock):
+    def test_repeated_instrument_names(self):
         with self.assertNotRaises(Exception):
             self.meter.create_counter("counter")
             self.meter.create_up_down_counter("up_down_counter")
@@ -602,18 +600,24 @@ class TestMeter(TestCase):
             "histogram",
             "gauge",
         ]:
-            getattr(self.meter, f"create_{instrument_name}")(instrument_name)
-            logger_mock.warning.assert_not_called()
+            with self.assertNoLogs(
+                "opentelemetry.sdk.metrics._internal", level="WARNING"
+            ):
+                getattr(self.meter, f"create_{instrument_name}")(
+                    instrument_name
+                )
 
         for instrument_name in [
             "observable_counter",
             "observable_gauge",
             "observable_up_down_counter",
         ]:
-            getattr(self.meter, f"create_{instrument_name}")(
-                instrument_name, callbacks=[Mock()]
-            )
-            logger_mock.warning.assert_not_called()
+            with self.assertNoLogs(
+                "opentelemetry.sdk.metrics._internal", level="WARNING"
+            ):
+                getattr(self.meter, f"create_{instrument_name}")(
+                    instrument_name, callbacks=[Mock()]
+                )
 
     def test_repeated_instrument_names_with_different_advisory(self):
         with self.assertNotRaises(Exception):


### PR DESCRIPTION
The minimum Python version was bumped to 3.10, but a few TODOs guarded by that
baseline were never addressed. This PR cleans them up:

- **`opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py`**: Simplify
  `traceback.format_exception()` call to use the single-argument form available
  since Python 3.10.
- **`opentelemetry-api/tests/metrics/test_meter.py`**: Replace `@patch` logger
  mock with `assertNoLogs` (available since Python 3.10).
- **`opentelemetry-sdk/tests/metrics/test_metrics.py`**: Same `assertNoLogs`
  conversion.