### PR TITLE
logs: add Enabled support to Logger API, SDK, and LogRecordProcessor

### DIFF
--- a/.changelog/5380.added
+++ b/.changelog/5380.added
@@ -1,1 +1,1 @@
-Add `enabled()` support to the Logger API, SDK, and `LogRecordProcessor` to let instrumentation skip expensive work when logging is disabled
+`opentelemetry-api`, `opentelemetry-sdk`: add `enabled()` support to the Logger API, SDK, and `LogRecordProcessor` to let instrumentation skip expensive work when logging is disabled

--- a/.changelog/5380.added
+++ b/.changelog/5380.added
@@ -1,0 +1,1 @@
+Add `enabled()` support to the Logger API, SDK, and `LogRecordProcessor` to let instrumentation skip expensive work when logging is disabled

--- a/.changelog/5380.changed
+++ b/.changelog/5380.changed
@@ -1,0 +1,1 @@
+`opentelemetry-api`: subclasses of `Logger` need to implement the `enabled` method

--- a/.changelog/5380.changed
+++ b/.changelog/5380.changed
@@ -1,1 +1,1 @@
-`opentelemetry-api`: subclasses of `Logger` need to implement the `enabled` method
+[BREAKING] `opentelemetry-api`: subclasses of `Logger` need to implement the `enabled` method

--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -175,7 +175,7 @@ class Logger(ABC):
     ) -> None:
         """Emits a :class:`LogRecord` representing a log to the processing pipeline."""
 
-    def enabled(
+    def enabled(  # pylint: disable=no-self-use
         self,
         *,
         context: Context | None = None,

--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -175,7 +175,8 @@ class Logger(ABC):
     ) -> None:
         """Emits a :class:`LogRecord` representing a log to the processing pipeline."""
 
-    def enabled(  # pylint: disable=no-self-use
+    @abstractmethod
+    def enabled(
         self,
         *,
         context: Context | None = None,
@@ -190,7 +191,6 @@ class Logger(ABC):
         The returned value may change over time and should be checked each time
         before emitting a log record.
         """
-        return True
 
 
 class NoOpLogger(Logger):

--- a/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/_logs/_internal/__init__.py
@@ -175,6 +175,23 @@ class Logger(ABC):
     ) -> None:
         """Emits a :class:`LogRecord` representing a log to the processing pipeline."""
 
+    def enabled(
+        self,
+        *,
+        context: Context | None = None,
+        severity_number: SeverityNumber | None = None,
+        event_name: str | None = None,
+    ) -> bool:
+        """Returns whether the logger is enabled for the given arguments.
+
+        Instrumentation should call this before performing expensive work to
+        construct a log record, and skip that work if ``False`` is returned.
+
+        The returned value may change over time and should be checked each time
+        before emitting a log record.
+        """
+        return True
+
 
 class NoOpLogger(Logger):
     """The default Logger used when no Logger implementation is available.
@@ -218,6 +235,15 @@ class NoOpLogger(Logger):
         exception: BaseException | None = None,
     ) -> None:
         pass
+
+    def enabled(
+        self,
+        *,
+        context: Context | None = None,
+        severity_number: SeverityNumber | None = None,
+        event_name: str | None = None,
+    ) -> bool:
+        return False
 
 
 class ProxyLogger(Logger):
@@ -299,6 +325,19 @@ class ProxyLogger(Logger):
                 event_name=event_name,
                 exception=exception,
             )
+
+    def enabled(
+        self,
+        *,
+        context: Context | None = None,
+        severity_number: SeverityNumber | None = None,
+        event_name: str | None = None,
+    ) -> bool:
+        return self._logger.enabled(
+            context=context,
+            severity_number=severity_number,
+            event_name=event_name,
+        )
 
 
 class LoggerProvider(ABC):

--- a/opentelemetry-api/tests/logs/test_proxy.py
+++ b/opentelemetry-api/tests/logs/test_proxy.py
@@ -74,3 +74,33 @@ class TestProxy(LoggingGlobalsTest, unittest.TestCase):
         logger.emit(record)
 
         logger._real_logger.emit.assert_called_once_with(record)
+
+    def test_proxy_logger_enabled_delegates_to_real_logger(self):
+        logger = _logs_internal.ProxyLogger("proxy-test")
+        real_logger = Mock(spec=LoggerTest("proxy-test"))
+        real_logger.enabled.return_value = True
+        logger._real_logger = real_logger
+
+        result = logger.enabled(
+            severity_number=_logs.SeverityNumber.INFO, event_name="test"
+        )
+
+        self.assertTrue(result)
+        real_logger.enabled.assert_called_once_with(
+            context=None,
+            severity_number=_logs.SeverityNumber.INFO,
+            event_name="test",
+        )
+
+    def test_proxy_logger_enabled_falls_back_to_noop(self):
+        logger = _logs_internal.ProxyLogger("proxy-test")
+        self.assertFalse(logger.enabled())
+
+    def test_noop_logger_enabled_returns_false(self):
+        logger = _logs.NoOpLogger("noop-test")
+        self.assertFalse(logger.enabled())
+        self.assertFalse(
+            logger.enabled(
+                severity_number=_logs.SeverityNumber.ERROR, event_name="e"
+            )
+        )

--- a/opentelemetry-api/tests/logs/test_proxy.py
+++ b/opentelemetry-api/tests/logs/test_proxy.py
@@ -72,3 +72,33 @@ class TestProxy(LoggingGlobalsTest, unittest.TestCase):
         logger.emit(record)
 
         logger._real_logger.emit.assert_called_once_with(record)
+
+    def test_proxy_logger_enabled_delegates_to_real_logger(self):
+        logger = _logs_internal.ProxyLogger("proxy-test")
+        real_logger = Mock(spec=LoggerTest("proxy-test"))
+        real_logger.enabled.return_value = True
+        logger._real_logger = real_logger
+
+        result = logger.enabled(
+            severity_number=_logs.SeverityNumber.INFO, event_name="test"
+        )
+
+        self.assertTrue(result)
+        real_logger.enabled.assert_called_once_with(
+            context=None,
+            severity_number=_logs.SeverityNumber.INFO,
+            event_name="test",
+        )
+
+    def test_proxy_logger_enabled_falls_back_to_noop(self):
+        logger = _logs_internal.ProxyLogger("proxy-test")
+        self.assertFalse(logger.enabled())
+
+    def test_noop_logger_enabled_returns_false(self):
+        logger = _logs.NoOpLogger("noop-test")
+        self.assertFalse(logger.enabled())
+        self.assertFalse(
+            logger.enabled(
+                severity_number=_logs.SeverityNumber.ERROR, event_name="e"
+            )
+        )

--- a/opentelemetry-api/tests/logs/test_proxy.py
+++ b/opentelemetry-api/tests/logs/test_proxy.py
@@ -79,9 +79,7 @@ class TestProxy(LoggingGlobalsTest, unittest.TestCase):
         real_logger.enabled.return_value = True
         logger._real_logger = real_logger
 
-        result = logger.enabled(
-            severity_number=_logs.SeverityNumber.INFO, event_name="test"
-        )
+        result = logger.enabled(severity_number=_logs.SeverityNumber.INFO, event_name="test")
 
         self.assertTrue(result)
         real_logger.enabled.assert_called_once_with(
@@ -97,8 +95,4 @@ class TestProxy(LoggingGlobalsTest, unittest.TestCase):
     def test_noop_logger_enabled_returns_false(self):
         logger = _logs.NoOpLogger("noop-test")
         self.assertFalse(logger.enabled())
-        self.assertFalse(
-            logger.enabled(
-                severity_number=_logs.SeverityNumber.ERROR, event_name="e"
-            )
-        )
+        self.assertFalse(logger.enabled(severity_number=_logs.SeverityNumber.ERROR, event_name="e"))

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -379,7 +379,7 @@ class LogRecordProcessor(abc.ABC):
         on error handling expectations.
         """
 
-    def enabled(
+    def enabled(  # pylint: disable=no-self-use
         self,
         *,
         context: Context | None = None,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -379,6 +379,21 @@ class LogRecordProcessor(abc.ABC):
         on error handling expectations.
         """
 
+    def enabled(
+        self,
+        *,
+        context: Context | None = None,
+        instrumentation_scope: InstrumentationScope | None = None,
+        severity_number: SeverityNumber | None = None,
+        event_name: str | None = None,
+    ) -> bool:
+        """Returns whether this processor would emit a record for the given arguments.
+
+        Processors that support filtering MAY override this method. The default
+        implementation returns ``True``.
+        """
+        return True  # pylint: disable=unused-argument
+
     @abc.abstractmethod
     def shutdown(self) -> None:
         """Called when a :class:`opentelemetry.sdk._logs.Logger` is shutdown"""
@@ -423,6 +438,27 @@ class SynchronousMultiLogRecordProcessor(LogRecordProcessor):
     def on_emit(self, log_record: ReadWriteLogRecord) -> None:
         for lp in self._log_record_processors:
             lp.on_emit(log_record)
+
+    def enabled(
+        self,
+        *,
+        context: Context | None = None,
+        instrumentation_scope: InstrumentationScope | None = None,
+        severity_number: SeverityNumber | None = None,
+        event_name: str | None = None,
+    ) -> bool:
+        processors = self._log_record_processors
+        if not processors:
+            return False
+        return any(
+            lp.enabled(
+                context=context,
+                instrumentation_scope=instrumentation_scope,
+                severity_number=severity_number,
+                event_name=event_name,
+            )
+            for lp in processors
+        )
 
     def shutdown(self) -> None:
         """Shutdown the log processors one by one"""
@@ -497,6 +533,27 @@ class ConcurrentMultiLogRecordProcessor(LogRecordProcessor):
 
     def on_emit(self, log_record: ReadWriteLogRecord) -> None:
         self._submit_and_wait(lambda lp: lp.on_emit, log_record)
+
+    def enabled(
+        self,
+        *,
+        context: Context | None = None,
+        instrumentation_scope: InstrumentationScope | None = None,
+        severity_number: SeverityNumber | None = None,
+        event_name: str | None = None,
+    ) -> bool:
+        processors = self._log_record_processors
+        if not processors:
+            return False
+        return any(
+            lp.enabled(
+                context=context,
+                instrumentation_scope=instrumentation_scope,
+                severity_number=severity_number,
+                event_name=event_name,
+            )
+            for lp in processors
+        )
 
     def shutdown(self) -> None:
         self._submit_and_wait(lambda lp: lp.shutdown)
@@ -718,6 +775,22 @@ class Logger(APILogger):
 
     def _is_enabled(self) -> bool:
         return self._logger_config.is_enabled
+
+    def enabled(
+        self,
+        *,
+        context: Context | None = None,
+        severity_number: SeverityNumber | None = None,
+        event_name: str | None = None,
+    ) -> bool:
+        if not self._is_enabled():
+            return False
+        return self._multi_log_record_processor.enabled(
+            context=context,
+            instrumentation_scope=self._instrumentation_scope,
+            severity_number=severity_number,
+            event_name=event_name,
+        )
 
     def _set_logger_config(self, logger_config: _LoggerConfig) -> None:
         self._logger_config = logger_config

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -362,6 +362,21 @@ class LogRecordProcessor(abc.ABC):
         on error handling expectations.
         """
 
+    def enabled(
+        self,
+        *,
+        context: Context | None = None,
+        instrumentation_scope: InstrumentationScope | None = None,
+        severity_number: SeverityNumber | None = None,
+        event_name: str | None = None,
+    ) -> bool:
+        """Returns whether this processor would emit a record for the given arguments.
+
+        Processors that support filtering MAY override this method. The default
+        implementation returns ``True``.
+        """
+        return True  # pylint: disable=unused-argument
+
     @abc.abstractmethod
     def shutdown(self) -> None:
         """Called when a :class:`opentelemetry.sdk._logs.Logger` is shutdown"""
@@ -404,6 +419,27 @@ class SynchronousMultiLogRecordProcessor(LogRecordProcessor):
     def on_emit(self, log_record: ReadWriteLogRecord) -> None:
         for lp in self._log_record_processors:
             lp.on_emit(log_record)
+
+    def enabled(
+        self,
+        *,
+        context: Context | None = None,
+        instrumentation_scope: InstrumentationScope | None = None,
+        severity_number: SeverityNumber | None = None,
+        event_name: str | None = None,
+    ) -> bool:
+        processors = self._log_record_processors
+        if not processors:
+            return False
+        return any(
+            lp.enabled(
+                context=context,
+                instrumentation_scope=instrumentation_scope,
+                severity_number=severity_number,
+                event_name=event_name,
+            )
+            for lp in processors
+        )
 
     def shutdown(self) -> None:
         """Shutdown the log processors one by one"""
@@ -474,6 +510,27 @@ class ConcurrentMultiLogRecordProcessor(LogRecordProcessor):
 
     def on_emit(self, log_record: ReadWriteLogRecord) -> None:
         self._submit_and_wait(lambda lp: lp.on_emit, log_record)
+
+    def enabled(
+        self,
+        *,
+        context: Context | None = None,
+        instrumentation_scope: InstrumentationScope | None = None,
+        severity_number: SeverityNumber | None = None,
+        event_name: str | None = None,
+    ) -> bool:
+        processors = self._log_record_processors
+        if not processors:
+            return False
+        return any(
+            lp.enabled(
+                context=context,
+                instrumentation_scope=instrumentation_scope,
+                severity_number=severity_number,
+                event_name=event_name,
+            )
+            for lp in processors
+        )
 
     def shutdown(self) -> None:
         self._submit_and_wait(lambda lp: lp.shutdown)
@@ -698,6 +755,22 @@ class Logger(APILogger):
 
     def _is_enabled(self) -> bool:
         return self._logger_config.is_enabled
+
+    def enabled(
+        self,
+        *,
+        context: Context | None = None,
+        severity_number: SeverityNumber | None = None,
+        event_name: str | None = None,
+    ) -> bool:
+        if not self._is_enabled():
+            return False
+        return self._multi_log_record_processor.enabled(
+            context=context,
+            instrumentation_scope=self._instrumentation_scope,
+            severity_number=severity_number,
+            event_name=event_name,
+        )
 
     def _set_logger_config(self, logger_config: _LoggerConfig) -> None:
         self._logger_config = logger_config

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -362,7 +362,7 @@ class LogRecordProcessor(abc.ABC):
         on error handling expectations.
         """
 
-    def enabled(
+    def enabled(  # pylint: disable=no-self-use
         self,
         *,
         context: Context | None = None,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -429,8 +429,6 @@ class SynchronousMultiLogRecordProcessor(LogRecordProcessor):
         event_name: str | None = None,
     ) -> bool:
         processors = self._log_record_processors
-        if not processors:
-            return False
         return any(
             lp.enabled(
                 context=context,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -518,8 +518,6 @@ class ConcurrentMultiLogRecordProcessor(LogRecordProcessor):
         event_name: str | None = None,
     ) -> bool:
         processors = self._log_record_processors
-        if not processors:
-            return False
         return any(
             lp.enabled(
                 context=context,

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -362,7 +362,7 @@ class LogRecordProcessor(abc.ABC):
         on error handling expectations.
         """
 
-    def enabled(  # pylint: disable=no-self-use
+    def enabled(  # pylint: disable=no-self-use,unused-argument
         self,
         *,
         context: Context | None = None,
@@ -375,7 +375,7 @@ class LogRecordProcessor(abc.ABC):
         Processors that support filtering MAY override this method. The default
         implementation returns ``True``.
         """
-        return True  # pylint: disable=unused-argument
+        return True
 
     @abc.abstractmethod
     def shutdown(self) -> None:

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -571,7 +571,7 @@ class TestLogger(unittest.TestCase):
         logger = provider.get_logger("test")
         self.assertFalse(logger.enabled())
 
-    def test_enabled_passes_args_to_processor(self):
+    def test_enabled_passes_args_to_processor(self):  # pylint: disable=no-self-use
         provider = LoggerProvider()
         processor_mock = Mock()
         processor_mock.enabled.return_value = True

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -551,3 +551,62 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(
             attributes[exception_attributes.EXCEPTION_TYPE], "RuntimeError"
         )
+
+    def test_enabled_with_no_processors_returns_false(self):
+        provider = LoggerProvider()
+        logger = provider.get_logger("test")
+        self.assertFalse(logger.enabled())
+
+    def test_enabled_with_processor_returns_true(self):
+        provider = LoggerProvider()
+        provider.add_log_record_processor(Mock())
+        logger = provider.get_logger("test")
+        self.assertTrue(logger.enabled())
+
+    def test_enabled_disabled_logger_returns_false(self):
+        provider = LoggerProvider(
+            _logger_configurator=_disable_logger_configurator
+        )
+        provider.add_log_record_processor(Mock())
+        logger = provider.get_logger("test")
+        self.assertFalse(logger.enabled())
+
+    def test_enabled_passes_args_to_processor(self):
+        provider = LoggerProvider()
+        processor_mock = Mock()
+        processor_mock.enabled.return_value = True
+        provider.add_log_record_processor(processor_mock)
+        logger = provider.get_logger("test")
+
+        logger.enabled(
+            severity_number=SeverityNumber.INFO, event_name="my.event"
+        )
+
+        processor_mock.enabled.assert_called_once_with(
+            context=None,
+            instrumentation_scope=logger._instrumentation_scope,
+            severity_number=SeverityNumber.INFO,
+            event_name="my.event",
+        )
+
+    def test_enabled_all_processors_disabled_returns_false(self):
+        provider = LoggerProvider()
+        p1 = Mock()
+        p1.enabled.return_value = False
+        p2 = Mock()
+        p2.enabled.return_value = False
+        provider.add_log_record_processor(p1)
+        provider.add_log_record_processor(p2)
+        logger = provider.get_logger("test")
+        self.assertFalse(logger.enabled())
+
+    def test_enabled_one_processor_enabled_returns_true(self):
+        provider = LoggerProvider()
+        p1 = Mock()
+        p1.enabled.return_value = False
+        p2 = Mock()
+        p2.enabled.return_value = True
+        provider.add_log_record_processor(p1)
+        provider.add_log_record_processor(p2)
+        logger = provider.get_logger("test")
+        self.assertTrue(logger.enabled())

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -481,4 +481,65 @@ class TestLogger(unittest.TestCase):
         log_record_processor_mock.on_emit.assert_called_once()
         log_data = log_record_processor_mock.on_emit.call_args.args[0]
         attributes = dict(log_data.log_record.attributes)
-        self.assertEqual(attributes[exception_attributes.EXCEPTION_TYPE], "RuntimeError")
+        self.assertEqual(
+            attributes[exception_attributes.EXCEPTION_TYPE], "RuntimeError"
+        )
+
+    def test_enabled_with_no_processors_returns_false(self):
+        provider = LoggerProvider()
+        logger = provider.get_logger("test")
+        self.assertFalse(logger.enabled())
+
+    def test_enabled_with_processor_returns_true(self):
+        provider = LoggerProvider()
+        provider.add_log_record_processor(Mock())
+        logger = provider.get_logger("test")
+        self.assertTrue(logger.enabled())
+
+    def test_enabled_disabled_logger_returns_false(self):
+        provider = LoggerProvider(
+            _logger_configurator=_disable_logger_configurator
+        )
+        provider.add_log_record_processor(Mock())
+        logger = provider.get_logger("test")
+        self.assertFalse(logger.enabled())
+
+    def test_enabled_passes_args_to_processor(self):
+        provider = LoggerProvider()
+        processor_mock = Mock()
+        processor_mock.enabled.return_value = True
+        provider.add_log_record_processor(processor_mock)
+        logger = provider.get_logger("test")
+
+        logger.enabled(
+            severity_number=SeverityNumber.INFO, event_name="my.event"
+        )
+
+        processor_mock.enabled.assert_called_once_with(
+            context=None,
+            instrumentation_scope=logger._instrumentation_scope,
+            severity_number=SeverityNumber.INFO,
+            event_name="my.event",
+        )
+
+    def test_enabled_all_processors_disabled_returns_false(self):
+        provider = LoggerProvider()
+        p1 = Mock()
+        p1.enabled.return_value = False
+        p2 = Mock()
+        p2.enabled.return_value = False
+        provider.add_log_record_processor(p1)
+        provider.add_log_record_processor(p2)
+        logger = provider.get_logger("test")
+        self.assertFalse(logger.enabled())
+
+    def test_enabled_one_processor_enabled_returns_true(self):
+        provider = LoggerProvider()
+        p1 = Mock()
+        p1.enabled.return_value = False
+        p2 = Mock()
+        p2.enabled.return_value = True
+        provider.add_log_record_processor(p1)
+        provider.add_log_record_processor(p2)
+        logger = provider.get_logger("test")
+        self.assertTrue(logger.enabled())

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -481,9 +481,7 @@ class TestLogger(unittest.TestCase):
         log_record_processor_mock.on_emit.assert_called_once()
         log_data = log_record_processor_mock.on_emit.call_args.args[0]
         attributes = dict(log_data.log_record.attributes)
-        self.assertEqual(
-            attributes[exception_attributes.EXCEPTION_TYPE], "RuntimeError"
-        )
+        self.assertEqual(attributes[exception_attributes.EXCEPTION_TYPE], "RuntimeError")
 
     def test_enabled_with_no_processors_returns_false(self):
         provider = LoggerProvider()
@@ -500,9 +498,7 @@ class TestLogger(unittest.TestCase):
         processor.enabled.assert_called_once()
 
     def test_enabled_disabled_logger_returns_false(self):
-        provider = LoggerProvider(
-            _logger_configurator=_disable_logger_configurator
-        )
+        provider = LoggerProvider(_logger_configurator=_disable_logger_configurator)
         provider.add_log_record_processor(Mock())
         logger = provider.get_logger("test")
         self.assertFalse(logger.enabled())
@@ -514,9 +510,7 @@ class TestLogger(unittest.TestCase):
         provider.add_log_record_processor(processor_mock)
         logger = provider.get_logger("test")
 
-        logger.enabled(
-            severity_number=SeverityNumber.INFO, event_name="my.event"
-        )
+        logger.enabled(severity_number=SeverityNumber.INFO, event_name="my.event")
 
         processor_mock.enabled.assert_called_once_with(
             context=None,

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -492,9 +492,12 @@ class TestLogger(unittest.TestCase):
 
     def test_enabled_with_processor_returns_true(self):
         provider = LoggerProvider()
-        provider.add_log_record_processor(Mock())
+        processor = Mock()
+        processor.enabled.return_value = True
+        provider.add_log_record_processor(processor)
         logger = provider.get_logger("test")
         self.assertTrue(logger.enabled())
+        processor.enabled.assert_called_once()
 
     def test_enabled_disabled_logger_returns_false(self):
         provider = LoggerProvider(

--- a/opentelemetry-sdk/tests/logs/test_logs.py
+++ b/opentelemetry-sdk/tests/logs/test_logs.py
@@ -504,7 +504,7 @@ class TestLogger(unittest.TestCase):
         logger = provider.get_logger("test")
         self.assertFalse(logger.enabled())
 
-    def test_enabled_passes_args_to_processor(self):
+    def test_enabled_passes_args_to_processor(self):  # pylint: disable=no-self-use
         provider = LoggerProvider()
         processor_mock = Mock()
         processor_mock.enabled.return_value = True


### PR DESCRIPTION
## Summary

Implements the `Enabled` chain from the [OpenTelemetry Logs specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/api.md#enabled), closes #5360.

- **API `Logger.enabled(context, severity_number, event_name) -> bool`**: non-abstract default returning `True`; `NoOpLogger` returns `False`; `ProxyLogger` delegates to the real logger.
- **SDK `LogRecordProcessor.enabled(context, instrumentation_scope, severity_number, event_name) -> bool`**: non-abstract default returning `True` — processors opt into filtering by overriding this method.
- **SDK `SynchronousMultiLogRecordProcessor` / `ConcurrentMultiLogRecordProcessor`**: `enabled()` returns `False` when no processors are registered, `False` when all processors return `False`, `True` otherwise.
- **SDK `Logger.enabled()`**: checks `LoggerConfig.is_enabled` first, then delegates to the multi-processor with the logger's instrumentation scope.

## Test plan

- [ ] New SDK tests covering: no processors → `False`, processor present → `True`, disabled logger config → `False`, args forwarded to processor, all processors disabled → `False`, one processor enabled → `True`
- [ ] New API tests covering: `NoOpLogger.enabled()` → `False`, `ProxyLogger.enabled()` delegates to real logger, `ProxyLogger.enabled()` falls back to no-op