### PR TITLE
docs: link example source files

### DIFF
--- a/docs/examples/error_handler/README.rst
+++ b/docs/examples/error_handler/README.rst
@@ -37,8 +37,8 @@ error handlers are installed: ``error_handler_0``  will handle
 Execution
 ---------
 
-An example is provided in the
-``opentelemetry-python/docs/examples/error_handler/example.py``.
+An example is provided in
+:scm_web:`example.py <docs/examples/error_handler/example.py>`.
 
 You can just run it, you should get output similar to this one:
 
@@ -74,7 +74,7 @@ The ``opentelemetry-sdk.error_handler`` module includes documentation that
 explains how this works. We recommend you read it also, here is just a small
 summary.
 
-In ``example.py`` we use ``GlobalErrorHandler`` as a context manager in several
+In :scm_web:`example.py <docs/examples/error_handler/example.py>` we use ``GlobalErrorHandler`` as a context manager in several
 places, for example:
 
 
@@ -87,7 +87,7 @@ Running that code will raise a ``KeyError`` exception.
 ``GlobalErrorHandler`` will "capture" that exception and pass it down to the
 registered error handlers. If there is one that handles ``KeyError`` exceptions
 then it will handle it. That can be seen in the result of the execution of
-``example.py``:
+:scm_web:`example.py <docs/examples/error_handler/example.py>`:
 
 .. code::
 

--- a/docs/examples/metrics/reader/README.rst
+++ b/docs/examples/metrics/reader/README.rst
@@ -3,10 +3,10 @@ MetricReader configuration scenarios
 
 These examples show how to customize the metrics that are output by the SDK using configuration on metric readers. There are multiple examples:
 
-* preferred_aggregation.py: Shows how to configure the preferred aggregation for metric instrument types.
-* preferred_temporality.py: Shows how to configure the preferred temporality for metric instrument types.
-* preferred_exemplarfilter.py: Shows how to configure the exemplar filter.
-* synchronous_gauge_read.py: Shows how to use `PeriodicExportingMetricReader` in a synchronous manner to explicitly control the collection of metrics.
+* :scm_web:`preferred_aggregation.py <docs/examples/metrics/reader/preferred_aggregation.py>`: Shows how to configure the preferred aggregation for metric instrument types.
+* :scm_web:`preferred_temporality.py <docs/examples/metrics/reader/preferred_temporality.py>`: Shows how to configure the preferred temporality for metric instrument types.
+* :scm_web:`preferred_exemplarfilter.py <docs/examples/metrics/reader/preferred_exemplarfilter.py>`: Shows how to configure the exemplar filter.
+* :scm_web:`synchronous_gauge_read.py <docs/examples/metrics/reader/synchronous_gauge_read.py>`: Shows how to use ``PeriodicExportingMetricReader`` in a synchronous manner to explicitly control the collection of metrics.
 
 The source files of these examples are available :scm_web:`here <docs/examples/metrics/reader/>`.
 

--- a/docs/examples/metrics/views/README.rst
+++ b/docs/examples/metrics/views/README.rst
@@ -3,11 +3,12 @@ View common scenarios
 
 These examples show how to customize the metrics that are output by the SDK using Views. There are multiple examples:
 
-* change_aggregation.py: Shows how to configure to change the default aggregation for an instrument.
-* change_name.py: Shows how to change the name of a metric.
-* limit_num_of_attrs.py: Shows how to limit the number of attributes that are output for a metric.
-* drop_metrics_from_instrument.py: Shows how to drop measurements from an instrument.
-* change_reservoir_factory.py: Shows how to use your own ``ExemplarReservoir``
+* :scm_web:`change_aggregation.py <docs/examples/metrics/views/change_aggregation.py>`: Shows how to configure to change the default aggregation for an instrument.
+* :scm_web:`change_name.py <docs/examples/metrics/views/change_name.py>`: Shows how to change the name of a metric.
+* :scm_web:`limit_num_of_attrs.py <docs/examples/metrics/views/limit_num_of_attrs.py>`: Shows how to limit the number of attributes that are output for a metric.
+* :scm_web:`drop_metrics_from_instrument.py <docs/examples/metrics/views/drop_metrics_from_instrument.py>`: Shows how to drop measurements from an instrument.
+* :scm_web:`disable_default_aggregation.py <docs/examples/metrics/views/disable_default_aggregation.py>`: Shows how to disable the default aggregation for an instrument.
+* :scm_web:`change_reservoir_factory.py <docs/examples/metrics/views/change_reservoir_factory.py>`: Shows how to use your own ``ExemplarReservoir``.
 
 The source files of these examples are available :scm_web:`here <docs/examples/metrics/views/>`.
 


### PR DESCRIPTION
## Description

Fixes #5427.

Link example filenames in the metrics Views, metric reader, and error-handler READMEs to their corresponding source files with the repository's `:scm_web:` role. The Views page also now lists the existing `disable_default_aggregation.py` example.

## Validation

- `git diff --check`
- `python -m compileall -q opentelemetry-api/src`

A local `rstcheck`/Sphinx executable was not available in this environment.