### PR TITLE
feat(config): validate declarative config file_format version

### DIFF
--- a/.changelog/5315.added
+++ b/.changelog/5315.added
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: validate the declarative config `file_format` version — reject an unsupported major version and warn on a newer minor version, per the configuration spec versioning rules

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/file/_loader.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/file/_loader.py
@@ -211,7 +211,7 @@ def _validate_file_format(data: dict) -> None:
     try:
         major = int(parts[0])
         minor = int(parts[1]) if len(parts) > 1 else 0
-    except (ValueError, IndexError) as exc:
+    except ValueError as exc:
         raise ConfigurationError(
             f"Invalid file_format '{file_format}': expected MAJOR.MINOR "
             f"version numbers"

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/file/_loader.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/file/_loader.py
@@ -33,6 +33,14 @@ except ImportError as exc:
         "Install with: pip install opentelemetry-sdk[file-configuration]"
     ) from exc
 
+# Schema version vendored in schema.json. ``file_format`` values are accepted
+# per the configuration spec's versioning rules: the major version must match,
+# and a minor version newer than the one this SDK targets is accepted with a
+# warning. See
+# https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md
+_SUPPORTED_SCHEMA_MAJOR = 1
+_SUPPORTED_SCHEMA_MINOR = 0
+
 _schema_cache: list[dict] = []
 
 
@@ -135,6 +143,7 @@ def load_config_file(
         )
 
     _validate_schema(data)
+    _validate_file_format(data)
 
     # Convert to OpenTelemetryConfiguration model
     try:
@@ -173,6 +182,55 @@ def _validate_schema(data: dict) -> None:
         raise ConfigurationError(
             f"Invalid configuration schema: {exc.message}"
         ) from exc
+
+
+def _validate_file_format(data: dict) -> None:
+    """Validate the ``file_format`` version per the configuration spec.
+
+    The spec requires implementations to fail on an unsupported major version
+    (a breaking-change boundary) and to accept, with a warning, a minor version
+    newer than the one this SDK targets. See
+    https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md
+
+    Raises:
+        ConfigurationError: If ``file_format`` is malformed or its major
+            version is not supported.
+    """
+    file_format = data.get("file_format")
+    # file_format is required and typed as a string by the schema, which is
+    # validated before this runs; guard defensively regardless.
+    if not isinstance(file_format, str):
+        raise ConfigurationError(
+            f"Invalid file_format: expected a version string, "
+            f"got {file_format!r}"
+        )
+
+    # Drop any pre-release / meta tag, e.g. "1.0-rc.2" -> "1.0".
+    version = file_format.split("-", 1)[0]
+    parts = version.split(".")
+    try:
+        major = int(parts[0])
+        minor = int(parts[1]) if len(parts) > 1 else 0
+    except (ValueError, IndexError) as exc:
+        raise ConfigurationError(
+            f"Invalid file_format '{file_format}': expected MAJOR.MINOR "
+            f"version numbers"
+        ) from exc
+
+    if major != _SUPPORTED_SCHEMA_MAJOR:
+        raise ConfigurationError(
+            f"Unsupported file_format '{file_format}': this SDK supports "
+            f"schema version {_SUPPORTED_SCHEMA_MAJOR}.x"
+        )
+
+    if minor > _SUPPORTED_SCHEMA_MINOR:
+        _logger.warning(
+            "Configuration file_format '%s' has a newer minor version than "
+            "this SDK supports (%d.%d); some settings may be ignored.",
+            file_format,
+            _SUPPORTED_SCHEMA_MAJOR,
+            _SUPPORTED_SCHEMA_MINOR,
+        )
 
 
 def _dict_to_model(data: dict[str, Any]) -> OpenTelemetryConfiguration:

--- a/opentelemetry-sdk/tests/_configuration/file/test_loader.py
+++ b/opentelemetry-sdk/tests/_configuration/file/test_loader.py
@@ -320,3 +320,50 @@ tracer_provider:
         self.assertEqual(len(processors), 1)
         self.assertIsInstance(processors[0], BatchSpanProcessor)
         self.assertIsInstance(processors[0].span_exporter, ConsoleSpanExporter)
+
+
+class TestFileFormatValidation(unittest.TestCase):
+    """Validate the file_format version per the configuration spec."""
+
+    @staticmethod
+    def _load(file_format: str) -> OpenTelemetryConfiguration:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as fh:
+            fh.write(f'file_format: "{file_format}"')
+            path = fh.name
+        try:
+            return load_config_file(path)
+        finally:
+            os.unlink(path)
+
+    def test_supported_version_is_accepted(self):
+        config = self._load("1.0")
+        self.assertEqual(config.file_format, "1.0")
+
+    def test_pre_release_meta_tag_is_accepted(self):
+        # The meta tag is stripped; "1.0-rc.2" is treated as 1.0.
+        config = self._load("1.0-rc.2")
+        self.assertEqual(config.file_format, "1.0-rc.2")
+
+    def test_newer_minor_is_accepted_with_warning(self):
+        with self.assertLogs(
+            "opentelemetry.sdk._configuration.file._loader", level="WARNING"
+        ) as logs:
+            config = self._load("1.1")
+        self.assertEqual(config.file_format, "1.1")
+        self.assertTrue(
+            any("newer minor version" in message for message in logs.output)
+        )
+
+    def test_unsupported_major_is_rejected(self):
+        for version in ("2.0", "0.4"):
+            with self.subTest(version=version):
+                with self.assertRaises(ConfigurationError) as ctx:
+                    self._load(version)
+                self.assertIn("file_format", str(ctx.exception))
+
+    def test_malformed_version_is_rejected(self):
+        with self.assertRaises(ConfigurationError) as ctx:
+            self._load("not-a-version")
+        self.assertIn("file_format", str(ctx.exception))


### PR DESCRIPTION
## Description

The vendored declarative-config schema only types `file_format` as a required string — it does not constrain the value. So the loader accepted any string (`"2.0"`, `"0.4"`, `"99"`, …) and proceeded to parse, even though the [configuration versioning spec](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md) requires implementations to **fail on an unsupported major version**.

This adds spec-aligned validation in `load_config_file`:

- Parse the `MAJOR.MINOR` version (pre-release/meta tags like `1.0-rc.2` are stripped).
- **Error** if the major version is not the one this SDK supports (currently `1.x`).
- **Warn but accept** if the minor version is newer than the schema this SDK targets (per the spec — newer minors are backward compatible).
- **Error** on a malformed version string.

This SDK currently vendors schema `1.0.0`, so `1.0` is accepted silently, `1.1` is accepted with a warning, and `0.x` / `2.x` are rejected.

Refs #3631

## Tests

Added `TestFileFormatValidation` covering supported, pre-release, newer-minor (warns), unsupported-major, and malformed versions. Full `_configuration` suite passes (299), pylint 10/10.

## Type of change

- New validation / spec conformance (experimental declarative-config feature)