### PR TITLE
fix(api): distinguish invalid extended attributes from None

### DIFF
--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -6,6 +6,7 @@ import logging
 import threading
 from collections import OrderedDict
 from collections.abc import Mapping, MutableMapping, Sequence
+from typing import cast
 
 from opentelemetry.util import types
 
@@ -23,6 +24,10 @@ _VALID_ANY_VALUE_TYPES = (
     Sequence,
     Mapping,
 )
+
+# ``None`` is a valid AnyValue for extended attributes, so it cannot also
+# represent a value rejected by the extended-attribute cleaner.
+_INVALID_ATTRIBUTE = object()
 
 
 # TODO: Remove this workaround and revert to the simpler implementation
@@ -134,7 +139,7 @@ def _clean_attribute(
 
 def _clean_extended_attribute_value(  # pylint: disable=too-many-branches
     value: types.AnyValue, max_len: int | None
-) -> types.AnyValue:
+) -> types.AnyValue | object:
     # for primitive types just return the value and eventually shorten the string length
     if value is None or isinstance(value, _VALID_ATTR_VALUE_TYPES):
         if max_len is not None and isinstance(value, str):
@@ -151,9 +156,11 @@ def _clean_extended_attribute_value(  # pylint: disable=too-many-branches
                 )
                 continue
 
-            cleaned_dict[key] = _clean_extended_attribute(
+            cleaned_value = _clean_extended_attribute(
                 key=key, value=element, max_len=max_len
             )
+            if cleaned_value is not _INVALID_ATTRIBUTE:
+                cleaned_dict[key] = cast(types.AnyValue, cleaned_value)
 
         return cleaned_dict
 
@@ -174,7 +181,9 @@ def _clean_extended_attribute_value(  # pylint: disable=too-many-branches
                 element = _clean_extended_attribute_value(
                     element, max_len=max_len
                 )
-                element_type = type(element)  # type: ignore
+                if element is _INVALID_ATTRIBUTE:
+                    return _INVALID_ATTRIBUTE
+                element_type = type(element)
 
             # The type of the sequence must be homogeneous. The first non-None
             # element determines the type of the sequence
@@ -187,7 +196,7 @@ def _clean_extended_attribute_value(  # pylint: disable=too-many-branches
                     sequence_first_valid_type.__name__,
                     type(element).__name__,
                 )
-                return None
+                return _INVALID_ATTRIBUTE
 
             cleaned_seq.append(element)
 
@@ -211,10 +220,11 @@ def _clean_extended_attribute_value(  # pylint: disable=too-many-branches
 
 def _clean_extended_attribute(
     key: str, value: types.AnyValue, max_len: int | None
-) -> types.AnyValue:
+) -> types.AnyValue | object:
     """Checks if attribute value is valid and cleans it if required.
 
-    The function returns the cleaned value or None if the value is not valid.
+    The function returns the cleaned value or ``_INVALID_ATTRIBUTE`` if the
+    value is not valid. ``None`` is a valid value for extended attributes.
 
     An attribute value is valid if it is an AnyValue.
     An attribute needs cleansing if:
@@ -223,13 +233,13 @@ def _clean_extended_attribute(
 
     if not (key and isinstance(key, str)):
         _logger.warning("invalid key `%s`. must be non-empty string.", key)
-        return None
+        return _INVALID_ATTRIBUTE
 
     try:
         return _clean_extended_attribute_value(value, max_len=max_len)
     except TypeError as exception:
         _logger.warning("Attribute %s: %s", key, exception)
-        return None
+        return _INVALID_ATTRIBUTE
 
 
 class BoundedAttributes(MutableMapping):  # type: ignore
@@ -283,6 +293,11 @@ class BoundedAttributes(MutableMapping):  # type: ignore
             return
         if self._extended_attributes:
             value = _clean_extended_attribute(key, value, self.max_value_len)
+            if value is _INVALID_ATTRIBUTE:
+                with self._lock:
+                    self.dropped += 1
+                return
+            value = cast(types.AnyValue, value)
         else:
             value = _clean_attribute(key, value, self.max_value_len)  # type: ignore
             if value is None:
@@ -301,6 +316,9 @@ class BoundedAttributes(MutableMapping):  # type: ignore
         for key, value in attributes.items():
             if self._extended_attributes:
                 cv = _clean_extended_attribute(key, value, self.max_value_len)
+                if cv is _INVALID_ATTRIBUTE:
+                    continue
+                cv = cast(types.AnyValue, cv)
             else:
                 cv = _clean_attribute(key, value, self.max_value_len)  # type: ignore
                 if cv is None:

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -12,6 +12,7 @@ from collections.abc import MutableSequence
 
 from opentelemetry.attributes import (
     BoundedAttributes,
+    _INVALID_ATTRIBUTE,
     _clean_attribute,
     _clean_extended_attribute,
     _clean_extended_attribute_value,
@@ -96,7 +97,9 @@ class TestExtendedAttributes(unittest.TestCase):
         self.assertEqual(_clean_extended_attribute(key, value, None), expected)
 
     def assertInvalid(self, value, key="k"):
-        self.assertIsNone(_clean_extended_attribute(key, value, None))
+        self.assertIs(
+            _clean_extended_attribute(key, value, None), _INVALID_ATTRIBUTE
+        )
 
     def test_attribute_key_validation(self):
         # only non-empty strings are valid keys
@@ -168,7 +171,6 @@ class TestExtendedAttributes(unittest.TestCase):
             "none": {},
             "valid_primitive": "str",
             "valid_sequence": ("str",),
-            "invalid_sequence": None,
             "valid_mapping": {"str": 1},
             "invalid_mapping": {},
         }
@@ -323,6 +325,26 @@ class TestBoundedAttributes(unittest.TestCase):
             bdict["key"] = "value"
 
         clean_extended_attribute_mock.assert_called_once()
+
+    def test_extended_attributes_reject_invalid_values_but_keep_none(self):
+        bdict = BoundedAttributes(extended_attributes=True, immutable=False)
+
+        bdict[""] = "invalid key"
+        bdict["none"] = None
+
+        self.assertNotIn("", bdict)
+        self.assertIn("none", bdict)
+        self.assertIsNone(bdict["none"])
+        self.assertEqual(bdict.dropped, 1)
+
+    def test_extended_attributes_batch_rejects_invalid_values(self):
+        bdict = BoundedAttributes(extended_attributes=True, immutable=False)
+
+        bdict._set_items({"": "invalid key", "none": None})
+
+        self.assertNotIn("", bdict)
+        self.assertIn("none", bdict)
+        self.assertIsNone(bdict["none"])
 
     def test_wsgi_request_conversion_to_string(self):
         """Test that WSGI request objects are converted to strings when _clean_extended_attribute is called."""


### PR DESCRIPTION
# Description\n\nNone is a valid AnyValue for extended attributes, but the cleaner also used it to signal invalid keys and values. BoundedAttributes therefore stored invalid entries instead of dropping them. This adds a private sentinel for rejected values, preserves valid None, and filters rejected values in both single-item and batch insertion paths.\n\nFixes #5432\n\n## Type of change\n\n- [x] Bug fix (non-breaking change which fixes an issue)\n- [ ] New feature (non-breaking change which adds functionality)\n- [ ] Breaking change or documentation update\n\n# How Has This Been Tested?\n\n- [x] PYTHONPATH=opentelemetry-api/src python -m pytest opentelemetry-api/tests/attributes/test_attributes.py -q (20 passed)\n- [x] PYTHONPATH=opentelemetry-api/src python -m pytest opentelemetry-api/tests -q (280 passed, 2 skipped, 49 subtests passed)\n- [x] python -m compileall -q opentelemetry-api/src/opentelemetry/attributes opentelemetry-api/tests/attributes/test_attributes.py\n- [x] git diff --check\n\n# Does This PR Require a Contrib Repo Change?\n\n- [x] No.\n\n# Checklist:\n\n- [x] Followed the style guidelines of this project\n- [ ] Changelogs have been updated (not required for this API bug fix)\n- [x] Unit tests have been added\n- [ ] Documentation has been updated (not required)