### PR TITLE
test(config): use file_format 1.0 in test fixtures

### DIFF
--- a/opentelemetry-sdk/tests/_configuration/file/test_env_substitution.py
+++ b/opentelemetry-sdk/tests/_configuration/file/test_env_substitution.py
@@ -119,7 +119,7 @@ line2: value2"""
             {"SERVICE_NAME": "legit-service\nmalicious_key: injected_value"},
         ):
             result = substitute_env_vars(
-                "file_format: '0.1'\nservice_name: ${SERVICE_NAME}"
+                "file_format: '1.0'\nservice_name: ${SERVICE_NAME}"
             )
         parsed = yaml.safe_load(result)
         self.assertNotIn("malicious_key", parsed)

--- a/opentelemetry-sdk/tests/_configuration/file/test_loader.py
+++ b/opentelemetry-sdk/tests/_configuration/file/test_loader.py
@@ -264,7 +264,7 @@ class TestConfigLoaderEndToEnd(unittest.TestCase):
     """
 
     _YAML = """
-file_format: '1.0-rc.1'
+file_format: '1.0'
 tracer_provider:
   processors:
     - batch:

--- a/opentelemetry-sdk/tests/_configuration/test_sdk.py
+++ b/opentelemetry-sdk/tests/_configuration/test_sdk.py
@@ -31,7 +31,7 @@ from opentelemetry.sdk._configuration.models import (
 )
 from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
 
-_MIN_CONFIG_KWARGS = {"file_format": "1.0-rc.1"}
+_MIN_CONFIG_KWARGS = {"file_format": "1.0"}
 
 
 def _config(**kwargs) -> OpenTelemetryConfiguration:


### PR DESCRIPTION
# Description

The vendored declarative-config schema has been at **v1.0.0** since #4965, but a few test fixtures still hardcoded pre-stable `file_format` strings (`1.0-rc.1`, `0.1`). The schema only validates that `file_format` is a string (not its value), so these passed — but they misleadingly imply we target a release candidate.

This updates the remaining fixtures to `1.0` so the test suite consistently reflects the stable schema version. No source or schema changes; `models.py` regeneration is not required.
