### PR TITLE
Make ProcessResourceDetector command args opt-in (security)

### DIFF
--- a/.changelog/5358.fixed
+++ b/.changelog/5358.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: `ProcessResourceDetector` no longer collects `process.command_line` and `process.command_args` by default, since these can contain secrets passed via CLI flags. Opt in via `ProcessResourceDetector(collect_command_args=True)`

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -322,6 +322,25 @@ class OTELResourceDetector(ResourceDetector):
 
 class ProcessResourceDetector(ResourceDetector):
     # pylint: disable=no-self-use
+    def __init__(
+        self,
+        raise_on_error: bool = False,
+        collect_command_args: bool = False,
+    ) -> None:
+        """
+        Args:
+            raise_on_error: See :class:`ResourceDetector`.
+            collect_command_args: Whether to collect the
+                ``process.command_line`` and ``process.command_args``
+                attributes. These attributes are **disabled by default**
+                because command-line arguments can contain secrets or other
+                sensitive data (e.g. ``--api-key=...``). Per the OpenTelemetry
+                semantic conventions, these attributes are opt-in:
+                https://opentelemetry.io/docs/specs/semconv/resource/process/
+        """
+        super().__init__(raise_on_error=raise_on_error)
+        self.collect_command_args = collect_command_args
+
     def detect(self) -> "Resource":
         _runtime_version = ".".join(
             map(
@@ -345,8 +364,6 @@ class ProcessResourceDetector(ResourceDetector):
         # conventions reference for these attributes.
         _process_argv = list(sys.orig_argv)
         _process_command = _process_argv[0] if _process_argv else ""
-        _process_command_line = " ".join(_process_argv)
-        _process_command_args = _process_argv
         resource_info = {
             PROCESS_RUNTIME_DESCRIPTION: sys.version,
             PROCESS_RUNTIME_NAME: sys.implementation.name,
@@ -355,9 +372,13 @@ class ProcessResourceDetector(ResourceDetector):
             PROCESS_EXECUTABLE_NAME: _process_executable_name,
             PROCESS_EXECUTABLE_PATH: _process_executable_path,
             PROCESS_COMMAND: _process_command,
-            PROCESS_COMMAND_LINE: _process_command_line,
-            PROCESS_COMMAND_ARGS: _process_command_args,
         }
+        # process.command_line and process.command_args can contain secrets
+        # passed via CLI flags, so per the semantic conventions they are
+        # opt-in only and excluded from the default resource attributes.
+        if self.collect_command_args:
+            resource_info[PROCESS_COMMAND_LINE] = " ".join(_process_argv)
+            resource_info[PROCESS_COMMAND_ARGS] = _process_argv
         if hasattr(os, "getppid"):
             # pypy3 does not have getppid()
             resource_info[PROCESS_PARENT_PID] = os.getppid()

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -657,6 +657,49 @@ class TestOTELResourceDetector(unittest.TestCase):
         self.assertEqual(
             aggregated_resource.attributes[PROCESS_COMMAND], sys.orig_argv[0]
         )
+
+        # process.command_line and process.command_args are opt-in only
+        # (see test_process_detector_command_args_excluded_by_default and
+        # test_process_detector_command_args_opt_in below), since they can
+        # contain secrets passed via CLI flags.
+        self.assertNotIn(
+            PROCESS_COMMAND_LINE,
+            aggregated_resource.attributes.keys(),
+        )
+        self.assertNotIn(
+            PROCESS_COMMAND_ARGS,
+            aggregated_resource.attributes.keys(),
+        )
+
+    def test_process_detector_command_args_excluded_by_default(self):
+        """process.command_line / process.command_args must NOT be
+        collected unless explicitly opted in, since they can leak secrets
+        passed via CLI flags (e.g. --api-key=...).
+        See https://github.com/open-telemetry/opentelemetry-python/issues/5358
+        and https://opentelemetry.io/docs/specs/semconv/resource/process/.
+        """
+        aggregated_resource = get_aggregated_resources(
+            [ProcessResourceDetector()], Resource({"foo": "bar"})
+        )
+
+        self.assertNotIn(
+            PROCESS_COMMAND_LINE,
+            aggregated_resource.attributes.keys(),
+        )
+        self.assertNotIn(
+            PROCESS_COMMAND_ARGS,
+            aggregated_resource.attributes.keys(),
+        )
+
+    def test_process_detector_command_args_opt_in(self):
+        """When explicitly opted in via collect_command_args=True,
+        process.command_line and process.command_args must be collected.
+        """
+        aggregated_resource = get_aggregated_resources(
+            [ProcessResourceDetector(collect_command_args=True)],
+            Resource({"foo": "bar"}),
+        )
+
         self.assertEqual(
             aggregated_resource.attributes[PROCESS_COMMAND_LINE],
             " ".join(sys.orig_argv),
@@ -674,7 +717,8 @@ class TestOTELResourceDetector(unittest.TestCase):
         See https://github.com/open-telemetry/opentelemetry-python/issues/4518.
         """
         aggregated_resource = get_aggregated_resources(
-            [ProcessResourceDetector()], Resource({"foo": "bar"})
+            [ProcessResourceDetector(collect_command_args=True)],
+            Resource({"foo": "bar"}),
         )
 
         self.assertEqual(


### PR DESCRIPTION
## Summary

Fixes #5358.

`ProcessResourceDetector` collected `process.command_line` and `process.command_args` **by default**, even though the OpenTelemetry semantic conventions explicitly require these attributes to be opt-in:

> https://opentelemetry.io/docs/specs/semconv/resource/process/

This is a real security concern — command-line arguments frequently contain secrets:

```bash
python myapp.py --api-key=secret-value
# process.command_line would include "--api-key=secret-value" verbatim
```

Any telemetry backend receiving this resource would silently capture the secret.

## Fix

Added a `collect_command_args: bool = False` constructor parameter to `ProcessResourceDetector`. The two sensitive attributes are only populated when explicitly opted in:

```python
# Before (and after this PR, still the default) — safe
ProcessResourceDetector()
# process.command_line / process.command_args: NOT collected

# Explicit opt-in for users who understand the risk
ProcessResourceDetector(collect_command_args=True)
# process.command_line / process.command_args: collected as before
```

`process.command` (just the program name / argv[0], no arguments) is unaffected and still collected by default, since it doesn't carry sensitive data.

## Changes

| File | Change |
|---|---|
| `opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py` | New `collect_command_args` param; `detect()` gates the two attributes behind it |
| `opentelemetry-sdk/tests/resources/test_resources.py` | Updated `test_process_detector` to assert absence by default; added `test_process_detector_command_args_excluded_by_default` and `test_process_detector_command_args_opt_in`; updated `test_process_detector_uses_orig_argv_for_python_m` to opt in explicitly |
| `.changelog/5358.fixed` | Towncrier changelog fragment |

## Backward compatibility note

This is a behavior change for anyone currently relying on `process.command_line` / `process.command_args` being present by default — but that default behavior was itself the bug (a spec violation with real security implications), so per the issue this is the correct fix. Callers who need the old behavior can opt back in with one keyword argument.