### PR TITLE
opentelemetry-sdk: merge doesn't need a copy, dict already does this

### DIFF
--- a/.changelog/5326.changed
+++ b/.changelog/5326.changed
@@ -1,0 +1,1 @@
+opentelemetry-sdk: merge doesn't need a copy, dict already does this

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -227,7 +227,7 @@ class Resource:
         Returns:
             The newly-created Resource.
         """
-        merged_attributes = dict(self.attributes).copy()
+        merged_attributes = dict(self.attributes)
         merged_attributes.update(other.attributes)
 
         if self.schema_url == "":


### PR DESCRIPTION
# Description

Removing a call to .copy() in the merge function as it is unnecessary.

## Type of change

Please delete options that are not relevant.

- [x] Small improvement

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran existing tests

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] ~Unit tests have been added~
- [ ] Documentation has been updated
