### PR TITLE
fix: support sequence metric attributes in view aggregation keys

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/_view_instrument_match.py
@@ -19,6 +19,8 @@ from opentelemetry.sdk.metrics._internal.instrument import _Instrument
 from opentelemetry.sdk.metrics._internal.measurement import Measurement
 from opentelemetry.sdk.metrics._internal.point import DataPointT
 from opentelemetry.sdk.metrics._internal.view import View
+from opentelemetry.sdk.util import get_dict_as_key
+from opentelemetry.util.types import AttributesAsKey
 
 _logger = getLogger(__name__)
 
@@ -32,7 +34,7 @@ class _ViewInstrumentMatch:
     ):
         self._view = view
         self._instrument = instrument
-        self._attributes_aggregation: dict[frozenset, _Aggregation] = {}
+        self._attributes_aggregation: dict[AttributesAsKey, _Aggregation] = {}
         self._lock = Lock()
         self._instrument_class_aggregation = instrument_class_aggregation
         self._name = self._view._name or self._instrument.name
@@ -98,7 +100,7 @@ class _ViewInstrumentMatch:
         else:
             attributes = {}
 
-        aggr_key = frozenset(attributes.items())
+        aggr_key = get_dict_as_key(attributes)
 
         if aggr_key not in self._attributes_aggregation:
             with self._lock:

--- a/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/util/__init__.py
@@ -24,7 +24,10 @@ def get_dict_as_key(labels):
         sorted(
             map(
                 lambda kv: (
-                    (kv[0], tuple(kv[1])) if isinstance(kv[1], list) else kv
+                    (kv[0], tuple(kv[1]))
+                    if isinstance(kv[1], Sequence)
+                    and not isinstance(kv[1], (str, bytes))
+                    else kv
                 ),
                 labels.items(),
             )

--- a/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
+++ b/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
@@ -37,6 +37,7 @@ from opentelemetry.sdk.metrics.view import (
     LastValueAggregation,
     View,
 )
+from opentelemetry.sdk.util import get_dict_as_key
 
 
 def generalized_reservoir_factory(
@@ -101,7 +102,7 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         )
         self.assertEqual(
             view_instrument_match._attributes_aggregation,
-            {frozenset([("c", "d")]): self.mock_created_aggregation},
+            {get_dict_as_key({"c": "d"}): self.mock_created_aggregation},
         )
 
         view_instrument_match.consume_measurement(
@@ -117,8 +118,8 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         self.assertEqual(
             view_instrument_match._attributes_aggregation,
             {
-                frozenset(): self.mock_created_aggregation,
-                frozenset([("c", "d")]): self.mock_created_aggregation,
+                get_dict_as_key({}): self.mock_created_aggregation,
+                get_dict_as_key({"c": "d"}): self.mock_created_aggregation,
             },
         )
 
@@ -147,8 +148,8 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         self.assertEqual(
             view_instrument_match._attributes_aggregation,
             {
-                frozenset(
-                    [("c", "d"), ("f", "g")]
+                get_dict_as_key(
+                    {"c": "d", "f": "g"}
                 ): self.mock_created_aggregation
             },
         )
@@ -178,7 +179,7 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         )
         self.assertEqual(
             view_instrument_match._attributes_aggregation,
-            {frozenset({}): self.mock_created_aggregation},
+            {get_dict_as_key({}): self.mock_created_aggregation},
         )
 
         # Test that a drop aggregation is handled in the same way as any
@@ -207,7 +208,7 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
             )
         )
         self.assertIsInstance(
-            view_instrument_match._attributes_aggregation[frozenset({})],
+            view_instrument_match._attributes_aggregation[get_dict_as_key({})],
             _DropAggregation,
         )
 
@@ -296,6 +297,53 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
         number_data_points = list(number_data_points)
         self.assertEqual(len(number_data_points), 1)
         self.assertEqual(number_data_points[0].attributes, {"key": "original"})
+
+    def test_consume_measurement_with_sequence_attributes(self):
+        instrument1 = _Counter(
+            "instrument1",
+            Mock(),
+            Mock(),
+            description="description",
+            unit="unit",
+        )
+        instrument1.instrumentation_scope = self.mock_instrumentation_scope
+        view_instrument_match = _ViewInstrumentMatch(
+            view=View(
+                instrument_name="instrument1",
+                name="name",
+                aggregation=DefaultAggregation(),
+            ),
+            instrument=instrument1,
+            instrument_class_aggregation=MagicMock(
+                **{"__getitem__.return_value": DefaultAggregation()}
+            ),
+        )
+
+        attributes = {
+            "list_attr": ["value"],
+            "tuple_attr": ("another", "value"),
+        }
+        view_instrument_match.consume_measurement(
+            Measurement(
+                value=1,
+                time_unix_nano=time_ns(),
+                instrument=instrument1,
+                context=Context(),
+                attributes=attributes,
+            )
+        )
+
+        self.assertIn(
+            get_dict_as_key(attributes),
+            view_instrument_match._attributes_aggregation,
+        )
+
+        number_data_points = view_instrument_match.collect(
+            AggregationTemporality.CUMULATIVE, 0
+        )
+        number_data_points = list(number_data_points)
+        self.assertEqual(len(number_data_points), 1)
+        self.assertEqual(number_data_points[0].attributes, attributes)
 
     @patch(
         "opentelemetry.sdk.metrics._internal._view_instrument_match.time_ns",
@@ -515,7 +563,7 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
 
         self.assertIsInstance(
             view_instrument_match._attributes_aggregation[
-                frozenset({("c", "d")})
+                get_dict_as_key({"c": "d"})
             ],
             _LastValueAggregation,
         )


### PR DESCRIPTION
Fixes #3750.

## Summary
- Use the SDK's attribute-key helper for metric view aggregation keys instead of `frozenset(attributes.items())`.
- Normalize sequence-valued attributes to tuples for the private aggregation key while preserving the original datapoint attributes.
- Broaden the existing `get_dict_as_key` helper from `list` values to non-string sequence values.
- Add a regression test for list and tuple metric attributes.

## Evidence
- `.tox\\py312-test-opentelemetry-sdk\\Scripts\\pytest.exe opentelemetry-sdk\\tests\\metrics\\test_view_instrument_match.py -q` passed: `11 passed`.
- `uv run ruff check opentelemetry-sdk\\src\\opentelemetry\\sdk\\metrics\\_internal\\_view_instrument_match.py opentelemetry-sdk\\src\\opentelemetry\\sdk\\util\\__init__.py opentelemetry-sdk\\tests\\metrics\\test_view_instrument_match.py` passed.
- `.tox\\lint-opentelemetry-sdk\\Scripts\\pylint.exe opentelemetry-sdk\\src\\opentelemetry\\sdk\\metrics\\_internal\\_view_instrument_match.py opentelemetry-sdk\\src\\opentelemetry\\sdk\\util\\__init__.py opentelemetry-sdk\\tests\\metrics\\test_view_instrument_match.py` passed: `10.00/10`.
- Earlier full SDK tox run for this branch with `uv run tox -e py312-test-opentelemetry-sdk -- opentelemetry-sdk/tests/metrics/test_view_instrument_match.py` passed: `1098 passed, 13 skipped`.
- `git diff --check` passed.