### PR TITLE
Fix copy-pasted log message in SpanContext.__delattr__

### DIFF
--- a/.changelog/5439.fixed
+++ b/.changelog/5439.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-api`: fix copy-pasted log message in `SpanContext.__delattr__`

--- a/opentelemetry-api/src/opentelemetry/trace/span.py
+++ b/opentelemetry-api/src/opentelemetry/trace/span.py
@@ -513,7 +513,7 @@ class SpanContext(tuple[int, int, bool, "TraceFlags", "TraceState", bool]):
 
     def __delattr__(self, *args: str) -> None:
         _logger.debug(
-            "Immutable type, ignoring call to set attribute", stack_info=True
+            "Immutable type, ignoring call to delete attribute", stack_info=True
         )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
# Description

Fix a copy-pasted log message in `SpanContext.__delattr__`.


This PR changes the message to "ignoring call to delete attribute" so
the log matches the intercepted operation. No behavior change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Trivial one-word change to a debug log string; no behavior change, so
  no new tests were added. Verified existing test suite passes with
  `tox -e py312-test-opentelemetry-api`.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
