### PR TITLE
Fix missing f-prefix in exponential histogram max_size error messages

### DIFF
--- a/.changelog/5434.fixed
+++ b/.changelog/5434.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: fix missing f-prefix in exponential histogram error messages

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -644,13 +644,13 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
         if max_size < self._min_max_size:
             raise ValueError(
                 f"Buckets max size {max_size} is smaller than "
-                "minimum max size {self._min_max_size}"
+                f"minimum max size {self._min_max_size}"
             )
 
         if max_size > self._max_max_size:
             raise ValueError(
                 f"Buckets max size {max_size} is larger than "
-                "maximum max size {self._max_max_size}"
+                f"maximum max size {self._max_max_size}"
             )
         if max_scale > 20:
             _logger.warning(


### PR DESCRIPTION
# Description

The two `ValueError` messages in `_ExponentialBucketHistogramAggregation` are built by concatenating an f-string with a plain string literal, and the continuation lines were missing the `f` prefix. As a result, users saw the literal placeholder text instead of the actual limits:

```
Buckets max size 1 is smaller than minimum max size {self._min_max_size}
```

This PR adds the missing `f` prefix to both continuation strings, so the messages now render the actual values:

```
Buckets max size 1 is smaller than minimum max size 2
Buckets max size 20000 is larger than maximum max size 16384
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually triggered both error paths and verified the rendered messages:

```python
from opentelemetry.sdk.metrics._internal.aggregation import _ExponentialBucketHistogramAggregation
from unittest.mock import Mock

for size in (1, 20000):
    try:
        _ExponentialBucketHistogramAggregation(Mock(), Mock(), 0, 0, max_size=size)
    except ValueError as e:
        print(e)
```

Existing unit tests for `_ExponentialBucketHistogramAggregation` still pass.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated

