### PR TITLE
Fix race in SimpleFixedSizeExemplarReservoir offer/collect (#5431)

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exemplar/exemplar_reservoir.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/exemplar/exemplar_reservoir.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
 from random import randrange
+from threading import Lock
 from typing import (
     Any,
 )
@@ -151,6 +152,14 @@ class FixedSizeExemplarReservoirABC(ExemplarReservoir):
         self._reservoir_storage: Mapping[int, ExemplarBucket] = defaultdict(
             ExemplarBucket
         )
+        # Guards `_reservoir_storage` and the subclass-specific reservoir state
+        # (e.g. `SimpleFixedSizeExemplarReservoir._measurements_seen`) against the
+        # offer()↔collect() race documented in #5431. Without it, collect() can
+        # run _reset() and zero `_measurements_seen` between the increment and the
+        # `randrange(0, self._measurements_seen)` call in `_find_bucket_index`,
+        # producing `ValueError: empty range for randrange() (0, 0, 0)`, and the
+        # `defaultdict` can also be read-while-written during collect()'s iteration.
+        self._lock: Lock = Lock()
 
     def collect(self, point_attributes: Attributes) -> list[Exemplar]:
         """Returns accumulated Exemplars and also resets the reservoir for the next
@@ -164,16 +173,17 @@ class FixedSizeExemplarReservoirABC(ExemplarReservoir):
             exemplars contain the attributes that were filtered out by the aggregator,
             but recorded alongside the original measurement.
         """
-        exemplars = [
-            e
-            for e in (
-                bucket.collect(point_attributes)
-                for _, bucket in sorted(self._reservoir_storage.items())
-            )
-            if e is not None
-        ]
-        self._reset()
-        return exemplars
+        with self._lock:
+            exemplars = [
+                e
+                for e in (
+                    bucket.collect(point_attributes)
+                    for _, bucket in sorted(self._reservoir_storage.items())
+                )
+                if e is not None
+            ]
+            self._reset()
+            return exemplars
 
     def offer(
         self,
@@ -190,17 +200,18 @@ class FixedSizeExemplarReservoirABC(ExemplarReservoir):
             attributes: Measurement attributes
             context: Measurement context
         """
-        try:
-            index = self._find_bucket_index(
-                value, time_unix_nano, attributes, context
-            )
+        with self._lock:
+            try:
+                index = self._find_bucket_index(
+                    value, time_unix_nano, attributes, context
+                )
 
-            self._reservoir_storage[index].offer(
-                value, time_unix_nano, attributes, context
-            )
-        except BucketIndexError:
-            # Ignore invalid bucket index
-            pass
+                self._reservoir_storage[index].offer(
+                    value, time_unix_nano, attributes, context
+                )
+            except BucketIndexError:
+                # Ignore invalid bucket index
+                pass
 
     @abstractmethod
     def _find_bucket_index(
@@ -287,12 +298,13 @@ class AlignedHistogramBucketExemplarReservoir(FixedSizeExemplarReservoirABC):
         context: Context,
     ) -> None:
         """Offers a measurement to be sampled."""
-        index = self._find_bucket_index(
-            value, time_unix_nano, attributes, context
-        )
-        self._reservoir_storage[index].offer(
-            value, time_unix_nano, attributes, context
-        )
+        with self._lock:
+            index = self._find_bucket_index(
+                value, time_unix_nano, attributes, context
+            )
+            self._reservoir_storage[index].offer(
+                value, time_unix_nano, attributes, context
+            )
 
     def _find_bucket_index(
         self,

--- a/opentelemetry-sdk/tests/metrics/test_exemplarreservoir.py
+++ b/opentelemetry-sdk/tests/metrics/test_exemplarreservoir.py
@@ -1,7 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from time import time_ns
+import threading
+from time import sleep, time_ns
 from unittest import TestCase
 
 from opentelemetry import trace
@@ -82,6 +83,66 @@ class TestSimpleFixedSizeExemplarReservoir(TestCase):
         self.assertEqual(len(new_exemplars), 2)
         self.assertEqual(new_exemplars[0].value, 4.0)
         self.assertEqual(new_exemplars[1].value, 5.0)
+
+    def test_concurrent_offer_and_collect_does_not_raise(self):
+        """Regression test for #5431.
+
+        ``offer()`` and ``collect()`` must be synchronized so that
+        ``collect()``→``_reset()`` cannot zero ``_measurements_seen`` between
+        the ``_measurements_seen += 1`` increment and the
+        ``randrange(0, self._measurements_seen)`` call in
+        ``_find_bucket_index``. Without the lock, that race produces
+        ``ValueError: empty range for randrange() (0, 0, 0)`` under concurrent
+        offer/collect.
+
+        size=1 maximizes the probability of hitting the randrange branch on
+        every offer after the first one, so the race shows up quickly.
+        """
+        reservoir = SimpleFixedSizeExemplarReservoir(size=1)
+        stop = threading.Event()
+        errors: list[BaseException] = []
+
+        def offer_loop() -> None:
+            i = 0
+            while not stop.is_set():
+                try:
+                    reservoir.offer(
+                        float(i), time_ns(), {"k": str(i)}, Context()
+                    )
+                    i += 1
+                except BaseException as e:  # noqa: BLE001 - surface any error
+                    errors.append(e)
+                    return
+
+        def collect_loop() -> None:
+            while not stop.is_set():
+                try:
+                    reservoir.collect({})
+                except BaseException as e:  # noqa: BLE001 - surface any error
+                    errors.append(e)
+                    return
+
+        threads = [
+            threading.Thread(target=offer_loop),
+            threading.Thread(target=offer_loop),
+            threading.Thread(target=collect_loop),
+        ]
+        for t in threads:
+            t.start()
+
+        # Bounded run. The race is reproducible in well under a second on
+        # Python 3.10+; 1.0s gives headroom on slow CI runners without
+        # noticeably slowing down the test suite.
+        sleep(1.0)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5.0)
+
+        self.assertEqual(
+            errors,
+            [],
+            f"expected no errors under concurrent offer/collect, got: {errors}",
+        )
 
 
 class TestAlignedHistogramBucketExemplarReservoir(TestCase):


### PR DESCRIPTION
Fixes #5431.

## Problem

`SimpleFixedSizeExemplarReservoir._find_bucket_index` does:

```python
self._measurements_seen += 1                                    # (a)
if self._measurements_seen < self._size:
    return self._measurements_seen - 1
index = randrange(0, self._measurements_seen)                   # (b)
```

Between (a) and (b), a concurrent `collect()` can run `_reset()` and zero
`_measurements_seen`, producing:

```
ValueError: empty range for randrange() (0, 0, 0)
```

`FixedSizeExemplarReservoirABC.collect()` has a matching race: it iterates
`self._reservoir_storage.items()` (a `defaultdict`) while `offer()` can
insert a new bucket, raising `RuntimeError: dictionary changed size
during iteration`.

## Fix

Add a `threading.Lock` on `FixedSizeExemplarReservoirABC.__init__` and
guard `offer()` and `collect()` with it.

`AlignedHistogramBucketExemplarReservoir` overrides `offer()` (because
it computes its bucket index from the value, not the reservoir state),
so its override must also acquire the lock — otherwise the shared
`_reservoir_storage` would still be unsafe.

## Verification

- New regression test `test_concurrent_offer_and_collect_does_not_raise`
  runs 2 `offer` threads + 1 `collect` thread for 1.0s on a `size=1`
  reservoir (maximizes the probability of hitting the `randrange`
  branch on every offer after the first).
- **Red → green**: with the fix stashed, the test fails with the exact
  \`ValueError: empty range for randrange() (0, 0, 0)\` from the issue.
  With the fix, it passes.
- Full exemplar test suite passes:
  ```
  uv run --python 3.10 --frozen --all-packages python -m unittest \\
    tests.metrics.test_aggregation \\
    tests.metrics.test_exemplarfilter \\
    tests.metrics.test_exemplarreservoir \\
    tests.metrics.integration_test.test_exemplars
  ```
  → 51 tests pass.
- \`ruff check\` clean.

## Notes

- The lock is on `FixedSizeExemplarReservoirABC`, not on the base
  `ExemplarReservoir`, because the base has no shared mutable state to
  protect — the race is specific to the `_reservoir_storage` defaultdict
  and the subclass-specific reservoir state (`_measurements_seen`).
- Performance: `offer()` is now O(1) under the lock (no I/O, no
  allocations beyond the existing `defaultdict` lookup), so contention
  is bounded. For high-throughput metrics pipelines, the next step would
  be a per-bucket lock or a lock-free reservoir, but neither is in scope
  for this bug fix.