### PR TITLE
docs: add :scm_web: links to example README files referencing source code

### DIFF
--- a/docs/examples/auto-instrumentation/README.rst
+++ b/docs/examples/auto-instrumentation/README.rst
@@ -5,3 +5,6 @@ To learn about automatic instrumentation and how to run the example in this
 directory, see `Automatic Instrumentation`_.
 
 .. _Automatic Instrumentation: https://opentelemetry.io/docs/instrumentation/python/automatic/example
+
+The source files of these examples are available :scm_web:`here <docs/examples/auto-instrumentation/>`.
+

--- a/docs/examples/auto-instrumentation/README.rst
+++ b/docs/examples/auto-instrumentation/README.rst
@@ -7,4 +7,3 @@ directory, see `Automatic Instrumentation`_.
 .. _Automatic Instrumentation: https://opentelemetry.io/docs/instrumentation/python/automatic/example
 
 The source files of these examples are available :scm_web:`here <docs/examples/auto-instrumentation/>`.
-

--- a/docs/examples/error_handler/error_handler_0/README.rst
+++ b/docs/examples/error_handler/error_handler_0/README.rst
@@ -4,4 +4,3 @@ Error Handler 0
 This is just an error handler for this example.
 
 The source files of this example are available :scm_web:`here <docs/examples/error_handler/>`.
-

--- a/docs/examples/error_handler/error_handler_0/README.rst
+++ b/docs/examples/error_handler/error_handler_0/README.rst
@@ -2,3 +2,6 @@ Error Handler 0
 ===============
 
 This is just an error handler for this example.
+
+The source files of this example are available :scm_web:`here <docs/examples/error_handler/>`.
+

--- a/docs/examples/error_handler/error_handler_1/README.rst
+++ b/docs/examples/error_handler/error_handler_1/README.rst
@@ -2,3 +2,6 @@ Error Handler 1
 ===============
 
 This is just an error handler for this example.
+
+The source files of this example are available :scm_web:`here <docs/examples/error_handler/>`.
+

--- a/docs/examples/error_handler/error_handler_1/README.rst
+++ b/docs/examples/error_handler/error_handler_1/README.rst
@@ -4,4 +4,3 @@ Error Handler 1
 This is just an error handler for this example.
 
 The source files of this example are available :scm_web:`here <docs/examples/error_handler/>`.
-

--- a/docs/examples/fork-process-model/flask-gunicorn/README.rst
+++ b/docs/examples/fork-process-model/flask-gunicorn/README.rst
@@ -9,3 +9,6 @@ Run application
 .. code-block:: sh
 
     gunicorn app -c gunicorn.conf.py
+
+The source files of this example are available :scm_web:`here <docs/examples/fork-process-model/flask-gunicorn/>`.
+

--- a/docs/examples/fork-process-model/flask-gunicorn/README.rst
+++ b/docs/examples/fork-process-model/flask-gunicorn/README.rst
@@ -11,4 +11,3 @@ Run application
     gunicorn app -c gunicorn.conf.py
 
 The source files of this example are available :scm_web:`here <docs/examples/fork-process-model/flask-gunicorn/>`.
-

--- a/docs/examples/fork-process-model/flask-uwsgi/README.rst
+++ b/docs/examples/fork-process-model/flask-uwsgi/README.rst
@@ -12,4 +12,3 @@ Run application
     uwsgi --http :8000 --wsgi-file app.py --callable application --master --enable-threads
 
 The source files of this example are available :scm_web:`here <docs/examples/fork-process-model/flask-uwsgi/>`.
-

--- a/docs/examples/fork-process-model/flask-uwsgi/README.rst
+++ b/docs/examples/fork-process-model/flask-uwsgi/README.rst
@@ -10,3 +10,6 @@ Run application
 .. code-block:: sh
 
     uwsgi --http :8000 --wsgi-file app.py --callable application --master --enable-threads
+
+The source files of this example are available :scm_web:`here <docs/examples/fork-process-model/flask-uwsgi/>`.
+

--- a/docs/examples/sqlcommenter/README.rst
+++ b/docs/examples/sqlcommenter/README.rst
@@ -75,7 +75,7 @@ After running the query script, check the MySQL general log contents:
 
 .. code-block:: sh
 
-    docker exec -it books-db tail -f /var/log/general.log
+    docker exec -it books-db tail -f /var/log.general.log
 
 For each instrumented ``SELECT`` call, a query was made and logged with
 a sqlcomment appended. For example:

--- a/docs/examples/sqlcommenter/README.rst
+++ b/docs/examples/sqlcommenter/README.rst
@@ -8,7 +8,7 @@ For more information on sqlcommenter concepts, see:
 * `Semantic Conventions - Database Spans <https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/database-spans.md#sql-commenter>`_
 * `sqlcommenter <https://google.github.io/sqlcommenter/>`_
 
-The source files of this example are available `here <https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/sqlcommenter/>`_.
+The source files of this example are available :scm_web:`here <docs/examples/sqlcommenter/>`.
 This example uses Docker to manage a database server and OpenTelemetry collector.
 
 Run MySQL server

--- a/docs/examples/sqlcommenter/README.rst
+++ b/docs/examples/sqlcommenter/README.rst
@@ -75,7 +75,7 @@ After running the query script, check the MySQL general log contents:
 
 .. code-block:: sh
 
-    docker exec -it books-db tail -f /var/log.general.log
+    docker exec -it books-db tail -f /var/log/general.log
 
 For each instrumented ``SELECT`` call, a query was made and logged with
 a sqlcomment appended. For example:


### PR DESCRIPTION
## What

Added `:scm_web:` links to 6 README.rst files under `docs/examples/` so the rendered docs link back to the actual source files on GitHub.

## Why

Fixes #5427 — some example README pages on Read the Docs list Python files but don't link them, making it hard for users to find the actual source code.

## Changes

| File | Change |
|------|--------|
| `docs/examples/auto-instrumentation/README.rst` | Added `:scm_web:` link |
| `docs/examples/error_handler/error_handler_0/README.rst` | Added `:scm_web:` link |
| `docs/examples/error_handler/error_handler_1/README.rst` | Added `:scm_web:` link |
| `docs/examples/fork-process-model/flask-gunicorn/README.rst` | Added `:scm_web:` link |
| `docs/examples/fork-process-model/flask-uwsgi/README.rst` | Added `:scm_web:` link |
| `docs/examples/sqlcommenter/README.rst` | Replaced hardcoded GitHub URL with `:scm_web:` |

Follows the same pattern used in `docs/examples/django/README.rst`.