### PR TITLE
ci: use uv action instead of pip install tox-uv

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout Core Repo @ SHA - ${{ github.sha }}
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up uv
-      uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
     - name: Run tox
       run: uvx --with tox-uv tox -e benchmark-opentelemetry-sdk -- -k opentelemetry-sdk/benchmarks --benchmark-json=opentelemetry-sdk/output.json
     - name: Report on SDK benchmark results

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,10 +23,10 @@ jobs:
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Checkout Core Repo @ SHA - ${{ github.sha }}
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - name: Install tox
-      run: pip install tox-uv
+    - name: Set up uv
+      uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
     - name: Run tox
-      run: tox -e benchmark-opentelemetry-sdk -- -k opentelemetry-sdk/benchmarks --benchmark-json=opentelemetry-sdk/output.json
+      run: uvx --with tox-uv tox -e benchmark-opentelemetry-sdk -- -k opentelemetry-sdk/benchmarks --benchmark-json=opentelemetry-sdk/output.json
     - name: Report on SDK benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,11 +37,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-api
+        run: uvx --with tox-uv tox -e lint-opentelemetry-api
 
   lint-opentelemetry-proto-gen-latest:
     name: opentelemetry-proto-gen-latest
@@ -56,11 +56,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-proto-gen-latest
+        run: uvx --with tox-uv tox -e lint-opentelemetry-proto-gen-latest
 
   lint-opentelemetry-protojson-gen-latest:
     name: opentelemetry-protojson-gen-latest
@@ -75,11 +75,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-protojson-gen-latest
+        run: uvx --with tox-uv tox -e lint-opentelemetry-protojson-gen-latest
 
   lint-opentelemetry-codegen-json:
     name: opentelemetry-codegen-json
@@ -94,11 +94,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-codegen-json
+        run: uvx --with tox-uv tox -e lint-opentelemetry-codegen-json
 
   lint-opentelemetry-sdk:
     name: opentelemetry-sdk
@@ -113,11 +113,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-sdk
+        run: uvx --with tox-uv tox -e lint-opentelemetry-sdk
 
   lint-opentelemetry-configuration:
     name: opentelemetry-configuration
@@ -132,11 +132,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-configuration
+        run: uvx --with tox-uv tox -e lint-opentelemetry-configuration
 
   lint-opentelemetry-semantic-conventions:
     name: opentelemetry-semantic-conventions
@@ -151,11 +151,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-semantic-conventions
+        run: uvx --with tox-uv tox -e lint-opentelemetry-semantic-conventions
 
   lint-opentelemetry-getting-started:
     name: opentelemetry-getting-started
@@ -170,11 +170,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-getting-started
+        run: uvx --with tox-uv tox -e lint-opentelemetry-getting-started
 
   lint-opentelemetry-opentracing-shim:
     name: opentelemetry-opentracing-shim
@@ -189,11 +189,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-opentracing-shim
+        run: uvx --with tox-uv tox -e lint-opentelemetry-opentracing-shim
 
   lint-opentelemetry-opencensus-shim:
     name: opentelemetry-opencensus-shim
@@ -208,11 +208,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-opencensus-shim
+        run: uvx --with tox-uv tox -e lint-opentelemetry-opencensus-shim
 
   lint-opentelemetry-exporter-http-transport:
     name: opentelemetry-exporter-http-transport
@@ -227,11 +227,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-http-transport
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-http-transport
 
   lint-opentelemetry-exporter-otlpcommon-latest:
     name: opentelemetry-exporter-otlpcommon-latest
@@ -246,11 +246,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-otlpcommon-latest
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlpcommon-latest
 
   lint-opentelemetry-exporter-opencensus:
     name: opentelemetry-exporter-opencensus
@@ -265,11 +265,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-opencensus
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-opencensus
 
   lint-opentelemetry-exporter-otlp-proto-common:
     name: opentelemetry-exporter-otlp-proto-common
@@ -284,11 +284,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-otlp-proto-common
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-proto-common
 
   lint-opentelemetry-exporter-otlp-json-common:
     name: opentelemetry-exporter-otlp-json-common
@@ -303,11 +303,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-otlp-json-common
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-json-common
 
   lint-opentelemetry-exporter-otlp-combined:
     name: opentelemetry-exporter-otlp-combined
@@ -322,11 +322,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-otlp-combined
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-combined
 
   lint-opentelemetry-exporter-otlp-json-file:
     name: opentelemetry-exporter-otlp-json-file
@@ -341,11 +341,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-otlp-json-file
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-json-file
 
   lint-opentelemetry-exporter-otlp-json-http:
     name: opentelemetry-exporter-otlp-json-http
@@ -360,11 +360,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-otlp-json-http
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-json-http
 
   lint-opentelemetry-exporter-otlp-proto-grpc-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-latest
@@ -379,11 +379,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-otlp-proto-grpc-latest
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-proto-grpc-latest
 
   lint-opentelemetry-exporter-otlp-proto-http:
     name: opentelemetry-exporter-otlp-proto-http
@@ -398,11 +398,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-otlp-proto-http
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-proto-http
 
   lint-opentelemetry-exporter-prometheus:
     name: opentelemetry-exporter-prometheus
@@ -417,11 +417,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-prometheus
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-prometheus
 
   lint-opentelemetry-exporter-zipkin-combined:
     name: opentelemetry-exporter-zipkin-combined
@@ -436,11 +436,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-zipkin-combined
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-zipkin-combined
 
   lint-opentelemetry-exporter-zipkin-proto-http:
     name: opentelemetry-exporter-zipkin-proto-http
@@ -455,11 +455,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-zipkin-proto-http
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-zipkin-proto-http
 
   lint-opentelemetry-exporter-zipkin-json:
     name: opentelemetry-exporter-zipkin-json
@@ -474,11 +474,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-exporter-zipkin-json
+        run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-zipkin-json
 
   lint-opentelemetry-propagator-b3:
     name: opentelemetry-propagator-b3
@@ -493,11 +493,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-propagator-b3
+        run: uvx --with tox-uv tox -e lint-opentelemetry-propagator-b3
 
   lint-opentelemetry-propagator-jaeger:
     name: opentelemetry-propagator-jaeger
@@ -512,11 +512,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-propagator-jaeger
+        run: uvx --with tox-uv tox -e lint-opentelemetry-propagator-jaeger
 
   lint-opentelemetry-test-utils:
     name: opentelemetry-test-utils
@@ -531,11 +531,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-opentelemetry-test-utils
+        run: uvx --with tox-uv tox -e lint-opentelemetry-test-utils
 
   lint-license-header-check:
     name: license-header-check
@@ -550,8 +550,8 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e lint-license-header-check
+        run: uvx --with tox-uv tox -e lint-license-header-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-api
@@ -57,7 +57,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-proto-gen-latest
@@ -76,7 +76,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-protojson-gen-latest
@@ -95,7 +95,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-codegen-json
@@ -114,7 +114,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-sdk
@@ -133,7 +133,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-configuration
@@ -152,7 +152,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-semantic-conventions
@@ -171,7 +171,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-getting-started
@@ -190,7 +190,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-opentracing-shim
@@ -209,7 +209,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-opencensus-shim
@@ -228,7 +228,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-http-transport
@@ -247,7 +247,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlpcommon-latest
@@ -266,7 +266,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-opencensus
@@ -285,7 +285,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-proto-common
@@ -304,7 +304,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-json-common
@@ -323,7 +323,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-combined
@@ -342,7 +342,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-json-file
@@ -361,7 +361,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-json-http
@@ -380,7 +380,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-proto-grpc-latest
@@ -399,7 +399,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-otlp-proto-http
@@ -418,7 +418,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-prometheus
@@ -437,7 +437,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-zipkin-combined
@@ -456,7 +456,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-zipkin-proto-http
@@ -475,7 +475,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-exporter-zipkin-json
@@ -494,7 +494,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-propagator-b3
@@ -513,7 +513,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-propagator-jaeger
@@ -532,7 +532,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-opentelemetry-test-utils
@@ -551,7 +551,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e lint-license-header-check

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e test-scripts
@@ -62,7 +62,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e spellcheck
@@ -88,7 +88,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e tracecontext
@@ -107,7 +107,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e typecheck
@@ -130,7 +130,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e docs
@@ -149,7 +149,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e docker-tests-otlpexporter
@@ -168,7 +168,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e docker-tests-opencensus
@@ -201,7 +201,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e public-symbols-check
@@ -220,7 +220,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e shellcheck
@@ -242,7 +242,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e generate-workflows
@@ -264,7 +264,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e precommit

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -42,11 +42,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e test-scripts
+        run: uvx --with tox-uv tox -e test-scripts
 
   spellcheck:
     name: spellcheck
@@ -61,11 +61,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e spellcheck
+        run: uvx --with tox-uv tox -e spellcheck
 
   tracecontext:
     name: tracecontext
@@ -87,11 +87,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e tracecontext
+        run: uvx --with tox-uv tox -e tracecontext
 
   typecheck:
     name: typecheck
@@ -106,11 +106,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e typecheck
+        run: uvx --with tox-uv tox -e typecheck
 
   docs:
     name: docs
@@ -129,11 +129,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e docs
+        run: uvx --with tox-uv tox -e docs
 
   docker-tests-otlpexporter:
     name: docker-tests-otlpexporter
@@ -148,11 +148,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e docker-tests-otlpexporter
+        run: uvx --with tox-uv tox -e docker-tests-otlpexporter
 
   docker-tests-opencensus:
     name: docker-tests-opencensus
@@ -167,11 +167,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e docker-tests-opencensus
+        run: uvx --with tox-uv tox -e docker-tests-opencensus
 
   public-symbols-check:
     name: public-symbols-check
@@ -200,11 +200,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e public-symbols-check
+        run: uvx --with tox-uv tox -e public-symbols-check
 
   shellcheck:
     name: shellcheck
@@ -219,11 +219,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e shellcheck
+        run: uvx --with tox-uv tox -e shellcheck
 
   generate-workflows:
     name: generate-workflows
@@ -241,11 +241,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e generate-workflows
+        run: uvx --with tox-uv tox -e generate-workflows
 
       - name: Check github workflows are up to date
         run: git diff --exit-code || (echo 'Generated workflows are out of date, run "tox -e generate-workflows" and commit the changes in this PR.' && exit 1)
@@ -263,8 +263,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e precommit
+        run: uvx --with tox-uv tox -e precommit

--- a/.github/workflows/templates/lint.yml.j2
+++ b/.github/workflows/templates/lint.yml.j2
@@ -38,9 +38,9 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e {{ job_data.tox_env }}
+        run: uvx --with tox-uv tox -e {{ job_data.tox_env }}
   {%- endfor %}

--- a/.github/workflows/templates/lint.yml.j2
+++ b/.github/workflows/templates/lint.yml.j2
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e {{ job_data.tox_env }}

--- a/.github/workflows/templates/misc.yml.j2
+++ b/.github/workflows/templates/misc.yml.j2
@@ -82,7 +82,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e {{ job_data }}

--- a/.github/workflows/templates/misc.yml.j2
+++ b/.github/workflows/templates/misc.yml.j2
@@ -81,11 +81,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e {{ job_data }}
+        run: uvx --with tox-uv tox -e {{ job_data }}
       {%- if job_data == "generate-workflows" %}
 
       - name: Check github workflows are up to date

--- a/.github/workflows/templates/test.yml.j2
+++ b/.github/workflows/templates/test.yml.j2
@@ -66,9 +66,9 @@ jobs:
         with:
           python-version: "{{ job_data.python_version }}"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e {{ job_data.tox_env }} -- -ra
+        run: uvx --with tox-uv tox -e {{ job_data.tox_env }} -- -ra
   {%- endfor %}

--- a/.github/workflows/templates/test.yml.j2
+++ b/.github/workflows/templates/test.yml.j2
@@ -67,7 +67,7 @@ jobs:
           python-version: "{{ job_data.python_version }}"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e {{ job_data.tox_env }} -- -ra

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-api -- -ra
 
   py311-test-opentelemetry-api_ubuntu-latest:
     name: opentelemetry-api 3.11 Ubuntu
@@ -62,11 +62,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-api -- -ra
 
   py312-test-opentelemetry-api_ubuntu-latest:
     name: opentelemetry-api 3.12 Ubuntu
@@ -81,11 +81,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-api -- -ra
 
   py313-test-opentelemetry-api_ubuntu-latest:
     name: opentelemetry-api 3.13 Ubuntu
@@ -100,11 +100,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-api -- -ra
 
   py314-test-opentelemetry-api_ubuntu-latest:
     name: opentelemetry-api 3.14 Ubuntu
@@ -119,11 +119,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-api -- -ra
 
   py314t-test-opentelemetry-api_ubuntu-latest:
     name: opentelemetry-api 3.14t Ubuntu
@@ -138,11 +138,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-api -- -ra
 
   pypy3-test-opentelemetry-api_ubuntu-latest:
     name: opentelemetry-api pypy-3.10 Ubuntu
@@ -157,11 +157,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-api -- -ra
 
   py310-test-opentelemetry-proto-gen-oldest_ubuntu-latest:
     name: opentelemetry-proto-gen-oldest 3.10 Ubuntu
@@ -176,11 +176,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-proto-gen-oldest -- -ra
 
   py310-test-opentelemetry-proto-gen-latest_ubuntu-latest:
     name: opentelemetry-proto-gen-latest 3.10 Ubuntu
@@ -195,11 +195,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-proto-gen-latest -- -ra
 
   py311-test-opentelemetry-proto-gen-oldest_ubuntu-latest:
     name: opentelemetry-proto-gen-oldest 3.11 Ubuntu
@@ -214,11 +214,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-proto-gen-oldest -- -ra
 
   py311-test-opentelemetry-proto-gen-latest_ubuntu-latest:
     name: opentelemetry-proto-gen-latest 3.11 Ubuntu
@@ -233,11 +233,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-proto-gen-latest -- -ra
 
   py312-test-opentelemetry-proto-gen-oldest_ubuntu-latest:
     name: opentelemetry-proto-gen-oldest 3.12 Ubuntu
@@ -252,11 +252,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-proto-gen-oldest -- -ra
 
   py312-test-opentelemetry-proto-gen-latest_ubuntu-latest:
     name: opentelemetry-proto-gen-latest 3.12 Ubuntu
@@ -271,11 +271,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-proto-gen-latest -- -ra
 
   py313-test-opentelemetry-proto-gen-oldest_ubuntu-latest:
     name: opentelemetry-proto-gen-oldest 3.13 Ubuntu
@@ -290,11 +290,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-proto-gen-oldest -- -ra
 
   py313-test-opentelemetry-proto-gen-latest_ubuntu-latest:
     name: opentelemetry-proto-gen-latest 3.13 Ubuntu
@@ -309,11 +309,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-proto-gen-latest -- -ra
 
   py314-test-opentelemetry-proto-gen-oldest_ubuntu-latest:
     name: opentelemetry-proto-gen-oldest 3.14 Ubuntu
@@ -328,11 +328,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-proto-gen-oldest -- -ra
 
   py314-test-opentelemetry-proto-gen-latest_ubuntu-latest:
     name: opentelemetry-proto-gen-latest 3.14 Ubuntu
@@ -347,11 +347,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-proto-gen-latest -- -ra
 
   py314t-test-opentelemetry-proto-gen-oldest_ubuntu-latest:
     name: opentelemetry-proto-gen-oldest 3.14t Ubuntu
@@ -366,11 +366,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-proto-gen-oldest -- -ra
 
   py314t-test-opentelemetry-proto-gen-latest_ubuntu-latest:
     name: opentelemetry-proto-gen-latest 3.14t Ubuntu
@@ -385,11 +385,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-proto-gen-latest -- -ra
 
   pypy3-test-opentelemetry-proto-gen-oldest_ubuntu-latest:
     name: opentelemetry-proto-gen-oldest pypy-3.10 Ubuntu
@@ -404,11 +404,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-proto-gen-oldest -- -ra
 
   pypy3-test-opentelemetry-proto-gen-latest_ubuntu-latest:
     name: opentelemetry-proto-gen-latest pypy-3.10 Ubuntu
@@ -423,11 +423,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-proto-gen-latest -- -ra
 
   py310-test-opentelemetry-protojson-gen-oldest_ubuntu-latest:
     name: opentelemetry-protojson-gen-oldest 3.10 Ubuntu
@@ -442,11 +442,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py310-test-opentelemetry-protojson-gen-latest_ubuntu-latest:
     name: opentelemetry-protojson-gen-latest 3.10 Ubuntu
@@ -461,11 +461,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-protojson-gen-latest -- -ra
 
   py311-test-opentelemetry-protojson-gen-oldest_ubuntu-latest:
     name: opentelemetry-protojson-gen-oldest 3.11 Ubuntu
@@ -480,11 +480,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py311-test-opentelemetry-protojson-gen-latest_ubuntu-latest:
     name: opentelemetry-protojson-gen-latest 3.11 Ubuntu
@@ -499,11 +499,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-protojson-gen-latest -- -ra
 
   py312-test-opentelemetry-protojson-gen-oldest_ubuntu-latest:
     name: opentelemetry-protojson-gen-oldest 3.12 Ubuntu
@@ -518,11 +518,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py312-test-opentelemetry-protojson-gen-latest_ubuntu-latest:
     name: opentelemetry-protojson-gen-latest 3.12 Ubuntu
@@ -537,11 +537,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-protojson-gen-latest -- -ra
 
   py313-test-opentelemetry-protojson-gen-oldest_ubuntu-latest:
     name: opentelemetry-protojson-gen-oldest 3.13 Ubuntu
@@ -556,11 +556,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py313-test-opentelemetry-protojson-gen-latest_ubuntu-latest:
     name: opentelemetry-protojson-gen-latest 3.13 Ubuntu
@@ -575,11 +575,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-protojson-gen-latest -- -ra
 
   py314-test-opentelemetry-protojson-gen-oldest_ubuntu-latest:
     name: opentelemetry-protojson-gen-oldest 3.14 Ubuntu
@@ -594,11 +594,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py314-test-opentelemetry-protojson-gen-latest_ubuntu-latest:
     name: opentelemetry-protojson-gen-latest 3.14 Ubuntu
@@ -613,11 +613,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-protojson-gen-latest -- -ra
 
   py314t-test-opentelemetry-protojson-gen-oldest_ubuntu-latest:
     name: opentelemetry-protojson-gen-oldest 3.14t Ubuntu
@@ -632,11 +632,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py314t-test-opentelemetry-protojson-gen-latest_ubuntu-latest:
     name: opentelemetry-protojson-gen-latest 3.14t Ubuntu
@@ -651,11 +651,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-protojson-gen-latest -- -ra
 
   pypy3-test-opentelemetry-protojson-gen-oldest_ubuntu-latest:
     name: opentelemetry-protojson-gen-oldest pypy-3.10 Ubuntu
@@ -670,11 +670,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-protojson-gen-oldest -- -ra
 
   pypy3-test-opentelemetry-protojson-gen-latest_ubuntu-latest:
     name: opentelemetry-protojson-gen-latest pypy-3.10 Ubuntu
@@ -689,11 +689,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-protojson-gen-latest -- -ra
 
   py310-test-opentelemetry-codegen-json_ubuntu-latest:
     name: opentelemetry-codegen-json 3.10 Ubuntu
@@ -708,11 +708,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-codegen-json -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-codegen-json -- -ra
 
   py311-test-opentelemetry-codegen-json_ubuntu-latest:
     name: opentelemetry-codegen-json 3.11 Ubuntu
@@ -727,11 +727,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-codegen-json -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-codegen-json -- -ra
 
   py312-test-opentelemetry-codegen-json_ubuntu-latest:
     name: opentelemetry-codegen-json 3.12 Ubuntu
@@ -746,11 +746,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-codegen-json -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-codegen-json -- -ra
 
   py313-test-opentelemetry-codegen-json_ubuntu-latest:
     name: opentelemetry-codegen-json 3.13 Ubuntu
@@ -765,11 +765,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-codegen-json -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-codegen-json -- -ra
 
   py314-test-opentelemetry-codegen-json_ubuntu-latest:
     name: opentelemetry-codegen-json 3.14 Ubuntu
@@ -784,11 +784,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-codegen-json -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-codegen-json -- -ra
 
   py310-test-opentelemetry-sdk_ubuntu-latest:
     name: opentelemetry-sdk 3.10 Ubuntu
@@ -803,11 +803,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-sdk -- -ra
 
   py311-test-opentelemetry-sdk_ubuntu-latest:
     name: opentelemetry-sdk 3.11 Ubuntu
@@ -822,11 +822,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-sdk -- -ra
 
   py312-test-opentelemetry-sdk_ubuntu-latest:
     name: opentelemetry-sdk 3.12 Ubuntu
@@ -841,11 +841,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-sdk -- -ra
 
   py313-test-opentelemetry-sdk_ubuntu-latest:
     name: opentelemetry-sdk 3.13 Ubuntu
@@ -860,11 +860,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-sdk -- -ra
 
   py314-test-opentelemetry-sdk_ubuntu-latest:
     name: opentelemetry-sdk 3.14 Ubuntu
@@ -879,11 +879,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-sdk -- -ra
 
   py314t-test-opentelemetry-sdk_ubuntu-latest:
     name: opentelemetry-sdk 3.14t Ubuntu
@@ -898,11 +898,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-sdk -- -ra
 
   pypy3-test-opentelemetry-sdk_ubuntu-latest:
     name: opentelemetry-sdk pypy-3.10 Ubuntu
@@ -917,11 +917,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-sdk -- -ra
 
   py310-test-opentelemetry-configuration_ubuntu-latest:
     name: opentelemetry-configuration 3.10 Ubuntu
@@ -936,11 +936,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-configuration -- -ra
 
   py311-test-opentelemetry-configuration_ubuntu-latest:
     name: opentelemetry-configuration 3.11 Ubuntu
@@ -955,11 +955,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-configuration -- -ra
 
   py312-test-opentelemetry-configuration_ubuntu-latest:
     name: opentelemetry-configuration 3.12 Ubuntu
@@ -974,11 +974,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-configuration -- -ra
 
   py313-test-opentelemetry-configuration_ubuntu-latest:
     name: opentelemetry-configuration 3.13 Ubuntu
@@ -993,11 +993,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-configuration -- -ra
 
   py314-test-opentelemetry-configuration_ubuntu-latest:
     name: opentelemetry-configuration 3.14 Ubuntu
@@ -1012,11 +1012,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-configuration -- -ra
 
   py314t-test-opentelemetry-configuration_ubuntu-latest:
     name: opentelemetry-configuration 3.14t Ubuntu
@@ -1031,11 +1031,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-configuration -- -ra
 
   pypy3-test-opentelemetry-configuration_ubuntu-latest:
     name: opentelemetry-configuration pypy-3.10 Ubuntu
@@ -1050,11 +1050,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-configuration -- -ra
 
   py310-test-opentelemetry-semantic-conventions_ubuntu-latest:
     name: opentelemetry-semantic-conventions 3.10 Ubuntu
@@ -1069,11 +1069,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-semantic-conventions -- -ra
 
   py311-test-opentelemetry-semantic-conventions_ubuntu-latest:
     name: opentelemetry-semantic-conventions 3.11 Ubuntu
@@ -1088,11 +1088,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-semantic-conventions -- -ra
 
   py312-test-opentelemetry-semantic-conventions_ubuntu-latest:
     name: opentelemetry-semantic-conventions 3.12 Ubuntu
@@ -1107,11 +1107,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-semantic-conventions -- -ra
 
   py313-test-opentelemetry-semantic-conventions_ubuntu-latest:
     name: opentelemetry-semantic-conventions 3.13 Ubuntu
@@ -1126,11 +1126,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-semantic-conventions -- -ra
 
   py314-test-opentelemetry-semantic-conventions_ubuntu-latest:
     name: opentelemetry-semantic-conventions 3.14 Ubuntu
@@ -1145,11 +1145,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-semantic-conventions -- -ra
 
   py314t-test-opentelemetry-semantic-conventions_ubuntu-latest:
     name: opentelemetry-semantic-conventions 3.14t Ubuntu
@@ -1164,11 +1164,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-semantic-conventions -- -ra
 
   pypy3-test-opentelemetry-semantic-conventions_ubuntu-latest:
     name: opentelemetry-semantic-conventions pypy-3.10 Ubuntu
@@ -1183,11 +1183,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-semantic-conventions -- -ra
 
   py310-test-opentelemetry-getting-started_ubuntu-latest:
     name: opentelemetry-getting-started 3.10 Ubuntu
@@ -1209,11 +1209,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-getting-started -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-getting-started -- -ra
 
   py311-test-opentelemetry-getting-started_ubuntu-latest:
     name: opentelemetry-getting-started 3.11 Ubuntu
@@ -1235,11 +1235,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-getting-started -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-getting-started -- -ra
 
   py312-test-opentelemetry-getting-started_ubuntu-latest:
     name: opentelemetry-getting-started 3.12 Ubuntu
@@ -1261,11 +1261,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-getting-started -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-getting-started -- -ra
 
   py313-test-opentelemetry-getting-started_ubuntu-latest:
     name: opentelemetry-getting-started 3.13 Ubuntu
@@ -1287,11 +1287,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-getting-started -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-getting-started -- -ra
 
   py314-test-opentelemetry-getting-started_ubuntu-latest:
     name: opentelemetry-getting-started 3.14 Ubuntu
@@ -1313,11 +1313,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-getting-started -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-getting-started -- -ra
 
   py310-test-opentelemetry-opentracing-shim_ubuntu-latest:
     name: opentelemetry-opentracing-shim 3.10 Ubuntu
@@ -1332,11 +1332,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-opentracing-shim -- -ra
 
   py311-test-opentelemetry-opentracing-shim_ubuntu-latest:
     name: opentelemetry-opentracing-shim 3.11 Ubuntu
@@ -1351,11 +1351,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-opentracing-shim -- -ra
 
   py312-test-opentelemetry-opentracing-shim_ubuntu-latest:
     name: opentelemetry-opentracing-shim 3.12 Ubuntu
@@ -1370,11 +1370,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-opentracing-shim -- -ra
 
   py313-test-opentelemetry-opentracing-shim_ubuntu-latest:
     name: opentelemetry-opentracing-shim 3.13 Ubuntu
@@ -1389,11 +1389,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-opentracing-shim -- -ra
 
   py314-test-opentelemetry-opentracing-shim_ubuntu-latest:
     name: opentelemetry-opentracing-shim 3.14 Ubuntu
@@ -1408,11 +1408,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-opentracing-shim -- -ra
 
   py314t-test-opentelemetry-opentracing-shim_ubuntu-latest:
     name: opentelemetry-opentracing-shim 3.14t Ubuntu
@@ -1427,11 +1427,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-opentracing-shim -- -ra
 
   pypy3-test-opentelemetry-opentracing-shim_ubuntu-latest:
     name: opentelemetry-opentracing-shim pypy-3.10 Ubuntu
@@ -1446,11 +1446,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-opentracing-shim -- -ra
 
   py310-test-opentelemetry-opencensus-shim_ubuntu-latest:
     name: opentelemetry-opencensus-shim 3.10 Ubuntu
@@ -1465,11 +1465,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-opencensus-shim -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-opencensus-shim -- -ra
 
   py311-test-opentelemetry-opencensus-shim_ubuntu-latest:
     name: opentelemetry-opencensus-shim 3.11 Ubuntu
@@ -1484,11 +1484,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-opencensus-shim -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-opencensus-shim -- -ra
 
   py312-test-opentelemetry-opencensus-shim_ubuntu-latest:
     name: opentelemetry-opencensus-shim 3.12 Ubuntu
@@ -1503,11 +1503,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-opencensus-shim -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-opencensus-shim -- -ra
 
   py313-test-opentelemetry-opencensus-shim_ubuntu-latest:
     name: opentelemetry-opencensus-shim 3.13 Ubuntu
@@ -1522,11 +1522,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-opencensus-shim -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-opencensus-shim -- -ra
 
   py314-test-opentelemetry-opencensus-shim_ubuntu-latest:
     name: opentelemetry-opencensus-shim 3.14 Ubuntu
@@ -1541,11 +1541,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-opencensus-shim -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-opencensus-shim -- -ra
 
   py310-test-opentelemetry-exporter-http-transport-oldest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.10 Ubuntu
@@ -1560,11 +1560,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py310-test-opentelemetry-exporter-http-transport-latest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-latest 3.10 Ubuntu
@@ -1579,11 +1579,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py311-test-opentelemetry-exporter-http-transport-oldest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.11 Ubuntu
@@ -1598,11 +1598,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py311-test-opentelemetry-exporter-http-transport-latest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-latest 3.11 Ubuntu
@@ -1617,11 +1617,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py312-test-opentelemetry-exporter-http-transport-oldest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.12 Ubuntu
@@ -1636,11 +1636,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py312-test-opentelemetry-exporter-http-transport-latest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-latest 3.12 Ubuntu
@@ -1655,11 +1655,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py313-test-opentelemetry-exporter-http-transport-oldest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.13 Ubuntu
@@ -1674,11 +1674,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py313-test-opentelemetry-exporter-http-transport-latest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-latest 3.13 Ubuntu
@@ -1693,11 +1693,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py314-test-opentelemetry-exporter-http-transport-oldest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.14 Ubuntu
@@ -1712,11 +1712,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py314-test-opentelemetry-exporter-http-transport-latest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-latest 3.14 Ubuntu
@@ -1731,11 +1731,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py314t-test-opentelemetry-exporter-http-transport-oldest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.14t Ubuntu
@@ -1750,11 +1750,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py314t-test-opentelemetry-exporter-http-transport-latest_ubuntu-latest:
     name: opentelemetry-exporter-http-transport-latest 3.14t Ubuntu
@@ -1769,11 +1769,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py310-test-opentelemetry-exporter-otlpcommon-oldest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.10 Ubuntu
@@ -1788,11 +1788,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py310-test-opentelemetry-exporter-otlpcommon-latest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.10 Ubuntu
@@ -1807,11 +1807,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py311-test-opentelemetry-exporter-otlpcommon-oldest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.11 Ubuntu
@@ -1826,11 +1826,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py311-test-opentelemetry-exporter-otlpcommon-latest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.11 Ubuntu
@@ -1845,11 +1845,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py312-test-opentelemetry-exporter-otlpcommon-oldest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.12 Ubuntu
@@ -1864,11 +1864,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py312-test-opentelemetry-exporter-otlpcommon-latest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.12 Ubuntu
@@ -1883,11 +1883,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py313-test-opentelemetry-exporter-otlpcommon-oldest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.13 Ubuntu
@@ -1902,11 +1902,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py313-test-opentelemetry-exporter-otlpcommon-latest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.13 Ubuntu
@@ -1921,11 +1921,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py314-test-opentelemetry-exporter-otlpcommon-oldest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.14 Ubuntu
@@ -1940,11 +1940,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py314-test-opentelemetry-exporter-otlpcommon-latest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.14 Ubuntu
@@ -1959,11 +1959,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py314t-test-opentelemetry-exporter-otlpcommon-oldest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.14t Ubuntu
@@ -1978,11 +1978,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py314t-test-opentelemetry-exporter-otlpcommon-latest_ubuntu-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.14t Ubuntu
@@ -1997,11 +1997,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py310-test-opentelemetry-exporter-opencensus_ubuntu-latest:
     name: opentelemetry-exporter-opencensus 3.10 Ubuntu
@@ -2016,11 +2016,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-opencensus -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-opencensus -- -ra
 
   py311-test-opentelemetry-exporter-opencensus_ubuntu-latest:
     name: opentelemetry-exporter-opencensus 3.11 Ubuntu
@@ -2035,11 +2035,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-opencensus -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-opencensus -- -ra
 
   py312-test-opentelemetry-exporter-opencensus_ubuntu-latest:
     name: opentelemetry-exporter-opencensus 3.12 Ubuntu
@@ -2054,11 +2054,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-opencensus -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-opencensus -- -ra
 
   py313-test-opentelemetry-exporter-opencensus_ubuntu-latest:
     name: opentelemetry-exporter-opencensus 3.13 Ubuntu
@@ -2073,11 +2073,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-opencensus -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-opencensus -- -ra
 
   py314-test-opentelemetry-exporter-opencensus_ubuntu-latest:
     name: opentelemetry-exporter-opencensus 3.14 Ubuntu
@@ -2092,11 +2092,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-opencensus -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-opencensus -- -ra
 
   py310-test-opentelemetry-exporter-otlp-proto-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.10 Ubuntu
@@ -2111,11 +2111,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py311-test-opentelemetry-exporter-otlp-proto-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.11 Ubuntu
@@ -2130,11 +2130,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py312-test-opentelemetry-exporter-otlp-proto-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.12 Ubuntu
@@ -2149,11 +2149,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py313-test-opentelemetry-exporter-otlp-proto-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.13 Ubuntu
@@ -2168,11 +2168,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py314-test-opentelemetry-exporter-otlp-proto-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.14 Ubuntu
@@ -2187,11 +2187,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py314t-test-opentelemetry-exporter-otlp-proto-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.14t Ubuntu
@@ -2206,11 +2206,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   pypy3-test-opentelemetry-exporter-otlp-proto-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-common pypy-3.10 Ubuntu
@@ -2225,11 +2225,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py310-test-opentelemetry-exporter-otlp-json-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-common 3.10 Ubuntu
@@ -2244,11 +2244,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py311-test-opentelemetry-exporter-otlp-json-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-common 3.11 Ubuntu
@@ -2263,11 +2263,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py312-test-opentelemetry-exporter-otlp-json-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-common 3.12 Ubuntu
@@ -2282,11 +2282,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py313-test-opentelemetry-exporter-otlp-json-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-common 3.13 Ubuntu
@@ -2301,11 +2301,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py314-test-opentelemetry-exporter-otlp-json-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-common 3.14 Ubuntu
@@ -2320,11 +2320,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py314t-test-opentelemetry-exporter-otlp-json-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-common 3.14t Ubuntu
@@ -2339,11 +2339,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   pypy3-test-opentelemetry-exporter-otlp-json-common_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-common pypy-3.10 Ubuntu
@@ -2358,11 +2358,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py310-test-opentelemetry-exporter-otlp-combined_ubuntu-latest:
     name: opentelemetry-exporter-otlp-combined 3.10 Ubuntu
@@ -2377,11 +2377,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-combined -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-combined -- -ra
 
   py311-test-opentelemetry-exporter-otlp-combined_ubuntu-latest:
     name: opentelemetry-exporter-otlp-combined 3.11 Ubuntu
@@ -2396,11 +2396,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-combined -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-combined -- -ra
 
   py312-test-opentelemetry-exporter-otlp-combined_ubuntu-latest:
     name: opentelemetry-exporter-otlp-combined 3.12 Ubuntu
@@ -2415,11 +2415,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-combined -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-combined -- -ra
 
   py313-test-opentelemetry-exporter-otlp-combined_ubuntu-latest:
     name: opentelemetry-exporter-otlp-combined 3.13 Ubuntu
@@ -2434,11 +2434,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-combined -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-combined -- -ra
 
   py314-test-opentelemetry-exporter-otlp-combined_ubuntu-latest:
     name: opentelemetry-exporter-otlp-combined 3.14 Ubuntu
@@ -2453,11 +2453,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-combined -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-combined -- -ra
 
   py310-test-opentelemetry-exporter-otlp-json-file_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-file 3.10 Ubuntu
@@ -2472,11 +2472,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py311-test-opentelemetry-exporter-otlp-json-file_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-file 3.11 Ubuntu
@@ -2491,11 +2491,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py312-test-opentelemetry-exporter-otlp-json-file_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-file 3.12 Ubuntu
@@ -2510,11 +2510,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py313-test-opentelemetry-exporter-otlp-json-file_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-file 3.13 Ubuntu
@@ -2529,11 +2529,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py314-test-opentelemetry-exporter-otlp-json-file_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-file 3.14 Ubuntu
@@ -2548,11 +2548,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py314t-test-opentelemetry-exporter-otlp-json-file_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-file 3.14t Ubuntu
@@ -2567,11 +2567,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   pypy3-test-opentelemetry-exporter-otlp-json-file_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-file pypy-3.10 Ubuntu
@@ -2586,11 +2586,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py310-test-opentelemetry-exporter-otlp-json-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-http 3.10 Ubuntu
@@ -2605,11 +2605,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py311-test-opentelemetry-exporter-otlp-json-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-http 3.11 Ubuntu
@@ -2624,11 +2624,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py312-test-opentelemetry-exporter-otlp-json-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-http 3.12 Ubuntu
@@ -2643,11 +2643,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py313-test-opentelemetry-exporter-otlp-json-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-http 3.13 Ubuntu
@@ -2662,11 +2662,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py314-test-opentelemetry-exporter-otlp-json-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-http 3.14 Ubuntu
@@ -2681,11 +2681,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py314t-test-opentelemetry-exporter-otlp-json-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-http 3.14t Ubuntu
@@ -2700,11 +2700,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   pypy3-test-opentelemetry-exporter-otlp-json-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-json-http pypy-3.10 Ubuntu
@@ -2719,11 +2719,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py310-test-opentelemetry-exporter-otlp-proto-grpc-oldest_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-oldest 3.10 Ubuntu
@@ -2738,11 +2738,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
 
   py310-test-opentelemetry-exporter-otlp-proto-grpc-latest_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-latest 3.10 Ubuntu
@@ -2757,11 +2757,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
 
   py311-test-opentelemetry-exporter-otlp-proto-grpc-oldest_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-oldest 3.11 Ubuntu
@@ -2776,11 +2776,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
 
   py311-test-opentelemetry-exporter-otlp-proto-grpc-latest_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-latest 3.11 Ubuntu
@@ -2795,11 +2795,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
 
   py312-test-opentelemetry-exporter-otlp-proto-grpc-oldest_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-oldest 3.12 Ubuntu
@@ -2814,11 +2814,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
 
   py312-test-opentelemetry-exporter-otlp-proto-grpc-latest_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-latest 3.12 Ubuntu
@@ -2833,11 +2833,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
 
   py313-test-opentelemetry-exporter-otlp-proto-grpc-oldest_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-oldest 3.13 Ubuntu
@@ -2852,11 +2852,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
 
   py313-test-opentelemetry-exporter-otlp-proto-grpc-latest_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-latest 3.13 Ubuntu
@@ -2871,11 +2871,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
 
   py314-test-opentelemetry-exporter-otlp-proto-grpc-oldest_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-oldest 3.14 Ubuntu
@@ -2890,11 +2890,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
 
   py314-test-opentelemetry-exporter-otlp-proto-grpc-latest_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-latest 3.14 Ubuntu
@@ -2909,11 +2909,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
 
   py310-test-opentelemetry-exporter-otlp-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.10 Ubuntu
@@ -2928,11 +2928,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py311-test-opentelemetry-exporter-otlp-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.11 Ubuntu
@@ -2947,11 +2947,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py312-test-opentelemetry-exporter-otlp-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.12 Ubuntu
@@ -2966,11 +2966,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py313-test-opentelemetry-exporter-otlp-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.13 Ubuntu
@@ -2985,11 +2985,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py314-test-opentelemetry-exporter-otlp-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.14 Ubuntu
@@ -3004,11 +3004,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py314t-test-opentelemetry-exporter-otlp-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.14t Ubuntu
@@ -3023,11 +3023,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   pypy3-test-opentelemetry-exporter-otlp-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-otlp-proto-http pypy-3.10 Ubuntu
@@ -3042,11 +3042,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py310-test-opentelemetry-exporter-prometheus_ubuntu-latest:
     name: opentelemetry-exporter-prometheus 3.10 Ubuntu
@@ -3061,11 +3061,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-prometheus -- -ra
 
   py311-test-opentelemetry-exporter-prometheus_ubuntu-latest:
     name: opentelemetry-exporter-prometheus 3.11 Ubuntu
@@ -3080,11 +3080,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-prometheus -- -ra
 
   py312-test-opentelemetry-exporter-prometheus_ubuntu-latest:
     name: opentelemetry-exporter-prometheus 3.12 Ubuntu
@@ -3099,11 +3099,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-prometheus -- -ra
 
   py313-test-opentelemetry-exporter-prometheus_ubuntu-latest:
     name: opentelemetry-exporter-prometheus 3.13 Ubuntu
@@ -3118,11 +3118,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-prometheus -- -ra
 
   py314-test-opentelemetry-exporter-prometheus_ubuntu-latest:
     name: opentelemetry-exporter-prometheus 3.14 Ubuntu
@@ -3137,11 +3137,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-prometheus -- -ra
 
   py314t-test-opentelemetry-exporter-prometheus_ubuntu-latest:
     name: opentelemetry-exporter-prometheus 3.14t Ubuntu
@@ -3156,11 +3156,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-prometheus -- -ra
 
   pypy3-test-opentelemetry-exporter-prometheus_ubuntu-latest:
     name: opentelemetry-exporter-prometheus pypy-3.10 Ubuntu
@@ -3175,11 +3175,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-prometheus -- -ra
 
   py310-test-opentelemetry-exporter-zipkin-combined_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-combined 3.10 Ubuntu
@@ -3194,11 +3194,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py311-test-opentelemetry-exporter-zipkin-combined_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-combined 3.11 Ubuntu
@@ -3213,11 +3213,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py312-test-opentelemetry-exporter-zipkin-combined_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-combined 3.12 Ubuntu
@@ -3232,11 +3232,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py313-test-opentelemetry-exporter-zipkin-combined_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-combined 3.13 Ubuntu
@@ -3251,11 +3251,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py314-test-opentelemetry-exporter-zipkin-combined_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-combined 3.14 Ubuntu
@@ -3270,11 +3270,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py314t-test-opentelemetry-exporter-zipkin-combined_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-combined 3.14t Ubuntu
@@ -3289,11 +3289,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   pypy3-test-opentelemetry-exporter-zipkin-combined_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-combined pypy-3.10 Ubuntu
@@ -3308,11 +3308,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py310-test-opentelemetry-exporter-zipkin-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.10 Ubuntu
@@ -3327,11 +3327,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py311-test-opentelemetry-exporter-zipkin-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.11 Ubuntu
@@ -3346,11 +3346,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py312-test-opentelemetry-exporter-zipkin-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.12 Ubuntu
@@ -3365,11 +3365,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py313-test-opentelemetry-exporter-zipkin-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.13 Ubuntu
@@ -3384,11 +3384,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py314-test-opentelemetry-exporter-zipkin-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.14 Ubuntu
@@ -3403,11 +3403,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py314t-test-opentelemetry-exporter-zipkin-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.14t Ubuntu
@@ -3422,11 +3422,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   pypy3-test-opentelemetry-exporter-zipkin-proto-http_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-proto-http pypy-3.10 Ubuntu
@@ -3441,11 +3441,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py310-test-opentelemetry-exporter-zipkin-json_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-json 3.10 Ubuntu
@@ -3460,11 +3460,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py311-test-opentelemetry-exporter-zipkin-json_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-json 3.11 Ubuntu
@@ -3479,11 +3479,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py312-test-opentelemetry-exporter-zipkin-json_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-json 3.12 Ubuntu
@@ -3498,11 +3498,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py313-test-opentelemetry-exporter-zipkin-json_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-json 3.13 Ubuntu
@@ -3517,11 +3517,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py314-test-opentelemetry-exporter-zipkin-json_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-json 3.14 Ubuntu
@@ -3536,11 +3536,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py314t-test-opentelemetry-exporter-zipkin-json_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-json 3.14t Ubuntu
@@ -3555,11 +3555,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-json -- -ra
 
   pypy3-test-opentelemetry-exporter-zipkin-json_ubuntu-latest:
     name: opentelemetry-exporter-zipkin-json pypy-3.10 Ubuntu
@@ -3574,11 +3574,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py310-test-opentelemetry-propagator-b3_ubuntu-latest:
     name: opentelemetry-propagator-b3 3.10 Ubuntu
@@ -3593,11 +3593,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-propagator-b3 -- -ra
 
   py311-test-opentelemetry-propagator-b3_ubuntu-latest:
     name: opentelemetry-propagator-b3 3.11 Ubuntu
@@ -3612,11 +3612,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-propagator-b3 -- -ra
 
   py312-test-opentelemetry-propagator-b3_ubuntu-latest:
     name: opentelemetry-propagator-b3 3.12 Ubuntu
@@ -3631,11 +3631,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-propagator-b3 -- -ra
 
   py313-test-opentelemetry-propagator-b3_ubuntu-latest:
     name: opentelemetry-propagator-b3 3.13 Ubuntu
@@ -3650,11 +3650,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-propagator-b3 -- -ra
 
   py314-test-opentelemetry-propagator-b3_ubuntu-latest:
     name: opentelemetry-propagator-b3 3.14 Ubuntu
@@ -3669,11 +3669,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-propagator-b3 -- -ra
 
   py314t-test-opentelemetry-propagator-b3_ubuntu-latest:
     name: opentelemetry-propagator-b3 3.14t Ubuntu
@@ -3688,11 +3688,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-propagator-b3 -- -ra
 
   pypy3-test-opentelemetry-propagator-b3_ubuntu-latest:
     name: opentelemetry-propagator-b3 pypy-3.10 Ubuntu
@@ -3707,11 +3707,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-propagator-b3 -- -ra
 
   py310-test-opentelemetry-propagator-jaeger_ubuntu-latest:
     name: opentelemetry-propagator-jaeger 3.10 Ubuntu
@@ -3726,11 +3726,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-propagator-jaeger -- -ra
 
   py311-test-opentelemetry-propagator-jaeger_ubuntu-latest:
     name: opentelemetry-propagator-jaeger 3.11 Ubuntu
@@ -3745,11 +3745,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-propagator-jaeger -- -ra
 
   py312-test-opentelemetry-propagator-jaeger_ubuntu-latest:
     name: opentelemetry-propagator-jaeger 3.12 Ubuntu
@@ -3764,11 +3764,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-propagator-jaeger -- -ra
 
   py313-test-opentelemetry-propagator-jaeger_ubuntu-latest:
     name: opentelemetry-propagator-jaeger 3.13 Ubuntu
@@ -3783,11 +3783,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-propagator-jaeger -- -ra
 
   py314-test-opentelemetry-propagator-jaeger_ubuntu-latest:
     name: opentelemetry-propagator-jaeger 3.14 Ubuntu
@@ -3802,11 +3802,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-propagator-jaeger -- -ra
 
   py314t-test-opentelemetry-propagator-jaeger_ubuntu-latest:
     name: opentelemetry-propagator-jaeger 3.14t Ubuntu
@@ -3821,11 +3821,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-propagator-jaeger -- -ra
 
   pypy3-test-opentelemetry-propagator-jaeger_ubuntu-latest:
     name: opentelemetry-propagator-jaeger pypy-3.10 Ubuntu
@@ -3840,11 +3840,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-propagator-jaeger -- -ra
 
   py310-test-opentelemetry-test-utils_ubuntu-latest:
     name: opentelemetry-test-utils 3.10 Ubuntu
@@ -3865,11 +3865,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-test-utils -- -ra
 
   py311-test-opentelemetry-test-utils_ubuntu-latest:
     name: opentelemetry-test-utils 3.11 Ubuntu
@@ -3890,11 +3890,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-test-utils -- -ra
 
   py312-test-opentelemetry-test-utils_ubuntu-latest:
     name: opentelemetry-test-utils 3.12 Ubuntu
@@ -3915,11 +3915,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-test-utils -- -ra
 
   py313-test-opentelemetry-test-utils_ubuntu-latest:
     name: opentelemetry-test-utils 3.13 Ubuntu
@@ -3940,11 +3940,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-test-utils -- -ra
 
   py314-test-opentelemetry-test-utils_ubuntu-latest:
     name: opentelemetry-test-utils 3.14 Ubuntu
@@ -3965,11 +3965,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-test-utils -- -ra
 
   pypy3-test-opentelemetry-test-utils_ubuntu-latest:
     name: opentelemetry-test-utils pypy-3.10 Ubuntu
@@ -3990,11 +3990,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-test-utils -- -ra
 
   py310-test-opentelemetry-api_windows-latest:
     name: opentelemetry-api 3.10 Windows
@@ -4011,11 +4011,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-api -- -ra
 
   py311-test-opentelemetry-api_windows-latest:
     name: opentelemetry-api 3.11 Windows
@@ -4032,11 +4032,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-api -- -ra
 
   py312-test-opentelemetry-api_windows-latest:
     name: opentelemetry-api 3.12 Windows
@@ -4053,11 +4053,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-api -- -ra
 
   py313-test-opentelemetry-api_windows-latest:
     name: opentelemetry-api 3.13 Windows
@@ -4074,11 +4074,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-api -- -ra
 
   py314-test-opentelemetry-api_windows-latest:
     name: opentelemetry-api 3.14 Windows
@@ -4095,11 +4095,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-api -- -ra
 
   py314t-test-opentelemetry-api_windows-latest:
     name: opentelemetry-api 3.14t Windows
@@ -4116,11 +4116,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-api -- -ra
 
   pypy3-test-opentelemetry-api_windows-latest:
     name: opentelemetry-api pypy-3.10 Windows
@@ -4137,11 +4137,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-api -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-api -- -ra
 
   py310-test-opentelemetry-proto-gen-oldest_windows-latest:
     name: opentelemetry-proto-gen-oldest 3.10 Windows
@@ -4158,11 +4158,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-proto-gen-oldest -- -ra
 
   py310-test-opentelemetry-proto-gen-latest_windows-latest:
     name: opentelemetry-proto-gen-latest 3.10 Windows
@@ -4179,11 +4179,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-proto-gen-latest -- -ra
 
   py311-test-opentelemetry-proto-gen-oldest_windows-latest:
     name: opentelemetry-proto-gen-oldest 3.11 Windows
@@ -4200,11 +4200,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-proto-gen-oldest -- -ra
 
   py311-test-opentelemetry-proto-gen-latest_windows-latest:
     name: opentelemetry-proto-gen-latest 3.11 Windows
@@ -4221,11 +4221,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-proto-gen-latest -- -ra
 
   py312-test-opentelemetry-proto-gen-oldest_windows-latest:
     name: opentelemetry-proto-gen-oldest 3.12 Windows
@@ -4242,11 +4242,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-proto-gen-oldest -- -ra
 
   py312-test-opentelemetry-proto-gen-latest_windows-latest:
     name: opentelemetry-proto-gen-latest 3.12 Windows
@@ -4263,11 +4263,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-proto-gen-latest -- -ra
 
   py313-test-opentelemetry-proto-gen-oldest_windows-latest:
     name: opentelemetry-proto-gen-oldest 3.13 Windows
@@ -4284,11 +4284,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-proto-gen-oldest -- -ra
 
   py313-test-opentelemetry-proto-gen-latest_windows-latest:
     name: opentelemetry-proto-gen-latest 3.13 Windows
@@ -4305,11 +4305,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-proto-gen-latest -- -ra
 
   py314-test-opentelemetry-proto-gen-oldest_windows-latest:
     name: opentelemetry-proto-gen-oldest 3.14 Windows
@@ -4326,11 +4326,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-proto-gen-oldest -- -ra
 
   py314-test-opentelemetry-proto-gen-latest_windows-latest:
     name: opentelemetry-proto-gen-latest 3.14 Windows
@@ -4347,11 +4347,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-proto-gen-latest -- -ra
 
   py314t-test-opentelemetry-proto-gen-oldest_windows-latest:
     name: opentelemetry-proto-gen-oldest 3.14t Windows
@@ -4368,11 +4368,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-proto-gen-oldest -- -ra
 
   py314t-test-opentelemetry-proto-gen-latest_windows-latest:
     name: opentelemetry-proto-gen-latest 3.14t Windows
@@ -4389,11 +4389,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-proto-gen-latest -- -ra
 
   pypy3-test-opentelemetry-proto-gen-oldest_windows-latest:
     name: opentelemetry-proto-gen-oldest pypy-3.10 Windows
@@ -4410,11 +4410,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-proto-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-proto-gen-oldest -- -ra
 
   pypy3-test-opentelemetry-proto-gen-latest_windows-latest:
     name: opentelemetry-proto-gen-latest pypy-3.10 Windows
@@ -4431,11 +4431,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-proto-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-proto-gen-latest -- -ra
 
   py310-test-opentelemetry-protojson-gen-oldest_windows-latest:
     name: opentelemetry-protojson-gen-oldest 3.10 Windows
@@ -4452,11 +4452,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py310-test-opentelemetry-protojson-gen-latest_windows-latest:
     name: opentelemetry-protojson-gen-latest 3.10 Windows
@@ -4473,11 +4473,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-protojson-gen-latest -- -ra
 
   py311-test-opentelemetry-protojson-gen-oldest_windows-latest:
     name: opentelemetry-protojson-gen-oldest 3.11 Windows
@@ -4494,11 +4494,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py311-test-opentelemetry-protojson-gen-latest_windows-latest:
     name: opentelemetry-protojson-gen-latest 3.11 Windows
@@ -4515,11 +4515,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-protojson-gen-latest -- -ra
 
   py312-test-opentelemetry-protojson-gen-oldest_windows-latest:
     name: opentelemetry-protojson-gen-oldest 3.12 Windows
@@ -4536,11 +4536,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py312-test-opentelemetry-protojson-gen-latest_windows-latest:
     name: opentelemetry-protojson-gen-latest 3.12 Windows
@@ -4557,11 +4557,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-protojson-gen-latest -- -ra
 
   py313-test-opentelemetry-protojson-gen-oldest_windows-latest:
     name: opentelemetry-protojson-gen-oldest 3.13 Windows
@@ -4578,11 +4578,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py313-test-opentelemetry-protojson-gen-latest_windows-latest:
     name: opentelemetry-protojson-gen-latest 3.13 Windows
@@ -4599,11 +4599,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-protojson-gen-latest -- -ra
 
   py314-test-opentelemetry-protojson-gen-oldest_windows-latest:
     name: opentelemetry-protojson-gen-oldest 3.14 Windows
@@ -4620,11 +4620,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py314-test-opentelemetry-protojson-gen-latest_windows-latest:
     name: opentelemetry-protojson-gen-latest 3.14 Windows
@@ -4641,11 +4641,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-protojson-gen-latest -- -ra
 
   py314t-test-opentelemetry-protojson-gen-oldest_windows-latest:
     name: opentelemetry-protojson-gen-oldest 3.14t Windows
@@ -4662,11 +4662,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-protojson-gen-oldest -- -ra
 
   py314t-test-opentelemetry-protojson-gen-latest_windows-latest:
     name: opentelemetry-protojson-gen-latest 3.14t Windows
@@ -4683,11 +4683,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-protojson-gen-latest -- -ra
 
   pypy3-test-opentelemetry-protojson-gen-oldest_windows-latest:
     name: opentelemetry-protojson-gen-oldest pypy-3.10 Windows
@@ -4704,11 +4704,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-protojson-gen-oldest -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-protojson-gen-oldest -- -ra
 
   pypy3-test-opentelemetry-protojson-gen-latest_windows-latest:
     name: opentelemetry-protojson-gen-latest pypy-3.10 Windows
@@ -4725,11 +4725,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-protojson-gen-latest -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-protojson-gen-latest -- -ra
 
   py310-test-opentelemetry-codegen-json_windows-latest:
     name: opentelemetry-codegen-json 3.10 Windows
@@ -4746,11 +4746,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-codegen-json -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-codegen-json -- -ra
 
   py311-test-opentelemetry-codegen-json_windows-latest:
     name: opentelemetry-codegen-json 3.11 Windows
@@ -4767,11 +4767,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-codegen-json -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-codegen-json -- -ra
 
   py312-test-opentelemetry-codegen-json_windows-latest:
     name: opentelemetry-codegen-json 3.12 Windows
@@ -4788,11 +4788,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-codegen-json -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-codegen-json -- -ra
 
   py313-test-opentelemetry-codegen-json_windows-latest:
     name: opentelemetry-codegen-json 3.13 Windows
@@ -4809,11 +4809,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-codegen-json -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-codegen-json -- -ra
 
   py314-test-opentelemetry-codegen-json_windows-latest:
     name: opentelemetry-codegen-json 3.14 Windows
@@ -4830,11 +4830,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-codegen-json -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-codegen-json -- -ra
 
   py310-test-opentelemetry-sdk_windows-latest:
     name: opentelemetry-sdk 3.10 Windows
@@ -4851,11 +4851,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-sdk -- -ra
 
   py311-test-opentelemetry-sdk_windows-latest:
     name: opentelemetry-sdk 3.11 Windows
@@ -4872,11 +4872,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-sdk -- -ra
 
   py312-test-opentelemetry-sdk_windows-latest:
     name: opentelemetry-sdk 3.12 Windows
@@ -4893,11 +4893,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-sdk -- -ra
 
   py313-test-opentelemetry-sdk_windows-latest:
     name: opentelemetry-sdk 3.13 Windows
@@ -4914,11 +4914,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-sdk -- -ra
 
   py314-test-opentelemetry-sdk_windows-latest:
     name: opentelemetry-sdk 3.14 Windows
@@ -4935,11 +4935,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-sdk -- -ra
 
   py314t-test-opentelemetry-sdk_windows-latest:
     name: opentelemetry-sdk 3.14t Windows
@@ -4956,11 +4956,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-sdk -- -ra
 
   pypy3-test-opentelemetry-sdk_windows-latest:
     name: opentelemetry-sdk pypy-3.10 Windows
@@ -4977,11 +4977,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-sdk -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-sdk -- -ra
 
   py310-test-opentelemetry-configuration_windows-latest:
     name: opentelemetry-configuration 3.10 Windows
@@ -4998,11 +4998,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-configuration -- -ra
 
   py311-test-opentelemetry-configuration_windows-latest:
     name: opentelemetry-configuration 3.11 Windows
@@ -5019,11 +5019,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-configuration -- -ra
 
   py312-test-opentelemetry-configuration_windows-latest:
     name: opentelemetry-configuration 3.12 Windows
@@ -5040,11 +5040,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-configuration -- -ra
 
   py313-test-opentelemetry-configuration_windows-latest:
     name: opentelemetry-configuration 3.13 Windows
@@ -5061,11 +5061,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-configuration -- -ra
 
   py314-test-opentelemetry-configuration_windows-latest:
     name: opentelemetry-configuration 3.14 Windows
@@ -5082,11 +5082,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-configuration -- -ra
 
   py314t-test-opentelemetry-configuration_windows-latest:
     name: opentelemetry-configuration 3.14t Windows
@@ -5103,11 +5103,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-configuration -- -ra
 
   pypy3-test-opentelemetry-configuration_windows-latest:
     name: opentelemetry-configuration pypy-3.10 Windows
@@ -5124,11 +5124,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-configuration -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-configuration -- -ra
 
   py310-test-opentelemetry-semantic-conventions_windows-latest:
     name: opentelemetry-semantic-conventions 3.10 Windows
@@ -5145,11 +5145,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-semantic-conventions -- -ra
 
   py311-test-opentelemetry-semantic-conventions_windows-latest:
     name: opentelemetry-semantic-conventions 3.11 Windows
@@ -5166,11 +5166,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-semantic-conventions -- -ra
 
   py312-test-opentelemetry-semantic-conventions_windows-latest:
     name: opentelemetry-semantic-conventions 3.12 Windows
@@ -5187,11 +5187,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-semantic-conventions -- -ra
 
   py313-test-opentelemetry-semantic-conventions_windows-latest:
     name: opentelemetry-semantic-conventions 3.13 Windows
@@ -5208,11 +5208,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-semantic-conventions -- -ra
 
   py314-test-opentelemetry-semantic-conventions_windows-latest:
     name: opentelemetry-semantic-conventions 3.14 Windows
@@ -5229,11 +5229,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-semantic-conventions -- -ra
 
   py314t-test-opentelemetry-semantic-conventions_windows-latest:
     name: opentelemetry-semantic-conventions 3.14t Windows
@@ -5250,11 +5250,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-semantic-conventions -- -ra
 
   pypy3-test-opentelemetry-semantic-conventions_windows-latest:
     name: opentelemetry-semantic-conventions pypy-3.10 Windows
@@ -5271,11 +5271,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-semantic-conventions -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-semantic-conventions -- -ra
 
   py310-test-opentelemetry-getting-started_windows-latest:
     name: opentelemetry-getting-started 3.10 Windows
@@ -5299,11 +5299,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-getting-started -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-getting-started -- -ra
 
   py311-test-opentelemetry-getting-started_windows-latest:
     name: opentelemetry-getting-started 3.11 Windows
@@ -5327,11 +5327,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-getting-started -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-getting-started -- -ra
 
   py312-test-opentelemetry-getting-started_windows-latest:
     name: opentelemetry-getting-started 3.12 Windows
@@ -5355,11 +5355,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-getting-started -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-getting-started -- -ra
 
   py313-test-opentelemetry-getting-started_windows-latest:
     name: opentelemetry-getting-started 3.13 Windows
@@ -5383,11 +5383,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-getting-started -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-getting-started -- -ra
 
   py314-test-opentelemetry-getting-started_windows-latest:
     name: opentelemetry-getting-started 3.14 Windows
@@ -5411,11 +5411,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-getting-started -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-getting-started -- -ra
 
   py310-test-opentelemetry-opentracing-shim_windows-latest:
     name: opentelemetry-opentracing-shim 3.10 Windows
@@ -5432,11 +5432,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-opentracing-shim -- -ra
 
   py311-test-opentelemetry-opentracing-shim_windows-latest:
     name: opentelemetry-opentracing-shim 3.11 Windows
@@ -5453,11 +5453,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-opentracing-shim -- -ra
 
   py312-test-opentelemetry-opentracing-shim_windows-latest:
     name: opentelemetry-opentracing-shim 3.12 Windows
@@ -5474,11 +5474,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-opentracing-shim -- -ra
 
   py313-test-opentelemetry-opentracing-shim_windows-latest:
     name: opentelemetry-opentracing-shim 3.13 Windows
@@ -5495,11 +5495,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-opentracing-shim -- -ra
 
   py314-test-opentelemetry-opentracing-shim_windows-latest:
     name: opentelemetry-opentracing-shim 3.14 Windows
@@ -5516,11 +5516,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-opentracing-shim -- -ra
 
   py314t-test-opentelemetry-opentracing-shim_windows-latest:
     name: opentelemetry-opentracing-shim 3.14t Windows
@@ -5537,11 +5537,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-opentracing-shim -- -ra
 
   pypy3-test-opentelemetry-opentracing-shim_windows-latest:
     name: opentelemetry-opentracing-shim pypy-3.10 Windows
@@ -5558,11 +5558,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-opentracing-shim -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-opentracing-shim -- -ra
 
   py310-test-opentelemetry-opencensus-shim_windows-latest:
     name: opentelemetry-opencensus-shim 3.10 Windows
@@ -5579,11 +5579,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-opencensus-shim -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-opencensus-shim -- -ra
 
   py311-test-opentelemetry-opencensus-shim_windows-latest:
     name: opentelemetry-opencensus-shim 3.11 Windows
@@ -5600,11 +5600,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-opencensus-shim -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-opencensus-shim -- -ra
 
   py312-test-opentelemetry-opencensus-shim_windows-latest:
     name: opentelemetry-opencensus-shim 3.12 Windows
@@ -5621,11 +5621,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-opencensus-shim -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-opencensus-shim -- -ra
 
   py313-test-opentelemetry-opencensus-shim_windows-latest:
     name: opentelemetry-opencensus-shim 3.13 Windows
@@ -5642,11 +5642,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-opencensus-shim -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-opencensus-shim -- -ra
 
   py314-test-opentelemetry-opencensus-shim_windows-latest:
     name: opentelemetry-opencensus-shim 3.14 Windows
@@ -5663,11 +5663,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-opencensus-shim -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-opencensus-shim -- -ra
 
   py310-test-opentelemetry-exporter-http-transport-oldest_windows-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.10 Windows
@@ -5684,11 +5684,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py310-test-opentelemetry-exporter-http-transport-latest_windows-latest:
     name: opentelemetry-exporter-http-transport-latest 3.10 Windows
@@ -5705,11 +5705,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py311-test-opentelemetry-exporter-http-transport-oldest_windows-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.11 Windows
@@ -5726,11 +5726,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py311-test-opentelemetry-exporter-http-transport-latest_windows-latest:
     name: opentelemetry-exporter-http-transport-latest 3.11 Windows
@@ -5747,11 +5747,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py312-test-opentelemetry-exporter-http-transport-oldest_windows-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.12 Windows
@@ -5768,11 +5768,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py312-test-opentelemetry-exporter-http-transport-latest_windows-latest:
     name: opentelemetry-exporter-http-transport-latest 3.12 Windows
@@ -5789,11 +5789,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py313-test-opentelemetry-exporter-http-transport-oldest_windows-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.13 Windows
@@ -5810,11 +5810,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py313-test-opentelemetry-exporter-http-transport-latest_windows-latest:
     name: opentelemetry-exporter-http-transport-latest 3.13 Windows
@@ -5831,11 +5831,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py314-test-opentelemetry-exporter-http-transport-oldest_windows-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.14 Windows
@@ -5852,11 +5852,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py314-test-opentelemetry-exporter-http-transport-latest_windows-latest:
     name: opentelemetry-exporter-http-transport-latest 3.14 Windows
@@ -5873,11 +5873,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py314t-test-opentelemetry-exporter-http-transport-oldest_windows-latest:
     name: opentelemetry-exporter-http-transport-oldest 3.14t Windows
@@ -5894,11 +5894,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-http-transport-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-http-transport-oldest -- -ra
 
   py314t-test-opentelemetry-exporter-http-transport-latest_windows-latest:
     name: opentelemetry-exporter-http-transport-latest 3.14t Windows
@@ -5915,11 +5915,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-http-transport-latest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-http-transport-latest -- -ra
 
   py310-test-opentelemetry-exporter-otlpcommon-oldest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.10 Windows
@@ -5936,11 +5936,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py310-test-opentelemetry-exporter-otlpcommon-latest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.10 Windows
@@ -5957,11 +5957,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py311-test-opentelemetry-exporter-otlpcommon-oldest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.11 Windows
@@ -5978,11 +5978,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py311-test-opentelemetry-exporter-otlpcommon-latest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.11 Windows
@@ -5999,11 +5999,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py312-test-opentelemetry-exporter-otlpcommon-oldest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.12 Windows
@@ -6020,11 +6020,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py312-test-opentelemetry-exporter-otlpcommon-latest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.12 Windows
@@ -6041,11 +6041,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py313-test-opentelemetry-exporter-otlpcommon-oldest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.13 Windows
@@ -6062,11 +6062,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py313-test-opentelemetry-exporter-otlpcommon-latest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.13 Windows
@@ -6083,11 +6083,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py314-test-opentelemetry-exporter-otlpcommon-oldest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.14 Windows
@@ -6104,11 +6104,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py314-test-opentelemetry-exporter-otlpcommon-latest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.14 Windows
@@ -6125,11 +6125,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py314t-test-opentelemetry-exporter-otlpcommon-oldest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-oldest 3.14t Windows
@@ -6146,11 +6146,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
 
   py314t-test-opentelemetry-exporter-otlpcommon-latest_windows-latest:
     name: opentelemetry-exporter-otlpcommon-latest 3.14t Windows
@@ -6167,11 +6167,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlpcommon-latest -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlpcommon-latest -- -ra
 
   py310-test-opentelemetry-exporter-opencensus_windows-latest:
     name: opentelemetry-exporter-opencensus 3.10 Windows
@@ -6188,11 +6188,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-opencensus -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-opencensus -- -ra
 
   py311-test-opentelemetry-exporter-opencensus_windows-latest:
     name: opentelemetry-exporter-opencensus 3.11 Windows
@@ -6209,11 +6209,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-opencensus -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-opencensus -- -ra
 
   py312-test-opentelemetry-exporter-opencensus_windows-latest:
     name: opentelemetry-exporter-opencensus 3.12 Windows
@@ -6230,11 +6230,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-opencensus -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-opencensus -- -ra
 
   py313-test-opentelemetry-exporter-opencensus_windows-latest:
     name: opentelemetry-exporter-opencensus 3.13 Windows
@@ -6251,11 +6251,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-opencensus -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-opencensus -- -ra
 
   py314-test-opentelemetry-exporter-opencensus_windows-latest:
     name: opentelemetry-exporter-opencensus 3.14 Windows
@@ -6272,11 +6272,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-opencensus -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-opencensus -- -ra
 
   py310-test-opentelemetry-exporter-otlp-proto-common_windows-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.10 Windows
@@ -6293,11 +6293,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py311-test-opentelemetry-exporter-otlp-proto-common_windows-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.11 Windows
@@ -6314,11 +6314,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py312-test-opentelemetry-exporter-otlp-proto-common_windows-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.12 Windows
@@ -6335,11 +6335,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py313-test-opentelemetry-exporter-otlp-proto-common_windows-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.13 Windows
@@ -6356,11 +6356,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py314-test-opentelemetry-exporter-otlp-proto-common_windows-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.14 Windows
@@ -6377,11 +6377,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py314t-test-opentelemetry-exporter-otlp-proto-common_windows-latest:
     name: opentelemetry-exporter-otlp-proto-common 3.14t Windows
@@ -6398,11 +6398,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   pypy3-test-opentelemetry-exporter-otlp-proto-common_windows-latest:
     name: opentelemetry-exporter-otlp-proto-common pypy-3.10 Windows
@@ -6419,11 +6419,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-otlp-proto-common -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-proto-common -- -ra
 
   py310-test-opentelemetry-exporter-otlp-json-common_windows-latest:
     name: opentelemetry-exporter-otlp-json-common 3.10 Windows
@@ -6440,11 +6440,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py311-test-opentelemetry-exporter-otlp-json-common_windows-latest:
     name: opentelemetry-exporter-otlp-json-common 3.11 Windows
@@ -6461,11 +6461,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py312-test-opentelemetry-exporter-otlp-json-common_windows-latest:
     name: opentelemetry-exporter-otlp-json-common 3.12 Windows
@@ -6482,11 +6482,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py313-test-opentelemetry-exporter-otlp-json-common_windows-latest:
     name: opentelemetry-exporter-otlp-json-common 3.13 Windows
@@ -6503,11 +6503,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py314-test-opentelemetry-exporter-otlp-json-common_windows-latest:
     name: opentelemetry-exporter-otlp-json-common 3.14 Windows
@@ -6524,11 +6524,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py314t-test-opentelemetry-exporter-otlp-json-common_windows-latest:
     name: opentelemetry-exporter-otlp-json-common 3.14t Windows
@@ -6545,11 +6545,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   pypy3-test-opentelemetry-exporter-otlp-json-common_windows-latest:
     name: opentelemetry-exporter-otlp-json-common pypy-3.10 Windows
@@ -6566,11 +6566,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-otlp-json-common -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-common -- -ra
 
   py310-test-opentelemetry-exporter-otlp-combined_windows-latest:
     name: opentelemetry-exporter-otlp-combined 3.10 Windows
@@ -6587,11 +6587,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-combined -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-combined -- -ra
 
   py311-test-opentelemetry-exporter-otlp-combined_windows-latest:
     name: opentelemetry-exporter-otlp-combined 3.11 Windows
@@ -6608,11 +6608,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-combined -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-combined -- -ra
 
   py312-test-opentelemetry-exporter-otlp-combined_windows-latest:
     name: opentelemetry-exporter-otlp-combined 3.12 Windows
@@ -6629,11 +6629,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-combined -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-combined -- -ra
 
   py313-test-opentelemetry-exporter-otlp-combined_windows-latest:
     name: opentelemetry-exporter-otlp-combined 3.13 Windows
@@ -6650,11 +6650,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-combined -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-combined -- -ra
 
   py314-test-opentelemetry-exporter-otlp-combined_windows-latest:
     name: opentelemetry-exporter-otlp-combined 3.14 Windows
@@ -6671,11 +6671,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-combined -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-combined -- -ra
 
   py310-test-opentelemetry-exporter-otlp-json-file_windows-latest:
     name: opentelemetry-exporter-otlp-json-file 3.10 Windows
@@ -6692,11 +6692,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py311-test-opentelemetry-exporter-otlp-json-file_windows-latest:
     name: opentelemetry-exporter-otlp-json-file 3.11 Windows
@@ -6713,11 +6713,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py312-test-opentelemetry-exporter-otlp-json-file_windows-latest:
     name: opentelemetry-exporter-otlp-json-file 3.12 Windows
@@ -6734,11 +6734,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py313-test-opentelemetry-exporter-otlp-json-file_windows-latest:
     name: opentelemetry-exporter-otlp-json-file 3.13 Windows
@@ -6755,11 +6755,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py314-test-opentelemetry-exporter-otlp-json-file_windows-latest:
     name: opentelemetry-exporter-otlp-json-file 3.14 Windows
@@ -6776,11 +6776,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py314t-test-opentelemetry-exporter-otlp-json-file_windows-latest:
     name: opentelemetry-exporter-otlp-json-file 3.14t Windows
@@ -6797,11 +6797,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   pypy3-test-opentelemetry-exporter-otlp-json-file_windows-latest:
     name: opentelemetry-exporter-otlp-json-file pypy-3.10 Windows
@@ -6818,11 +6818,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-otlp-json-file -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-file -- -ra
 
   py310-test-opentelemetry-exporter-otlp-json-http_windows-latest:
     name: opentelemetry-exporter-otlp-json-http 3.10 Windows
@@ -6839,11 +6839,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py311-test-opentelemetry-exporter-otlp-json-http_windows-latest:
     name: opentelemetry-exporter-otlp-json-http 3.11 Windows
@@ -6860,11 +6860,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py312-test-opentelemetry-exporter-otlp-json-http_windows-latest:
     name: opentelemetry-exporter-otlp-json-http 3.12 Windows
@@ -6881,11 +6881,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py313-test-opentelemetry-exporter-otlp-json-http_windows-latest:
     name: opentelemetry-exporter-otlp-json-http 3.13 Windows
@@ -6902,11 +6902,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py314-test-opentelemetry-exporter-otlp-json-http_windows-latest:
     name: opentelemetry-exporter-otlp-json-http 3.14 Windows
@@ -6923,11 +6923,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py314t-test-opentelemetry-exporter-otlp-json-http_windows-latest:
     name: opentelemetry-exporter-otlp-json-http 3.14t Windows
@@ -6944,11 +6944,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   pypy3-test-opentelemetry-exporter-otlp-json-http_windows-latest:
     name: opentelemetry-exporter-otlp-json-http pypy-3.10 Windows
@@ -6965,11 +6965,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-otlp-json-http -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-http -- -ra
 
   py310-test-opentelemetry-exporter-otlp-proto-grpc-oldest_windows-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-oldest 3.10 Windows
@@ -6986,11 +6986,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
 
   py310-test-opentelemetry-exporter-otlp-proto-grpc-latest_windows-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-latest 3.10 Windows
@@ -7007,11 +7007,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
 
   py311-test-opentelemetry-exporter-otlp-proto-grpc-oldest_windows-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-oldest 3.11 Windows
@@ -7028,11 +7028,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
 
   py311-test-opentelemetry-exporter-otlp-proto-grpc-latest_windows-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-latest 3.11 Windows
@@ -7049,11 +7049,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
 
   py312-test-opentelemetry-exporter-otlp-proto-grpc-oldest_windows-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-oldest 3.12 Windows
@@ -7070,11 +7070,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
 
   py312-test-opentelemetry-exporter-otlp-proto-grpc-latest_windows-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-latest 3.12 Windows
@@ -7091,11 +7091,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
 
   py313-test-opentelemetry-exporter-otlp-proto-grpc-oldest_windows-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-oldest 3.13 Windows
@@ -7112,11 +7112,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
 
   py313-test-opentelemetry-exporter-otlp-proto-grpc-latest_windows-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-latest 3.13 Windows
@@ -7133,11 +7133,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
 
   py314-test-opentelemetry-exporter-otlp-proto-grpc-oldest_windows-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-oldest 3.14 Windows
@@ -7154,11 +7154,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
 
   py314-test-opentelemetry-exporter-otlp-proto-grpc-latest_windows-latest:
     name: opentelemetry-exporter-otlp-proto-grpc-latest 3.14 Windows
@@ -7175,11 +7175,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
 
   py310-test-opentelemetry-exporter-otlp-proto-http_windows-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.10 Windows
@@ -7196,11 +7196,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py311-test-opentelemetry-exporter-otlp-proto-http_windows-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.11 Windows
@@ -7217,11 +7217,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py312-test-opentelemetry-exporter-otlp-proto-http_windows-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.12 Windows
@@ -7238,11 +7238,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py313-test-opentelemetry-exporter-otlp-proto-http_windows-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.13 Windows
@@ -7259,11 +7259,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py314-test-opentelemetry-exporter-otlp-proto-http_windows-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.14 Windows
@@ -7280,11 +7280,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py314t-test-opentelemetry-exporter-otlp-proto-http_windows-latest:
     name: opentelemetry-exporter-otlp-proto-http 3.14t Windows
@@ -7301,11 +7301,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   pypy3-test-opentelemetry-exporter-otlp-proto-http_windows-latest:
     name: opentelemetry-exporter-otlp-proto-http pypy-3.10 Windows
@@ -7322,11 +7322,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-otlp-proto-http -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-proto-http -- -ra
 
   py310-test-opentelemetry-exporter-prometheus_windows-latest:
     name: opentelemetry-exporter-prometheus 3.10 Windows
@@ -7343,11 +7343,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-prometheus -- -ra
 
   py311-test-opentelemetry-exporter-prometheus_windows-latest:
     name: opentelemetry-exporter-prometheus 3.11 Windows
@@ -7364,11 +7364,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-prometheus -- -ra
 
   py312-test-opentelemetry-exporter-prometheus_windows-latest:
     name: opentelemetry-exporter-prometheus 3.12 Windows
@@ -7385,11 +7385,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-prometheus -- -ra
 
   py313-test-opentelemetry-exporter-prometheus_windows-latest:
     name: opentelemetry-exporter-prometheus 3.13 Windows
@@ -7406,11 +7406,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-prometheus -- -ra
 
   py314-test-opentelemetry-exporter-prometheus_windows-latest:
     name: opentelemetry-exporter-prometheus 3.14 Windows
@@ -7427,11 +7427,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-prometheus -- -ra
 
   py314t-test-opentelemetry-exporter-prometheus_windows-latest:
     name: opentelemetry-exporter-prometheus 3.14t Windows
@@ -7448,11 +7448,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-prometheus -- -ra
 
   pypy3-test-opentelemetry-exporter-prometheus_windows-latest:
     name: opentelemetry-exporter-prometheus pypy-3.10 Windows
@@ -7469,11 +7469,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-prometheus -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-prometheus -- -ra
 
   py310-test-opentelemetry-exporter-zipkin-combined_windows-latest:
     name: opentelemetry-exporter-zipkin-combined 3.10 Windows
@@ -7490,11 +7490,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py311-test-opentelemetry-exporter-zipkin-combined_windows-latest:
     name: opentelemetry-exporter-zipkin-combined 3.11 Windows
@@ -7511,11 +7511,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py312-test-opentelemetry-exporter-zipkin-combined_windows-latest:
     name: opentelemetry-exporter-zipkin-combined 3.12 Windows
@@ -7532,11 +7532,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py313-test-opentelemetry-exporter-zipkin-combined_windows-latest:
     name: opentelemetry-exporter-zipkin-combined 3.13 Windows
@@ -7553,11 +7553,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py314-test-opentelemetry-exporter-zipkin-combined_windows-latest:
     name: opentelemetry-exporter-zipkin-combined 3.14 Windows
@@ -7574,11 +7574,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py314t-test-opentelemetry-exporter-zipkin-combined_windows-latest:
     name: opentelemetry-exporter-zipkin-combined 3.14t Windows
@@ -7595,11 +7595,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   pypy3-test-opentelemetry-exporter-zipkin-combined_windows-latest:
     name: opentelemetry-exporter-zipkin-combined pypy-3.10 Windows
@@ -7616,11 +7616,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-zipkin-combined -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-combined -- -ra
 
   py310-test-opentelemetry-exporter-zipkin-proto-http_windows-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.10 Windows
@@ -7637,11 +7637,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py311-test-opentelemetry-exporter-zipkin-proto-http_windows-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.11 Windows
@@ -7658,11 +7658,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py312-test-opentelemetry-exporter-zipkin-proto-http_windows-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.12 Windows
@@ -7679,11 +7679,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py313-test-opentelemetry-exporter-zipkin-proto-http_windows-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.13 Windows
@@ -7700,11 +7700,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py314-test-opentelemetry-exporter-zipkin-proto-http_windows-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.14 Windows
@@ -7721,11 +7721,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py314t-test-opentelemetry-exporter-zipkin-proto-http_windows-latest:
     name: opentelemetry-exporter-zipkin-proto-http 3.14t Windows
@@ -7742,11 +7742,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   pypy3-test-opentelemetry-exporter-zipkin-proto-http_windows-latest:
     name: opentelemetry-exporter-zipkin-proto-http pypy-3.10 Windows
@@ -7763,11 +7763,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-zipkin-proto-http -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-proto-http -- -ra
 
   py310-test-opentelemetry-exporter-zipkin-json_windows-latest:
     name: opentelemetry-exporter-zipkin-json 3.10 Windows
@@ -7784,11 +7784,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py311-test-opentelemetry-exporter-zipkin-json_windows-latest:
     name: opentelemetry-exporter-zipkin-json 3.11 Windows
@@ -7805,11 +7805,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py312-test-opentelemetry-exporter-zipkin-json_windows-latest:
     name: opentelemetry-exporter-zipkin-json 3.12 Windows
@@ -7826,11 +7826,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py313-test-opentelemetry-exporter-zipkin-json_windows-latest:
     name: opentelemetry-exporter-zipkin-json 3.13 Windows
@@ -7847,11 +7847,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py314-test-opentelemetry-exporter-zipkin-json_windows-latest:
     name: opentelemetry-exporter-zipkin-json 3.14 Windows
@@ -7868,11 +7868,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py314t-test-opentelemetry-exporter-zipkin-json_windows-latest:
     name: opentelemetry-exporter-zipkin-json 3.14t Windows
@@ -7889,11 +7889,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-json -- -ra
 
   pypy3-test-opentelemetry-exporter-zipkin-json_windows-latest:
     name: opentelemetry-exporter-zipkin-json pypy-3.10 Windows
@@ -7910,11 +7910,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-exporter-zipkin-json -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-json -- -ra
 
   py310-test-opentelemetry-propagator-b3_windows-latest:
     name: opentelemetry-propagator-b3 3.10 Windows
@@ -7931,11 +7931,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-propagator-b3 -- -ra
 
   py311-test-opentelemetry-propagator-b3_windows-latest:
     name: opentelemetry-propagator-b3 3.11 Windows
@@ -7952,11 +7952,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-propagator-b3 -- -ra
 
   py312-test-opentelemetry-propagator-b3_windows-latest:
     name: opentelemetry-propagator-b3 3.12 Windows
@@ -7973,11 +7973,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-propagator-b3 -- -ra
 
   py313-test-opentelemetry-propagator-b3_windows-latest:
     name: opentelemetry-propagator-b3 3.13 Windows
@@ -7994,11 +7994,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-propagator-b3 -- -ra
 
   py314-test-opentelemetry-propagator-b3_windows-latest:
     name: opentelemetry-propagator-b3 3.14 Windows
@@ -8015,11 +8015,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-propagator-b3 -- -ra
 
   py314t-test-opentelemetry-propagator-b3_windows-latest:
     name: opentelemetry-propagator-b3 3.14t Windows
@@ -8036,11 +8036,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-propagator-b3 -- -ra
 
   pypy3-test-opentelemetry-propagator-b3_windows-latest:
     name: opentelemetry-propagator-b3 pypy-3.10 Windows
@@ -8057,11 +8057,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-propagator-b3 -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-propagator-b3 -- -ra
 
   py310-test-opentelemetry-propagator-jaeger_windows-latest:
     name: opentelemetry-propagator-jaeger 3.10 Windows
@@ -8078,11 +8078,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-propagator-jaeger -- -ra
 
   py311-test-opentelemetry-propagator-jaeger_windows-latest:
     name: opentelemetry-propagator-jaeger 3.11 Windows
@@ -8099,11 +8099,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-propagator-jaeger -- -ra
 
   py312-test-opentelemetry-propagator-jaeger_windows-latest:
     name: opentelemetry-propagator-jaeger 3.12 Windows
@@ -8120,11 +8120,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-propagator-jaeger -- -ra
 
   py313-test-opentelemetry-propagator-jaeger_windows-latest:
     name: opentelemetry-propagator-jaeger 3.13 Windows
@@ -8141,11 +8141,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-propagator-jaeger -- -ra
 
   py314-test-opentelemetry-propagator-jaeger_windows-latest:
     name: opentelemetry-propagator-jaeger 3.14 Windows
@@ -8162,11 +8162,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-propagator-jaeger -- -ra
 
   py314t-test-opentelemetry-propagator-jaeger_windows-latest:
     name: opentelemetry-propagator-jaeger 3.14t Windows
@@ -8183,11 +8183,11 @@ jobs:
         with:
           python-version: "3.14t"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314t-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e py314t-test-opentelemetry-propagator-jaeger -- -ra
 
   pypy3-test-opentelemetry-propagator-jaeger_windows-latest:
     name: opentelemetry-propagator-jaeger pypy-3.10 Windows
@@ -8204,11 +8204,11 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-propagator-jaeger -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-propagator-jaeger -- -ra
 
   py310-test-opentelemetry-test-utils_windows-latest:
     name: opentelemetry-test-utils 3.10 Windows
@@ -8225,11 +8225,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py310-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e py310-test-opentelemetry-test-utils -- -ra
 
   py311-test-opentelemetry-test-utils_windows-latest:
     name: opentelemetry-test-utils 3.11 Windows
@@ -8246,11 +8246,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py311-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e py311-test-opentelemetry-test-utils -- -ra
 
   py312-test-opentelemetry-test-utils_windows-latest:
     name: opentelemetry-test-utils 3.12 Windows
@@ -8267,11 +8267,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py312-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e py312-test-opentelemetry-test-utils -- -ra
 
   py313-test-opentelemetry-test-utils_windows-latest:
     name: opentelemetry-test-utils 3.13 Windows
@@ -8288,11 +8288,11 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py313-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e py313-test-opentelemetry-test-utils -- -ra
 
   py314-test-opentelemetry-test-utils_windows-latest:
     name: opentelemetry-test-utils 3.14 Windows
@@ -8309,11 +8309,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e py314-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e py314-test-opentelemetry-test-utils -- -ra
 
   pypy3-test-opentelemetry-test-utils_windows-latest:
     name: opentelemetry-test-utils pypy-3.10 Windows
@@ -8330,8 +8330,8 @@ jobs:
         with:
           python-version: "pypy-3.10"
 
-      - name: Install tox
-        run: pip install tox-uv
+      - name: Set up uv
+        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
 
       - name: Run tests
-        run: tox -e pypy3-test-opentelemetry-test-utils -- -ra
+        run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-test-utils -- -ra

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-api -- -ra
@@ -63,7 +63,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-api -- -ra
@@ -82,7 +82,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-api -- -ra
@@ -101,7 +101,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-api -- -ra
@@ -120,7 +120,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-api -- -ra
@@ -139,7 +139,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-api -- -ra
@@ -158,7 +158,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-api -- -ra
@@ -177,7 +177,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-proto-gen-oldest -- -ra
@@ -196,7 +196,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-proto-gen-latest -- -ra
@@ -215,7 +215,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-proto-gen-oldest -- -ra
@@ -234,7 +234,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-proto-gen-latest -- -ra
@@ -253,7 +253,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-proto-gen-oldest -- -ra
@@ -272,7 +272,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-proto-gen-latest -- -ra
@@ -291,7 +291,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-proto-gen-oldest -- -ra
@@ -310,7 +310,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-proto-gen-latest -- -ra
@@ -329,7 +329,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-proto-gen-oldest -- -ra
@@ -348,7 +348,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-proto-gen-latest -- -ra
@@ -367,7 +367,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-proto-gen-oldest -- -ra
@@ -386,7 +386,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-proto-gen-latest -- -ra
@@ -405,7 +405,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-proto-gen-oldest -- -ra
@@ -424,7 +424,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-proto-gen-latest -- -ra
@@ -443,7 +443,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -462,7 +462,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-protojson-gen-latest -- -ra
@@ -481,7 +481,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -500,7 +500,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-protojson-gen-latest -- -ra
@@ -519,7 +519,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -538,7 +538,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-protojson-gen-latest -- -ra
@@ -557,7 +557,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -576,7 +576,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-protojson-gen-latest -- -ra
@@ -595,7 +595,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -614,7 +614,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-protojson-gen-latest -- -ra
@@ -633,7 +633,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -652,7 +652,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-protojson-gen-latest -- -ra
@@ -671,7 +671,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -690,7 +690,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-protojson-gen-latest -- -ra
@@ -709,7 +709,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-codegen-json -- -ra
@@ -728,7 +728,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-codegen-json -- -ra
@@ -747,7 +747,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-codegen-json -- -ra
@@ -766,7 +766,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-codegen-json -- -ra
@@ -785,7 +785,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-codegen-json -- -ra
@@ -804,7 +804,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-sdk -- -ra
@@ -823,7 +823,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-sdk -- -ra
@@ -842,7 +842,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-sdk -- -ra
@@ -861,7 +861,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-sdk -- -ra
@@ -880,7 +880,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-sdk -- -ra
@@ -899,7 +899,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-sdk -- -ra
@@ -918,7 +918,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-sdk -- -ra
@@ -937,7 +937,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-configuration -- -ra
@@ -956,7 +956,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-configuration -- -ra
@@ -975,7 +975,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-configuration -- -ra
@@ -994,7 +994,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-configuration -- -ra
@@ -1013,7 +1013,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-configuration -- -ra
@@ -1032,7 +1032,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-configuration -- -ra
@@ -1051,7 +1051,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-configuration -- -ra
@@ -1070,7 +1070,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-semantic-conventions -- -ra
@@ -1089,7 +1089,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-semantic-conventions -- -ra
@@ -1108,7 +1108,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-semantic-conventions -- -ra
@@ -1127,7 +1127,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-semantic-conventions -- -ra
@@ -1146,7 +1146,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-semantic-conventions -- -ra
@@ -1165,7 +1165,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-semantic-conventions -- -ra
@@ -1184,7 +1184,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-semantic-conventions -- -ra
@@ -1210,7 +1210,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-getting-started -- -ra
@@ -1236,7 +1236,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-getting-started -- -ra
@@ -1262,7 +1262,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-getting-started -- -ra
@@ -1288,7 +1288,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-getting-started -- -ra
@@ -1314,7 +1314,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-getting-started -- -ra
@@ -1333,7 +1333,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-opentracing-shim -- -ra
@@ -1352,7 +1352,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-opentracing-shim -- -ra
@@ -1371,7 +1371,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-opentracing-shim -- -ra
@@ -1390,7 +1390,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-opentracing-shim -- -ra
@@ -1409,7 +1409,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-opentracing-shim -- -ra
@@ -1428,7 +1428,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-opentracing-shim -- -ra
@@ -1447,7 +1447,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-opentracing-shim -- -ra
@@ -1466,7 +1466,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-opencensus-shim -- -ra
@@ -1485,7 +1485,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-opencensus-shim -- -ra
@@ -1504,7 +1504,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-opencensus-shim -- -ra
@@ -1523,7 +1523,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-opencensus-shim -- -ra
@@ -1542,7 +1542,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-opencensus-shim -- -ra
@@ -1561,7 +1561,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -1580,7 +1580,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -1599,7 +1599,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -1618,7 +1618,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -1637,7 +1637,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -1656,7 +1656,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -1675,7 +1675,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -1694,7 +1694,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -1713,7 +1713,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -1732,7 +1732,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -1751,7 +1751,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -1770,7 +1770,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -1789,7 +1789,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -1808,7 +1808,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -1827,7 +1827,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -1846,7 +1846,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -1865,7 +1865,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -1884,7 +1884,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -1903,7 +1903,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -1922,7 +1922,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -1941,7 +1941,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -1960,7 +1960,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -1979,7 +1979,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -1998,7 +1998,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -2017,7 +2017,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-opencensus -- -ra
@@ -2036,7 +2036,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-opencensus -- -ra
@@ -2055,7 +2055,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-opencensus -- -ra
@@ -2074,7 +2074,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-opencensus -- -ra
@@ -2093,7 +2093,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-opencensus -- -ra
@@ -2112,7 +2112,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -2131,7 +2131,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -2150,7 +2150,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -2169,7 +2169,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -2188,7 +2188,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -2207,7 +2207,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -2226,7 +2226,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -2245,7 +2245,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -2264,7 +2264,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -2283,7 +2283,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -2302,7 +2302,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -2321,7 +2321,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -2340,7 +2340,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -2359,7 +2359,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -2378,7 +2378,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-combined -- -ra
@@ -2397,7 +2397,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-combined -- -ra
@@ -2416,7 +2416,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-combined -- -ra
@@ -2435,7 +2435,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-combined -- -ra
@@ -2454,7 +2454,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-combined -- -ra
@@ -2473,7 +2473,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -2492,7 +2492,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -2511,7 +2511,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -2530,7 +2530,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -2549,7 +2549,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -2568,7 +2568,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -2587,7 +2587,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -2606,7 +2606,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -2625,7 +2625,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -2644,7 +2644,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -2663,7 +2663,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -2682,7 +2682,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -2701,7 +2701,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -2720,7 +2720,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -2739,7 +2739,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
@@ -2758,7 +2758,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
@@ -2777,7 +2777,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
@@ -2796,7 +2796,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
@@ -2815,7 +2815,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
@@ -2834,7 +2834,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
@@ -2853,7 +2853,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
@@ -2872,7 +2872,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
@@ -2891,7 +2891,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
@@ -2910,7 +2910,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
@@ -2929,7 +2929,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -2948,7 +2948,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -2967,7 +2967,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -2986,7 +2986,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -3005,7 +3005,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -3024,7 +3024,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -3043,7 +3043,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -3062,7 +3062,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-prometheus -- -ra
@@ -3081,7 +3081,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-prometheus -- -ra
@@ -3100,7 +3100,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-prometheus -- -ra
@@ -3119,7 +3119,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-prometheus -- -ra
@@ -3138,7 +3138,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-prometheus -- -ra
@@ -3157,7 +3157,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-prometheus -- -ra
@@ -3176,7 +3176,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-prometheus -- -ra
@@ -3195,7 +3195,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -3214,7 +3214,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -3233,7 +3233,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -3252,7 +3252,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -3271,7 +3271,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -3290,7 +3290,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -3309,7 +3309,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -3328,7 +3328,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -3347,7 +3347,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -3366,7 +3366,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -3385,7 +3385,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -3404,7 +3404,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -3423,7 +3423,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -3442,7 +3442,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -3461,7 +3461,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -3480,7 +3480,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -3499,7 +3499,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -3518,7 +3518,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -3537,7 +3537,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -3556,7 +3556,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -3575,7 +3575,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -3594,7 +3594,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-propagator-b3 -- -ra
@@ -3613,7 +3613,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-propagator-b3 -- -ra
@@ -3632,7 +3632,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-propagator-b3 -- -ra
@@ -3651,7 +3651,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-propagator-b3 -- -ra
@@ -3670,7 +3670,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-propagator-b3 -- -ra
@@ -3689,7 +3689,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-propagator-b3 -- -ra
@@ -3708,7 +3708,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-propagator-b3 -- -ra
@@ -3727,7 +3727,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-propagator-jaeger -- -ra
@@ -3746,7 +3746,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-propagator-jaeger -- -ra
@@ -3765,7 +3765,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-propagator-jaeger -- -ra
@@ -3784,7 +3784,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-propagator-jaeger -- -ra
@@ -3803,7 +3803,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-propagator-jaeger -- -ra
@@ -3822,7 +3822,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-propagator-jaeger -- -ra
@@ -3841,7 +3841,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-propagator-jaeger -- -ra
@@ -3866,7 +3866,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-test-utils -- -ra
@@ -3891,7 +3891,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-test-utils -- -ra
@@ -3916,7 +3916,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-test-utils -- -ra
@@ -3941,7 +3941,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-test-utils -- -ra
@@ -3966,7 +3966,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-test-utils -- -ra
@@ -3991,7 +3991,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-test-utils -- -ra
@@ -4012,7 +4012,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-api -- -ra
@@ -4033,7 +4033,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-api -- -ra
@@ -4054,7 +4054,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-api -- -ra
@@ -4075,7 +4075,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-api -- -ra
@@ -4096,7 +4096,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-api -- -ra
@@ -4117,7 +4117,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-api -- -ra
@@ -4138,7 +4138,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-api -- -ra
@@ -4159,7 +4159,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-proto-gen-oldest -- -ra
@@ -4180,7 +4180,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-proto-gen-latest -- -ra
@@ -4201,7 +4201,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-proto-gen-oldest -- -ra
@@ -4222,7 +4222,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-proto-gen-latest -- -ra
@@ -4243,7 +4243,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-proto-gen-oldest -- -ra
@@ -4264,7 +4264,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-proto-gen-latest -- -ra
@@ -4285,7 +4285,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-proto-gen-oldest -- -ra
@@ -4306,7 +4306,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-proto-gen-latest -- -ra
@@ -4327,7 +4327,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-proto-gen-oldest -- -ra
@@ -4348,7 +4348,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-proto-gen-latest -- -ra
@@ -4369,7 +4369,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-proto-gen-oldest -- -ra
@@ -4390,7 +4390,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-proto-gen-latest -- -ra
@@ -4411,7 +4411,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-proto-gen-oldest -- -ra
@@ -4432,7 +4432,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-proto-gen-latest -- -ra
@@ -4453,7 +4453,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -4474,7 +4474,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-protojson-gen-latest -- -ra
@@ -4495,7 +4495,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -4516,7 +4516,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-protojson-gen-latest -- -ra
@@ -4537,7 +4537,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -4558,7 +4558,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-protojson-gen-latest -- -ra
@@ -4579,7 +4579,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -4600,7 +4600,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-protojson-gen-latest -- -ra
@@ -4621,7 +4621,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -4642,7 +4642,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-protojson-gen-latest -- -ra
@@ -4663,7 +4663,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -4684,7 +4684,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-protojson-gen-latest -- -ra
@@ -4705,7 +4705,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-protojson-gen-oldest -- -ra
@@ -4726,7 +4726,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-protojson-gen-latest -- -ra
@@ -4747,7 +4747,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-codegen-json -- -ra
@@ -4768,7 +4768,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-codegen-json -- -ra
@@ -4789,7 +4789,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-codegen-json -- -ra
@@ -4810,7 +4810,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-codegen-json -- -ra
@@ -4831,7 +4831,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-codegen-json -- -ra
@@ -4852,7 +4852,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-sdk -- -ra
@@ -4873,7 +4873,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-sdk -- -ra
@@ -4894,7 +4894,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-sdk -- -ra
@@ -4915,7 +4915,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-sdk -- -ra
@@ -4936,7 +4936,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-sdk -- -ra
@@ -4957,7 +4957,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-sdk -- -ra
@@ -4978,7 +4978,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-sdk -- -ra
@@ -4999,7 +4999,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-configuration -- -ra
@@ -5020,7 +5020,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-configuration -- -ra
@@ -5041,7 +5041,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-configuration -- -ra
@@ -5062,7 +5062,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-configuration -- -ra
@@ -5083,7 +5083,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-configuration -- -ra
@@ -5104,7 +5104,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-configuration -- -ra
@@ -5125,7 +5125,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-configuration -- -ra
@@ -5146,7 +5146,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-semantic-conventions -- -ra
@@ -5167,7 +5167,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-semantic-conventions -- -ra
@@ -5188,7 +5188,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-semantic-conventions -- -ra
@@ -5209,7 +5209,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-semantic-conventions -- -ra
@@ -5230,7 +5230,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-semantic-conventions -- -ra
@@ -5251,7 +5251,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-semantic-conventions -- -ra
@@ -5272,7 +5272,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-semantic-conventions -- -ra
@@ -5300,7 +5300,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-getting-started -- -ra
@@ -5328,7 +5328,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-getting-started -- -ra
@@ -5356,7 +5356,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-getting-started -- -ra
@@ -5384,7 +5384,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-getting-started -- -ra
@@ -5412,7 +5412,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-getting-started -- -ra
@@ -5433,7 +5433,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-opentracing-shim -- -ra
@@ -5454,7 +5454,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-opentracing-shim -- -ra
@@ -5475,7 +5475,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-opentracing-shim -- -ra
@@ -5496,7 +5496,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-opentracing-shim -- -ra
@@ -5517,7 +5517,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-opentracing-shim -- -ra
@@ -5538,7 +5538,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-opentracing-shim -- -ra
@@ -5559,7 +5559,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-opentracing-shim -- -ra
@@ -5580,7 +5580,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-opencensus-shim -- -ra
@@ -5601,7 +5601,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-opencensus-shim -- -ra
@@ -5622,7 +5622,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-opencensus-shim -- -ra
@@ -5643,7 +5643,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-opencensus-shim -- -ra
@@ -5664,7 +5664,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-opencensus-shim -- -ra
@@ -5685,7 +5685,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -5706,7 +5706,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -5727,7 +5727,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -5748,7 +5748,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -5769,7 +5769,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -5790,7 +5790,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -5811,7 +5811,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -5832,7 +5832,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -5853,7 +5853,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -5874,7 +5874,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -5895,7 +5895,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-http-transport-oldest -- -ra
@@ -5916,7 +5916,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-http-transport-latest -- -ra
@@ -5937,7 +5937,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -5958,7 +5958,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -5979,7 +5979,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -6000,7 +6000,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -6021,7 +6021,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -6042,7 +6042,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -6063,7 +6063,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -6084,7 +6084,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -6105,7 +6105,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -6126,7 +6126,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -6147,7 +6147,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlpcommon-oldest -- -ra
@@ -6168,7 +6168,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlpcommon-latest -- -ra
@@ -6189,7 +6189,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-opencensus -- -ra
@@ -6210,7 +6210,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-opencensus -- -ra
@@ -6231,7 +6231,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-opencensus -- -ra
@@ -6252,7 +6252,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-opencensus -- -ra
@@ -6273,7 +6273,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-opencensus -- -ra
@@ -6294,7 +6294,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -6315,7 +6315,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -6336,7 +6336,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -6357,7 +6357,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -6378,7 +6378,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -6399,7 +6399,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -6420,7 +6420,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-proto-common -- -ra
@@ -6441,7 +6441,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -6462,7 +6462,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -6483,7 +6483,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -6504,7 +6504,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -6525,7 +6525,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -6546,7 +6546,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -6567,7 +6567,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-common -- -ra
@@ -6588,7 +6588,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-combined -- -ra
@@ -6609,7 +6609,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-combined -- -ra
@@ -6630,7 +6630,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-combined -- -ra
@@ -6651,7 +6651,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-combined -- -ra
@@ -6672,7 +6672,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-combined -- -ra
@@ -6693,7 +6693,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -6714,7 +6714,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -6735,7 +6735,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -6756,7 +6756,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -6777,7 +6777,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -6798,7 +6798,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -6819,7 +6819,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-file -- -ra
@@ -6840,7 +6840,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -6861,7 +6861,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -6882,7 +6882,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -6903,7 +6903,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -6924,7 +6924,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -6945,7 +6945,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -6966,7 +6966,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-json-http -- -ra
@@ -6987,7 +6987,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
@@ -7008,7 +7008,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
@@ -7029,7 +7029,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
@@ -7050,7 +7050,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
@@ -7071,7 +7071,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
@@ -7092,7 +7092,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
@@ -7113,7 +7113,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
@@ -7134,7 +7134,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
@@ -7155,7 +7155,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-oldest -- -ra
@@ -7176,7 +7176,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-grpc-latest -- -ra
@@ -7197,7 +7197,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -7218,7 +7218,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -7239,7 +7239,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -7260,7 +7260,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -7281,7 +7281,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -7302,7 +7302,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -7323,7 +7323,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-otlp-proto-http -- -ra
@@ -7344,7 +7344,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-prometheus -- -ra
@@ -7365,7 +7365,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-prometheus -- -ra
@@ -7386,7 +7386,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-prometheus -- -ra
@@ -7407,7 +7407,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-prometheus -- -ra
@@ -7428,7 +7428,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-prometheus -- -ra
@@ -7449,7 +7449,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-prometheus -- -ra
@@ -7470,7 +7470,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-prometheus -- -ra
@@ -7491,7 +7491,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -7512,7 +7512,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -7533,7 +7533,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -7554,7 +7554,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -7575,7 +7575,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -7596,7 +7596,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -7617,7 +7617,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-combined -- -ra
@@ -7638,7 +7638,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -7659,7 +7659,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -7680,7 +7680,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -7701,7 +7701,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -7722,7 +7722,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -7743,7 +7743,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -7764,7 +7764,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-proto-http -- -ra
@@ -7785,7 +7785,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -7806,7 +7806,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -7827,7 +7827,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -7848,7 +7848,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -7869,7 +7869,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -7890,7 +7890,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -7911,7 +7911,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-exporter-zipkin-json -- -ra
@@ -7932,7 +7932,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-propagator-b3 -- -ra
@@ -7953,7 +7953,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-propagator-b3 -- -ra
@@ -7974,7 +7974,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-propagator-b3 -- -ra
@@ -7995,7 +7995,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-propagator-b3 -- -ra
@@ -8016,7 +8016,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-propagator-b3 -- -ra
@@ -8037,7 +8037,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-propagator-b3 -- -ra
@@ -8058,7 +8058,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-propagator-b3 -- -ra
@@ -8079,7 +8079,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-propagator-jaeger -- -ra
@@ -8100,7 +8100,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-propagator-jaeger -- -ra
@@ -8121,7 +8121,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-propagator-jaeger -- -ra
@@ -8142,7 +8142,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-propagator-jaeger -- -ra
@@ -8163,7 +8163,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-propagator-jaeger -- -ra
@@ -8184,7 +8184,7 @@ jobs:
           python-version: "3.14t"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314t-test-opentelemetry-propagator-jaeger -- -ra
@@ -8205,7 +8205,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-propagator-jaeger -- -ra
@@ -8226,7 +8226,7 @@ jobs:
           python-version: "3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py310-test-opentelemetry-test-utils -- -ra
@@ -8247,7 +8247,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py311-test-opentelemetry-test-utils -- -ra
@@ -8268,7 +8268,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py312-test-opentelemetry-test-utils -- -ra
@@ -8289,7 +8289,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py313-test-opentelemetry-test-utils -- -ra
@@ -8310,7 +8310,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e py314-test-opentelemetry-test-utils -- -ra
@@ -8331,7 +8331,7 @@ jobs:
           python-version: "pypy-3.10"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@507230998c9541d67814b57463ac00e454ff6991 # v0.12.3
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run tests
         run: uvx --with tox-uv tox -e pypy3-test-opentelemetry-test-utils -- -ra


### PR DESCRIPTION
Current CI has a step to `pip install tox-uv` which takes between 7-10s. Here we use uv action and `uvx --with tox-uv` to save that time for each job.