### PR TITLE
opentelemetry-sdk: update iterator for BoundedList

### DIFF
--- a/.changelog/5297.changed
+++ b/.changelog/5297.changed
@@ -1,0 +1,1 @@
+opentelemetry-sdk: update iterator for BoundedList

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -307,9 +307,9 @@ class BoundedAttributes(MutableMapping):  # type: ignore
         with self._lock:
             del self._dict[key]
 
-    def __iter__(self):  # type: ignore
+    def __iter__(self):
         with self._lock:
-            return iter(list(self._dict))  # type: ignore
+            return iter(list(self._dict))
 
     def __len__(self) -> int:
         return len(self._dict)

--- a/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
@@ -8,7 +8,6 @@ import pytest
 
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.util import BoundedList
 from opentelemetry.sdk.trace import (
     ReadableSpan,
     SpanProcessor,
@@ -176,8 +175,8 @@ def test_read_events(benchmark, num_events):
     peaks = []
     for _ in range(200):
         span = tp.start_span("benchmarkedSpan")
-        for i in range(num_events):
-            span.add_event(f"event{i}", {"k": "v"})
+        for event in range(num_events):
+            span.add_event(f"event{event}", {"k": "v"})
         tracemalloc.start()
         span.end()
         _, peak = tracemalloc.get_traced_memory()

--- a/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
@@ -8,6 +8,7 @@ import pytest
 
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.util import BoundedList
 from opentelemetry.sdk.trace import (
     ReadableSpan,
     SpanProcessor,
@@ -172,6 +173,18 @@ def test_read_events(benchmark, num_events):
     provider.add_span_processor(_EventsReadingProcessor())
     tp = provider.get_tracer("bench")
 
+    peaks = []
+    for _ in range(200):
+        span = tp.start_span("benchmarkedSpan")
+        for i in range(num_events):
+            span.add_event(f"event{i}", {"k": "v"})
+        tracemalloc.start()
+        span.end()
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peaks.append(peak)
+    benchmark.extra_info["mean_alloc_bytes"] = sum(peaks) / len(peaks)
+
     def benchmark_read_events():
         span = tp.start_span("benchmarkedSpan")
         for event in range(num_events):
@@ -186,6 +199,18 @@ def test_read_links(benchmark, num_links):
     provider = TracerProvider(sampler=sampling.DEFAULT_ON)
     provider.add_span_processor(_LinksReadingProcessor())
     tp = provider.get_tracer("bench")
+
+    peaks = []
+    for _ in range(200):
+        span = tp.start_span("benchmarkedSpan")
+        for _ in range(num_links):
+            span.add_link(_link_context)
+        tracemalloc.start()
+        span.end()
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peaks.append(peak)
+    benchmark.extra_info["mean_alloc_bytes"] = sum(peaks) / len(peaks)
 
     def benchmark_read_links():
         span = tp.start_span("benchmarkedSpan")

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -63,7 +63,7 @@ class BoundedList(Sequence):
 
     def __iter__(self):
         with self._lock:
-            return iter(deque(self._dq))
+            return iter(list(self._dq))
 
     def append(self, item):
         with self._lock:


### PR DESCRIPTION
# Description

Return the list of keys instead of a copy of the BoundedList in a deque.

## Type of change

Please delete options that are not relevant.

- [x] small perf improvement

# How Has This Been Tested?

Ran the benchmark 10x and got the following output:

Type | Items | CPU Before (µs) | CPU After (µs) | CPU Δ | Mem Before (B) | Mem After (B) | Mem Δ
-- | -- | -- | -- | -- | -- | -- | --
events | 1 | 6.0 | 6.0 | -1.0% | 1,580 | 964 | -39.0%
events | 10 | 16.2 | 16.1 | -0.4% | 1,708 | 964 | -43.6%
events | 50 | 61.1 | 61.1 | -0.0% | 1,996 | 1,140 | -42.9%
events | 128 | 149.3 | 149.0 | -0.2% | 3,660 | 2,372 | -35.2%
links | 1 | 5.6 | 5.4 | -2.5% | 1,580 | 964 | -39.0%
links | 10 | 12.0 | 12.1 | +0.5% | 1,708 | 964 | -43.6%
links | 50 | 41.4 | 41.1 | -0.6% | 1,996 | 1,140 | -42.9%
links | 128 | 98.7 | 100.2 | +1.5% | 3,660 | 2,372 | -35.2%


# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Benchmark tests have been updated
- [ ] Documentation has been updated
