### PR TITLE
docs: link example source files from READMEs

### DIFF
--- a/docs/examples/auto-instrumentation/README.rst
+++ b/docs/examples/auto-instrumentation/README.rst
@@ -4,4 +4,6 @@ Auto-instrumentation
 To learn about automatic instrumentation and how to run the example in this
 directory, see `Automatic Instrumentation`_.
 
+The source files of this example are available :scm_web:`here <docs/examples/auto-instrumentation/>`.
+
 .. _Automatic Instrumentation: https://opentelemetry.io/docs/instrumentation/python/automatic/example

--- a/docs/examples/error_handler/error_handler_0/README.rst
+++ b/docs/examples/error_handler/error_handler_0/README.rst
@@ -2,3 +2,5 @@ Error Handler 0
 ===============
 
 This is just an error handler for this example.
+
+The source files for this subexample are available :scm_web:`here <docs/examples/error_handler/error_handler_0/>`.

--- a/docs/examples/error_handler/error_handler_1/README.rst
+++ b/docs/examples/error_handler/error_handler_1/README.rst
@@ -2,3 +2,5 @@ Error Handler 1
 ===============
 
 This is just an error handler for this example.
+
+The source files for this subexample are available :scm_web:`here <docs/examples/error_handler/error_handler_1/>`.

--- a/docs/examples/fork-process-model/flask-gunicorn/README.rst
+++ b/docs/examples/fork-process-model/flask-gunicorn/README.rst
@@ -1,5 +1,8 @@
 Installation
 ------------
+
+The source files of this example are available :scm_web:`here <docs/examples/fork-process-model/flask-gunicorn/>`.
+
 .. code-block:: sh
 
     pip install -rrequirements.txt

--- a/docs/examples/fork-process-model/flask-uwsgi/README.rst
+++ b/docs/examples/fork-process-model/flask-uwsgi/README.rst
@@ -1,5 +1,8 @@
 Installation
 ------------
+
+The source files of this example are available :scm_web:`here <docs/examples/fork-process-model/flask-uwsgi/>`.
+
 .. code-block:: sh
 
     pip install -rrequirements.txt

--- a/docs/examples/metrics/views/README.rst
+++ b/docs/examples/metrics/views/README.rst
@@ -3,11 +3,11 @@ View common scenarios
 
 These examples show how to customize the metrics that are output by the SDK using Views. There are multiple examples:
 
-* change_aggregation.py: Shows how to configure to change the default aggregation for an instrument.
-* change_name.py: Shows how to change the name of a metric.
-* limit_num_of_attrs.py: Shows how to limit the number of attributes that are output for a metric.
-* drop_metrics_from_instrument.py: Shows how to drop measurements from an instrument.
-* change_reservoir_factory.py: Shows how to use your own ``ExemplarReservoir``
+* :scm_web:`change_aggregation.py <docs/examples/metrics/views/change_aggregation.py>`: Shows how to configure to change the default aggregation for an instrument.
+* :scm_web:`change_name.py <docs/examples/metrics/views/change_name.py>`: Shows how to change the name of a metric.
+* :scm_web:`limit_num_of_attrs.py <docs/examples/metrics/views/limit_num_of_attrs.py>`: Shows how to limit the number of attributes that are output for a metric.
+* :scm_web:`drop_metrics_from_instrument.py <docs/examples/metrics/views/drop_metrics_from_instrument.py>`: Shows how to drop measurements from an instrument.
+* :scm_web:`change_reservoir_factory.py <docs/examples/metrics/views/change_reservoir_factory.py>`: Shows how to use your own ``ExemplarReservoir``
 
 The source files of these examples are available :scm_web:`here <docs/examples/metrics/views/>`.
 

--- a/docs/examples/sqlcommenter/README.rst
+++ b/docs/examples/sqlcommenter/README.rst
@@ -8,7 +8,7 @@ For more information on sqlcommenter concepts, see:
 * `Semantic Conventions - Database Spans <https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/database-spans.md#sql-commenter>`_
 * `sqlcommenter <https://google.github.io/sqlcommenter/>`_
 
-The source files of this example are available `here <https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/sqlcommenter/>`_.
+The source files of this example are available :scm_web:`here <docs/examples/sqlcommenter/>`.
 This example uses Docker to manage a database server and OpenTelemetry collector.
 
 Run MySQL server


### PR DESCRIPTION
## Summary

Adds `:scm_web:` source links to example READMEs that referenced code without linking it, and converts the remaining raw GitHub tree URL to the same role.

## Changes

- Links each listed example file in `docs/examples/metrics/views/README.rst`.
- Adds source links to the sqlcommenter, auto-instrumentation, Flask gunicorn, and Flask uWSGI READMEs.
- Adds source links to the error handler subexample READMEs.
- Replaces the raw GitHub URL in sqlcommenter with `:scm_web:` for consistency with the rest of the tree.

## Verification

- Every `README.rst` under `docs/examples` now includes `:scm_web:`.
- No remaining raw `github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples` links.

Closes #5427