### PR TITLE
fix(configuration): include executable in default service name

### DIFF
--- a/.changelog/5469.fixed
+++ b/.changelog/5469.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-configuration`: include the executable in the default service name

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_resource.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_resource.py
@@ -7,6 +7,7 @@ import dataclasses
 import fnmatch
 import logging
 import os
+import sys
 from collections.abc import Callable
 from typing import Any
 from urllib import parse
@@ -100,8 +101,14 @@ def create_resource(config: ResourceConfig | None) -> Resource:
         config-specified attributes merged in priority order.
     """
     # Spec requires service.name to always be present; detectors and explicit
-    # config attributes can override this default.
-    base = _DEFAULT_RESOURCE.merge(Resource({SERVICE_NAME: "unknown_service"}))
+    # config attributes can override this default. Match the SDK's fallback by
+    # including the process executable name when no service name is provided.
+    default_service_name = "unknown_service"
+    if sys.executable:
+        default_service_name += ":" + sys.executable
+    base = _DEFAULT_RESOURCE.merge(
+        Resource({SERVICE_NAME: default_service_name})
+    )
 
     if config is None:
         return base

--- a/opentelemetry-configuration/tests/test_resource.py
+++ b/opentelemetry-configuration/tests/test_resource.py
@@ -33,7 +33,25 @@ from opentelemetry.sdk.resources import (
 )
 
 
+def _default_service_name():
+    return (
+        f"unknown_service:{sys.executable}"
+        if sys.executable
+        else "unknown_service"
+    )
+
+
 class TestCreateResourceDefaults(unittest.TestCase):
+    def test_default_service_name_uses_process_executable_name(self):
+        with patch(
+            "opentelemetry.configuration._resource.sys.executable", "python"
+        ):
+            resource = create_resource(None)
+
+        self.assertEqual(
+            resource.attributes[SERVICE_NAME], "unknown_service:python"
+        )
+
     def test_none_config_returns_sdk_defaults(self):
         resource = create_resource(None)
         self.assertIsInstance(resource, Resource)
@@ -42,7 +60,9 @@ class TestCreateResourceDefaults(unittest.TestCase):
             resource.attributes[TELEMETRY_SDK_NAME], "opentelemetry"
         )
         self.assertIn(TELEMETRY_SDK_VERSION, resource.attributes)
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        self.assertEqual(
+            resource.attributes[SERVICE_NAME], _default_service_name()
+        )
 
     def test_none_config_does_not_read_env_vars(self):
         with patch.dict(
@@ -54,19 +74,25 @@ class TestCreateResourceDefaults(unittest.TestCase):
         ):
             resource = create_resource(None)
         self.assertNotIn("foo", resource.attributes)
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        self.assertEqual(
+            resource.attributes[SERVICE_NAME], _default_service_name()
+        )
 
     def test_empty_resource_config(self):
         resource = create_resource(ResourceConfig())
         self.assertEqual(resource.attributes[TELEMETRY_SDK_LANGUAGE], "python")
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        self.assertEqual(
+            resource.attributes[SERVICE_NAME], _default_service_name()
+        )
 
     def test_service_name_default_added_when_missing(self):
         config = ResourceConfig(
             attributes=[AttributeNameValue(name="env", value="staging")]
         )
         resource = create_resource(config)
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        self.assertEqual(
+            resource.attributes[SERVICE_NAME], _default_service_name()
+        )
 
     def test_service_name_not_overridden_when_set(self):
         config = ResourceConfig(
@@ -361,7 +387,9 @@ class TestServiceResourceDetector(unittest.TestCase):
     def test_service_detector_no_env_var_leaves_default_service_name(self):
         with patch.dict(os.environ, {}, clear=True):
             resource = create_resource(self._config_with_service())
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        self.assertEqual(
+            resource.attributes[SERVICE_NAME], _default_service_name()
+        )
 
     def test_explicit_service_name_overrides_env_var(self):
         """Config attributes win over the service detector's env-var value."""
@@ -412,8 +440,10 @@ class TestServiceResourceDetector(unittest.TestCase):
             resource = create_resource(config)
         self.assertIn(SERVICE_INSTANCE_ID, resource.attributes)
         # service.name comes from the filter-excluded detector output, but the
-        # default "unknown_service" is still added by create_resource directly
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        # The process-specific default is still added by create_resource.
+        self.assertEqual(
+            resource.attributes[SERVICE_NAME], _default_service_name()
+        )
 
 
 class TestHostResourceDetector(unittest.TestCase):

--- a/opentelemetry-configuration/tests/test_resource.py
+++ b/opentelemetry-configuration/tests/test_resource.py
@@ -52,6 +52,12 @@ class TestCreateResourceDefaults(unittest.TestCase):
             resource.attributes[SERVICE_NAME], "unknown_service:python"
         )
 
+    def test_default_service_name_without_process_executable(self):
+        with patch("opentelemetry.configuration._resource.sys.executable", ""):
+            resource = create_resource(None)
+
+        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+
     def test_none_config_returns_sdk_defaults(self):
         resource = create_resource(None)
         self.assertIsInstance(resource, Resource)


### PR DESCRIPTION
## Description

Fixes #5459.

Declarative configuration now derives the default `service.name` using the same `unknown_service:<process executable>` fallback as the SDK. Explicit resource attributes and configured resource detectors continue to override the fallback, and declarative configuration still avoids reading the environment by default.

## Validation

- `PYTHONPATH=opentelemetry-configuration/src;opentelemetry-sdk/src;opentelemetry-api/src python -m pytest opentelemetry-configuration/tests -q` (381 passed, 29 subtests)
- Follow-up resource regression suite: 63 passed
- `git diff --check`

The PR includes `.changelog/5469.fixed` as required by the repository.