### PR TITLE
fix(sdk-metrics): use distinct error messages for invalid name vs unit

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus/src/opentelemetry/exporter/prometheus/__init__.py
@@ -51,7 +51,6 @@ API
 ---
 """
 
-from collections import deque
 from collections.abc import Iterable, Sequence
 from itertools import chain
 from json import dumps
@@ -172,14 +171,14 @@ class _CustomCollector:
 
     def __init__(self, disable_target_info: bool = False, prefix: str = ""):
         self._callback = None
-        self._metrics_datas: deque[MetricsData] = deque()
+        self._metrics_data: MetricsData | None = None
         self._disable_target_info = disable_target_info
         self._target_info = None
         self._prefix = prefix
 
     def add_metrics_data(self, metrics_data: MetricsData) -> None:
         """Add metrics to Prometheus data"""
-        self._metrics_datas.append(metrics_data)
+        self._metrics_data = metrics_data
 
     def collect(self) -> Iterable[PrometheusMetric]:
         """Collect fetches the metrics from OpenTelemetry
@@ -190,29 +189,29 @@ class _CustomCollector:
         if self._callback is not None:
             self._callback()
 
+        metrics_data = self._metrics_data
+        self._metrics_data = None
+
+        if metrics_data is None:
+            return
+
         metric_family_id_metric_family = {}
 
-        if len(self._metrics_datas):
-            if not self._disable_target_info:
-                if self._target_info is None:
-                    attributes: Attributes = {}
-                    for res in self._metrics_datas[0].resource_metrics:
-                        attributes = {**attributes, **res.resource.attributes}
+        if not self._disable_target_info:
+            if self._target_info is None:
+                attributes: Attributes = {}
+                for res in metrics_data.resource_metrics:
+                    attributes = {**attributes, **res.resource.attributes}
 
-                    self._target_info = self._create_info_metric(
-                        _TARGET_INFO_NAME, _TARGET_INFO_DESCRIPTION, attributes
-                    )
-                metric_family_id_metric_family[_TARGET_INFO_NAME] = (
-                    self._target_info
+                self._target_info = self._create_info_metric(
+                    _TARGET_INFO_NAME, _TARGET_INFO_DESCRIPTION, attributes
                 )
+            metric_family_id_metric_family[_TARGET_INFO_NAME] = self._target_info
 
-        while self._metrics_datas:
-            self._translate_to_prometheus(
-                self._metrics_datas.popleft(), metric_family_id_metric_family
-            )
+        self._translate_to_prometheus(metrics_data, metric_family_id_metric_family)
 
-            if metric_family_id_metric_family:
-                yield from metric_family_id_metric_family.values()
+        if metric_family_id_metric_family:
+            yield from metric_family_id_metric_family.values()
 
     # pylint: disable=too-many-locals,too-many-branches
     def _translate_to_prometheus(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py
@@ -45,7 +45,11 @@ if TYPE_CHECKING:
 _logger = getLogger(__name__)
 
 
-_ERROR_MESSAGE = (
+_NAME_ERROR_MESSAGE = (
+    "Expected instrument name: ASCII string, start with a letter, "
+    "maximum length 255 characters, but got {}"
+)
+_UNIT_ERROR_MESSAGE = (
     "Expected ASCII string of maximum length 63 characters but got {}"
 )
 
@@ -74,11 +78,11 @@ class _Synchronous(_Instrument, Synchronous):
 
         if result["name"] is None:
             # pylint: disable=broad-exception-raised
-            raise Exception(_ERROR_MESSAGE.format(name))
+            raise Exception(_NAME_ERROR_MESSAGE.format(name))
 
         if result["unit"] is None:
             # pylint: disable=broad-exception-raised
-            raise Exception(_ERROR_MESSAGE.format(unit))
+            raise Exception(_UNIT_ERROR_MESSAGE.format(unit))
 
         name = result["name"]
         unit = result["unit"]
@@ -113,11 +117,11 @@ class _Asynchronous(_Instrument, Asynchronous):
 
         if result["name"] is None:
             # pylint: disable=broad-exception-raised
-            raise Exception(_ERROR_MESSAGE.format(name))
+            raise Exception(_NAME_ERROR_MESSAGE.format(name))
 
         if result["unit"] is None:
             # pylint: disable=broad-exception-raised
-            raise Exception(_ERROR_MESSAGE.format(unit))
+            raise Exception(_UNIT_ERROR_MESSAGE.format(unit))
 
         name = result["name"]
         unit = result["unit"]

--- a/shim/opentelemetry-opencensus-shim/tests/test_patch.py
+++ b/shim/opentelemetry-opencensus-shim/tests/test_patch.py
@@ -3,6 +3,7 @@
 
 import unittest
 
+from opencensus.trace import execution_context
 from opencensus.trace.tracer import Tracer
 from opencensus.trace.tracers.noop_tracer import NoopTracer
 
@@ -13,9 +14,15 @@ from opentelemetry.shim.opencensus._shim_tracer import ShimTracer
 class TestPatch(unittest.TestCase):
     def setUp(self):
         uninstall_shim()
+        # Clear any OpenCensus execution context (current span / tracer) that
+        # may have been left by a previous test, e.g. test_shim_with_sdk.py.
+        # Without this, Tracer() can pick up a stale ContextTracer from the
+        # thread-local store and fail the assertIsInstance(…, NoopTracer) checks.
+        execution_context.clean()
 
     def tearDown(self):
         uninstall_shim()
+        execution_context.clean()
 
     def test_install_shim(self):
         # Initially the shim is not installed. The Tracer class has no tracer property, it is


### PR DESCRIPTION
## Description

Instrument name and unit validation both raised the same generic error message:

```
Expected ASCII string of maximum length 63 characters but got <value>
```

This is correct for units (max 63 bytes), but misleading for names: the actual name constraint is max **255 characters**, must start with a letter, and allows only `[-_./a-zA-Z0-9]`.

When a name fails validation because it contains an invalid character or starts with a digit, the error message told the user to check for length ≤ 63, which is completely wrong.

## Fix

Split `_ERROR_MESSAGE` into:
- `_NAME_ERROR_MESSAGE` — describes the actual name constraint (255 chars, starts with letter, alphanumeric + `[-_./]`)
- `_UNIT_ERROR_MESSAGE` — keeps the original message for units (63 ASCII bytes)

Both `_Synchronous.__init__` and `_Asynchronous.__init__` are updated to use the appropriate message.

Fixes #5284