### PR TITLE
Remove duplicate session header update in OTLP HTTP exporters

### DIFF
--- a/.changelog/5442.fixed
+++ b/.changelog/5442.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-exporter-otlp-proto-http`: remove duplicate session header update in the span, metric and log exporters

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -133,7 +133,6 @@ class OTLPLogExporter(LogRecordExporter):
             )
             or requests.Session()
         )
-        self._session.headers.update(self._headers)
         self._session.headers.update(_OTLP_HTTP_HEADERS)
         # let users override our defaults
         self._session.headers.update(self._headers)

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
@@ -191,7 +191,6 @@ class OTLPMetricExporter(MetricExporter, OTLPMetricExporterMixin):
             )
             or requests.Session()
         )
-        self._session.headers.update(self._headers)
         self._session.headers.update(_OTLP_HTTP_HEADERS)
         # let users override our defaults
         self._session.headers.update(self._headers)

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -128,7 +128,6 @@ class OTLPSpanExporter(SpanExporter):
             )
             or requests.Session()
         )
-        self._session.headers.update(self._headers)
         self._session.headers.update(_OTLP_HTTP_HEADERS)
         # let users override our defaults
         self._session.headers.update(self._headers)


### PR DESCRIPTION
## Description

All three OTLP HTTP exporters (span, metric, log) call `self._session.headers.update(self._headers)` twice — once before the default `_OTLP_HTTP_HEADERS` and once after. #4634 deliberately moved the user-header update after the defaults so users can override them, but a later merge accidentally reintroduced the earlier call.

The first call is fully overwritten by the subsequent updates, so it is dead code — and it invites a maintainer to remove the wrong line and silently revert #4634. This PR removes the earlier call in all three exporters. No behavior change.

## Type of change

- [x] Refactoring (no functional changes)

## How Has This Been Tested?

- Full `opentelemetry-exporter-otlp-proto-http` test suite passes (59 tests), including the existing tests covering user headers overriding defaults.

## Does This PR Require a Contrib Repo Change?

- [x] No.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated