### PR TITLE
Fix: Address-family mismatch confirmed: the shared mock server in test_otlp_e

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
@@ -75,6 +75,14 @@ class OTLPSpanExporterForTesting(
     ],
 ):
     def __init__(self, **kwargs):
+        # Default to the explicit IPv4 loopback address rather than
+        # "localhost", which can resolve to the IPv6 loopback address
+        # ("::1") first depending on the OS/environment. The mock server
+        # used by these tests only binds to 127.0.0.1, so resolving
+        # "localhost" to ::1 would cause tests to try to connect to an
+        # unrelated service (if any) listening on ::1:4317 instead of the
+        # mock server, producing confusing, environment-dependent failures.
+        kwargs.setdefault("endpoint", "http://127.0.0.1:4317")
         super().__init__(
             TraceServiceStub,
             SpanExportResult,
@@ -277,7 +285,7 @@ class TestOTLPExporterMixin(TestCase):
         """No env or kwarg should be NoCompression"""
         OTLPSpanExporterForTesting(insecure=True)
         mock_insecure_channel.assert_called_once_with(
-            "localhost:4317",
+            "127.0.0.1:4317",
             compression=Compression.NoCompression,
             options=(
                 (
@@ -339,7 +347,7 @@ class TestOTLPExporterMixin(TestCase):
         """Just OTEL_EXPORTER_OTLP_COMPRESSION should work"""
         OTLPSpanExporterForTesting(insecure=True)
         mock_insecure_channel.assert_called_once_with(
-            "localhost:4317",
+            "127.0.0.1:4317",
             compression=Compression.Gzip,
             options=(
                 (
@@ -529,7 +537,7 @@ class TestOTLPExporterMixin(TestCase):
                 )
             after = time.time()
             self.assertEqual(
-                "Failed to export traces to localhost:4317, error code: StatusCode.DEADLINE_EXCEEDED, error details: Deadline Exceeded",
+                "Failed to export traces to 127.0.0.1:4317, error code: StatusCode.DEADLINE_EXCEEDED, error details: Deadline Exceeded",
                 warning.records[-1].message,
             )
             self.assertEqual(mock_trace_service.num_requests, 2)
@@ -565,7 +573,7 @@ class TestOTLPExporterMixin(TestCase):
             self.assertEqual(exporter.export([self.span]), SpanExportResult.FAILURE)
             self.assertEqual(
                 warning.records[-1].message,
-                "Failed to export traces to localhost:4317, error code: StatusCode.ALREADY_EXISTS, error details: This already exists.",
+                "Failed to export traces to 127.0.0.1:4317, error code: StatusCode.ALREADY_EXISTS, error details: This already exists.",
             )
 
         metrics_data = self.metric_reader.get_metrics_data()
@@ -683,5 +691,5 @@ class TestOTLPExporterMixin(TestCase):
     def assert_standard_metric_attrs(self, attributes):
         self.assertEqual(attributes["otel.component.type"], "otlp_grpc_span_exporter")
         self.assertTrue(attributes["otel.component.name"].startswith("otlp_grpc_span_exporter/"))
-        self.assertEqual(attributes["server.address"], "localhost")
+        self.assertEqual(attributes["server.address"], "127.0.0.1")
         self.assertEqual(attributes["server.port"], 4317)


### PR DESCRIPTION
## Summary
Gave the test-only OTLPSpanExporterForTesting helper class (in test_otlp_exporter_mixin.py) a default endpoint of "http://127.0.0.1:4317" via kwargs.setdefault, applied only when a test doesn't already pass its own endpoint (so test_otlp_exporter_endpoint, which explicitly parametrizes endpoint/insecure combinations, is unaffected). This makes every real-connection test target the same IPv4 address the mock server binds to, eliminating the address-family mismatch. Updated the handful of assertions that hard-coded the old 'localhost:4317' string (two warning-log message checks, two mocked insecure_channel call assertions, and the server.address metric attribute check) to expect 127.0.0.1:4317 / 127.0.0.1, since those exporters now genuinely resolve to that address. Production default endpoint values in exporter.py were not touched. test_otlp_trace_exporter.py and test_otlp_metrics_exporter.py only assert against mocked gRPC channels (never make a real socket connection) and are verifying the production default endpoint value, so they were left unchanged as instructed.

## Problem
open-telemetry/opentelemetry-python issue reference: open-telemetry/opentelemetry-python#4062

## Root Cause
Address-family mismatch confirmed: the shared mock server in test_otlp_exporter_mixin.py binds explicitly to the IPv4 loopback (127.0.0.1:4317), but tests exercising real exports rely on the exporter's default endpoint resolution of the ambiguous hostname 'localhost', which can resolve to the IPv6 loopback (::1) first depending on OS/DNS/hosts configuration. This is purely a test-fixture issue, not a production defect.

## Testing
PASS - all 51 tests passed, 5 skipped (Windows-only timing skips, pre-existing and unrelated to this fix)

## Related Issue
open-telemetry/opentelemetry-python#4062
