### PR TITLE
opentelemetry-exporter-otlp-proto-grpc: tolerate invalid timeout env vars

### DIFF
--- a/.changelog/5448.fixed
+++ b/.changelog/5448.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-exporter-otlp-proto-grpc`: warn and fall back to the default instead of raising `ValueError` when a timeout environment variable holds an invalid value, and stop discarding an explicit `timeout=0`.

--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Mapping, Sequence
+from os import environ
 from typing import (
     Any,
     TypeVar,
+    overload,
 )
 
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue as PB2AnyValue
@@ -33,6 +35,36 @@ _logger = logging.getLogger(__name__)
 
 _TypingResourceT = TypeVar("_TypingResourceT")
 _ResourceDataT = TypeVar("_ResourceDataT")
+
+
+@overload
+def _timeout_from_env(*environ_keys: str, default: float) -> float: ...
+
+
+@overload
+def _timeout_from_env(*environ_keys: str, default: None = None) -> float | None: ...
+
+
+def _timeout_from_env(*environ_keys: str, default: float | None = None) -> float | None:
+    """Return the first environment variable in ``environ_keys`` holding a
+    valid float, or ``default`` if none does.
+
+    Unset or empty variables are skipped silently; variables with a
+    non-numeric value are skipped with a warning.
+    """
+    for environ_key in environ_keys:
+        value = environ.get(environ_key)
+        if value is None or not value.strip():
+            continue
+        try:
+            return float(value)
+        except ValueError:
+            _logger.warning(
+                "Invalid value %r for environment variable %s, ignoring it.",
+                value,
+                environ_key,
+            )
+    return default
 
 
 def _encode_instrumentation_scope(

--- a/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_timeout_from_env.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/tests/test_timeout_from_env.py
@@ -1,0 +1,90 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from logging import WARNING
+from unittest.mock import patch
+
+import pytest
+
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    _timeout_from_env,
+)
+
+
+@pytest.mark.parametrize(
+    "environ,keys,default,expected,warns_for",
+    [
+        pytest.param(
+            {"TEST_TIMEOUT": "15"},
+            ("TEST_TIMEOUT",),
+            10,
+            15,
+            None,
+            id="valid value",
+        ),
+        pytest.param(
+            {},
+            ("TEST_TIMEOUT",),
+            10,
+            10,
+            None,
+            id="unset falls back to default",
+        ),
+        pytest.param(
+            {},
+            ("TEST_TIMEOUT",),
+            None,
+            None,
+            None,
+            id="unset with no default returns None",
+        ),
+        pytest.param(
+            {"TEST_TIMEOUT": " "},
+            ("TEST_TIMEOUT",),
+            10,
+            10,
+            None,
+            id="empty/whitespace falls back to default",
+        ),
+        pytest.param(
+            {"TEST_TIMEOUT": "abc"},
+            ("TEST_TIMEOUT",),
+            10,
+            10,
+            "TEST_TIMEOUT",
+            id="invalid value warns and falls back to default",
+        ),
+        pytest.param(
+            {"TEST_SIGNAL_TIMEOUT": "5", "TEST_TIMEOUT": "15"},
+            ("TEST_SIGNAL_TIMEOUT", "TEST_TIMEOUT"),
+            10,
+            5,
+            None,
+            id="first key takes priority",
+        ),
+        pytest.param(
+            {"TEST_SIGNAL_TIMEOUT": "abc", "TEST_TIMEOUT": "15"},
+            ("TEST_SIGNAL_TIMEOUT", "TEST_TIMEOUT"),
+            10,
+            15,
+            "TEST_SIGNAL_TIMEOUT",
+            id="invalid first key warns and falls back to next key",
+        ),
+    ],
+)
+def test_timeout_from_env(caplog, environ, keys, default, expected, warns_for):
+    """``warns_for`` names the environment variable the warning must mention,
+    or is ``None`` when no warning is expected."""
+    with (
+        patch.dict("os.environ", environ, clear=True),
+        caplog.at_level(WARNING),
+    ):
+        result = _timeout_from_env(*keys, default=default)
+
+    assert result == expected
+    if warns_for is None:
+        assert not caplog.records
+    else:
+        assert len(caplog.records) == 1
+        assert "Invalid value" in caplog.records[0].message
+        assert warns_for in caplog.records[0].message

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/_log_exporter/__init__.py
@@ -7,6 +7,9 @@ from os import environ
 from typing import Literal
 
 from grpc import ChannelCredentials, Compression, StatusCode
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    _timeout_from_env,
+)
 from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
 from opentelemetry.exporter.otlp.proto.grpc.exporter import (
     OTLPExporterMixin,
@@ -76,8 +79,7 @@ class OTLPLogExporter(
                 OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE,
             )
 
-        environ_timeout = environ.get(OTEL_EXPORTER_OTLP_LOGS_TIMEOUT)
-        environ_timeout = float(environ_timeout) if environ_timeout is not None else None
+        environ_timeout = _timeout_from_env(OTEL_EXPORTER_OTLP_LOGS_TIMEOUT)
 
         compression = (
             environ_to_compression(OTEL_EXPORTER_OTLP_LOGS_COMPRESSION) if compression is None else compression
@@ -89,7 +91,7 @@ class OTLPLogExporter(
             insecure=insecure,
             credentials=credentials,
             headers=headers or environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS),
-            timeout=timeout or environ_timeout,
+            timeout=timeout if timeout is not None else environ_timeout,
             compression=compression,
             stub=LogsServiceStub,
             result=LogRecordExportResult,

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -49,6 +49,7 @@ from opentelemetry.exporter.otlp.proto.common._exporter_metrics import (
 )
 from opentelemetry.exporter.otlp.proto.common._internal import (
     _get_resource_data,
+    _timeout_from_env,
 )
 from opentelemetry.exporter.otlp.proto.grpc import (
     _OTLP_GRPC_CHANNEL_OPTIONS,
@@ -322,7 +323,7 @@ class OTLPExporterMixin(ABC, Generic[SDKDataT, ExportServiceRequestT, ExportResu
         else:
             self._channel_options = tuple(_OTLP_GRPC_CHANNEL_OPTIONS)
 
-        self._timeout = timeout or float(environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, 10))
+        self._timeout = timeout if timeout is not None else _timeout_from_env(OTEL_EXPORTER_OTLP_TIMEOUT, default=10)
         self._collector_kwargs = None
 
         self._compression = (

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/metric_exporter/__init__.py
@@ -10,6 +10,9 @@ from logging import getLogger
 from os import environ
 
 from grpc import ChannelCredentials, Compression, StatusCode
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    _timeout_from_env,
+)
 from opentelemetry.exporter.otlp.proto.common._internal.metrics_encoder import (
     OTLPMetricExporterMixin,
 )
@@ -118,8 +121,7 @@ class OTLPMetricExporter(
                 OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE,
             )
 
-        environ_timeout = environ.get(OTEL_EXPORTER_OTLP_METRICS_TIMEOUT)
-        environ_timeout = float(environ_timeout) if environ_timeout is not None else None
+        environ_timeout = _timeout_from_env(OTEL_EXPORTER_OTLP_METRICS_TIMEOUT)
 
         compression = (
             environ_to_compression(OTEL_EXPORTER_OTLP_METRICS_COMPRESSION) if compression is None else compression
@@ -135,7 +137,7 @@ class OTLPMetricExporter(
             insecure=insecure,
             credentials=credentials,
             headers=headers or environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS),
-            timeout=timeout or environ_timeout,
+            timeout=timeout if timeout is not None else environ_timeout,
             compression=compression,
             channel_options=channel_options,
             retryable_error_codes=retryable_error_codes,

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py
@@ -9,6 +9,9 @@ from collections.abc import Sequence as TypingSequence
 from os import environ
 
 from grpc import ChannelCredentials, Compression, StatusCode
+from opentelemetry.exporter.otlp.proto.common._internal import (
+    _timeout_from_env,
+)
 from opentelemetry.exporter.otlp.proto.common.trace_encoder import (
     encode_spans,
 )
@@ -104,8 +107,7 @@ class OTLPSpanExporter(
                 OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE,
             )
 
-        environ_timeout = environ.get(OTEL_EXPORTER_OTLP_TRACES_TIMEOUT)
-        environ_timeout = float(environ_timeout) if environ_timeout is not None else None
+        environ_timeout = _timeout_from_env(OTEL_EXPORTER_OTLP_TRACES_TIMEOUT)
 
         compression = (
             environ_to_compression(OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) if compression is None else compression
@@ -119,7 +121,7 @@ class OTLPSpanExporter(
             insecure=insecure,
             credentials=credentials,
             headers=headers or environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS),
-            timeout=timeout or environ_timeout,
+            timeout=timeout if timeout is not None else environ_timeout,
             compression=compression,
             channel_options=channel_options,
             retryable_error_codes=retryable_error_codes,

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
@@ -45,6 +45,7 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2_grpc import (
 from opentelemetry.sdk.environment_variables import (
     _OTEL_PYTHON_EXPORTER_OTLP_GRPC_CREDENTIAL_PROVIDER,
     OTEL_EXPORTER_OTLP_COMPRESSION,
+    OTEL_EXPORTER_OTLP_TIMEOUT,
     OTEL_PYTHON_SDK_INTERNAL_METRICS_ENABLED,
 )
 from opentelemetry.sdk.metrics import MeterProvider
@@ -534,6 +535,21 @@ class TestOTLPExporterMixin(TestCase):
             )
             self.assertEqual(mock_trace_service.num_requests, 2)
             self.assertAlmostEqual(after - before, 1.4, 1)
+
+    @patch.dict("os.environ", {OTEL_EXPORTER_OTLP_TIMEOUT: "invalid"})
+    def test_invalid_timeout_from_env_uses_default(self):
+        # pylint: disable=protected-access
+        with self.assertLogs(level=WARNING) as warning:
+            exporter = OTLPSpanExporterForTesting(insecure=True)
+        self.assertEqual(exporter._timeout, 10)
+        self.assertIn("Invalid value", warning.records[0].message)
+        self.assertIn(OTEL_EXPORTER_OTLP_TIMEOUT, warning.records[0].message)
+
+    @patch.dict("os.environ", {OTEL_EXPORTER_OTLP_TIMEOUT: "15"})
+    def test_timeout_zero_takes_priority_over_env(self):
+        # pylint: disable=protected-access
+        exporter = OTLPSpanExporterForTesting(insecure=True, timeout=0)
+        self.assertEqual(exporter._timeout, 0)
 
     def test_channel_options_set_correctly(self):
         """Test that gRPC channel options are set correctly for keepalive and reconnection"""

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_trace_exporter.py
@@ -4,6 +4,7 @@
 # pylint: disable=too-many-lines
 
 import os
+from logging import WARNING
 from unittest import TestCase
 from unittest.mock import Mock, PropertyMock, patch
 
@@ -166,6 +167,19 @@ class TestOTLPSpanExporter(TestCase):
         self.assertEqual(kwargs["timeout"], 10)
         self.assertEqual(kwargs["compression"], Compression.Gzip)
         self.assertIsNone(kwargs["credentials"])
+
+    @patch.dict(
+        "os.environ",
+        {OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: "invalid"},
+    )
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.OTLPExporterMixin.__init__")
+    def test_env_variables_invalid_timeout(self, mock_exporter_mixin):
+        with self.assertLogs(level=WARNING) as warning:
+            OTLPSpanExporter()
+        _, kwargs = mock_exporter_mixin.call_args_list[0]
+        self.assertIsNone(kwargs["timeout"])
+        self.assertIn("Invalid value", warning.records[0].message)
+        self.assertIn(OTEL_EXPORTER_OTLP_TRACES_TIMEOUT, warning.records[0].message)
 
     @patch.dict(
         "os.environ",


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

The OTLP gRPC exporters parse their timeout env vars with a bare `float()` in `__init__`, so an invalid value like `OTEL_EXPORTER_OTLP_TIMEOUT=10s` — or a declared-but-empty variable — raises `ValueError` during exporter construction and takes down SDK startup.

This adds a shared `_timeout_from_env()` helper in `opentelemetry-exporter-otlp-proto-common` that warns and falls back to the default instead, matching how the repo already handles invalid temporality and export-interval values. Applied to the four gRPC call sites (mixin, trace, metric, log); precedence between the signal-specific and generic variables is unchanged.

Also fixes `timeout or ...` silently discarding an explicit `timeout=0`; it is now `timeout is not None`.

**Scope note:** this PR originally covered the HTTP exporters as well. #5389 landed the same warn-and-fall-back behaviour for HTTP while this was open (`_resolve_timeout()` in `otlp/proto/http/_common`), so the HTTP half has been dropped and this is now gRPC-only. Deduplicating `_resolve_timeout()` between `otlp-proto-http` and `otlp-json-http` is left for a follow-up.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```bash
uv run --with pytest pytest exporter/opentelemetry-exporter-otlp-proto-common/tests/ -q   # 27 passed
uv run --with pytest pytest exporter/opentelemetry-exporter-otlp-proto-grpc/tests/ -q     # 70 passed
uv run --with ruff ruff check <the two packages>                                          # clean
uv run --with ruff ruff format --check <the two packages>                                 # clean
```

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
