### PR TITLE
feat(config): wire top-level attribute_limits into per-signal providers

### DIFF
--- a/.changelog/5365.added
+++ b/.changelog/5365.added
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: wire top-level `attribute_limits` into per-signal providers via declarative config; add `log_record_limits` support to `LoggerProvider`

--- a/.changelog/5365.added
+++ b/.changelog/5365.added
@@ -1,1 +1,1 @@
-`opentelemetry-sdk`: wire top-level `attribute_limits` into per-signal providers via declarative config; add `log_record_limits` support to `LoggerProvider`
+`opentelemetry-configuration`, `opentelemetry-sdk`: wire top-level `attribute_limits` into per-signal providers via declarative config; add `log_record_limits` support to `LoggerProvider`

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_logger_provider.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_logger_provider.py
@@ -17,6 +17,9 @@ from opentelemetry.configuration._exceptions import (
     MissingDependencyError,
 )
 from opentelemetry.configuration.models import (
+    AttributeLimits,
+)
+from opentelemetry.configuration.models import (
     BatchLogRecordProcessor as BatchLogRecordProcessorConfig,
 )
 from opentelemetry.configuration.models import (
@@ -35,6 +38,9 @@ from opentelemetry.configuration.models import (
     LogRecordExporter as LogRecordExporterConfig,
 )
 from opentelemetry.configuration.models import (
+    LogRecordLimits as LogRecordLimitsConfig,
+)
+from opentelemetry.configuration.models import (
     LogRecordProcessor as LogRecordProcessorConfig,
 )
 from opentelemetry.configuration.models import (
@@ -48,6 +54,7 @@ from opentelemetry.configuration.models import (
 )
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs._internal import (
+    LogRecordLimits,
     _LoggerConfig,
     _RuleBasedLoggerConfigurator,
 )
@@ -61,6 +68,8 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.util.instrumentation import _scope_name_matches_glob
 
 _logger = logging.getLogger(__name__)
+
+_DEFAULT_OTEL_LOG_ATTRIBUTE_COUNT_LIMIT = 128
 
 # BatchLogRecordProcessor defaults per OTel spec (milliseconds).
 _DEFAULT_SCHEDULE_DELAY_MILLIS = 1000
@@ -272,9 +281,44 @@ def _create_logger_configurator(
     )
 
 
+def _create_log_record_limits(
+    config: LogRecordLimitsConfig,
+    global_limits: AttributeLimits | None = None,
+) -> LogRecordLimits:
+    """Create LogRecordLimits from config.
+
+    Absent fields fall back to global_limits (if provided), then to OTel spec
+    defaults (128 for counts, unlimited for lengths).
+    Explicit values suppress env-var reading — matching Java SDK behavior.
+    """
+    attribute_count_limit = config.attribute_count_limit
+    if attribute_count_limit is None and global_limits is not None:
+        attribute_count_limit = global_limits.attribute_count_limit
+
+    attribute_value_length_limit = config.attribute_value_length_limit
+    if attribute_value_length_limit is None and global_limits is not None:
+        attribute_value_length_limit = (
+            global_limits.attribute_value_length_limit
+        )
+
+    return LogRecordLimits(
+        max_attributes=(
+            attribute_count_limit
+            if attribute_count_limit is not None
+            else _DEFAULT_OTEL_LOG_ATTRIBUTE_COUNT_LIMIT
+        ),
+        max_attribute_length=(
+            attribute_value_length_limit
+            if attribute_value_length_limit is not None
+            else LogRecordLimits.UNSET
+        ),
+    )
+
+
 def create_logger_provider(
     config: LoggerProviderConfig | None,
     resource: Resource | None = None,
+    global_attribute_limits: AttributeLimits | None = None,
 ) -> LoggerProvider:
     """Create an SDK LoggerProvider from declarative config.
 
@@ -284,6 +328,8 @@ def create_logger_provider(
     Args:
         config: LoggerProvider config from the parsed config file, or None.
         resource: Resource to attach to the provider.
+        global_attribute_limits: Top-level attribute_limits from the root config,
+            used as a fallback when per-signal limits are not specified.
 
     Returns:
         A configured LoggerProvider.
@@ -294,16 +340,19 @@ def create_logger_provider(
         else None
     )
 
-    provider = LoggerProvider(resource=resource, _logger_configurator=logger_configurator)
+    if config is not None and config.limits is not None:
+        log_record_limits = _create_log_record_limits(config.limits, global_attribute_limits)
+    else:
+        log_record_limits = _create_log_record_limits(LogRecordLimitsConfig(), global_attribute_limits)
+
+    provider = LoggerProvider(
+        resource=resource,
+        log_record_limits=log_record_limits,
+        _logger_configurator=logger_configurator,
+    )
 
     if config is None:
         return provider
-
-    if config.limits is not None:
-        _logger.warning(
-            "log_record_limits are specified in config but are not supported "
-            "by the Python SDK LoggerProvider constructor; limits will be ignored."
-        )
 
     for processor_config in config.processors:
         provider.add_log_record_processor(_create_log_record_processor(processor_config))
@@ -314,6 +363,7 @@ def create_logger_provider(
 def configure_logger_provider(
     config: LoggerProviderConfig | None,
     resource: Resource | None = None,
+    global_attribute_limits: AttributeLimits | None = None,
 ) -> None:
     """Configure the global LoggerProvider from declarative config.
 
@@ -323,7 +373,11 @@ def configure_logger_provider(
     Args:
         config: LoggerProvider config from the parsed config file, or None.
         resource: Resource to attach to the provider.
+        global_attribute_limits: Top-level attribute_limits from the root config,
+            used as a fallback when per-signal limits are not specified.
     """
     if config is None:
         return
-    set_logger_provider(create_logger_provider(config, resource))
+    set_logger_provider(
+        create_logger_provider(config, resource, global_attribute_limits)
+    )

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_logger_provider.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_logger_provider.py
@@ -299,13 +299,21 @@ def _create_log_record_limits(
     if attribute_value_length_limit is None and global_limits is not None:
         attribute_value_length_limit = global_limits.attribute_value_length_limit
 
+    max_attributes = (
+        attribute_count_limit if attribute_count_limit is not None else _DEFAULT_OTEL_LOG_ATTRIBUTE_COUNT_LIMIT
+    )
+    max_attribute_length = (
+        attribute_value_length_limit if attribute_value_length_limit is not None else LogRecordLimits.UNSET
+    )
+
+    # The log-record-specific fields are the ones the SDK enforces, so they are
+    # set explicitly too. Leaving them absent would let OTEL_LOGRECORD_ATTRIBUTE_*
+    # override the configured values.
     return LogRecordLimits(
-        max_attributes=(
-            attribute_count_limit if attribute_count_limit is not None else _DEFAULT_OTEL_LOG_ATTRIBUTE_COUNT_LIMIT
-        ),
-        max_attribute_length=(
-            attribute_value_length_limit if attribute_value_length_limit is not None else LogRecordLimits.UNSET
-        ),
+        max_attributes=max_attributes,
+        max_attribute_length=max_attribute_length,
+        max_log_record_attributes=max_attributes,
+        max_log_record_attribute_length=max_attribute_length,
     )
 
 

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_logger_provider.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_logger_provider.py
@@ -297,20 +297,14 @@ def _create_log_record_limits(
 
     attribute_value_length_limit = config.attribute_value_length_limit
     if attribute_value_length_limit is None and global_limits is not None:
-        attribute_value_length_limit = (
-            global_limits.attribute_value_length_limit
-        )
+        attribute_value_length_limit = global_limits.attribute_value_length_limit
 
     return LogRecordLimits(
         max_attributes=(
-            attribute_count_limit
-            if attribute_count_limit is not None
-            else _DEFAULT_OTEL_LOG_ATTRIBUTE_COUNT_LIMIT
+            attribute_count_limit if attribute_count_limit is not None else _DEFAULT_OTEL_LOG_ATTRIBUTE_COUNT_LIMIT
         ),
         max_attribute_length=(
-            attribute_value_length_limit
-            if attribute_value_length_limit is not None
-            else LogRecordLimits.UNSET
+            attribute_value_length_limit if attribute_value_length_limit is not None else LogRecordLimits.UNSET
         ),
     )
 
@@ -341,16 +335,12 @@ def create_logger_provider(
     )
 
     if config is not None and config.limits is not None:
-
         limits = config.limits
 
     else:
-
         limits = LogRecordLimitsConfig()
 
-    log_record_limits = _create_log_record_limits(
-        limits, global_attribute_limits
-    )
+    log_record_limits = _create_log_record_limits(limits, global_attribute_limits)
 
     provider = LoggerProvider(
         resource=resource,
@@ -385,6 +375,4 @@ def configure_logger_provider(
     """
     if config is None:
         return
-    set_logger_provider(
-        create_logger_provider(config, resource, global_attribute_limits)
-    )
+    set_logger_provider(create_logger_provider(config, resource, global_attribute_limits))

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_logger_provider.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_logger_provider.py
@@ -341,9 +341,16 @@ def create_logger_provider(
     )
 
     if config is not None and config.limits is not None:
-        log_record_limits = _create_log_record_limits(config.limits, global_attribute_limits)
+
+        limits = config.limits
+
     else:
-        log_record_limits = _create_log_record_limits(LogRecordLimitsConfig(), global_attribute_limits)
+
+        limits = LogRecordLimitsConfig()
+
+    log_record_limits = _create_log_record_limits(
+        limits, global_attribute_limits
+    )
 
     provider = LoggerProvider(
         resource=resource,

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
@@ -100,7 +100,7 @@ def configure_sdk(config: OpenTelemetryConfiguration) -> None:
         level = _SEVERITY_TO_LOGGING_LEVEL.get(config.log_level, INFO)
         getLogger("opentelemetry").setLevel(level)
 
-    global_attribute_limits: AttributeLimits | None = config.attribute_limits
+    global_attribute_limits = config.attribute_limits
     resource = create_resource(config.resource)
     configure_tracer_provider(
         config.tracer_provider, resource, global_attribute_limits

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
@@ -27,6 +27,7 @@ from opentelemetry.configuration.instrumentation import (
     configure_instrumentation,
 )
 from opentelemetry.configuration.models import (
+    AttributeLimits,
     OpenTelemetryConfiguration,
     SeverityNumber,
 )
@@ -99,9 +100,14 @@ def configure_sdk(config: OpenTelemetryConfiguration) -> None:
         level = _SEVERITY_TO_LOGGING_LEVEL.get(config.log_level, INFO)
         getLogger("opentelemetry").setLevel(level)
 
+    global_attribute_limits: AttributeLimits | None = config.attribute_limits
     resource = create_resource(config.resource)
-    configure_tracer_provider(config.tracer_provider, resource)
+    configure_tracer_provider(
+        config.tracer_provider, resource, global_attribute_limits
+    )
     configure_meter_provider(config.meter_provider, resource)
-    configure_logger_provider(config.logger_provider, resource)
+    configure_logger_provider(
+        config.logger_provider, resource, global_attribute_limits
+    )
     configure_propagator(config.propagator)
     configure_instrumentation(config.instrumentation_development)

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_sdk.py
@@ -27,7 +27,6 @@ from opentelemetry.configuration.instrumentation import (
     configure_instrumentation,
 )
 from opentelemetry.configuration.models import (
-    AttributeLimits,
     OpenTelemetryConfiguration,
     SeverityNumber,
 )
@@ -102,12 +101,8 @@ def configure_sdk(config: OpenTelemetryConfiguration) -> None:
 
     global_attribute_limits = config.attribute_limits
     resource = create_resource(config.resource)
-    configure_tracer_provider(
-        config.tracer_provider, resource, global_attribute_limits
-    )
+    configure_tracer_provider(config.tracer_provider, resource, global_attribute_limits)
     configure_meter_provider(config.meter_provider, resource)
-    configure_logger_provider(
-        config.logger_provider, resource, global_attribute_limits
-    )
+    configure_logger_provider(config.logger_provider, resource, global_attribute_limits)
     configure_propagator(config.propagator)
     configure_instrumentation(config.instrumentation_development)

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_tracer_provider.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_tracer_provider.py
@@ -482,13 +482,16 @@ def create_tracer_provider(
         _create_id_generator(config.id_generator) if config is not None and config.id_generator is not None else None
     )
     if config is not None and config.limits is not None:
-        span_limits = _create_span_limits(
-            config.limits, global_attribute_limits
-        )
+
+        limits = config.limits
+
     else:
-        span_limits = _create_span_limits(
-            SpanLimitsConfig(), global_attribute_limits
-        )
+
+        limits = SpanLimitsConfig()
+
+    span_limits = _create_span_limits(
+        limits, global_attribute_limits
+    )
 
     tracer_configurator = (
         _create_tracer_configurator(config.tracer_configurator_development)

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_tracer_provider.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_tracer_provider.py
@@ -17,6 +17,9 @@ from opentelemetry.configuration._exceptions import (
     MissingDependencyError,
 )
 from opentelemetry.configuration.models import (
+    AttributeLimits,
+)
+from opentelemetry.configuration.models import (
     ExperimentalComposableRuleBasedSampler as RuleBasedSamplerConfig,
 )
 from opentelemetry.configuration.models import (
@@ -366,16 +369,30 @@ def _create_parent_based_sampler(config: ParentBasedSamplerConfig) -> Sampler:
     return ParentBased(**kwargs)
 
 
-def _create_span_limits(config: SpanLimitsConfig) -> SpanLimits:
+def _create_span_limits(
+    config: SpanLimitsConfig,
+    global_limits: AttributeLimits | None = None,
+) -> SpanLimits:
     """Create SpanLimits from config.
 
-    Absent fields use the OTel spec defaults (128 for counts, unlimited for lengths).
+    Absent fields fall back to global_limits (if provided), then to OTel spec
+    defaults (128 for counts, unlimited for lengths).
     Explicit values suppress env-var reading — matching Java SDK behavior.
     """
+    attribute_count_limit = config.attribute_count_limit
+    if attribute_count_limit is None and global_limits is not None:
+        attribute_count_limit = global_limits.attribute_count_limit
+
+    attribute_value_length_limit = config.attribute_value_length_limit
+    if attribute_value_length_limit is None and global_limits is not None:
+        attribute_value_length_limit = (
+            global_limits.attribute_value_length_limit
+        )
+
     return SpanLimits(
         max_span_attributes=(
-            config.attribute_count_limit
-            if config.attribute_count_limit is not None
+            attribute_count_limit
+            if attribute_count_limit is not None
             else _DEFAULT_OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
         ),
         max_events=(
@@ -394,7 +411,16 @@ def _create_span_limits(config: SpanLimitsConfig) -> SpanLimits:
             if config.link_attribute_count_limit is not None
             else _DEFAULT_OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
         ),
-        max_attribute_length=config.attribute_value_length_limit,
+        max_attribute_length=(
+            attribute_value_length_limit
+            if attribute_value_length_limit is not None
+            else SpanLimits.UNSET
+        ),
+        max_span_attribute_length=(
+            attribute_value_length_limit
+            if attribute_value_length_limit is not None
+            else SpanLimits.UNSET
+        ),
     )
 
 
@@ -434,6 +460,7 @@ def _create_tracer_configurator(
 def create_tracer_provider(
     config: TracerProviderConfig | None,
     resource: Resource | None = None,
+    global_attribute_limits: AttributeLimits | None = None,
 ) -> TracerProvider:
     """Create an SDK TracerProvider from declarative config.
 
@@ -444,6 +471,8 @@ def create_tracer_provider(
     Args:
         config: TracerProvider config from the parsed config file, or None.
         resource: Resource to attach to the provider.
+        global_attribute_limits: Top-level attribute_limits from the root config,
+            used as a fallback when per-signal limits are not specified.
 
     Returns:
         A configured TracerProvider.
@@ -452,17 +481,14 @@ def create_tracer_provider(
     id_generator = (
         _create_id_generator(config.id_generator) if config is not None and config.id_generator is not None else None
     )
-    span_limits = (
-        _create_span_limits(config.limits)
-        if config is not None and config.limits is not None
-        else SpanLimits(
-            max_span_attributes=_DEFAULT_OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
-            max_events=_DEFAULT_OTEL_SPAN_EVENT_COUNT_LIMIT,
-            max_links=_DEFAULT_OTEL_SPAN_LINK_COUNT_LIMIT,
-            max_event_attributes=_DEFAULT_OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT,
-            max_link_attributes=_DEFAULT_OTEL_LINK_ATTRIBUTE_COUNT_LIMIT,
+    if config is not None and config.limits is not None:
+        span_limits = _create_span_limits(
+            config.limits, global_attribute_limits
         )
-    )
+    else:
+        span_limits = _create_span_limits(
+            SpanLimitsConfig(), global_attribute_limits
+        )
 
     tracer_configurator = (
         _create_tracer_configurator(config.tracer_configurator_development)
@@ -488,6 +514,7 @@ def create_tracer_provider(
 def configure_tracer_provider(
     config: TracerProviderConfig | None,
     resource: Resource | None = None,
+    global_attribute_limits: AttributeLimits | None = None,
 ) -> None:
     """Configure the global TracerProvider from declarative config.
 
@@ -498,7 +525,11 @@ def configure_tracer_provider(
     Args:
         config: TracerProvider config from the parsed config file, or None.
         resource: Resource to attach to the provider.
+        global_attribute_limits: Top-level attribute_limits from the root config,
+            used as a fallback when per-signal limits are not specified.
     """
     if config is None:
         return
-    trace.set_tracer_provider(create_tracer_provider(config, resource))
+    trace.set_tracer_provider(
+        create_tracer_provider(config, resource, global_attribute_limits)
+    )

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_tracer_provider.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_tracer_provider.py
@@ -385,15 +385,11 @@ def _create_span_limits(
 
     attribute_value_length_limit = config.attribute_value_length_limit
     if attribute_value_length_limit is None and global_limits is not None:
-        attribute_value_length_limit = (
-            global_limits.attribute_value_length_limit
-        )
+        attribute_value_length_limit = global_limits.attribute_value_length_limit
 
     return SpanLimits(
         max_span_attributes=(
-            attribute_count_limit
-            if attribute_count_limit is not None
-            else _DEFAULT_OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+            attribute_count_limit if attribute_count_limit is not None else _DEFAULT_OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
         ),
         max_events=(
             config.event_count_limit if config.event_count_limit is not None else _DEFAULT_OTEL_SPAN_EVENT_COUNT_LIMIT
@@ -412,14 +408,10 @@ def _create_span_limits(
             else _DEFAULT_OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
         ),
         max_attribute_length=(
-            attribute_value_length_limit
-            if attribute_value_length_limit is not None
-            else SpanLimits.UNSET
+            attribute_value_length_limit if attribute_value_length_limit is not None else SpanLimits.UNSET
         ),
         max_span_attribute_length=(
-            attribute_value_length_limit
-            if attribute_value_length_limit is not None
-            else SpanLimits.UNSET
+            attribute_value_length_limit if attribute_value_length_limit is not None else SpanLimits.UNSET
         ),
     )
 
@@ -482,16 +474,12 @@ def create_tracer_provider(
         _create_id_generator(config.id_generator) if config is not None and config.id_generator is not None else None
     )
     if config is not None and config.limits is not None:
-
         limits = config.limits
 
     else:
-
         limits = SpanLimitsConfig()
 
-    span_limits = _create_span_limits(
-        limits, global_attribute_limits
-    )
+    span_limits = _create_span_limits(limits, global_attribute_limits)
 
     tracer_configurator = (
         _create_tracer_configurator(config.tracer_configurator_development)
@@ -533,6 +521,4 @@ def configure_tracer_provider(
     """
     if config is None:
         return
-    trace.set_tracer_provider(
-        create_tracer_provider(config, resource, global_attribute_limits)
-    )
+    trace.set_tracer_provider(create_tracer_provider(config, resource, global_attribute_limits))

--- a/opentelemetry-configuration/tests/test_logger_provider.py
+++ b/opentelemetry-configuration/tests/test_logger_provider.py
@@ -434,6 +434,8 @@ class TestLogRecordLimits(unittest.TestCase):
         provider = create_logger_provider(None)
         self.assertEqual(provider._log_record_limits.max_attributes, 128)
         self.assertIsNone(provider._log_record_limits.max_attribute_length)
+        self.assertEqual(provider._log_record_limits.max_log_record_attributes, 128)
+        self.assertIsNone(provider._log_record_limits.max_log_record_attribute_length)
 
     def test_default_limits_do_not_read_env_vars(self):
         with patch.dict(
@@ -446,6 +448,8 @@ class TestLogRecordLimits(unittest.TestCase):
             provider = create_logger_provider(None)
         self.assertEqual(provider._log_record_limits.max_attributes, 128)
         self.assertIsNone(provider._log_record_limits.max_attribute_length)
+        self.assertEqual(provider._log_record_limits.max_log_record_attributes, 128)
+        self.assertIsNone(provider._log_record_limits.max_log_record_attribute_length)
 
     def test_limits_from_config(self):
         config = LoggerProviderConfig(
@@ -458,16 +462,6 @@ class TestLogRecordLimits(unittest.TestCase):
         provider = create_logger_provider(config)
         self.assertEqual(provider._log_record_limits.max_attributes, 64)
         self.assertEqual(provider._log_record_limits.max_attribute_length, 256)
-
-    def test_config_limits_are_set_on_the_enforced_log_record_fields(self):
-        config = LoggerProviderConfig(
-            processors=[],
-            limits=LogRecordLimitsConfig(
-                attribute_count_limit=64,
-                attribute_value_length_limit=256,
-            ),
-        )
-        provider = create_logger_provider(config)
         self.assertEqual(provider._log_record_limits.max_log_record_attributes, 64)
         self.assertEqual(provider._log_record_limits.max_log_record_attribute_length, 256)
 
@@ -502,12 +496,6 @@ class TestLogRecordLimits(unittest.TestCase):
         self.assertEqual(provider._log_record_limits.max_log_record_attributes, 128)
         self.assertIsNone(provider._log_record_limits.max_log_record_attribute_length)
 
-    def test_global_attribute_limits_are_set_on_the_enforced_log_record_fields(self):
-        global_limits = AttributeLimits(attribute_count_limit=42, attribute_value_length_limit=64)
-        provider = create_logger_provider(None, global_attribute_limits=global_limits)
-        self.assertEqual(provider._log_record_limits.max_log_record_attributes, 42)
-        self.assertEqual(provider._log_record_limits.max_log_record_attribute_length, 64)
-
     @staticmethod
     def test_no_limits_no_warning():
         config = LoggerProviderConfig(processors=[])
@@ -519,6 +507,7 @@ class TestLogRecordLimits(unittest.TestCase):
         global_limits = AttributeLimits(attribute_count_limit=42)
         provider = create_logger_provider(None, global_attribute_limits=global_limits)
         self.assertEqual(provider._log_record_limits.max_attributes, 42)
+        self.assertEqual(provider._log_record_limits.max_log_record_attributes, 42)
 
     def test_global_attribute_value_length_limit_used_when_no_per_signal_limits(
         self,
@@ -526,6 +515,7 @@ class TestLogRecordLimits(unittest.TestCase):
         global_limits = AttributeLimits(attribute_value_length_limit=64)
         provider = create_logger_provider(None, global_attribute_limits=global_limits)
         self.assertEqual(provider._log_record_limits.max_attribute_length, 64)
+        self.assertEqual(provider._log_record_limits.max_log_record_attribute_length, 64)
 
     def test_per_signal_limits_override_global(self):
         global_limits = AttributeLimits(attribute_count_limit=100, attribute_value_length_limit=200)
@@ -539,6 +529,8 @@ class TestLogRecordLimits(unittest.TestCase):
         provider = create_logger_provider(config, global_attribute_limits=global_limits)
         self.assertEqual(provider._log_record_limits.max_attributes, 7)
         self.assertEqual(provider._log_record_limits.max_attribute_length, 16)
+        self.assertEqual(provider._log_record_limits.max_log_record_attributes, 7)
+        self.assertEqual(provider._log_record_limits.max_log_record_attribute_length, 16)
 
 
 # Configurator tests access the SDK LoggerProvider private

--- a/opentelemetry-configuration/tests/test_logger_provider.py
+++ b/opentelemetry-configuration/tests/test_logger_provider.py
@@ -459,6 +459,55 @@ class TestLogRecordLimits(unittest.TestCase):
         self.assertEqual(provider._log_record_limits.max_attributes, 64)
         self.assertEqual(provider._log_record_limits.max_attribute_length, 256)
 
+    def test_config_limits_are_set_on_the_enforced_log_record_fields(self):
+        config = LoggerProviderConfig(
+            processors=[],
+            limits=LogRecordLimitsConfig(
+                attribute_count_limit=64,
+                attribute_value_length_limit=256,
+            ),
+        )
+        provider = create_logger_provider(config)
+        self.assertEqual(provider._log_record_limits.max_log_record_attributes, 64)
+        self.assertEqual(provider._log_record_limits.max_log_record_attribute_length, 256)
+
+    def test_config_limits_are_not_overridden_by_log_record_env_vars(self):
+        config = LoggerProviderConfig(
+            processors=[],
+            limits=LogRecordLimitsConfig(
+                attribute_count_limit=64,
+                attribute_value_length_limit=256,
+            ),
+        )
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT": "5",
+                "OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT": "3",
+            },
+        ):
+            provider = create_logger_provider(config)
+        self.assertEqual(provider._log_record_limits.max_log_record_attributes, 64)
+        self.assertEqual(provider._log_record_limits.max_log_record_attribute_length, 256)
+
+    def test_default_limits_are_not_overridden_by_log_record_env_vars(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT": "5",
+                "OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT": "3",
+            },
+        ):
+            provider = create_logger_provider(None)
+        self.assertEqual(provider._log_record_limits.max_log_record_attributes, 128)
+        self.assertIsNone(provider._log_record_limits.max_log_record_attribute_length)
+
+    def test_global_attribute_limits_are_set_on_the_enforced_log_record_fields(self):
+        global_limits = AttributeLimits(attribute_count_limit=42, attribute_value_length_limit=64)
+        provider = create_logger_provider(None, global_attribute_limits=global_limits)
+        self.assertEqual(provider._log_record_limits.max_log_record_attributes, 42)
+        self.assertEqual(provider._log_record_limits.max_log_record_attribute_length, 64)
+
     @staticmethod
     def test_no_limits_no_warning():
         config = LoggerProviderConfig(processors=[])

--- a/opentelemetry-configuration/tests/test_logger_provider.py
+++ b/opentelemetry-configuration/tests/test_logger_provider.py
@@ -26,6 +26,7 @@ from opentelemetry.configuration.file._loader import ConfigurationError
 from opentelemetry.configuration.models import (
     AttributeLimits,
     NameStringValuePair,
+    SeverityNumber,
 )
 from opentelemetry.configuration.models import (
     BatchLogRecordProcessor as BatchLogRecordProcessorConfig,
@@ -53,10 +54,6 @@ from opentelemetry.configuration.models import (
 )
 from opentelemetry.configuration.models import (
     LogRecordProcessor as LogRecordProcessorConfig,
-)
-from opentelemetry.configuration.models import (
-    NameStringValuePair,
-    SeverityNumber,
 )
 from opentelemetry.configuration.models import (
     OtlpGrpcExporter as OtlpGrpcExporterConfig,
@@ -471,24 +468,18 @@ class TestLogRecordLimits(unittest.TestCase):
 
     def test_global_attribute_count_limit_used_when_no_per_signal_limits(self):
         global_limits = AttributeLimits(attribute_count_limit=42)
-        provider = create_logger_provider(
-            None, global_attribute_limits=global_limits
-        )
+        provider = create_logger_provider(None, global_attribute_limits=global_limits)
         self.assertEqual(provider._log_record_limits.max_attributes, 42)
 
     def test_global_attribute_value_length_limit_used_when_no_per_signal_limits(
         self,
     ):
         global_limits = AttributeLimits(attribute_value_length_limit=64)
-        provider = create_logger_provider(
-            None, global_attribute_limits=global_limits
-        )
+        provider = create_logger_provider(None, global_attribute_limits=global_limits)
         self.assertEqual(provider._log_record_limits.max_attribute_length, 64)
 
     def test_per_signal_limits_override_global(self):
-        global_limits = AttributeLimits(
-            attribute_count_limit=100, attribute_value_length_limit=200
-        )
+        global_limits = AttributeLimits(attribute_count_limit=100, attribute_value_length_limit=200)
         config = LoggerProviderConfig(
             processors=[],
             limits=LogRecordLimitsConfig(
@@ -496,9 +487,7 @@ class TestLogRecordLimits(unittest.TestCase):
                 attribute_value_length_limit=16,
             ),
         )
-        provider = create_logger_provider(
-            config, global_attribute_limits=global_limits
-        )
+        provider = create_logger_provider(config, global_attribute_limits=global_limits)
         self.assertEqual(provider._log_record_limits.max_attributes, 7)
         self.assertEqual(provider._log_record_limits.max_attribute_length, 16)
 

--- a/opentelemetry-configuration/tests/test_logger_provider.py
+++ b/opentelemetry-configuration/tests/test_logger_provider.py
@@ -4,6 +4,7 @@
 # Tests access private members of SDK classes to assert correct configuration.
 # pylint: disable=protected-access
 
+import os
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
@@ -22,6 +23,10 @@ from opentelemetry.configuration._logger_provider import (
     create_logger_provider,
 )
 from opentelemetry.configuration.file._loader import ConfigurationError
+from opentelemetry.configuration.models import (
+    AttributeLimits,
+    NameStringValuePair,
+)
 from opentelemetry.configuration.models import (
     BatchLogRecordProcessor as BatchLogRecordProcessorConfig,
 )
@@ -428,20 +433,34 @@ class TestCreateLogRecordExporters(unittest.TestCase):
 
 
 class TestLogRecordLimits(unittest.TestCase):
-    def test_limits_logs_warning(self):
+    def test_default_limits(self):
+        provider = create_logger_provider(None)
+        self.assertEqual(provider._log_record_limits.max_attributes, 128)
+        self.assertIsNone(provider._log_record_limits.max_attribute_length)
+
+    def test_default_limits_do_not_read_env_vars(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_ATTRIBUTE_COUNT_LIMIT": "1",
+                "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT": "2",
+            },
+        ):
+            provider = create_logger_provider(None)
+        self.assertEqual(provider._log_record_limits.max_attributes, 128)
+        self.assertIsNone(provider._log_record_limits.max_attribute_length)
+
+    def test_limits_from_config(self):
         config = LoggerProviderConfig(
             processors=[],
-            limits=LogRecordLimitsConfig(attribute_count_limit=64),
+            limits=LogRecordLimitsConfig(
+                attribute_count_limit=64,
+                attribute_value_length_limit=256,
+            ),
         )
-        with self.assertLogs(
-            "opentelemetry.configuration._logger_provider",
-            level="WARNING",
-        ) as cm:
-            create_logger_provider(config)
-        self.assertTrue(
-            any("limits" in msg for msg in cm.output),
-            "Expected warning about unsupported limits",
-        )
+        provider = create_logger_provider(config)
+        self.assertEqual(provider._log_record_limits.max_attributes, 64)
+        self.assertEqual(provider._log_record_limits.max_attribute_length, 256)
 
     @staticmethod
     def test_no_limits_no_warning():
@@ -449,6 +468,39 @@ class TestLogRecordLimits(unittest.TestCase):
         with patch("opentelemetry.configuration._logger_provider._logger") as mock_logger:
             create_logger_provider(config)
             mock_logger.warning.assert_not_called()
+
+    def test_global_attribute_count_limit_used_when_no_per_signal_limits(self):
+        global_limits = AttributeLimits(attribute_count_limit=42)
+        provider = create_logger_provider(
+            None, global_attribute_limits=global_limits
+        )
+        self.assertEqual(provider._log_record_limits.max_attributes, 42)
+
+    def test_global_attribute_value_length_limit_used_when_no_per_signal_limits(
+        self,
+    ):
+        global_limits = AttributeLimits(attribute_value_length_limit=64)
+        provider = create_logger_provider(
+            None, global_attribute_limits=global_limits
+        )
+        self.assertEqual(provider._log_record_limits.max_attribute_length, 64)
+
+    def test_per_signal_limits_override_global(self):
+        global_limits = AttributeLimits(
+            attribute_count_limit=100, attribute_value_length_limit=200
+        )
+        config = LoggerProviderConfig(
+            processors=[],
+            limits=LogRecordLimitsConfig(
+                attribute_count_limit=7,
+                attribute_value_length_limit=16,
+            ),
+        )
+        provider = create_logger_provider(
+            config, global_attribute_limits=global_limits
+        )
+        self.assertEqual(provider._log_record_limits.max_attributes, 7)
+        self.assertEqual(provider._log_record_limits.max_attribute_length, 16)
 
 
 # Configurator tests access the SDK LoggerProvider private

--- a/opentelemetry-configuration/tests/test_sdk.py
+++ b/opentelemetry-configuration/tests/test_sdk.py
@@ -70,9 +70,11 @@ class TestConfigureSdk(unittest.TestCase):
         configure_sdk(config)
 
         mock_create_resource.assert_called_once_with(resource_cfg)
-        mock_tracer.assert_called_once_with(tracer_cfg, sentinel_resource)
+        mock_tracer.assert_called_once_with(
+            tracer_cfg, sentinel_resource, None
+        )
         mock_meter.assert_called_once_with(None, sentinel_resource)
-        mock_logger.assert_called_once_with(None, sentinel_resource)
+        mock_logger.assert_called_once_with(None, sentinel_resource, None)
         mock_propagator.assert_called_once_with(propagator_cfg)
 
     @patch("opentelemetry.configuration._sdk.configure_propagator")

--- a/opentelemetry-configuration/tests/test_sdk.py
+++ b/opentelemetry-configuration/tests/test_sdk.py
@@ -70,9 +70,7 @@ class TestConfigureSdk(unittest.TestCase):
         configure_sdk(config)
 
         mock_create_resource.assert_called_once_with(resource_cfg)
-        mock_tracer.assert_called_once_with(
-            tracer_cfg, sentinel_resource, None
-        )
+        mock_tracer.assert_called_once_with(tracer_cfg, sentinel_resource, None)
         mock_meter.assert_called_once_with(None, sentinel_resource)
         mock_logger.assert_called_once_with(None, sentinel_resource, None)
         mock_propagator.assert_called_once_with(propagator_cfg)

--- a/opentelemetry-configuration/tests/test_tracer_provider.py
+++ b/opentelemetry-configuration/tests/test_tracer_provider.py
@@ -18,6 +18,9 @@ from opentelemetry.configuration._tracer_provider import (
 )
 from opentelemetry.configuration.file._loader import ConfigurationError
 from opentelemetry.configuration.models import (
+    AttributeLimits,
+)
+from opentelemetry.configuration.models import (
     BatchSpanProcessor as BatchSpanProcessorConfig,
 )
 from opentelemetry.configuration.models import (
@@ -799,11 +802,15 @@ class TestCreateSpanLimits(unittest.TestCase):
             {
                 "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT": "1",
                 "OTEL_SPAN_EVENT_COUNT_LIMIT": "2",
+                "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT": "3",
+                "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT": "4",
             },
         ):
             provider = self._create_with_limits(SpanLimitsConfig())
         self.assertEqual(provider._span_limits.max_span_attributes, 128)
         self.assertEqual(provider._span_limits.max_events, 128)
+        self.assertIsNone(provider._span_limits.max_attribute_length)
+        self.assertIsNone(provider._span_limits.max_span_attribute_length)
 
 
 class TestCreateIdGenerator(unittest.TestCase):
@@ -926,3 +933,66 @@ class TestTracerConfigurator(unittest.TestCase):
         )
         provider = create_tracer_provider(config)
         self.assertTrue(self._enabled(provider, "any.scope"))
+
+
+class TestGlobalAttributeLimitsFallback(unittest.TestCase):
+    # pylint: disable=no-self-use
+
+    def test_global_attribute_count_limit_used_when_no_per_signal_limits(self):
+        global_limits = AttributeLimits(attribute_count_limit=42)
+        provider = create_tracer_provider(
+            TracerProviderConfig(processors=[]),
+            global_attribute_limits=global_limits,
+        )
+        self.assertEqual(provider._span_limits.max_span_attributes, 42)
+
+    def test_global_attribute_value_length_limit_used_when_no_per_signal_limits(
+        self,
+    ):
+        global_limits = AttributeLimits(attribute_value_length_limit=64)
+        provider = create_tracer_provider(
+            TracerProviderConfig(processors=[]),
+            global_attribute_limits=global_limits,
+        )
+        self.assertEqual(provider._span_limits.max_attribute_length, 64)
+
+    def test_per_signal_limits_take_precedence_over_global(self):
+        global_limits = AttributeLimits(
+            attribute_count_limit=99,
+            attribute_value_length_limit=99,
+        )
+        provider = create_tracer_provider(
+            TracerProviderConfig(
+                processors=[],
+                limits=SpanLimitsConfig(
+                    attribute_count_limit=7,
+                    attribute_value_length_limit=16,
+                ),
+            ),
+            global_attribute_limits=global_limits,
+        )
+        self.assertEqual(provider._span_limits.max_span_attributes, 7)
+        self.assertEqual(provider._span_limits.max_attribute_length, 16)
+
+    def test_global_limits_absent_uses_sdk_defaults(self):
+        provider = create_tracer_provider(
+            TracerProviderConfig(processors=[]),
+        )
+        self.assertEqual(provider._span_limits.max_span_attributes, 128)
+        self.assertIsNone(provider._span_limits.max_attribute_length)
+
+    def test_global_limits_absent_does_not_read_env_vars(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_ATTRIBUTE_COUNT_LIMIT": "1",
+                "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT": "2",
+                "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT": "3",
+            },
+        ):
+            provider = create_tracer_provider(
+                TracerProviderConfig(processors=[]),
+            )
+        self.assertEqual(provider._span_limits.max_span_attributes, 128)
+        self.assertIsNone(provider._span_limits.max_attribute_length)
+        self.assertIsNone(provider._span_limits.max_span_attribute_length)

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -123,7 +123,7 @@ class LogRecordLimits:
     This class does not enforce any limits itself. It only provides a way to read limits from env,
     default values and from user provided arguments.
 
-    All limit arguments must be either a non-negative integer or ``None``.
+    All limit arguments must be either a non-negative integer, ``None`` or ``LogRecordLimits.UNSET``.
 
     - All limit arguments are optional.
     - If a limit argument is not set, the class will try to read its value from the corresponding
@@ -150,6 +150,8 @@ class LogRecordLimits:
             Environment variable: ``OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT``
             Falls back to ``max_attribute_length`` when unset.
     """
+
+    UNSET = -1
 
     def __init__(
         self,
@@ -193,6 +195,9 @@ class LogRecordLimits:
 
     @classmethod
     def _from_env_if_absent(cls, value: int | None, env_var: str, default: int | None = None) -> int | None:
+        if value == cls.UNSET:
+            return None
+
         err_msg = "{} must be a non-negative integer but got {}"
 
         # if no value is provided for the limit, try to load it from env
@@ -310,11 +315,13 @@ class ReadWriteLogRecord:
         record: LogRecord,
         resource: Resource,
         instrumentation_scope: InstrumentationScope | None = None,
+        limits: LogRecordLimits | None = None,
     ) -> ReadWriteLogRecord:
         return cls(
             log_record=record,
             resource=resource,
             instrumentation_scope=instrumentation_scope,
+            **({} if limits is None else {"limits": limits}),
         )
 
 
@@ -682,6 +689,7 @@ class Logger(APILogger):
         instrumentation_scope: InstrumentationScope,
         *,
         logger_metrics: LoggerMetricsT,
+        log_record_limits: LogRecordLimits | None = None,
         _logger_config: _LoggerConfig,
     ):
         super().__init__(
@@ -695,6 +703,7 @@ class Logger(APILogger):
         self._instrumentation_scope = instrumentation_scope
         self._logger_metrics = logger_metrics
         self._logger_config = _logger_config
+        self._log_record_limits = log_record_limits or LogRecordLimits()
 
     def _is_enabled(self) -> bool:
         return self._logger_config.is_enabled
@@ -743,6 +752,7 @@ class Logger(APILogger):
                     record=record,
                     resource=self._resource,
                     instrumentation_scope=self._instrumentation_scope,
+                    limits=self._log_record_limits,
                 )
             else:
                 _set_log_record_exception_attributes(record.log_record)
@@ -765,6 +775,7 @@ class Logger(APILogger):
                 record=log_record,
                 resource=self._resource,
                 instrumentation_scope=self._instrumentation_scope,
+                limits=self._log_record_limits,
             )
 
         self._logger_metrics.emit_log()
@@ -797,6 +808,7 @@ class LoggerProvider(APILoggerProvider):
         | None = None,
         *,
         meter_provider: MeterProvider | None = None,
+        log_record_limits: LogRecordLimits | None = None,
         _logger_configurator: _LoggerConfiguratorT | None = None,
     ):
         if resource is None:
@@ -811,6 +823,7 @@ class LoggerProvider(APILoggerProvider):
         disabled = environ.get(OTEL_SDK_DISABLED, "")
         self._disabled = disabled.lower().strip() == "true"
         self._logger_configurator = _logger_configurator or _default_logger_configurator
+        self._log_record_limits = log_record_limits or LogRecordLimits()
         self._at_exit_handler = None
         if shutdown_on_exit:
             self._at_exit_handler = atexit.register(self.shutdown)
@@ -858,6 +871,7 @@ class LoggerProvider(APILoggerProvider):
             scope,
             logger_metrics=self._logger_metrics,
             _logger_config=self._apply_logger_configurator(scope),
+            log_record_limits=self._log_record_limits,
         )
 
     def _get_logger_cached(


### PR DESCRIPTION
Closes #5357

## Summary

- Reads `config.attribute_limits` in `configure_sdk()` and passes it as a global fallback to `create_tracer_provider()` and `create_logger_provider()`
- Per-signal limits (`tracer_provider.limits` / `logger_provider.limits`) always take precedence; absent fields fall back to the global value, then to OTel spec defaults
- Adds `log_record_limits` parameter to `LoggerProvider`, threads it through `Logger` down to each `ReadWriteLogRecord` — mirroring how `SpanLimits` flows through `TracerProvider`

## Test plan

- [ ] `tests/_configuration/test_sdk.py` — global limits passed to per-signal factories
- [ ] `tests/_configuration/test_tracer_provider.py` — per-signal override, global fallback, spec defaults
- [ ] `tests/_configuration/test_logger_provider.py` — same coverage for logs; verifies limits are applied (not just warned about)
- [ ] `tests/logs/` — no regressions in existing log SDK tests