### PR TITLE
docs(sdk): remove stale trace_config TODO

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -774,7 +774,7 @@ class Span(trace_api.Span, ReadableSpan):
         context: trace_api.SpanContext,
         parent: trace_api.SpanContext | None = None,
         sampler: sampling.Sampler | None = None,
-        trace_config: None = None,  # TODO
+        trace_config: None = None,
         resource: Resource | None = None,
         attributes: types.Attributes = None,
         events: Sequence[Event] | None = None,


### PR DESCRIPTION
Closes #4944.

Removes the stale TODO from the `Span.__init__` signature. The docstring already documents that `trace_config` is unused and retained for backwards compatibility, since the upstream `TraceConfig` proto was removed.