### PR TITLE
opentelemetry-sdk: make 'consume_measurement' lock free

### DIFF
--- a/.changelog/5321.fixed
+++ b/.changelog/5321.fixed
@@ -1,1 +1,1 @@
-opentelemetry-sdk: make 'consume_measurment' lock free
+`opentelemetry-sdk`: make `SynchronousMeasurementConsumer.consume_measurement` lock free to avoid deadlocks

--- a/.changelog/5321.fixed
+++ b/.changelog/5321.fixed
@@ -1,0 +1,1 @@
+opentelemetry-sdk: make 'consume_measurment' lock free

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
@@ -3,7 +3,6 @@
 
 # pylint: disable=unused-import
 
-import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
 from threading import Lock
@@ -75,9 +74,10 @@ class SynchronousMeasurementConsumer(MeasurementConsumer):
                 measurement.context,
             )
         )
-        with self._lock:
-            reader_storages = weakref.WeakSet(self._reader_storages.values())
-        for reader_storage in reader_storages:
+        # `_reader_storages` is replaced (never mutated in place) by
+        # `add_metric_reader` and `remove_metric_reader`, so it is safe
+        # to iterate over without a lock.
+        for reader_storage in self._reader_storages.values():
             reader_storage.consume_measurement(
                 measurement, should_sample_exemplar
             )
@@ -139,18 +139,26 @@ class SynchronousMeasurementConsumer(MeasurementConsumer):
         self, metric_reader: "opentelemetry.sdk.metrics.MetricReader"
     ) -> None:
         """Registers a new metric reader."""
+        # Build a new mapping and swap it in atomically so that
+        # a concurrent consume_measurement never iterates a mapping
+        # that is being mutated in place.
         with self._lock:
-            self._reader_storages[metric_reader] = MetricReaderStorage(
+            new_reader_storages = dict(self._reader_storages)
+            new_reader_storages[metric_reader] = MetricReaderStorage(
                 self._sdk_config,
                 # pylint: disable-next=protected-access
                 metric_reader._instrument_class_temporality,
                 # pylint: disable-next=protected-access
                 metric_reader._instrument_class_aggregation,
             )
+            self._reader_storages = new_reader_storages
 
     def remove_metric_reader(
         self, metric_reader: "opentelemetry.sdk.metrics.MetricReader"
     ) -> None:
         """Unregisters the given metric reader."""
+        # Mutate using copy-on-write: see add_metric_reader.
         with self._lock:
-            self._reader_storages.pop(metric_reader)
+            new_reader_storages = dict(self._reader_storages)
+            new_reader_storages.pop(metric_reader)
+            self._reader_storages = new_reader_storages

--- a/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
+++ b/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
@@ -193,6 +193,31 @@ class TestSynchronousMeasurementConsumer(TestCase):
 
 
 class TestSynchronousMeasurementConsumerConcurrency(TestCase):
+    def test_consume_measurement_does_not_acquire_lock(self):
+        """consume_measurement must stay lock free on the hot path."""
+        with patch(
+            "opentelemetry.sdk.metrics._internal."
+            "measurement_consumer.MetricReaderStorage"
+        ):
+            consumer = SynchronousMeasurementConsumer(
+                SdkConfiguration(
+                    exemplar_filter=Mock(
+                        should_sample=Mock(return_value=False)
+                    ),
+                    resource=Mock(),
+                    views=Mock(),
+                ),
+                metric_readers=[Mock()],
+            )
+
+        mock_lock = MagicMock()
+        # pylint: disable-next=protected-access
+        consumer._lock = mock_lock
+
+        consumer.consume_measurement(Mock())
+
+        mock_lock.__enter__.assert_not_called()
+
     def test_concurrent_changes_to_metric_readers(self):
         timeout = 1
         failure = None
@@ -221,17 +246,8 @@ class TestSynchronousMeasurementConsumerConcurrency(TestCase):
             yield from iterable
 
         class HookedDict(dict):
-            def __iter__(self):
-                return _hooked_iter(super().__iter__())
-
-            def keys(self):
-                return _hooked_iter(super().keys())
-
             def values(self):
                 return _hooked_iter(super().values())
-
-            def items(self):
-                return _hooked_iter(super().items())
 
         with patch.object(
             consumer,
@@ -247,6 +263,7 @@ class TestSynchronousMeasurementConsumerConcurrency(TestCase):
                     failure = iteration_timeout_error
                 # pylint: disable-next=protected-access
                 consumer._reader_storages.clear()
+                mutation_done.set()
 
             # Verify that test setup works (direct mutation with no synchronization fails)
             with self.assertRaises(RuntimeError) as cm:
@@ -259,22 +276,37 @@ class TestSynchronousMeasurementConsumerConcurrency(TestCase):
             self.assertEqual(
                 "dictionary changed size during iteration", str(cm.exception)
             )
+            self.assertIsNone(failure)
+
+        # Reset the events for the second scenario
+        iteration_started.clear()
+        mutation_done.clear()
+        failure = None
+
+        with patch.object(
+            consumer,
+            "_reader_storages",
+            # pylint: disable-next=protected-access
+            HookedDict(consumer._reader_storages),
+        ):
 
             def add_and_remove_readers():
-                """Modifies _reader_storages after iteration starts"""
+                """Mutate via the public API while consume_measurement runs"""
                 nonlocal failure
                 if not iteration_started.wait(timeout):
                     failure = iteration_timeout_error
                 reader = MagicMock()
                 consumer.add_metric_reader(reader)
                 consumer.remove_metric_reader(reader)
+                mutation_done.set()
 
-            # Verify the API calls do not attempt concurrent modification of reader storages
+            # The copy-on-write API never mutates the mapping being
+            # iterated, so `consume_measurement` completes without raising even
+            # though add/remove run concurrently mid-iteration.
             t = Thread(target=add_and_remove_readers)
             t.start()
             try:
-                consumer.add_metric_reader(MagicMock())
                 consumer.consume_measurement(MagicMock())
             finally:
                 t.join()
-            self.assertEqual(mutation_timeout_error, failure)
+            self.assertIsNone(failure)


### PR DESCRIPTION
# Description

This PR fixes a deadlock scenario with `consume_measurement()` in `SynchronousMeasurementConsumer` by changing `_reader_storages` to use COW semantics. 

The original PR #4863 also introduced a significant performance regression as seen in the benchmarks here: https://opentelemetry.io/docs/languages/python/benchmarks/ 

This fix brings the performance close to the performance before these changes were introduced:
```
  ┌───────────────────────────────────────────────────────────────────────┬──────────────┬───────────┬────────┬─────────┐
  │                               Benchmark                               │ without (ns) │ with (ns) │ change │ speedup │
  ├───────────────────────────────────────────────────────────────────────┼──────────────┼───────────┼────────┼─────────┤
  │ test_counter_add[0-cumulative]                                        │         2167 │      1208 │ −44.3% │   1.79× │
  ├───────────────────────────────────────────────────────────────────────┼──────────────┼───────────┼────────┼─────────┤
  │ test_counter_add[10-cumulative]                                       │         2458 │      1500 │ −39.0% │   1.64× │
  ├───────────────────────────────────────────────────────────────────────┼──────────────┼───────────┼────────┼─────────┤
  │ test_counter_add[0-delta]                                             │         2167 │      1208 │ −44.3% │   1.79× │
  ├───────────────────────────────────────────────────────────────────────┼──────────────┼───────────┼────────┼─────────┤
  │ test_counter_add[10-delta]                                            │         2458 │      1500 │ −39.0% │   1.64× │
  ├───────────────────────────────────────────────────────────────────────┼──────────────┼───────────┼────────┼─────────┤
  │ test_up_down_counter_add[0]                                           │         2125 │      1208 │ −43.2% │   1.76× │
  ├───────────────────────────────────────────────────────────────────────┼──────────────┼───────────┼────────┼─────────┤
  │ test_up_down_counter_add[10]                                          │         2458 │      1500 │ −39.0% │   1.64× │
  ├───────────────────────────────────────────────────────────────────────┼──────────────┼───────────┼────────┼─────────┤
  │ test_counter_add_with_meter_configurator_rules[1]                     │         2167 │      1208 │ −44.3% │   1.79× │
  ├───────────────────────────────────────────────────────────────────────┼──────────────┼───────────┼────────┼─────────┤

```

Fixes #5313

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```bash
uv run tox -e py314t-test-opentelemetry-sdk
```

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
