### PR TITLE
opentelemetry-sdk: reduce lock contention in attributes

### DIFF
--- a/.changelog/5298.changed
+++ b/.changelog/5298.changed
@@ -1,0 +1,1 @@
+opentelemetry-sdk: reduce lock contention in attributes

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -290,7 +290,7 @@ class BoundedAttributes(MutableMapping):  # type: ignore
         with self._lock:
             self._setitem_locked(key, value)
 
-    def _set_many(self, attributes: "types._ExtendedAttributes") -> None:
+    def _set_items(self, attributes: "types._ExtendedAttributes") -> None:
         if getattr(self, "_immutable", False):  # type: ignore
             raise TypeError
         if self.maxlen is not None and self.maxlen == 0:

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -278,28 +278,31 @@ class BoundedAttributes(MutableMapping):  # type: ignore
         if getattr(self, "_immutable", False):  # type: ignore
             raise TypeError
         with self._lock:
-            if self.maxlen is not None and self.maxlen == 0:
-                self.dropped += 1
+            self._setitem_locked(key, value)
+
+    def _setitem_locked(self, key: str, value: types.AnyValue) -> None:
+        if self.maxlen is not None and self.maxlen == 0:
+            self.dropped += 1
+            return
+
+        if self._extended_attributes:
+            value = _clean_extended_attribute(
+                key, value, self.max_value_len
+            )
+        else:
+            value = _clean_attribute(key, value, self.max_value_len)  # type: ignore
+            if value is None:
                 return
 
-            if self._extended_attributes:
-                value = _clean_extended_attribute(
-                    key, value, self.max_value_len
-                )
-            else:
-                value = _clean_attribute(key, value, self.max_value_len)  # type: ignore
-                if value is None:
-                    return
+        if key in self._dict:
+            del self._dict[key]
+        elif self.maxlen is not None and len(self._dict) == self.maxlen:
+            if not isinstance(self._dict, OrderedDict):
+                self._dict = OrderedDict(self._dict)
+            self._dict.popitem(last=False)  # type: ignore
+            self.dropped += 1
 
-            if key in self._dict:
-                del self._dict[key]
-            elif self.maxlen is not None and len(self._dict) == self.maxlen:
-                if not isinstance(self._dict, OrderedDict):
-                    self._dict = OrderedDict(self._dict)
-                self._dict.popitem(last=False)  # type: ignore
-                self.dropped += 1
-
-            self._dict[key] = value  # type: ignore
+        self._dict[key] = value  # type: ignore
 
     def __delitem__(self, key: str) -> None:
         if getattr(self, "_immutable", False):  # type: ignore
@@ -308,6 +311,8 @@ class BoundedAttributes(MutableMapping):  # type: ignore
             del self._dict[key]
 
     def __iter__(self):
+        if self._immutable:
+            return iter(self._dict)
         with self._lock:
             return iter(list(self._dict))
 

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -277,23 +277,40 @@ class BoundedAttributes(MutableMapping):  # type: ignore
     def __setitem__(self, key: str, value: types.AnyValue) -> None:
         if getattr(self, "_immutable", False):  # type: ignore
             raise TypeError
-        with self._lock:
-            self._setitem_locked(key, value)
-
-    def _setitem_locked(self, key: str, value: types.AnyValue) -> None:
         if self.maxlen is not None and self.maxlen == 0:
-            self.dropped += 1
+            with self._lock:
+                self.dropped += 1
             return
-
         if self._extended_attributes:
-            value = _clean_extended_attribute(
-                key, value, self.max_value_len
-            )
+            value = _clean_extended_attribute(key, value, self.max_value_len)
         else:
             value = _clean_attribute(key, value, self.max_value_len)  # type: ignore
             if value is None:
                 return
+        with self._lock:
+            self._setitem_locked(key, value)
 
+    def _set_many(self, attributes: "types._ExtendedAttributes") -> None:
+        if getattr(self, "_immutable", False):  # type: ignore
+            raise TypeError
+        if self.maxlen is not None and self.maxlen == 0:
+            with self._lock:
+                self.dropped += len(attributes)
+            return
+        cleaned = []
+        for key, value in attributes.items():
+            if self._extended_attributes:
+                cv = _clean_extended_attribute(key, value, self.max_value_len)
+            else:
+                cv = _clean_attribute(key, value, self.max_value_len)  # type: ignore
+                if cv is None:
+                    continue
+            cleaned.append((key, cv))
+        with self._lock:
+            for key, cv in cleaned:
+                self._setitem_locked(key, cv)
+
+    def _setitem_locked(self, key: str, value: types.AnyValue) -> None:
         if key in self._dict:
             del self._dict[key]
         elif self.maxlen is not None and len(self._dict) == self.maxlen:

--- a/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
@@ -293,9 +293,9 @@ def test_gil_contention_batch_processor(benchmark, num_threads):
 
     def benchmark_fn():
         threads = [threading.Thread(target=worker) for _ in range(num_threads)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
 
     benchmark(benchmark_fn)

--- a/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
+++ b/opentelemetry-sdk/benchmarks/trace/test_benchmark_trace.py
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import threading
 import tracemalloc
 from functools import lru_cache
 
@@ -17,6 +18,11 @@ from opentelemetry.sdk.trace import (
     _TracerConfig,
     sampling,
 )
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.sdk.util import BoundedList
 from opentelemetry.sdk.util.instrumentation import _scope_name_matches_glob
 from opentelemetry.trace import SpanContext, TraceFlags
 
@@ -239,3 +245,57 @@ def test_bounded_attribute_iterator(benchmark, num_attrs):
         list(attrs)
 
     benchmark(benchmark_iter)
+
+
+@pytest.mark.parametrize("num_items", [1, 10, 50, 128])
+def test_bounded_list_iterator(benchmark, num_items):
+    blist = BoundedList.from_seq(num_items, range(num_items))
+
+    peaks = []
+    for _ in range(200):
+        tracemalloc.start()
+        list(blist)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peaks.append(peak)
+    benchmark.extra_info["mean_alloc_bytes"] = sum(peaks) / len(peaks)
+
+    def benchmark_iter():
+        list(blist)
+
+    benchmark(benchmark_iter)
+
+
+# Total span work is fixed at TOTAL_SPANS regardless of thread count so that
+# ideal (GIL-free) parallelism would produce a flat wall-clock time across
+# thread counts. Any increase instead reveals GIL + lock contention.
+_TOTAL_SPANS = 128
+_ATTRS_PER_SPAN = {f"key{i}": f"value{i}" for i in range(50)}
+
+
+@pytest.mark.parametrize("num_threads", [1, 2, 4, 8])
+def test_gil_contention_batch_processor(benchmark, num_threads):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(sampler=sampling.DEFAULT_ON)
+    # max_export_batch_size=16 ensures the export threshold is crossed
+    # during the benchmark so _worker_awaken.set() contention is exercised.
+    provider.add_span_processor(
+        BatchSpanProcessor(exporter, max_export_batch_size=16)
+    )
+    tracer = provider.get_tracer("bench")
+    spans_per_thread = _TOTAL_SPANS // num_threads
+
+    def worker():
+        for _ in range(spans_per_thread):
+            span = tracer.start_span("s")
+            span.set_attributes(_ATTRS_PER_SPAN)
+            span.end()
+
+    def benchmark_fn():
+        threads = [threading.Thread(target=worker) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    benchmark(benchmark_fn)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
@@ -206,7 +206,7 @@ class BatchProcessor(Generic[Telemetry]):
             self._metrics.drop_items(1)
         # This will drop a log from the right side if the queue is at _max_queue_size.
         self._queue.appendleft(data)
-        if len(self._queue) >= self._max_export_batch_size:
+        if len(self._queue) >= self._max_export_batch_size and not self._worker_awaken.is_set():
             self._worker_awaken.set()
 
     def shutdown(self, timeout_millis: int = 30000):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
@@ -206,7 +206,10 @@ class BatchProcessor(Generic[Telemetry]):
             self._metrics.drop_items(1)
         # This will drop a log from the right side if the queue is at _max_queue_size.
         self._queue.appendleft(data)
-        if len(self._queue) >= self._max_export_batch_size and not self._worker_awaken.is_set():
+        if (
+            len(self._queue) >= self._max_export_batch_size
+            and not self._worker_awaken.is_set()
+        ):
             self._worker_awaken.set()
 
     def shutdown(self, timeout_millis: int = 30000):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -891,7 +891,7 @@ class Span(trace_api.Span, ReadableSpan):
                 logger.warning("Setting attribute on ended span.")
                 return
 
-            self._attributes._set_items(attributes) # pylint: disable=protected-access
+            self._attributes._set_items(attributes)  # pylint: disable=protected-access
 
     def set_attribute(self, key: str, value: types.AttributeValue) -> None:
         with self._lock:
@@ -989,7 +989,7 @@ class Span(trace_api.Span, ReadableSpan):
                 return
 
             self._end_time = end_time if end_time is not None else time_ns()
-            self._attributes._immutable = True # pylint: disable=protected-access
+            self._attributes._immutable = True  # pylint: disable=protected-access
 
         if self._record_end_metrics:
             self._record_end_metrics()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -891,9 +891,7 @@ class Span(trace_api.Span, ReadableSpan):
                 logger.warning("Setting attribute on ended span.")
                 return
 
-            with self._attributes._lock:
-                for key, value in attributes.items():
-                    self._attributes._setitem_locked(key, value)
+            self._attributes._set_many(attributes)
 
     def set_attribute(self, key: str, value: types.AttributeValue) -> None:
         with self._lock:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -891,8 +891,9 @@ class Span(trace_api.Span, ReadableSpan):
                 logger.warning("Setting attribute on ended span.")
                 return
 
-            for key, value in attributes.items():
-                self._attributes[key] = value
+            with self._attributes._lock:
+                for key, value in attributes.items():
+                    self._attributes._setitem_locked(key, value)
 
     def set_attribute(self, key: str, value: types.AttributeValue) -> None:
         with self._lock:
@@ -990,6 +991,7 @@ class Span(trace_api.Span, ReadableSpan):
                 return
 
             self._end_time = end_time if end_time is not None else time_ns()
+            self._attributes._immutable = True
 
         if self._record_end_metrics:
             self._record_end_metrics()

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -891,7 +891,7 @@ class Span(trace_api.Span, ReadableSpan):
                 logger.warning("Setting attribute on ended span.")
                 return
 
-            self._attributes._set_many(attributes)
+            self._attributes._set_items(attributes) # pylint: disable=protected-access
 
     def set_attribute(self, key: str, value: types.AttributeValue) -> None:
         with self._lock:
@@ -989,7 +989,7 @@ class Span(trace_api.Span, ReadableSpan):
                 return
 
             self._end_time = end_time if end_time is not None else time_ns()
-            self._attributes._immutable = True
+            self._attributes._immutable = True # pylint: disable=protected-access
 
         if self._record_end_metrics:
             self._record_end_metrics()


### PR DESCRIPTION
# Description

There are a few improvements here:
- `set_attributes` was double locking (once in `set_attributes` and once in `__setitem__`. This change updates the call to a private `_setitem_locked` for `set_attributes` once the lock has been obtained
- `__iter__` doesn't use a lock if the `BoundedAttributes`'s instantiated as immutable
- `_worker_awaken` was being set even when it's already set, adding a check in emit to avoid unnecessary calls

## Type of change

Please delete options that are not relevant.

- [x] Small performance improvements

# How Has This Been Tested?

Ran unit tests to validate functionality was still passing and ran benchmarks including a new test to try and capture GIL contention. See the results below:

Test | Before OPS | After OPS | OPS Δ | Before (ns) | After (ns) | Latency Δ | Memory before→after
-- | -- | -- | -- | -- | -- | -- | --
test_bounded_attribute_iterator[10] | 6,900,599 | 7,044,875 | +2.1% | 144.2 | 144.6 | +0.3% | 208 → 208 (+0.0%)
test_bounded_attribute_iterator[128] | 2,425,554 | 2,458,973 | +1.4% | 412.5 | 410.7 | -0.4% | 1152 → 1152 (+0.0%)
test_bounded_attribute_iterator[1] | 8,008,301 | 8,068,857 | +0.8% | 124.6 | 125.0 | +0.3% | 144 → 144 (+0.0%)
test_bounded_attribute_iterator[50] | 4,452,807 | 4,474,884 | +0.5% | 223.7 | 223.7 | +0.0% | 528 → 528 (+0.0%)
test_gil_contention_batch_processor[1] | 392 | 525 | +33.9% | 2,319,250 | 1,696,584 | -26.8% | n/a
test_gil_contention_batch_processor[2] | 379 | 506 | +33.4% | 2,343,875 | 1,722,792 | -26.5% | n/a
test_gil_contention_batch_processor[4] | 333 | 435 | +30.7% | 2,589,709 | 1,818,813 | -29.8% | n/a
test_gil_contention_batch_processor[8] | 297 | 458 | +54.2% | 2,720,563 | 2,113,458 | -22.3% | n/a
test_read_events[1] | 158,702 | 165,482 | +4.3% | 6,250 | 5,792 | -7.3% | 964 → 964 (+0.0%)
test_read_events[10] | 59,338 | 59,196 | -0.2% | 16,833 | 15,666 | -6.9% | 964 → 964 (+0.0%)
test_read_events[50] | 16,001 | 16,134 | +0.8% | 62,625 | 60,417 | -3.5% | 1140 → 1140 (+0.0%)
test_read_events[128] | 6,425 | 6,418 | -0.1% | 154,750 | 146,417 | -5.4% | 2372 → 2372 (+0.0%)
test_read_links[1] | 176,111 | 177,023 | +0.5% | 5,541 | 5,375 | -3.0% | 964 → 964 (+0.0%)
test_read_links[10] | 79,587 | 79,777 | +0.2% | 11,917 | 12,500 | +4.9% | 964 → 964 (+0.0%)
test_read_links[50] | 23,526 | 24,213 | +2.9% | 41,708 | 41,583 | -0.3% | 1140 → 1140 (+0.0%)
test_read_links[128] | 9,917 | 10,148 | +2.3% | 100,083 | 98,667 | -1.4% | 2372 → 2372 (+0.0%)
test_start_span_with_attributes[0] | 224,978 | 227,978 | +1.3% | 4,167 | 4,208 | +1.0% | n/a
test_start_span_with_attributes[1] | 199,233 | 213,340 | +7.1% | 4,875 | 4,500 | -7.7% | n/a
test_start_span_with_attributes[10] | 140,692 | 144,839 | +2.9% | 6,792 | 6,625 | -2.5% | n/a
test_start_span_with_attributes[50] | 58,161 | 59,936 | +3.1% | 17,125 | 15,958 | -6.8% | n/a
test_start_span_with_attributes[128] | 27,675 | 27,575 | -0.4% | 36,458 | 35,833 | -1.7% | n/a

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Benchmark have been added
- [ ] Documentation has been updated
