### PR TITLE
Fix missed wakeup race condition in BatchProcessor

### DIFF
--- a/.changelog/5409.fixed
+++ b/.changelog/5409.fixed
@@ -1,0 +1,1 @@
+Fix missed wakeup race in `BatchProcessor` that could delay span/log export by a full schedule delay when a batch filled while the worker was clearing its wakeup event

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py
@@ -154,6 +154,12 @@ class BatchProcessor(Generic[Telemetry]):
             # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#batching-processor.
             # Shutdown will interrupt this sleep. Emit will interrupt this sleep only if the queue is bigger then threshold.
             sleep_interrupted = self._worker_awaken.wait(self._schedule_delay)
+            # Clear the event before exporting, not after. A wakeup signaled by
+            # `emit` between the export loop finishing and a late `clear` would
+            # be erased, leaving a full batch stuck in the queue for up to
+            # `schedule_delay`. Clearing first means any `set` that arrives
+            # while exporting is kept for the next `wait`.
+            self._worker_awaken.clear()
             if self._shutdown:
                 break
             self._export(
@@ -161,7 +167,6 @@ class BatchProcessor(Generic[Telemetry]):
                 if sleep_interrupted
                 else BatchExportStrategy.EXPORT_AT_LEAST_ONE_BATCH
             )
-            self._worker_awaken.clear()
         self._export(BatchExportStrategy.EXPORT_ALL)
 
     def _export(self, batch_strategy: BatchExportStrategy) -> None:

--- a/opentelemetry-sdk/tests/shared_internal/test_batch_processor.py
+++ b/opentelemetry-sdk/tests/shared_internal/test_batch_processor.py
@@ -119,6 +119,56 @@ class TestBatchProcessor:
         exporter.export.assert_called_once_with([telemetry])
         batch_processor.shutdown()
 
+    # pylint: disable=no-self-use
+    def test_wakeup_not_lost_when_batch_fills_during_event_clear(
+        self, batch_processor_class, telemetry
+    ):
+        # Regression test for a missed wakeup race: if `emit` filled a batch
+        # and set `_worker_awaken` after the worker's export loop drained the
+        # queue but before the worker cleared the event, the signal was erased
+        # and the batch sat in the queue for a full schedule delay.
+        exporter = Mock()
+        batch_processor = batch_processor_class(
+            exporter,
+            max_queue_size=100,
+            max_export_batch_size=10,
+            # Will not be reached during the test; if the wakeup is lost the
+            # asserts below fail long before this delay elapses.
+            schedule_delay_millis=30000,
+            export_timeout_millis=500,
+        )
+        processor = batch_processor._batch_processor
+        original_clear = processor._worker_awaken.clear
+        raced = threading.Event()
+
+        def emit_batch_then_clear():
+            # Fill a full batch (which calls `_worker_awaken.set()`) at the
+            # exact point the worker is about to clear the event, simulating
+            # an application thread that raced with the worker.
+            if not raced.is_set():
+                raced.set()
+                for _ in range(10):
+                    processor.emit(telemetry)
+            original_clear()
+
+        processor._worker_awaken.clear = emit_batch_then_clear
+        # Trigger the first export; the worker wakes, exports this batch, and
+        # then races with the batch emitted from the clear hook.
+        for _ in range(10):
+            processor.emit(telemetry)
+
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            exported = sum(
+                len(call.args[0]) for call in exporter.export.call_args_list
+            )
+            if exported == 20:
+                break
+            time.sleep(0.01)
+        assert exported == 20
+        assert len(processor._queue) == 0
+        batch_processor.shutdown()
+
     def test_telemetry_flushed_before_shutdown_and_dropped_after_shutdown(
         self, batch_processor_class, telemetry
     ):


### PR DESCRIPTION
## Description

`BatchProcessor.worker()` clears `_worker_awaken` only after its export loop finishes. If an application thread fills a batch and calls `_worker_awaken.set()` in the window between the export loop draining the queue and the worker calling `clear()`, the wakeup signal is erased and the full batch sits in the queue for up to `schedule_delay` (5s by default). This affects both `BatchSpanProcessor` and `BatchLogRecordProcessor` since they share this implementation, and shows up as recurring export-latency spikes under high throughput.

This PR clears the event immediately after `wait()` returns, before exporting, so a `set()` that arrives while the worker is exporting is preserved for the next `wait()`. Worst case is one benign spurious wakeup that exports nothing. `shutdown()` is unaffected because worker exit is gated on the `_shutdown` flag, not the event.

Regarding the question raised on the earlier attempt (#5401) — whether `_should_export_batch` already covers this because it keeps exporting while the queue exceeds the batch size: it doesn't cover this window, because the lost signal arrives *after* the export loop has already exited and before the event is cleared. The regression test demonstrates this deterministically: it fails on `main` (items stay queued while the worker sleeps) and passes with this change.

Fixes #5400

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New regression test `test_wakeup_not_lost_when_batch_fills_during_event_clear` in `opentelemetry-sdk/tests/shared_internal/test_batch_processor.py`, parametrized over `BatchLogRecordProcessor` and `BatchSpanProcessor`. It hooks `_worker_awaken.clear` to inject a full batch at the exact race point; fails without the fix, passes with it (~0.05s, stable across repeated runs).
- Full `opentelemetry-sdk` test suite, `tox -e precommit` (ruff), `tox -e lint-opentelemetry-sdk` (pylint 10/10), and `tox -e typecheck` (pyright) all pass.

## Does This PR Require a Contrib Repo Change?

- [x] No.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated

Assisted-by: Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
