### PR TITLE
docs: add declarative configuration guide and example

### DIFF
--- a/docs/examples/declarative-config/README.rst
+++ b/docs/examples/declarative-config/README.rst
@@ -1,0 +1,96 @@
+Declarative Configuration
+=========================
+
+This example configures the OpenTelemetry SDK from a single YAML file using
+:doc:`declarative configuration </sdk/configuration>` instead of environment
+variables or hand-written provider setup.
+
+The source files of this example are available :scm_web:`here
+<docs/examples/declarative-config/>`.
+
+Install the SDK with the ``file-configuration`` extra (it pulls in ``pyyaml``
+and ``jsonschema``) along with the OTLP/HTTP exporter:
+
+.. code-block:: sh
+
+    pip install "opentelemetry-sdk[file-configuration]" \
+        opentelemetry-exporter-otlp-proto-http
+
+Start an OTLP-capable backend locally so there is somewhere to send data. Write
+the following file:
+
+.. code-block:: yaml
+
+    # otel-collector-config.yaml
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318
+
+    exporters:
+      debug:
+        verbosity: detailed
+
+    service:
+        pipelines:
+            traces:
+                receivers: [otlp]
+                exporters: [debug]
+            metrics:
+                receivers: [otlp]
+                exporters: [debug]
+            logs:
+                receivers: [otlp]
+                exporters: [debug]
+
+Then start the Collector:
+
+.. code-block:: sh
+
+    docker run \
+        -p 4318:4318 \
+        -v $(pwd)/otel-collector-config.yaml:/etc/otel-collector-config.yaml \
+        otel/opentelemetry-collector:latest \
+        --config=/etc/otel-collector-config.yaml
+
+Apply the configuration programmatically
+----------------------------------------
+
+``app.py`` loads ``otel-config.yaml`` and applies it with ``configure_sdk``:
+
+.. code-block:: python
+
+    from opentelemetry.sdk.configuration import configure_sdk, load_config_file
+
+    configure_sdk(load_config_file("otel-config.yaml"))
+
+Run it:
+
+.. code-block:: sh
+
+    python app.py
+
+You should see the exported span in the Collector's debug output.
+
+Apply the configuration with an environment variable
+----------------------------------------------------
+
+Alternatively, point the SDK at the file with ``OTEL_CONFIG_FILE`` and let
+auto-instrumentation apply it — no configuration code in your application:
+
+.. code-block:: sh
+
+    export OTEL_CONFIG_FILE=$(pwd)/otel-config.yaml
+    opentelemetry-instrument python app.py
+
+Environment variable substitution
+----------------------------------
+
+``otel-config.yaml`` uses ``${DEPLOYMENT_ENVIRONMENT:-development}`` to read the
+deployment environment from the environment, defaulting to ``development``. Set
+it before running to override:
+
+.. code-block:: sh
+
+    export DEPLOYMENT_ENVIRONMENT=staging

--- a/docs/examples/declarative-config/README.rst
+++ b/docs/examples/declarative-config/README.rst
@@ -9,11 +9,13 @@ The source files of this example are available :scm_web:`here
 <docs/examples/declarative-config/>`.
 
 Install the SDK with the ``file-configuration`` extra (it pulls in ``pyyaml``
-and ``jsonschema``) along with the OTLP/HTTP exporter:
+and ``jsonschema``), the auto-instrumentation entry point, and the OTLP/HTTP
+exporter:
 
 .. code-block:: sh
 
     pip install "opentelemetry-sdk[file-configuration]" \
+        opentelemetry-distro \
         opentelemetry-exporter-otlp-proto-http
 
 Start an OTLP-capable backend locally so there is somewhere to send data. Write
@@ -54,35 +56,18 @@ Then start the Collector:
         otel/opentelemetry-collector:latest \
         --config=/etc/otel-collector-config.yaml
 
-Apply the configuration programmatically
-----------------------------------------
+Run the example
+---------------
 
-``app.py`` loads ``otel-config.yaml`` and applies it with ``configure_sdk``:
-
-.. code-block:: python
-
-    from opentelemetry.sdk.configuration import configure_sdk, load_config_file
-
-    configure_sdk(load_config_file("otel-config.yaml"))
-
-Run it:
-
-.. code-block:: sh
-
-    python app.py
-
-You should see the exported span in the Collector's debug output.
-
-Apply the configuration with an environment variable
-----------------------------------------------------
-
-Alternatively, point the SDK at the file with ``OTEL_CONFIG_FILE`` and let
-auto-instrumentation apply it — no configuration code in your application:
+Point the SDK at ``otel-config.yaml`` with ``OTEL_CONFIG_FILE`` and let
+auto-instrumentation apply it. No configuration code lives in ``app.py``:
 
 .. code-block:: sh
 
     export OTEL_CONFIG_FILE=$(pwd)/otel-config.yaml
     opentelemetry-instrument python app.py
+
+You should see the exported span in the Collector's debug output.
 
 Environment variable substitution
 ----------------------------------

--- a/docs/examples/declarative-config/README.rst
+++ b/docs/examples/declarative-config/README.rst
@@ -1,6 +1,13 @@
 Declarative Configuration
 =========================
 
+.. note::
+
+   Declarative configuration support is new in this release and may still
+   have rough edges. If you hit a problem, please open an issue on the
+   `opentelemetry-python tracker
+   <https://github.com/open-telemetry/opentelemetry-python/issues>`_.
+
 This example configures the OpenTelemetry SDK from a single YAML file using
 :doc:`declarative configuration </sdk/configuration>` instead of environment
 variables or hand-written provider setup.

--- a/docs/examples/declarative-config/app.py
+++ b/docs/examples/declarative-config/app.py
@@ -1,20 +1,16 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Configure the OpenTelemetry SDK from a declarative configuration file.
+"""A minimal application driven by declarative configuration.
 
-Run an OTLP-capable backend (for example the OpenTelemetry Collector) on
-localhost:4318, then run this script to emit a span using the configuration
-in ``otel-config.yaml``.
+The SDK is configured entirely from ``otel-config.yaml`` via the
+``OTEL_CONFIG_FILE`` environment variable. Run with
+``opentelemetry-instrument`` so the configurator picks up the env var:
+
+    OTEL_CONFIG_FILE=$(pwd)/otel-config.yaml opentelemetry-instrument python app.py
 """
 
-from pathlib import Path
-
 from opentelemetry import trace
-from opentelemetry.sdk.configuration import configure_sdk, load_config_file
-
-config_path = Path(__file__).parent / "otel-config.yaml"
-configure_sdk(load_config_file(config_path))
 
 tracer = trace.get_tracer("declarative-config-example")
 

--- a/docs/examples/declarative-config/app.py
+++ b/docs/examples/declarative-config/app.py
@@ -1,0 +1,22 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configure the OpenTelemetry SDK from a declarative configuration file.
+
+Run an OTLP-capable backend (for example the OpenTelemetry Collector) on
+localhost:4318, then run this script to emit a span using the configuration
+in ``otel-config.yaml``.
+"""
+
+from pathlib import Path
+
+from opentelemetry import trace
+from opentelemetry.sdk.configuration import configure_sdk, load_config_file
+
+config_path = Path(__file__).parent / "otel-config.yaml"
+configure_sdk(load_config_file(config_path))
+
+tracer = trace.get_tracer("declarative-config-example")
+
+with tracer.start_as_current_span("hello"):
+    print("Hello from a declaratively configured SDK!")

--- a/docs/examples/declarative-config/otel-config.yaml
+++ b/docs/examples/declarative-config/otel-config.yaml
@@ -1,0 +1,34 @@
+file_format: "1.0"
+
+resource:
+  attributes:
+    - name: service.name
+      value: my-service
+    - name: deployment.environment.name
+      value: ${DEPLOYMENT_ENVIRONMENT:-development}
+
+tracer_provider:
+  processors:
+    - batch:
+        exporter:
+          otlp_http:
+            endpoint: http://localhost:4318/v1/traces
+  sampler:
+    parent_based:
+      root:
+        always_on: {}
+
+meter_provider:
+  readers:
+    - periodic:
+        interval: 60000
+        exporter:
+          otlp_http:
+            endpoint: http://localhost:4318/v1/metrics
+
+logger_provider:
+  processors:
+    - batch:
+        exporter:
+          otlp_http:
+            endpoint: http://localhost:4318/v1/logs

--- a/docs/sdk/configuration.rst
+++ b/docs/sdk/configuration.rst
@@ -24,34 +24,16 @@ File configuration relies on optional dependencies (``pyyaml`` and
 Enabling with an environment variable
 -------------------------------------
 
-The simplest way to use declarative configuration is to point the SDK at a
-file with the ``OTEL_CONFIG_FILE`` environment variable. When it is set, the
-file is the sole source of configuration and other ``OTEL_*`` variables are
-ignored (except where referenced inside the file — see
+Point the SDK at a file with the ``OTEL_CONFIG_FILE`` environment variable.
+When it is set, the file is the sole source of SDK construction. Spec-defined
+``OTEL_*`` variables with schema equivalents are ignored. Environment variables
+can still be read via ``${env:VAR}`` substitution inside the file (see
 `Environment variable substitution`_).
 
 .. code-block:: sh
 
     export OTEL_CONFIG_FILE=/etc/otel/otel-config.yaml
     opentelemetry-instrument python app.py
-
-Configuring programmatically
-----------------------------
-
-You can also load and apply a configuration file directly. This is useful when
-you want to construct or inspect the configuration in code:
-
-.. code-block:: python
-
-    from opentelemetry.sdk.configuration import configure_sdk, load_config_file
-
-    config = load_config_file("otel-config.yaml")
-    configure_sdk(config)
-
-``load_config_file`` parses and validates the file and returns a typed
-``OpenTelemetryConfiguration`` object; ``configure_sdk`` applies it to the
-global tracer, meter, and logger providers and the global propagator. A failure
-to read, parse, or validate the file raises ``ConfigurationError``.
 
 Example configuration
 ---------------------
@@ -113,10 +95,10 @@ Values in the file may reference environment variables, which keeps secrets
 such as API keys out of the file itself. Substitution happens before the file
 is parsed.
 
-* ``${VAR}`` — replaced with the value of ``VAR``. If ``VAR`` is unset, loading
+* ``${VAR}``: replaced with the value of ``VAR``. If ``VAR`` is unset, loading
   fails with an error.
-* ``${VAR:-default}`` — replaced with ``VAR`` if set, otherwise ``default``.
-* ``$$`` — a literal ``$``.
+* ``${VAR:-default}``: replaced with ``VAR`` if set, otherwise ``default``.
+* ``$$``: a literal ``$``.
 
 In the example above, ``${OTLP_API_KEY}`` is required, while
 ``${DEPLOYMENT_ENVIRONMENT:-development}`` falls back to ``development`` when
@@ -125,8 +107,11 @@ unset.
 Behavior notes
 --------------
 
-* When ``OTEL_CONFIG_FILE`` is set, the file is authoritative; other ``OTEL_*``
-  environment variables are not consulted.
+* When ``OTEL_CONFIG_FILE`` is set, the file is authoritative for SDK
+  construction; spec-defined ``OTEL_*`` variables with schema equivalents are
+  not consulted. Environment variables can still be read indirectly by
+  components the file enables (for example resource detectors) and via
+  ``${env:VAR}`` substitution.
 * Sections omitted from the file leave the corresponding global provider
   unset (a no-op provider), per the specification.
 * Setting ``disabled: true`` at the top level turns the SDK into a no-op.
@@ -136,4 +121,4 @@ See also
 
 * `OpenTelemetry configuration specification
   <https://opentelemetry.io/docs/specs/otel/configuration/>`_
-* :doc:`environment_variables` — the environment-variable configuration path
+* :doc:`environment_variables`: the environment-variable configuration path

--- a/docs/sdk/configuration.rst
+++ b/docs/sdk/configuration.rst
@@ -76,10 +76,10 @@ OTLP/HTTP. The source is available :scm_web:`here
         - batch:
             exporter:
               otlp_http:
-                endpoint: https://api.honeycomb.io/v1/traces
+                endpoint: https://otlp.example.com:4318/v1/traces
                 headers:
-                  - name: x-honeycomb-team
-                    value: ${HONEYCOMB_API_KEY}
+                  - name: api-key
+                    value: ${OTLP_API_KEY}
       sampler:
         parent_based:
           root:
@@ -91,20 +91,20 @@ OTLP/HTTP. The source is available :scm_web:`here
             interval: 60000
             exporter:
               otlp_http:
-                endpoint: https://api.honeycomb.io/v1/metrics
+                endpoint: https://otlp.example.com:4318/v1/metrics
                 headers:
-                  - name: x-honeycomb-team
-                    value: ${HONEYCOMB_API_KEY}
+                  - name: api-key
+                    value: ${OTLP_API_KEY}
 
     logger_provider:
       processors:
         - batch:
             exporter:
               otlp_http:
-                endpoint: https://api.honeycomb.io/v1/logs
+                endpoint: https://otlp.example.com:4318/v1/logs
                 headers:
-                  - name: x-honeycomb-team
-                    value: ${HONEYCOMB_API_KEY}
+                  - name: api-key
+                    value: ${OTLP_API_KEY}
 
 Environment variable substitution
 ----------------------------------
@@ -118,7 +118,7 @@ is parsed.
 * ``${VAR:-default}`` — replaced with ``VAR`` if set, otherwise ``default``.
 * ``$$`` — a literal ``$``.
 
-In the example above, ``${HONEYCOMB_API_KEY}`` is required, while
+In the example above, ``${OTLP_API_KEY}`` is required, while
 ``${DEPLOYMENT_ENVIRONMENT:-development}`` falls back to ``development`` when
 unset.
 

--- a/docs/sdk/configuration.rst
+++ b/docs/sdk/configuration.rst
@@ -76,7 +76,7 @@ OTLP/HTTP. The source is available :scm_web:`here
         - batch:
             exporter:
               otlp_http:
-                endpoint: https://otlp.example.com:4318/v1/traces
+                endpoint: https://example.com:4318/v1/traces
                 headers:
                   - name: api-key
                     value: ${OTLP_API_KEY}
@@ -91,7 +91,7 @@ OTLP/HTTP. The source is available :scm_web:`here
             interval: 60000
             exporter:
               otlp_http:
-                endpoint: https://otlp.example.com:4318/v1/metrics
+                endpoint: https://example.com:4318/v1/metrics
                 headers:
                   - name: api-key
                     value: ${OTLP_API_KEY}
@@ -101,7 +101,7 @@ OTLP/HTTP. The source is available :scm_web:`here
         - batch:
             exporter:
               otlp_http:
-                endpoint: https://otlp.example.com:4318/v1/logs
+                endpoint: https://example.com:4318/v1/logs
                 headers:
                   - name: api-key
                     value: ${OTLP_API_KEY}

--- a/docs/sdk/configuration.rst
+++ b/docs/sdk/configuration.rst
@@ -1,6 +1,13 @@
 Declarative Configuration
 =========================
 
+.. note::
+
+   Declarative configuration support is new in this release and may still
+   have rough edges. If you hit a problem, please open an issue on the
+   `opentelemetry-python tracker
+   <https://github.com/open-telemetry/opentelemetry-python/issues>`_.
+
 Declarative configuration lets you configure the OpenTelemetry SDK from a
 single YAML (or JSON) file instead of setting many individual ``OTEL_*``
 environment variables or writing provider-construction code by hand. The file

--- a/docs/sdk/configuration.rst
+++ b/docs/sdk/configuration.rst
@@ -1,0 +1,139 @@
+Declarative Configuration
+=========================
+
+Declarative configuration lets you configure the OpenTelemetry SDK from a
+single YAML (or JSON) file instead of setting many individual ``OTEL_*``
+environment variables or writing provider-construction code by hand. The file
+format is defined by the `OpenTelemetry configuration specification
+<https://opentelemetry.io/docs/specs/otel/configuration/>`_.
+
+A single file describes your resource, providers, processors, exporters,
+samplers, and propagators. The SDK reads the file, validates it against the
+configuration schema, and applies it globally.
+
+Installing
+----------
+
+File configuration relies on optional dependencies (``pyyaml`` and
+``jsonschema``). Install them with the ``file-configuration`` extra:
+
+.. code-block:: sh
+
+    pip install "opentelemetry-sdk[file-configuration]"
+
+Enabling with an environment variable
+-------------------------------------
+
+The simplest way to use declarative configuration is to point the SDK at a
+file with the ``OTEL_CONFIG_FILE`` environment variable. When it is set, the
+file is the sole source of configuration and other ``OTEL_*`` variables are
+ignored (except where referenced inside the file — see
+`Environment variable substitution`_).
+
+.. code-block:: sh
+
+    export OTEL_CONFIG_FILE=/etc/otel/otel-config.yaml
+    opentelemetry-instrument python app.py
+
+Configuring programmatically
+----------------------------
+
+You can also load and apply a configuration file directly. This is useful when
+you want to construct or inspect the configuration in code:
+
+.. code-block:: python
+
+    from opentelemetry.sdk.configuration import configure_sdk, load_config_file
+
+    config = load_config_file("otel-config.yaml")
+    configure_sdk(config)
+
+``load_config_file`` parses and validates the file and returns a typed
+``OpenTelemetryConfiguration`` object; ``configure_sdk`` applies it to the
+global tracer, meter, and logger providers and the global propagator. A failure
+to read, parse, or validate the file raises ``ConfigurationError``.
+
+Example configuration
+---------------------
+
+The following file configures traces, metrics, and logs to be exported over
+OTLP/HTTP. The source is available :scm_web:`here
+<docs/examples/declarative-config/>`.
+
+.. code-block:: yaml
+
+    file_format: "1.0"
+
+    resource:
+      attributes:
+        - name: service.name
+          value: my-service
+        - name: deployment.environment.name
+          value: ${DEPLOYMENT_ENVIRONMENT:-development}
+
+    tracer_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_http:
+                endpoint: https://api.honeycomb.io/v1/traces
+                headers:
+                  - name: x-honeycomb-team
+                    value: ${HONEYCOMB_API_KEY}
+      sampler:
+        parent_based:
+          root:
+            always_on: {}
+
+    meter_provider:
+      readers:
+        - periodic:
+            interval: 60000
+            exporter:
+              otlp_http:
+                endpoint: https://api.honeycomb.io/v1/metrics
+                headers:
+                  - name: x-honeycomb-team
+                    value: ${HONEYCOMB_API_KEY}
+
+    logger_provider:
+      processors:
+        - batch:
+            exporter:
+              otlp_http:
+                endpoint: https://api.honeycomb.io/v1/logs
+                headers:
+                  - name: x-honeycomb-team
+                    value: ${HONEYCOMB_API_KEY}
+
+Environment variable substitution
+----------------------------------
+
+Values in the file may reference environment variables, which keeps secrets
+such as API keys out of the file itself. Substitution happens before the file
+is parsed.
+
+* ``${VAR}`` — replaced with the value of ``VAR``. If ``VAR`` is unset, loading
+  fails with an error.
+* ``${VAR:-default}`` — replaced with ``VAR`` if set, otherwise ``default``.
+* ``$$`` — a literal ``$``.
+
+In the example above, ``${HONEYCOMB_API_KEY}`` is required, while
+``${DEPLOYMENT_ENVIRONMENT:-development}`` falls back to ``development`` when
+unset.
+
+Behavior notes
+--------------
+
+* When ``OTEL_CONFIG_FILE`` is set, the file is authoritative; other ``OTEL_*``
+  environment variables are not consulted.
+* Sections omitted from the file leave the corresponding global provider
+  unset (a no-op provider), per the specification.
+* Setting ``disabled: true`` at the top level turns the SDK into a no-op.
+
+See also
+--------
+
+* `OpenTelemetry configuration specification
+  <https://opentelemetry.io/docs/specs/otel/configuration/>`_
+* :doc:`environment_variables` — the environment-variable configuration path

--- a/docs/sdk/index.rst
+++ b/docs/sdk/index.rst
@@ -20,3 +20,4 @@ processed, and exported.
     metrics
     error_handler
     environment_variables
+    configuration


### PR DESCRIPTION
## Description

Adds user-facing documentation for declarative (file-based) configuration of the SDK, scoped to the env-var path for now. Programmatic configuration via the `opentelemetry.sdk.configuration` namespace is held until #5276 lands and will be documented in a follow-up.

- New SDK guide page `docs/sdk/configuration.rst` covering:
  - enabling via `OTEL_CONFIG_FILE` + `opentelemetry-instrument`
  - the `opentelemetry-sdk[file-configuration]` install extra
  - environment variable substitution (`${VAR}`, `${VAR:-default}`, `$$`)
  - interaction with other `OTEL_*` variables
- A runnable example under `docs/examples/declarative-config/`: a schema-1.0 `otel-config.yaml`, a plain `app.py` driven by `opentelemetry-instrument`, and a `README.rst`.

The example YAML was validated against the bundled configuration schema via the loader, and the new pages build with no Sphinx warnings.

Fixes #5308

Part of #3631.

## Type of change

- Documentation
