### PR TITLE
opentelemetry-test-utils: skip weaver tests on PyPy

### DIFF
--- a/tests/opentelemetry-test-utils/tests/test_weaver_live_check.py
+++ b/tests/opentelemetry-test-utils/tests/test_weaver_live_check.py
@@ -8,6 +8,7 @@ Requires the `weaver` binary on PATH:
 """
 
 import os
+import platform
 import shutil
 import unittest
 
@@ -41,6 +42,11 @@ def _make_provider(otlp_endpoint: str) -> TracerProvider:
     return provider
 
 
+@unittest.skipIf(
+    platform.python_implementation() == "PyPy",
+    "weaver tests are skipped on PyPy: the weaver binary's gRPC C core crashes with "
+    "epoll_wait EBADF under PyPy subprocesses (see issue #5176)",
+)
 @unittest.skipUnless(
     _HAS_GRPC,
     "grpc exporter not installed",
@@ -164,6 +170,11 @@ class TestSDKInitLiveCheck(unittest.TestCase):
         )
 
 
+@unittest.skipIf(
+    platform.python_implementation() == "PyPy",
+    "weaver tests are skipped on PyPy: the weaver binary's gRPC C core crashes with "
+    "epoll_wait EBADF under PyPy subprocesses (see issue #5176)",
+)
 @unittest.skipUnless(
     _HAS_GRPC,
     "grpc exporter not installed",


### PR DESCRIPTION
## Summary

Fixes #5176.

- The weaver binary's gRPC C core crashes with SIGABRT (exit code -6) on PyPy due to an `epoll_wait EBADF` error in `ev_epoll1_linux.cc`. This is a known incompatibility between gRPC's epoll1 event engine and PyPy subprocesses that cannot be fixed from the Python side.
- Skip both weaver test classes on PyPy using `@unittest.skipIf(platform.python_implementation() == "PyPy", ...)`, consistent with how other gRPC-dependent tests are already excluded from PyPy in this repo (e.g., `opencensus-shim`).

## Test plan

- [ ] Verify `pypy3-test-opentelemetry-test-utils` now shows the weaver tests as skipped rather than failing/erroring
- [ ] Verify `py312-test-opentelemetry-test-utils` (CPython) continues to run the weaver tests as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)