### PR TITLE
opentelemetry-configuration: fix default service name

### DIFF
--- a/.changelog/5534.fixed
+++ b/.changelog/5534.fixed
@@ -1,1 +1,1 @@
-`opentelemetry-configuration`: add missing process executable name to default service name when available
+`opentelemetry-configuration`: add missing process executable name to default service name when available in resource attributes

--- a/.changelog/5534.fixed
+++ b/.changelog/5534.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-configuration`: add missing process executable name to default service name when available

--- a/opentelemetry-configuration/src/opentelemetry/configuration/_resource.py
+++ b/opentelemetry-configuration/src/opentelemetry/configuration/_resource.py
@@ -7,6 +7,7 @@ import dataclasses
 import fnmatch
 import logging
 import os
+import sys
 from collections.abc import Callable
 from typing import Any
 from urllib import parse
@@ -101,7 +102,9 @@ def create_resource(config: ResourceConfig | None) -> Resource:
     """
     # Spec requires service.name to always be present; detectors and explicit
     # config attributes can override this default.
-    base = _DEFAULT_RESOURCE.merge(Resource({SERVICE_NAME: "unknown_service"}))
+    executable_name = os.path.basename(sys.executable) if sys.executable else None
+    default_service_name = f"unknown_service:{executable_name}" if executable_name else "unknown_service"
+    base = _DEFAULT_RESOURCE.merge(Resource({SERVICE_NAME: default_service_name}))
 
     if config is None:
         return base

--- a/opentelemetry-configuration/tests/test_resource.py
+++ b/opentelemetry-configuration/tests/test_resource.py
@@ -34,14 +34,16 @@ from opentelemetry.sdk.resources import (
 
 
 class TestCreateResourceDefaults(unittest.TestCase):
+    @patch("sys.executable", "/usr/bin/python3")
     def test_none_config_returns_sdk_defaults(self):
         resource = create_resource(None)
         self.assertIsInstance(resource, Resource)
         self.assertEqual(resource.attributes[TELEMETRY_SDK_LANGUAGE], "python")
         self.assertEqual(resource.attributes[TELEMETRY_SDK_NAME], "opentelemetry")
         self.assertIn(TELEMETRY_SDK_VERSION, resource.attributes)
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service:python3")
 
+    @patch("sys.executable", "/usr/bin/python3")
     def test_none_config_does_not_read_env_vars(self):
         with patch.dict(
             os.environ,
@@ -52,22 +54,29 @@ class TestCreateResourceDefaults(unittest.TestCase):
         ):
             resource = create_resource(None)
         self.assertNotIn("foo", resource.attributes)
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service:python3")
 
+    @patch("sys.executable", "/usr/bin/python3")
     def test_empty_resource_config(self):
         resource = create_resource(ResourceConfig())
         self.assertEqual(resource.attributes[TELEMETRY_SDK_LANGUAGE], "python")
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service:python3")
 
+    @patch("sys.executable", "/usr/bin/python3")
     def test_service_name_default_added_when_missing(self):
         config = ResourceConfig(attributes=[AttributeNameValue(name="env", value="staging")])
         resource = create_resource(config)
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service:python3")
 
     def test_service_name_not_overridden_when_set(self):
         config = ResourceConfig(attributes=[AttributeNameValue(name="service.name", value="my-app")])
         resource = create_resource(config)
         self.assertEqual(resource.attributes[SERVICE_NAME], "my-app")
+
+    @patch("sys.executable", None)
+    def test_default_service_name_without_sys_executable_returns_plain_unkwnon_service(self):
+        resource = create_resource(None)
+        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
 
     def test_env_vars_not_read(self):
         """OTEL_RESOURCE_ATTRIBUTES must not affect declarative config resource."""
@@ -294,10 +303,11 @@ class TestServiceResourceDetector(unittest.TestCase):
             resource = create_resource(self._config_with_service())
         self.assertEqual(resource.attributes[SERVICE_NAME], "my-service")
 
+    @patch("sys.executable", "/usr/bin/python3")
     def test_service_detector_no_env_var_leaves_default_service_name(self):
         with patch.dict(os.environ, {}, clear=True):
             resource = create_resource(self._config_with_service())
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service:python3")
 
     def test_explicit_service_name_overrides_env_var(self):
         """Config attributes win over the service detector's env-var value."""
@@ -333,6 +343,7 @@ class TestServiceResourceDetector(unittest.TestCase):
         self.assertEqual(resource.attributes[TELEMETRY_SDK_LANGUAGE], "python")
         self.assertIn(TELEMETRY_SDK_VERSION, resource.attributes)
 
+    @patch("sys.executable", "/usr/bin/python3")
     def test_included_filter_limits_service_attributes(self):
         config = ResourceConfig(
             detection_development=ExperimentalResourceDetection(
@@ -345,7 +356,7 @@ class TestServiceResourceDetector(unittest.TestCase):
         self.assertIn(SERVICE_INSTANCE_ID, resource.attributes)
         # service.name comes from the filter-excluded detector output, but the
         # default "unknown_service" is still added by create_resource directly
-        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service")
+        self.assertEqual(resource.attributes[SERVICE_NAME], "unknown_service:python3")
 
 
 class TestHostResourceDetector(unittest.TestCase):


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

When the service name is unknown and the process executable name is available we should join them.

Fixes #5459

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
