### PR TITLE
docs: fix grammar in README Python Version Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Python SDK, see the [documentation](https://opentelemetry.io/docs/languages/pyth
 
 ## Python Version Support
 
-This project ensures compatibility with the current supported versions of the Python. As new Python versions are released, support for them is added and
+This project ensures compatibility with the current supported versions of Python. As new Python versions are released, support for them is added and
 as old Python versions reach their end of life, support for them is removed.
 
 We add support for new Python versions no later than 3 months after they become stable.


### PR DESCRIPTION
# Description

Remove the spurious definite article in the **Python Version Support** section of `README.md`:

```diff
-This project ensures compatibility with the current supported versions of the Python.
+This project ensures compatibility with the current supported versions of Python.
```

"the Python" is grammatically incorrect — "Python" is a proper noun and does not take an article in this context.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Documentation-only change — no code tests required.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated