### PR TITLE
fix(attributes): use sentinel to distinguish invalid from AnyValue(None) in BoundedAttributes extended path

### DIFF
--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -34,6 +34,10 @@ def _type_name(t):
 
 _logger = logging.getLogger(__name__)
 
+# Sentinel returned by _clean_extended_attribute to signal invalid input,
+# distinguishing it from a valid AnyValue(None).
+_INVALID_ATTRIBUTE = object()
+
 
 # pylint: disable=too-many-return-statements
 # pylint: disable=too-many-branches
@@ -214,7 +218,7 @@ def _clean_extended_attribute(
 ) -> types.AnyValue:
     """Checks if attribute value is valid and cleans it if required.
 
-    The function returns the cleaned value or None if the value is not valid.
+    Returns the cleaned value, or _INVALID_ATTRIBUTE if the input is invalid.
 
     An attribute value is valid if it is an AnyValue.
     An attribute needs cleansing if:
@@ -223,13 +227,13 @@ def _clean_extended_attribute(
 
     if not (key and isinstance(key, str)):
         _logger.warning("invalid key `%s`. must be non-empty string.", key)
-        return None
+        return _INVALID_ATTRIBUTE
 
     try:
         return _clean_extended_attribute_value(value, max_len=max_len)
     except TypeError as exception:
         _logger.warning("Attribute %s: %s", key, exception)
-        return None
+        return _INVALID_ATTRIBUTE
 
 
 class BoundedAttributes(MutableMapping):  # type: ignore
@@ -283,6 +287,10 @@ class BoundedAttributes(MutableMapping):  # type: ignore
             return
         if self._extended_attributes:
             value = _clean_extended_attribute(key, value, self.max_value_len)
+            if value is _INVALID_ATTRIBUTE:
+                with self._lock:
+                    self.dropped += 1
+                return
         else:
             value = _clean_attribute(key, value, self.max_value_len)  # type: ignore
             if value is None:
@@ -298,15 +306,20 @@ class BoundedAttributes(MutableMapping):  # type: ignore
                 self.dropped += len(attributes)
             return
         cleaned = []
+        dropped = 0
         for key, value in attributes.items():
             if self._extended_attributes:
                 cv = _clean_extended_attribute(key, value, self.max_value_len)
+                if cv is _INVALID_ATTRIBUTE:
+                    dropped += 1
+                    continue
             else:
                 cv = _clean_attribute(key, value, self.max_value_len)  # type: ignore
                 if cv is None:
                     continue
             cleaned.append((key, cv))
         with self._lock:
+            self.dropped += dropped
             for key, cv in cleaned:
                 self._setitem_locked(key, cv)
 


### PR DESCRIPTION
## Description

Fixes #5432

`_clean_extended_attribute()` returned `None` as a dual-purpose signal:
- **Invalid input** — empty/non-string key, or unserializable value.
- **Valid attribute value** — `AnyValue(None)` is a legitimate value per the OTel spec.

`__setitem__` and `_set_items` on the extended path had no guard against the return value, so invalid attributes were silently written into the backing dict under the invalid key and `self.dropped` was never incremented.

**Fix:** introduce a module-level `_INVALID_ATTRIBUTE = object()` sentinel. `_clean_extended_attribute` now returns this sentinel (instead of `None`) for invalid input. Both `__setitem__` and `_set_items` check for the sentinel, drop the entry, and increment `self.dropped`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with an inline Python script against the exact reproduction case from the issue:

```python
from opentelemetry.attributes import BoundedAttributes

# Test 1: empty key rejected, dropped counter incremented
ba = BoundedAttributes(maxlen=10, extended_attributes=True, immutable=False)
ba[""] = "hello"
assert "" not in ba
assert ba.dropped == 1

# Test 2: valid AnyValue(None) still accepted
ba2 = BoundedAttributes(maxlen=10, extended_attributes=True, immutable=False)
ba2["valid_key"] = None
assert "valid_key" in ba2
assert ba2["valid_key"] is None
assert ba2.dropped == 0

# Test 3: unserializable value rejected, dropped counter incremented
ba3 = BoundedAttributes(maxlen=10, extended_attributes=True, immutable=False)
ba3["key"] = object()  # not a valid AnyValue
assert "key" not in ba3
assert ba3.dropped == 1
```

All three assertions pass with this patch applied.

## Does This PR Require a Contrib Repo Change?

No.