### PR TITLE
docs: fix PathLike warning breaking the strict docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,6 +191,9 @@ nitpick_ignore = [
         "_ExtendedAttributes",
     ),
     ("py:class", "Token"),
+    # ``from os import PathLike`` renders as the bare name ``PathLike`` in the
+    # file exporter type hints, which sphinx cannot resolve to os.PathLike.
+    ("py:class", "PathLike"),
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## Description

The file exporter added in #5207 annotates its constructors with
`path: str | PathLike[str]` using `from os import PathLike`. `sphinx_autodoc_typehints`
renders this as the bare name `PathLike`, which (under `nitpicky = True`) cannot be
resolved to `os.PathLike`. This makes the strict docs build (`sphinx-build -W`) fail:

```
WARNING: py:class reference target not found: PathLike
```

across `FileSpanExporter`, `FileMetricExporter`, and `FileLogExporter`.

This adds `("py:class", "PathLike")` to `nitpick_ignore` in `docs/conf.py`, consistent
with how the repo already handles other unresolvable stdlib/third-party targets
(`Token`, `ObjectProxy`, `Union`, etc.).

## Verification

`uv run tox -e docs` (the same `-W` build CI runs) now succeeds.

## Type of change

- Documentation / build fix