### PR TITLE
Hide ruff line width change from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Switch to SPDX license headers (#5177)
 4d978892d3253da1d6f4e6e6abfbe1e1bee87b05
+
+# Update line length to 120 (#5514)
+0110bb1d273dbe848312d429326b844da9e86d93


### PR DESCRIPTION
# Description
Hides #5514 (commit 0110bb1d273dbe848312d429326b844da9e86d93) from git blame 