### PR TITLE
docs: warn about dictConfig clearing OTel handlers in logs example

### DIFF
--- a/.changelog/5420.changed
+++ b/.changelog/5420.changed
@@ -1,0 +1,1 @@
+docs: warn about `dictConfig` clearing OTel handlers in logs example

--- a/docs/examples/logs/README.rst
+++ b/docs/examples/logs/README.rst
@@ -14,6 +14,28 @@ The source files of these examples are available :scm_web:`here <docs/examples/l
    ``opentelemetry-instrumentation-logging`` package in the contrib repo
    and is deprecated in ``opentelemetry-sdk``.
 
+.. warning::
+   If you configure logging using ``logging.config.dictConfig``, be aware
+   that it may clear existing handlers on the root logger, including the
+   OTel handler. To avoid losing telemetry, save and restore the root
+   logger handlers around the ``dictConfig`` call:
+
+   .. code-block:: python
+
+      import logging
+      import logging.config
+
+      # Save OTel handlers before calling dictConfig
+      otel_handlers = logging.getLogger().handlers[:]
+
+      logging.config.dictConfig({
+          "version": 1,
+          "root": {"level": "DEBUG"},
+      })
+
+      # Re-apply saved handlers
+      for handler in otel_handlers:
+          logging.getLogger().addHandler(handler)
 
 Installation
 ------------


### PR DESCRIPTION
## Description

Follow-up to #5344 which addressed the LoggingHandler move to contrib.

Refs #4738

This PR documents the `dictConfig` handler-saving pattern from point 3
of #4738. When `dictConfig` is called with a root section that defines
handlers, it clears existing handlers on the root logger including the
OTel handler, silently breaking telemetry. Users need to save and
restore handlers around the call.

Tested locally — confirmed that `dictConfig` with a root section wipes
all existing handlers.

Opening as draft to confirm scope before requesting review.
@xrmx does this belong in the logs example README or somewhere else?

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

Verified locally that calling `dictConfig` with a root section clears
existing handlers:

```python
import logging, logging.config
handler = logging.StreamHandler()
logging.getLogger().addHandler(handler)
print('Before:', logging.getLogger().handlers)  # [StreamHandler]
logging.config.dictConfig({'version': 1, 'root': {'level': 'DEBUG', 'handlers': []}})
print('After:', logging.getLogger().handlers)   # []
```

## Does This PR Require a Contrib Repo Change?

- [x] No.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated