### PR TITLE
fix(trace): TraceState.from_header last-wins for duplicate keys across multiple headers

### DIFF
--- a/.changelog/5316.fixed
+++ b/.changelog/5316.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-api`: fix `TraceState.from_header` to use last-wins for duplicate keys across multiple headers per W3C spec

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -393,6 +393,7 @@ class TraceState(typing.Mapping[str, str]):
         pairs = {}  # type: dict[str, str]
         for header in header_list:
             members: list[str] = re.split(_delimiter_pattern, header)
+            current_header_keys: set[str] = set()
             for member in members:
                 # empty members are valid, but no need to process further.
                 if not member:
@@ -406,9 +407,12 @@ class TraceState(typing.Mapping[str, str]):
                     return cls()
                 groups: tuple[str, ...] = match.groups()
                 key, _eq, value = groups
-                # duplicate keys are not legal in header
-                if key in pairs:
+                # duplicate keys within a single header are not legal
+                if key in current_header_keys:
                     return cls()
+                current_header_keys.add(key)
+                # per W3C spec, when the same key appears across multiple
+                # headers the last value wins
                 pairs[key] = value
         return cls(list(pairs.items()))
 

--- a/opentelemetry-api/tests/trace/test_tracestate.py
+++ b/opentelemetry-api/tests/trace/test_tracestate.py
@@ -86,6 +86,16 @@ class TestTraceContextFormat(unittest.TestCase):
         prev_first_place = entries.index(("1a-2f@foo", "bar1"))  # type: ignore
         self.assertLessEqual(foo_place, prev_first_place)
 
+    def test_from_header_duplicate_key_across_headers_last_wins(self):
+        # W3C spec: when the same key appears in multiple headers, last wins
+        state = TraceState.from_header(["vendora=value1", "vendora=value2"])
+        self.assertEqual(state.get("vendora"), "value2")
+
+    def test_from_header_duplicate_key_within_header_returns_empty(self):
+        # duplicate keys within a single header are still illegal
+        state = TraceState.from_header(["vendora=value1,vendora=value2"])
+        self.assertEqual(len(state), 0)
+
     def test_trace_contains(self):
         entries = [
             "1a-2f@foo=bar1",


### PR DESCRIPTION
## Summary

Fixes #5314.

`TraceState.from_header` takes a list of header strings because HTTP/1.1 allows the same header name to be sent multiple times. Proxies and load balancers do this regularly.

The W3C Trace Context spec ([section 3.3.1.1](https://www.w3.org/TR/trace-context/#list)) says:

> If there are duplicate list-members, all but the last MUST be ignored.

The previous code applied the single-header duplicate rule (return empty) to the multi-header case as well, silently dropping all trace context whenever a proxy split a tracestate header.

**What changed:**

- Track keys seen within the current header using a per-header set (`current_header_keys`)
- Duplicate keys within a single header still return an empty `TraceState` (unchanged behavior)
- Duplicate keys across multiple headers now keep the last value (spec-correct behavior)

## Test plan

- `test_from_header_duplicate_key_across_headers_last_wins` — verifies the fixed behavior
- `test_from_header_duplicate_key_within_header_returns_empty` — verifies single-header duplicate still returns empty
- All 12 existing tracestate tests pass
- `ruff check` and `ruff format --check` pass