### PR TITLE
feat(otlp-http): add insecure parameter and fix certificate_file resolution

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_common/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_common/__init__.py
@@ -20,6 +20,25 @@ def _is_retryable(resp: requests.Response) -> bool:
     return False
 
 
+def _resolve_insecure(
+    insecure: bool | None,
+    signal_env_var: str,
+    generic_env_var: str,
+) -> bool:
+    """Resolve the insecure flag from the constructor argument or environment variables.
+
+    Priority: constructor argument > signal-specific env var > generic env var > default (False).
+
+    Per the OpenTelemetry spec, empty environment variable values are treated as unset.
+    """
+    if insecure is not None:
+        return insecure
+    env_value = environ.get(signal_env_var) or environ.get(generic_env_var)
+    if env_value is not None:
+        return env_value.strip().lower() == "true"
+    return False
+
+
 def _load_session_from_envvar(
     cred_envvar: Literal[
         "OTEL_PYTHON_EXPORTER_OTLP_HTTP_LOGS_CREDENTIAL_PROVIDER",

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -27,6 +27,7 @@ from opentelemetry.exporter.otlp.proto.http import (
 from opentelemetry.exporter.otlp.proto.http._common import (
     _is_retryable,
     _load_session_from_envvar,
+    _resolve_insecure,
 )
 from opentelemetry.metrics import MeterProvider
 from opentelemetry.sdk._logs import ReadableLogRecord
@@ -43,12 +44,14 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_COMPRESSION,
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_HEADERS,
+    OTEL_EXPORTER_OTLP_INSECURE,
     OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE,
     OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE,
     OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY,
     OTEL_EXPORTER_OTLP_LOGS_COMPRESSION,
     OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
     OTEL_EXPORTER_OTLP_LOGS_HEADERS,
+    OTEL_EXPORTER_OTLP_LOGS_INSECURE,
     OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
     OTEL_EXPORTER_OTLP_TIMEOUT,
     OTEL_PYTHON_SDK_INTERNAL_METRICS_ENABLED,
@@ -84,6 +87,7 @@ class OTLPLogExporter(LogRecordExporter):
         timeout: float | None = None,
         compression: Compression | None = None,
         session: requests.Session | None = None,
+        insecure: bool | None = None,
         *,
         meter_provider: MeterProvider | None = None,
     ):
@@ -94,11 +98,22 @@ class OTLPLogExporter(LogRecordExporter):
                 environ.get(OTEL_EXPORTER_OTLP_ENDPOINT, DEFAULT_ENDPOINT)
             ),
         )
-        # Keeping these as instance variables because they are used in tests
-        self._certificate_file = certificate_file or environ.get(
-            OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE,
-            environ.get(OTEL_EXPORTER_OTLP_CERTIFICATE, True),
+        self._insecure = _resolve_insecure(
+            insecure,
+            OTEL_EXPORTER_OTLP_LOGS_INSECURE,
+            OTEL_EXPORTER_OTLP_INSECURE,
         )
+        if self._insecure:
+            self._certificate_file = False
+        else:
+            self._certificate_file = (
+                certificate_file
+                if certificate_file is not None
+                else environ.get(
+                    OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE,
+                    environ.get(OTEL_EXPORTER_OTLP_CERTIFICATE, True),
+                )
+            )
         self._client_key_file = client_key_file or environ.get(
             OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY,
             environ.get(OTEL_EXPORTER_OTLP_CLIENT_KEY, None),
@@ -291,3 +306,5 @@ def _append_logs_path(endpoint: str) -> str:
     if endpoint.endswith("/"):
         return endpoint + DEFAULT_LOGS_EXPORT_PATH
     return endpoint + f"/{DEFAULT_LOGS_EXPORT_PATH}"
+
+

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
@@ -41,6 +41,7 @@ from opentelemetry.exporter.otlp.proto.http import (
 from opentelemetry.exporter.otlp.proto.http._common import (
     _is_retryable,
     _load_session_from_envvar,
+    _resolve_insecure,
 )
 from opentelemetry.metrics import MeterProvider
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (  # noqa: F401
@@ -66,12 +67,14 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_COMPRESSION,
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_HEADERS,
+    OTEL_EXPORTER_OTLP_INSECURE,
     OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
     OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE,
     OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY,
     OTEL_EXPORTER_OTLP_METRICS_COMPRESSION,
     OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
     OTEL_EXPORTER_OTLP_METRICS_HEADERS,
+    OTEL_EXPORTER_OTLP_METRICS_INSECURE,
     OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
     OTEL_EXPORTER_OTLP_TIMEOUT,
     OTEL_PYTHON_SDK_INTERNAL_METRICS_ENABLED,
@@ -122,6 +125,7 @@ class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
         | None = None,
         preferred_aggregation: dict[type, Aggregation] | None = None,
         max_export_batch_size: int | None = None,
+        insecure: bool | None = None,
         *,
         meter_provider: MeterProvider | None = None,
     ):
@@ -145,6 +149,10 @@ class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
             max_export_batch_size: Maximum number of data points to export in a single request.
                 If not set there is no limit to the number of data points in a request.
                 If it is set and the number of data points exceeds the max, the request will be split.
+            insecure: Whether to disable TLS certificate verification. If True, the
+                exporter will not verify the server's TLS certificate. Can also be
+                configured via OTEL_EXPORTER_OTLP_METRICS_INSECURE or
+                OTEL_EXPORTER_OTLP_INSECURE environment variables.
         """
         self._shutdown_in_progress = threading.Event()
         self._endpoint = endpoint or environ.get(
@@ -153,10 +161,22 @@ class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
                 environ.get(OTEL_EXPORTER_OTLP_ENDPOINT, DEFAULT_ENDPOINT)
             ),
         )
-        self._certificate_file = certificate_file or environ.get(
-            OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
-            environ.get(OTEL_EXPORTER_OTLP_CERTIFICATE, True),
+        self._insecure = _resolve_insecure(
+            insecure,
+            OTEL_EXPORTER_OTLP_METRICS_INSECURE,
+            OTEL_EXPORTER_OTLP_INSECURE,
         )
+        if self._insecure:
+            self._certificate_file = False
+        else:
+            self._certificate_file = (
+                certificate_file
+                if certificate_file is not None
+                else environ.get(
+                    OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
+                    environ.get(OTEL_EXPORTER_OTLP_CERTIFICATE, True),
+                )
+            )
         self._client_key_file = client_key_file or environ.get(
             OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY,
             environ.get(OTEL_EXPORTER_OTLP_CLIENT_KEY, None),
@@ -748,3 +768,5 @@ def _append_metrics_path(endpoint: str) -> str:
     if endpoint.endswith("/"):
         return endpoint + DEFAULT_METRICS_EXPORT_PATH
     return endpoint + f"/{DEFAULT_METRICS_EXPORT_PATH}"
+
+

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -29,6 +29,7 @@ from opentelemetry.exporter.otlp.proto.http import (
 from opentelemetry.exporter.otlp.proto.http._common import (
     _is_retryable,
     _load_session_from_envvar,
+    _resolve_insecure,
 )
 from opentelemetry.metrics import MeterProvider
 from opentelemetry.sdk.environment_variables import (
@@ -39,6 +40,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_COMPRESSION,
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_HEADERS,
+    OTEL_EXPORTER_OTLP_INSECURE,
     OTEL_EXPORTER_OTLP_TIMEOUT,
     OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
     OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE,
@@ -46,6 +48,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
     OTEL_EXPORTER_OTLP_TRACES_HEADERS,
+    OTEL_EXPORTER_OTLP_TRACES_INSECURE,
     OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
     OTEL_PYTHON_SDK_INTERNAL_METRICS_ENABLED,
 )
@@ -80,6 +83,7 @@ class OTLPSpanExporter(SpanExporter):
         timeout: float | None = None,
         compression: Compression | None = None,
         session: requests.Session | None = None,
+        insecure: bool | None = None,
         *,
         meter_provider: MeterProvider | None = None,
     ):
@@ -90,10 +94,22 @@ class OTLPSpanExporter(SpanExporter):
                 environ.get(OTEL_EXPORTER_OTLP_ENDPOINT, DEFAULT_ENDPOINT)
             ),
         )
-        self._certificate_file = certificate_file or environ.get(
-            OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
-            environ.get(OTEL_EXPORTER_OTLP_CERTIFICATE, True),
+        self._insecure = _resolve_insecure(
+            insecure,
+            OTEL_EXPORTER_OTLP_TRACES_INSECURE,
+            OTEL_EXPORTER_OTLP_INSECURE,
         )
+        if self._insecure:
+            self._certificate_file = False
+        else:
+            self._certificate_file = (
+                certificate_file
+                if certificate_file is not None
+                else environ.get(
+                    OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
+                    environ.get(OTEL_EXPORTER_OTLP_CERTIFICATE, True),
+                )
+            )
         self._client_key_file = client_key_file or environ.get(
             OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY,
             environ.get(OTEL_EXPORTER_OTLP_CLIENT_KEY, None),
@@ -284,3 +300,5 @@ def _append_trace_path(endpoint: str) -> str:
     if endpoint.endswith("/"):
         return endpoint + DEFAULT_TRACES_EXPORT_PATH
     return endpoint + f"/{DEFAULT_TRACES_EXPORT_PATH}"
+
+

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
@@ -47,6 +47,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_COMPRESSION,
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_HEADERS,
+    OTEL_EXPORTER_OTLP_INSECURE,
     OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
     OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE,
     OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY,
@@ -54,6 +55,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
     OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
     OTEL_EXPORTER_OTLP_METRICS_HEADERS,
+    OTEL_EXPORTER_OTLP_METRICS_INSECURE,
     OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
     OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
     OTEL_EXPORTER_OTLP_TIMEOUT,
@@ -1559,3 +1561,98 @@ def _number_data_point(value: int) -> pb2.NumberDataPoint:
         time_unix_nano=1641946016139533244,
         as_int=value,
     )
+
+
+class TestOTLPMetricExporterInsecure(TestCase):
+    def test_insecure_default_is_false(self):
+        exporter = OTLPMetricExporter()
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    def test_insecure_true_disables_verification(self):
+        exporter = OTLPMetricExporter(insecure=True)
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    def test_insecure_false_keeps_verification(self):
+        exporter = OTLPMetricExporter(insecure=False)
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    def test_insecure_true_ignores_certificate_file(self):
+        exporter = OTLPMetricExporter(
+            insecure=True, certificate_file="/path/to/cert.pem"
+        )
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    def test_insecure_false_uses_certificate_file(self):
+        exporter = OTLPMetricExporter(
+            insecure=False, certificate_file="/path/to/cert.pem"
+        )
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, "/path/to/cert.pem")
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_METRICS_INSECURE: "true"},
+    )
+    def test_signal_env_var_sets_insecure(self):
+        exporter = OTLPMetricExporter()
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_INSECURE: "true"},
+    )
+    def test_generic_env_var_sets_insecure(self):
+        exporter = OTLPMetricExporter()
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    @patch.dict(
+        "os.environ",
+        {
+            OTEL_EXPORTER_OTLP_METRICS_INSECURE: "false",
+            OTEL_EXPORTER_OTLP_INSECURE: "true",
+        },
+    )
+    def test_signal_env_var_takes_priority_over_generic(self):
+        exporter = OTLPMetricExporter()
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_METRICS_INSECURE: "true"},
+    )
+    def test_constructor_takes_priority_over_env_var(self):
+        exporter = OTLPMetricExporter(insecure=False)
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_METRICS_INSECURE: "TRUE"},
+    )
+    def test_env_var_case_insensitive(self):
+        exporter = OTLPMetricExporter()
+        self.assertTrue(exporter._insecure)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_METRICS_INSECURE: "  true  "},
+    )
+    def test_env_var_strips_whitespace(self):
+        exporter = OTLPMetricExporter()
+        self.assertTrue(exporter._insecure)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_METRICS_INSECURE: "invalid"},
+    )
+    def test_env_var_invalid_value_is_false(self):
+        exporter = OTLPMetricExporter()
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_common.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_common.py
@@ -1,0 +1,77 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest.mock import patch
+
+from opentelemetry.exporter.otlp.proto.http._common import _resolve_insecure
+
+
+class TestResolveInsecure(unittest.TestCase):
+    def test_constructor_true_returns_true(self):
+        result = _resolve_insecure(True, "SIGNAL_VAR", "GENERIC_VAR")
+        self.assertTrue(result)
+
+    def test_constructor_false_returns_false(self):
+        result = _resolve_insecure(False, "SIGNAL_VAR", "GENERIC_VAR")
+        self.assertFalse(result)
+
+    def test_constructor_none_no_env_returns_false(self):
+        result = _resolve_insecure(None, "SIGNAL_VAR", "GENERIC_VAR")
+        self.assertFalse(result)
+
+    @patch.dict("os.environ", {"MY_SIGNAL_INSECURE": "true"})
+    def test_signal_env_var_true(self):
+        result = _resolve_insecure(None, "MY_SIGNAL_INSECURE", "MY_GENERIC_INSECURE")
+        self.assertTrue(result)
+
+    @patch.dict("os.environ", {"MY_SIGNAL_INSECURE": "false"})
+    def test_signal_env_var_false(self):
+        result = _resolve_insecure(None, "MY_SIGNAL_INSECURE", "MY_GENERIC_INSECURE")
+        self.assertFalse(result)
+
+    @patch.dict("os.environ", {"MY_GENERIC_INSECURE": "true"})
+    def test_generic_env_var_true(self):
+        result = _resolve_insecure(None, "MY_SIGNAL_INSECURE", "MY_GENERIC_INSECURE")
+        self.assertTrue(result)
+
+    @patch.dict(
+        "os.environ",
+        {"MY_SIGNAL_INSECURE": "false", "MY_GENERIC_INSECURE": "true"},
+    )
+    def test_signal_env_var_takes_priority(self):
+        result = _resolve_insecure(None, "MY_SIGNAL_INSECURE", "MY_GENERIC_INSECURE")
+        self.assertFalse(result)
+
+    @patch.dict("os.environ", {"MY_SIGNAL_INSECURE": "true"})
+    def test_constructor_overrides_env_var(self):
+        result = _resolve_insecure(False, "MY_SIGNAL_INSECURE", "MY_GENERIC_INSECURE")
+        self.assertFalse(result)
+
+    @patch.dict("os.environ", {"MY_SIGNAL_INSECURE": "TRUE"})
+    def test_env_var_case_insensitive(self):
+        result = _resolve_insecure(None, "MY_SIGNAL_INSECURE", "MY_GENERIC_INSECURE")
+        self.assertTrue(result)
+
+    @patch.dict("os.environ", {"MY_SIGNAL_INSECURE": "  True  "})
+    def test_env_var_strips_whitespace(self):
+        result = _resolve_insecure(None, "MY_SIGNAL_INSECURE", "MY_GENERIC_INSECURE")
+        self.assertTrue(result)
+
+    @patch.dict("os.environ", {"MY_SIGNAL_INSECURE": "yes"})
+    def test_env_var_non_true_value_is_false(self):
+        result = _resolve_insecure(None, "MY_SIGNAL_INSECURE", "MY_GENERIC_INSECURE")
+        self.assertFalse(result)
+
+    @patch.dict("os.environ", {"MY_SIGNAL_INSECURE": ""})
+    def test_empty_signal_env_var_falls_through_to_generic(self):
+        result = _resolve_insecure(None, "MY_SIGNAL_INSECURE", "MY_GENERIC_INSECURE")
+        self.assertFalse(result)
+
+    @patch.dict(
+        "os.environ",
+        {"MY_SIGNAL_INSECURE": "", "MY_GENERIC_INSECURE": "true"},
+    )
+    def test_empty_signal_env_falls_through_to_generic_true(self):
+        result = _resolve_insecure(None, "MY_SIGNAL_INSECURE", "MY_GENERIC_INSECURE")
+        self.assertTrue(result)

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
@@ -38,12 +38,14 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_COMPRESSION,
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_HEADERS,
+    OTEL_EXPORTER_OTLP_INSECURE,
     OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE,
     OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE,
     OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY,
     OTEL_EXPORTER_OTLP_LOGS_COMPRESSION,
     OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
     OTEL_EXPORTER_OTLP_LOGS_HEADERS,
+    OTEL_EXPORTER_OTLP_LOGS_INSECURE,
     OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
     OTEL_EXPORTER_OTLP_TIMEOUT,
     OTEL_PYTHON_SDK_INTERNAL_METRICS_ENABLED,
@@ -667,3 +669,98 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
         )
         self.assertEqual(attributes["server.address"], "localhost")
         self.assertEqual(attributes["server.port"], 4318)
+
+
+class TestOTLPLogExporterInsecure(unittest.TestCase):
+    def test_insecure_default_is_false(self):
+        exporter = OTLPLogExporter()
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    def test_insecure_true_disables_verification(self):
+        exporter = OTLPLogExporter(insecure=True)
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    def test_insecure_false_keeps_verification(self):
+        exporter = OTLPLogExporter(insecure=False)
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    def test_insecure_true_ignores_certificate_file(self):
+        exporter = OTLPLogExporter(
+            insecure=True, certificate_file="/path/to/cert.pem"
+        )
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    def test_insecure_false_uses_certificate_file(self):
+        exporter = OTLPLogExporter(
+            insecure=False, certificate_file="/path/to/cert.pem"
+        )
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, "/path/to/cert.pem")
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_LOGS_INSECURE: "true"},
+    )
+    def test_signal_env_var_sets_insecure(self):
+        exporter = OTLPLogExporter()
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_INSECURE: "true"},
+    )
+    def test_generic_env_var_sets_insecure(self):
+        exporter = OTLPLogExporter()
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    @patch.dict(
+        "os.environ",
+        {
+            OTEL_EXPORTER_OTLP_LOGS_INSECURE: "false",
+            OTEL_EXPORTER_OTLP_INSECURE: "true",
+        },
+    )
+    def test_signal_env_var_takes_priority_over_generic(self):
+        exporter = OTLPLogExporter()
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_LOGS_INSECURE: "true"},
+    )
+    def test_constructor_takes_priority_over_env_var(self):
+        exporter = OTLPLogExporter(insecure=False)
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_LOGS_INSECURE: "TRUE"},
+    )
+    def test_env_var_case_insensitive(self):
+        exporter = OTLPLogExporter()
+        self.assertTrue(exporter._insecure)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_LOGS_INSECURE: "  true  "},
+    )
+    def test_env_var_strips_whitespace(self):
+        exporter = OTLPLogExporter()
+        self.assertTrue(exporter._insecure)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_LOGS_INSECURE: "invalid"},
+    )
+    def test_env_var_invalid_value_is_false(self):
+        exporter = OTLPLogExporter()
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
@@ -29,6 +29,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_COMPRESSION,
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_HEADERS,
+    OTEL_EXPORTER_OTLP_INSECURE,
     OTEL_EXPORTER_OTLP_TIMEOUT,
     OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
     OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE,
@@ -36,6 +37,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
     OTEL_EXPORTER_OTLP_TRACES_HEADERS,
+    OTEL_EXPORTER_OTLP_TRACES_INSECURE,
     OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
     OTEL_PYTHON_SDK_INTERNAL_METRICS_ENABLED,
 )
@@ -497,3 +499,98 @@ class TestOTLPSpanExporter(unittest.TestCase):
         )
         self.assertEqual(attributes["server.address"], "localhost")
         self.assertEqual(attributes["server.port"], 4318)
+
+
+class TestOTLPSpanExporterInsecure(unittest.TestCase):
+    def test_insecure_default_is_false(self):
+        exporter = OTLPSpanExporter()
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    def test_insecure_true_disables_verification(self):
+        exporter = OTLPSpanExporter(insecure=True)
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    def test_insecure_false_keeps_verification(self):
+        exporter = OTLPSpanExporter(insecure=False)
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    def test_insecure_true_ignores_certificate_file(self):
+        exporter = OTLPSpanExporter(
+            insecure=True, certificate_file="/path/to/cert.pem"
+        )
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    def test_insecure_false_uses_certificate_file(self):
+        exporter = OTLPSpanExporter(
+            insecure=False, certificate_file="/path/to/cert.pem"
+        )
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, "/path/to/cert.pem")
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_TRACES_INSECURE: "true"},
+    )
+    def test_signal_env_var_sets_insecure(self):
+        exporter = OTLPSpanExporter()
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_INSECURE: "true"},
+    )
+    def test_generic_env_var_sets_insecure(self):
+        exporter = OTLPSpanExporter()
+        self.assertTrue(exporter._insecure)
+        self.assertFalse(exporter._certificate_file)
+
+    @patch.dict(
+        "os.environ",
+        {
+            OTEL_EXPORTER_OTLP_TRACES_INSECURE: "false",
+            OTEL_EXPORTER_OTLP_INSECURE: "true",
+        },
+    )
+    def test_signal_env_var_takes_priority_over_generic(self):
+        exporter = OTLPSpanExporter()
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_TRACES_INSECURE: "true"},
+    )
+    def test_constructor_takes_priority_over_env_var(self):
+        exporter = OTLPSpanExporter(insecure=False)
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_TRACES_INSECURE: "TRUE"},
+    )
+    def test_env_var_case_insensitive(self):
+        exporter = OTLPSpanExporter()
+        self.assertTrue(exporter._insecure)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_TRACES_INSECURE: "  true  "},
+    )
+    def test_env_var_strips_whitespace(self):
+        exporter = OTLPSpanExporter()
+        self.assertTrue(exporter._insecure)
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_TRACES_INSECURE: "invalid"},
+    )
+    def test_env_var_invalid_value_is_false(self):
+        exporter = OTLPSpanExporter()
+        self.assertFalse(exporter._insecure)
+        self.assertEqual(exporter._certificate_file, True)


### PR DESCRIPTION
## Summary

Add explicit `insecure` parameter to OTLP HTTP exporters and fix a bug in `certificate_file` resolution.

## Changes

### Bug fix: `certificate_file` resolution

The previous code used `certificate_file or environ.get(...)`, which incorrectly ignored falsy values (e.g. empty string). Changed to `certificate_file if certificate_file is not None` to properly respect explicitly provided values.

### New feature: `insecure` parameter

Added `insecure: bool | None = None` to all three OTLP HTTP exporters (traces, logs, metrics). When `True`, TLS certificate verification is disabled (`verify=False` in requests).

Resolution priority:
1. Constructor argument (highest)
2. Signal-specific env var (`OTEL_EXPORTER_OTLP_TRACES_INSECURE`, etc.)
3. Generic env var (`OTEL_EXPORTER_OTLP_INSECURE`)
4. Default: `False`

These env vars were already defined in the SDK (used by gRPC exporter) — the HTTP exporter now respects them too.

### Code quality

Extracted `_resolve_insecure()` helper to `_common` module to avoid duplication across the three exporters.

## Backward compatibility

- Without the new parameter, behavior is identical to before
- No changes to `certificate_file` type signature (`str | None`)
- Default is secure (TLS verification enabled)

## Testing

Added 49 new tests covering:
- Unit tests for `_resolve_insecure()` helper
- Integration tests for each exporter: constructor priority, env var handling, interaction with `certificate_file`
- All 108 tests pass

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Assisted-by: Claude Sonnet 4