### PR TITLE
feat(config): wire top-level log_level field in declarative configuration

### DIFF
--- a/.changelog/5351.added
+++ b/.changelog/5351.added
@@ -1,1 +1,1 @@
-`opentelemetry-sdk`: wire the top-level `log_level` field in declarative configuration — when set, maps the OTel `SeverityNumber` value to a Python logging level and applies it to the `opentelemetry` root logger so SDK internal diagnostics respect the configured severity.
+`opentelemetry-sdk`: wire the top-level `log_level` field in declarative configuration — when set, maps the OTel `SeverityNumber` value to a Python logging level and applies it to the `opentelemetry` logger so SDK internal diagnostics respect the configured severity.

--- a/.changelog/5351.added
+++ b/.changelog/5351.added
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: wire the top-level `log_level` field in declarative configuration — when set, maps the OTel `SeverityNumber` value to a Python logging level and applies it to the `opentelemetry` root logger so SDK internal diagnostics respect the configured severity.

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
@@ -75,6 +75,9 @@ def configure_sdk(config: OpenTelemetryConfiguration) -> None:
     behavior.
 
     Honors the top-level ``disabled`` flag: when true, no globals are set.
+    The ``log_level`` field, when present, is applied to the internal
+    ``opentelemetry`` logger regardless of ``disabled`` — it configures
+    SDK self-diagnostics, not telemetry emission.
 
     Args:
         config: Parsed ``OpenTelemetryConfiguration`` (typically from
@@ -87,15 +90,15 @@ def configure_sdk(config: OpenTelemetryConfiguration) -> None:
         >>> config = load_config_file("otel-config.yaml")
         >>> configure_sdk(config)
     """
+    if config.log_level is not None:
+        level = _SEVERITY_TO_LOGGING_LEVEL.get(config.log_level, logging.INFO)
+        logging.getLogger("opentelemetry").setLevel(level)
+
     if config.disabled:
         _logger.warning(
             "Declarative configuration has disabled=true; skipping SDK setup."
         )
         return
-
-    if config.log_level is not None:
-        level = _SEVERITY_TO_LOGGING_LEVEL.get(config.log_level, logging.INFO)
-        logging.getLogger("opentelemetry").setLevel(level)
 
     resource = create_resource(config.resource)
     configure_tracer_provider(config.tracer_provider, resource)

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
@@ -26,9 +26,42 @@ from opentelemetry.configuration._tracer_provider import (
 from opentelemetry.configuration.instrumentation import (
     configure_instrumentation,
 )
-from opentelemetry.configuration.models import OpenTelemetryConfiguration
+from opentelemetry.configuration.models import (
+    OpenTelemetryConfiguration,
+    SeverityNumber,
+)
 
 _logger = getLogger(__name__)
+
+# Maps OTel SeverityNumber groups to Python logging levels.
+# The numbered variants (debug2, info3, …) are sub-levels within the same
+# Python tier, so they collapse to the same level constant.
+_SEVERITY_TO_LOGGING_LEVEL: dict[SeverityNumber, int] = {
+    SeverityNumber.trace: logging.DEBUG,
+    SeverityNumber.trace2: logging.DEBUG,
+    SeverityNumber.trace3: logging.DEBUG,
+    SeverityNumber.trace4: logging.DEBUG,
+    SeverityNumber.debug: logging.DEBUG,
+    SeverityNumber.debug2: logging.DEBUG,
+    SeverityNumber.debug3: logging.DEBUG,
+    SeverityNumber.debug4: logging.DEBUG,
+    SeverityNumber.info: logging.INFO,
+    SeverityNumber.info2: logging.INFO,
+    SeverityNumber.info3: logging.INFO,
+    SeverityNumber.info4: logging.INFO,
+    SeverityNumber.warn: logging.WARNING,
+    SeverityNumber.warn2: logging.WARNING,
+    SeverityNumber.warn3: logging.WARNING,
+    SeverityNumber.warn4: logging.WARNING,
+    SeverityNumber.error: logging.ERROR,
+    SeverityNumber.error2: logging.ERROR,
+    SeverityNumber.error3: logging.ERROR,
+    SeverityNumber.error4: logging.ERROR,
+    SeverityNumber.fatal: logging.CRITICAL,
+    SeverityNumber.fatal2: logging.CRITICAL,
+    SeverityNumber.fatal3: logging.CRITICAL,
+    SeverityNumber.fatal4: logging.CRITICAL,
+}
 
 
 def configure_sdk(config: OpenTelemetryConfiguration) -> None:
@@ -59,6 +92,10 @@ def configure_sdk(config: OpenTelemetryConfiguration) -> None:
             "Declarative configuration has disabled=true; skipping SDK setup."
         )
         return
+
+    if config.log_level is not None:
+        level = _SEVERITY_TO_LOGGING_LEVEL[config.log_level]
+        logging.getLogger("opentelemetry").setLevel(level)
 
     resource = create_resource(config.resource)
     configure_tracer_provider(config.tracer_provider, resource)

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
@@ -10,7 +10,7 @@ entry point for "apply this config" on the declarative path.
 
 from __future__ import annotations
 
-from logging import getLogger
+from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING, getLogger
 
 from opentelemetry.configuration._logger_provider import (
     configure_logger_provider,
@@ -37,30 +37,30 @@ _logger = getLogger(__name__)
 # The numbered variants (debug2, info3, …) are sub-levels within the same
 # Python tier, so they collapse to the same level constant.
 _SEVERITY_TO_LOGGING_LEVEL: dict[SeverityNumber, int] = {
-    SeverityNumber.trace: logging.DEBUG,
-    SeverityNumber.trace2: logging.DEBUG,
-    SeverityNumber.trace3: logging.DEBUG,
-    SeverityNumber.trace4: logging.DEBUG,
-    SeverityNumber.debug: logging.DEBUG,
-    SeverityNumber.debug2: logging.DEBUG,
-    SeverityNumber.debug3: logging.DEBUG,
-    SeverityNumber.debug4: logging.DEBUG,
-    SeverityNumber.info: logging.INFO,
-    SeverityNumber.info2: logging.INFO,
-    SeverityNumber.info3: logging.INFO,
-    SeverityNumber.info4: logging.INFO,
-    SeverityNumber.warn: logging.WARNING,
-    SeverityNumber.warn2: logging.WARNING,
-    SeverityNumber.warn3: logging.WARNING,
-    SeverityNumber.warn4: logging.WARNING,
-    SeverityNumber.error: logging.ERROR,
-    SeverityNumber.error2: logging.ERROR,
-    SeverityNumber.error3: logging.ERROR,
-    SeverityNumber.error4: logging.ERROR,
-    SeverityNumber.fatal: logging.CRITICAL,
-    SeverityNumber.fatal2: logging.CRITICAL,
-    SeverityNumber.fatal3: logging.CRITICAL,
-    SeverityNumber.fatal4: logging.CRITICAL,
+    SeverityNumber.trace: DEBUG,
+    SeverityNumber.trace2: DEBUG,
+    SeverityNumber.trace3: DEBUG,
+    SeverityNumber.trace4: DEBUG,
+    SeverityNumber.debug: DEBUG,
+    SeverityNumber.debug2: DEBUG,
+    SeverityNumber.debug3: DEBUG,
+    SeverityNumber.debug4: DEBUG,
+    SeverityNumber.info: INFO,
+    SeverityNumber.info2: INFO,
+    SeverityNumber.info3: INFO,
+    SeverityNumber.info4: INFO,
+    SeverityNumber.warn: WARNING,
+    SeverityNumber.warn2: WARNING,
+    SeverityNumber.warn3: WARNING,
+    SeverityNumber.warn4: WARNING,
+    SeverityNumber.error: ERROR,
+    SeverityNumber.error2: ERROR,
+    SeverityNumber.error3: ERROR,
+    SeverityNumber.error4: ERROR,
+    SeverityNumber.fatal: CRITICAL,
+    SeverityNumber.fatal2: CRITICAL,
+    SeverityNumber.fatal3: CRITICAL,
+    SeverityNumber.fatal4: CRITICAL,
 }
 
 
@@ -91,8 +91,8 @@ def configure_sdk(config: OpenTelemetryConfiguration) -> None:
         >>> configure_sdk(config)
     """
     if config.log_level is not None:
-        level = _SEVERITY_TO_LOGGING_LEVEL.get(config.log_level, logging.INFO)
-        logging.getLogger("opentelemetry").setLevel(level)
+        level = _SEVERITY_TO_LOGGING_LEVEL.get(config.log_level, INFO)
+        getLogger("opentelemetry").setLevel(level)
 
     if config.disabled:
         _logger.warning(

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
@@ -94,7 +94,7 @@ def configure_sdk(config: OpenTelemetryConfiguration) -> None:
         return
 
     if config.log_level is not None:
-        level = _SEVERITY_TO_LOGGING_LEVEL[config.log_level]
+        level = _SEVERITY_TO_LOGGING_LEVEL.get(config.log_level, logging.INFO)
         logging.getLogger("opentelemetry").setLevel(level)
 
     resource = create_resource(config.resource)

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
@@ -74,10 +74,10 @@ def configure_sdk(config: OpenTelemetryConfiguration) -> None:
     corresponding global untouched — matching the spec's "noop default"
     behavior.
 
-    Honors the top-level ``disabled`` flag: when true, no globals are set.
-    The ``log_level`` field, when present, is applied to the internal
-    ``opentelemetry`` logger regardless of ``disabled`` — it configures
-    SDK self-diagnostics, not telemetry emission.
+    Honors the top-level ``disabled`` flag: when true, the function returns
+    early without setting any globals. The ``log_level`` field, when present
+    and not disabled, is applied to the internal ``opentelemetry`` logger to
+    control the verbosity of SDK self-diagnostics.
 
     Args:
         config: Parsed ``OpenTelemetryConfiguration`` (typically from

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
@@ -90,15 +90,15 @@ def configure_sdk(config: OpenTelemetryConfiguration) -> None:
         >>> config = load_config_file("otel-config.yaml")
         >>> configure_sdk(config)
     """
-    if config.log_level is not None:
-        level = _SEVERITY_TO_LOGGING_LEVEL.get(config.log_level, INFO)
-        getLogger("opentelemetry").setLevel(level)
-
     if config.disabled:
         _logger.warning(
             "Declarative configuration has disabled=true; skipping SDK setup."
         )
         return
+
+    if config.log_level is not None:
+        level = _SEVERITY_TO_LOGGING_LEVEL.get(config.log_level, INFO)
+        getLogger("opentelemetry").setLevel(level)
 
     resource = create_resource(config.resource)
     configure_tracer_provider(config.tracer_provider, resource)

--- a/opentelemetry-configuration/tests/test_sdk.py
+++ b/opentelemetry-configuration/tests/test_sdk.py
@@ -4,12 +4,14 @@
 # Tests access private members of SDK classes to assert correct configuration.
 # pylint: disable=protected-access
 
+import logging
 import unittest
 from unittest.mock import patch
 
 from opentelemetry.configuration._sdk import configure_sdk
 from opentelemetry.configuration.models import (
     OpenTelemetryConfiguration,
+    SeverityNumber,
 )
 from opentelemetry.configuration.models import (
     Propagator as PropagatorConfig,
@@ -120,6 +122,66 @@ class TestConfigureSdk(unittest.TestCase):
         self.assertEqual(mock_meter.call_args.args[0], None)
         self.assertEqual(mock_logger.call_args.args[0], None)
         self.assertEqual(mock_propagator.call_args.args[0], None)
+
+
+class TestConfigureSdkLogLevel(unittest.TestCase):
+    def setUp(self):
+        # Reset the opentelemetry logger level before each test.
+        logging.getLogger("opentelemetry").setLevel(logging.NOTSET)
+
+    def tearDown(self):
+        logging.getLogger("opentelemetry").setLevel(logging.NOTSET)
+
+    @patch("opentelemetry.sdk._configuration._sdk.configure_propagator")
+    @patch("opentelemetry.sdk._configuration._sdk.configure_logger_provider")
+    @patch("opentelemetry.sdk._configuration._sdk.configure_meter_provider")
+    @patch("opentelemetry.sdk._configuration._sdk.configure_tracer_provider")
+    @patch("opentelemetry.sdk._configuration._sdk.create_resource")
+    def test_sets_opentelemetry_logger_level(self, *_mocks):
+        configure_sdk(_config(log_level=SeverityNumber.warn))
+        self.assertEqual(
+            logging.getLogger("opentelemetry").level, logging.WARNING
+        )
+
+    @patch("opentelemetry.sdk._configuration._sdk.configure_propagator")
+    @patch("opentelemetry.sdk._configuration._sdk.configure_logger_provider")
+    @patch("opentelemetry.sdk._configuration._sdk.configure_meter_provider")
+    @patch("opentelemetry.sdk._configuration._sdk.configure_tracer_provider")
+    @patch("opentelemetry.sdk._configuration._sdk.create_resource")
+    def test_absent_log_level_leaves_logger_unchanged(self, *_mocks):
+        logging.getLogger("opentelemetry").setLevel(logging.ERROR)
+        configure_sdk(_config())
+        self.assertEqual(
+            logging.getLogger("opentelemetry").level, logging.ERROR
+        )
+
+    @patch("opentelemetry.sdk._configuration._sdk.configure_propagator")
+    @patch("opentelemetry.sdk._configuration._sdk.configure_logger_provider")
+    @patch("opentelemetry.sdk._configuration._sdk.configure_meter_provider")
+    @patch("opentelemetry.sdk._configuration._sdk.configure_tracer_provider")
+    @patch("opentelemetry.sdk._configuration._sdk.create_resource")
+    def test_severity_number_variants_map_correctly(self, *_mocks):
+        cases = [
+            (SeverityNumber.trace, logging.DEBUG),
+            (SeverityNumber.trace4, logging.DEBUG),
+            (SeverityNumber.debug, logging.DEBUG),
+            (SeverityNumber.debug4, logging.DEBUG),
+            (SeverityNumber.info, logging.INFO),
+            (SeverityNumber.info4, logging.INFO),
+            (SeverityNumber.warn, logging.WARNING),
+            (SeverityNumber.warn4, logging.WARNING),
+            (SeverityNumber.error, logging.ERROR),
+            (SeverityNumber.error4, logging.ERROR),
+            (SeverityNumber.fatal, logging.CRITICAL),
+            (SeverityNumber.fatal4, logging.CRITICAL),
+        ]
+        for severity, expected_level in cases:
+            with self.subTest(severity=severity):
+                configure_sdk(_config(log_level=severity))
+                self.assertEqual(
+                    logging.getLogger("opentelemetry").level,
+                    expected_level,
+                )
 
 
 class TestConfigureSdkIntegration(unittest.TestCase):

--- a/opentelemetry-configuration/tests/test_sdk.py
+++ b/opentelemetry-configuration/tests/test_sdk.py
@@ -126,11 +126,13 @@ class TestConfigureSdk(unittest.TestCase):
 
 class TestConfigureSdkLogLevel(unittest.TestCase):
     def setUp(self):
-        # Reset the opentelemetry logger level before each test.
-        logging.getLogger("opentelemetry").setLevel(logging.NOTSET)
+        # Preserve whatever level was set before this test so we can
+        # restore it in tearDown, keeping tests isolated from each other
+        # and from the ambient logging configuration.
+        self._original_level = logging.getLogger("opentelemetry").level
 
     def tearDown(self):
-        logging.getLogger("opentelemetry").setLevel(logging.NOTSET)
+        logging.getLogger("opentelemetry").setLevel(self._original_level)
 
     @patch("opentelemetry.sdk._configuration._sdk.configure_propagator")
     @patch("opentelemetry.sdk._configuration._sdk.configure_logger_provider")
@@ -163,16 +165,28 @@ class TestConfigureSdkLogLevel(unittest.TestCase):
     def test_severity_number_variants_map_correctly(self, *_mocks):
         cases = [
             (SeverityNumber.trace, logging.DEBUG),
+            (SeverityNumber.trace2, logging.DEBUG),
+            (SeverityNumber.trace3, logging.DEBUG),
             (SeverityNumber.trace4, logging.DEBUG),
             (SeverityNumber.debug, logging.DEBUG),
+            (SeverityNumber.debug2, logging.DEBUG),
+            (SeverityNumber.debug3, logging.DEBUG),
             (SeverityNumber.debug4, logging.DEBUG),
             (SeverityNumber.info, logging.INFO),
+            (SeverityNumber.info2, logging.INFO),
+            (SeverityNumber.info3, logging.INFO),
             (SeverityNumber.info4, logging.INFO),
             (SeverityNumber.warn, logging.WARNING),
+            (SeverityNumber.warn2, logging.WARNING),
+            (SeverityNumber.warn3, logging.WARNING),
             (SeverityNumber.warn4, logging.WARNING),
             (SeverityNumber.error, logging.ERROR),
+            (SeverityNumber.error2, logging.ERROR),
+            (SeverityNumber.error3, logging.ERROR),
             (SeverityNumber.error4, logging.ERROR),
             (SeverityNumber.fatal, logging.CRITICAL),
+            (SeverityNumber.fatal2, logging.CRITICAL),
+            (SeverityNumber.fatal3, logging.CRITICAL),
             (SeverityNumber.fatal4, logging.CRITICAL),
         ]
         for severity, expected_level in cases:
@@ -182,6 +196,12 @@ class TestConfigureSdkLogLevel(unittest.TestCase):
                     logging.getLogger("opentelemetry").level,
                     expected_level,
                 )
+
+    def test_log_level_applies_even_when_disabled(self):
+        configure_sdk(_config(disabled=True, log_level=SeverityNumber.error))
+        self.assertEqual(
+            logging.getLogger("opentelemetry").level, logging.ERROR
+        )
 
 
 class TestConfigureSdkIntegration(unittest.TestCase):

--- a/opentelemetry-configuration/tests/test_sdk.py
+++ b/opentelemetry-configuration/tests/test_sdk.py
@@ -134,22 +134,22 @@ class TestConfigureSdkLogLevel(unittest.TestCase):
     def tearDown(self):
         logging.getLogger("opentelemetry").setLevel(self._original_level)
 
-    @patch("opentelemetry.sdk._configuration._sdk.configure_propagator")
-    @patch("opentelemetry.sdk._configuration._sdk.configure_logger_provider")
-    @patch("opentelemetry.sdk._configuration._sdk.configure_meter_provider")
-    @patch("opentelemetry.sdk._configuration._sdk.configure_tracer_provider")
-    @patch("opentelemetry.sdk._configuration._sdk.create_resource")
+    @patch("opentelemetry.configuration._sdk.configure_propagator")
+    @patch("opentelemetry.configuration._sdk.configure_logger_provider")
+    @patch("opentelemetry.configuration._sdk.configure_meter_provider")
+    @patch("opentelemetry.configuration._sdk.configure_tracer_provider")
+    @patch("opentelemetry.configuration._sdk.create_resource")
     def test_sets_opentelemetry_logger_level(self, *_mocks):
         configure_sdk(_config(log_level=SeverityNumber.warn))
         self.assertEqual(
             logging.getLogger("opentelemetry").level, logging.WARNING
         )
 
-    @patch("opentelemetry.sdk._configuration._sdk.configure_propagator")
-    @patch("opentelemetry.sdk._configuration._sdk.configure_logger_provider")
-    @patch("opentelemetry.sdk._configuration._sdk.configure_meter_provider")
-    @patch("opentelemetry.sdk._configuration._sdk.configure_tracer_provider")
-    @patch("opentelemetry.sdk._configuration._sdk.create_resource")
+    @patch("opentelemetry.configuration._sdk.configure_propagator")
+    @patch("opentelemetry.configuration._sdk.configure_logger_provider")
+    @patch("opentelemetry.configuration._sdk.configure_meter_provider")
+    @patch("opentelemetry.configuration._sdk.configure_tracer_provider")
+    @patch("opentelemetry.configuration._sdk.create_resource")
     def test_absent_log_level_leaves_logger_unchanged(self, *_mocks):
         logging.getLogger("opentelemetry").setLevel(logging.ERROR)
         configure_sdk(_config())
@@ -157,11 +157,11 @@ class TestConfigureSdkLogLevel(unittest.TestCase):
             logging.getLogger("opentelemetry").level, logging.ERROR
         )
 
-    @patch("opentelemetry.sdk._configuration._sdk.configure_propagator")
-    @patch("opentelemetry.sdk._configuration._sdk.configure_logger_provider")
-    @patch("opentelemetry.sdk._configuration._sdk.configure_meter_provider")
-    @patch("opentelemetry.sdk._configuration._sdk.configure_tracer_provider")
-    @patch("opentelemetry.sdk._configuration._sdk.create_resource")
+    @patch("opentelemetry.configuration._sdk.configure_propagator")
+    @patch("opentelemetry.configuration._sdk.configure_logger_provider")
+    @patch("opentelemetry.configuration._sdk.configure_meter_provider")
+    @patch("opentelemetry.configuration._sdk.configure_tracer_provider")
+    @patch("opentelemetry.configuration._sdk.create_resource")
     def test_severity_number_variants_map_correctly(self, *_mocks):
         cases = [
             (SeverityNumber.trace, logging.DEBUG),

--- a/opentelemetry-configuration/tests/test_sdk.py
+++ b/opentelemetry-configuration/tests/test_sdk.py
@@ -197,10 +197,11 @@ class TestConfigureSdkLogLevel(unittest.TestCase):
                     expected_level,
                 )
 
-    def test_log_level_applies_even_when_disabled(self):
+    def test_log_level_not_applied_when_disabled(self):
+        logging.getLogger("opentelemetry").setLevel(logging.WARNING)
         configure_sdk(_config(disabled=True, log_level=SeverityNumber.error))
         self.assertEqual(
-            logging.getLogger("opentelemetry").level, logging.ERROR
+            logging.getLogger("opentelemetry").level, logging.WARNING
         )
 
 


### PR DESCRIPTION
## Description

The declarative configuration schema has a top-level `log_level` field that controls the SDK's internal diagnostic logging verbosity. It was parsed and validated by the schema loader but never read by `configure_sdk` — so setting it in a config file had no observable effect.

This PR wires `log_level` into `configure_sdk`: when the field is present, it maps the OTel `SeverityNumber` value to a Python `logging` level and sets it on the `opentelemetry` root logger. All numbered severity variants (e.g. `debug2`, `warn3`) collapse to the same Python tier.

Mapping:

| OTel severity | Python level |
|---|---|
| `trace`, `trace2–4` | `DEBUG` |
| `debug`, `debug2–4` | `DEBUG` |
| `info`, `info2–4` | `INFO` |
| `warn`, `warn2–4` | `WARNING` |
| `error`, `error2–4` | `ERROR` |
| `fatal`, `fatal2–4` | `CRITICAL` |

When `log_level` is absent the logger is untouched, preserving existing behaviour.

Fixes the gap noted in #5347 (`log_level ❌ — No tracker yet`).

## Type of change

- [x] Bug fix / gap closure (non-breaking change that makes existing behaviour match the spec)

## How Has This Been Tested?

Three new unit tests in `test_sdk.py`:
- `test_sets_opentelemetry_logger_level` — verifies a specific severity sets the expected level
- `test_absent_log_level_leaves_logger_unchanged` — verifies no mutation when field is absent
- `test_severity_number_variants_map_correctly` — exhaustive subTest over all tiers (trace, debug, info, warn, error, fatal + their `*4` variants)

## Does This PR Require a Contrib Repo Change?

- [ ] Yes.
- [x] No.

## Checklist

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated (will add once PR number is known)
- [x] Unit tests have been added
- [x] Documentation has been updated (spec-conformance.md row will change from ❌ to ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)