### PR TITLE
Retry OTLP/HTTP exports on HTTP 429 (Too Many Requests) (#3122)

### DIFF
--- a/.changelog/5473.fixed
+++ b/.changelog/5473.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-exporter-otlp-proto-http`: retry exports on HTTP 429 (Too Many Requests) responses

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_common/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_common/__init__.py
@@ -26,6 +26,12 @@ class RequestPayloadTooLargeError(Exception):
 def _is_retryable(resp: requests.Response) -> bool:
     if resp.status_code == 408:
         return True
+    # 429 (Too Many Requests) is listed as a retryable status code by the OTLP
+    # specification, so a throttled export should be retried with backoff rather
+    # than dropped. See
+    # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#failures-1
+    if resp.status_code == 429:
+        return True
     if resp.status_code >= 500 and resp.status_code <= 599:
         return True
     return False

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/metrics/test_otlp_metrics_exporter.py
@@ -1427,6 +1427,24 @@ class TestOTLPMetricExporter(TestCase):
             exporter._preferred_aggregation[Histogram], histogram_aggregation
         )
 
+    @patch.object(Session, "post")
+    def test_retryable_status_code_429(self, mock_post):
+        # HTTP 429 (Too Many Requests) is retryable per the OTLP spec, so the
+        # exporter should back off and retry instead of dropping the batch.
+        exporter = OTLPMetricExporter(timeout=1.5)
+
+        resp = Response()
+        resp.status_code = 429
+        resp.reason = "Too Many Requests"
+        mock_post.return_value = resp
+        with self.assertLogs(level=WARNING):
+            self.assertEqual(
+                exporter.export(self.metrics["sum_int"]),
+                MetricExportResult.FAILURE,
+            )
+        # More than one call proves the 429 response was retried.
+        self.assertGreater(mock_post.call_count, 1)
+
     @patch.dict(
         "os.environ", {OTEL_PYTHON_SDK_INTERNAL_METRICS_ENABLED: "true"}
     )

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_common.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_common.py
@@ -1,0 +1,28 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+import requests
+
+from opentelemetry.exporter.otlp.proto.http._common import _is_retryable
+
+
+class TestIsRetryable(unittest.TestCase):
+    @staticmethod
+    def _response(status_code: int) -> requests.Response:
+        resp = requests.Response()
+        resp.status_code = status_code
+        return resp
+
+    def test_retryable_status_codes(self):
+        # 408 (Request Timeout), 429 (Too Many Requests) and any 5xx are
+        # retryable per the OTLP specification.
+        for status_code in (408, 429, 500, 502, 503, 504, 599):
+            with self.subTest(status_code=status_code):
+                self.assertTrue(_is_retryable(self._response(status_code)))
+
+    def test_non_retryable_status_codes(self):
+        for status_code in (200, 400, 401, 403, 404, 409):
+            with self.subTest(status_code=status_code):
+                self.assertFalse(_is_retryable(self._response(status_code)))

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_log_exporter.py
@@ -457,6 +457,24 @@ class TestOTLPHTTPLogExporter(unittest.TestCase):
             LogRecordExportResult.SUCCESS,
         )
 
+    @patch.object(Session, "post")
+    def test_retryable_status_code_429(self, mock_post):
+        # HTTP 429 (Too Many Requests) is retryable per the OTLP spec, so the
+        # exporter should back off and retry instead of dropping the batch.
+        exporter = OTLPLogExporter(timeout=1.5)
+
+        resp = Response()
+        resp.status_code = 429
+        resp.reason = "Too Many Requests"
+        mock_post.return_value = resp
+        with self.assertLogs(level=WARNING):
+            self.assertEqual(
+                exporter.export(self._get_sdk_log_data()),
+                LogRecordExportResult.FAILURE,
+            )
+        # More than one call proves the 429 response was retried.
+        self.assertGreater(mock_post.call_count, 1)
+
     @patch.dict(
         "os.environ", {OTEL_PYTHON_SDK_INTERNAL_METRICS_ENABLED: " true "}
     )

--- a/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/tests/test_proto_span_exporter.py
@@ -313,6 +313,24 @@ class TestOTLPSpanExporter(unittest.TestCase):
 
         self.assertIsNone(self.metric_reader.get_metrics_data())
 
+    @patch.object(Session, "post")
+    def test_retryable_status_code_429(self, mock_post):
+        # HTTP 429 (Too Many Requests) is retryable per the OTLP spec, so the
+        # exporter should back off and retry instead of dropping the batch.
+        exporter = OTLPSpanExporter(timeout=1.5)
+
+        resp = Response()
+        resp.status_code = 429
+        resp.reason = "Too Many Requests"
+        mock_post.return_value = resp
+        with self.assertLogs(level=WARNING):
+            self.assertEqual(
+                exporter.export([BASIC_SPAN]),
+                SpanExportResult.FAILURE,
+            )
+        # More than one call proves the 429 response was retried.
+        self.assertGreater(mock_post.call_count, 1)
+
     @patch.dict(
         "os.environ", {OTEL_PYTHON_SDK_INTERNAL_METRICS_ENABLED: " true "}
     )


### PR DESCRIPTION
# Description

The `_is_retryable` helper shared by the OTLP/HTTP trace, metric and log exporters
(`exporter/opentelemetry-exporter-otlp-proto-http/.../http/_common/__init__.py`) treated
`408` and any `5xx` response as retryable, but not `429` (Too Many Requests). Since `429`
is neither `408` nor in the `500`–`599` range, a throttled export was reported as a
non-retryable failure and dropped instead of being retried with backoff.

The OTLP specification lists `429` as a retryable status code
([otlp.md#failures-1](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#failures-1)),
so this adds `429` to `_is_retryable`.

This change is intentionally limited to the missing, spec-required `429` case and does not
alter the existing `408`/`5xx` handling, to avoid the broader `5xx`-narrowing question raised
in the issue.

Fixes #3122

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Added `exporter/opentelemetry-exporter-otlp-proto-http/tests/test_common.py`, a direct unit
  test of `_is_retryable` covering retryable status codes (`408`, `429`, `500`, `502`, `503`,
  `504`, `599`) and non-retryable ones (`200`, `400`, `401`, `403`, `404`, `409`).
- Ran the full existing OTLP/HTTP exporter test suite (80 tests) — all pass.
- `ruff check` and `ruff format --check` pass on the changed files.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
