### PR TITLE
opentelemetry-sdk: fix values for process.executable resource attributes

### DIFF
--- a/.changelog/5535.fixed
+++ b/.changelog/5535.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: fix values for `process.executable.name` and `process.executable.path` to match semantic conventions.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -367,21 +367,20 @@ class ProcessResourceDetector(ResourceDetector):
             )
         )
         _process_pid = os.getpid()
-        _process_executable_name = sys.executable
-        _process_executable_path = os.path.dirname(_process_executable_name)
         # Use sys.orig_argv, which preserves the original arguments received
         # by the interpreter. This correctly captures ``python -m <module>``
         # invocations where sys.argv is rewritten to the resolved module path
         # and the ``-m <module>`` information is lost. Only read argv[0] by
         # default because full command arguments are opt-in.
         _process_command = sys.orig_argv[0] if sys.orig_argv else ""
+        executable = sys.executable or ""
         resource_info: dict[str, AttributeValue] = {
             PROCESS_RUNTIME_DESCRIPTION: sys.version,
             PROCESS_RUNTIME_NAME: sys.implementation.name,
             PROCESS_RUNTIME_VERSION: _runtime_version,
             PROCESS_PID: _process_pid,
-            PROCESS_EXECUTABLE_NAME: _process_executable_name,
-            PROCESS_EXECUTABLE_PATH: _process_executable_path,
+            PROCESS_EXECUTABLE_NAME: os.path.basename(executable),
+            PROCESS_EXECUTABLE_PATH: executable,
             PROCESS_COMMAND: _process_command,
         }
         if self._include_command_args:

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -630,6 +630,7 @@ class TestOTELResourceDetector(unittest.TestCase):
         "sys.orig_argv",
         ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"],
     )
+    @patch("sys.executable", "/usr/bin/uvicorn")
     def test_process_detector(self):
         initial_resource = Resource({"foo": "bar"})
         aggregated_resource = get_aggregated_resources([ProcessResourceDetector()], initial_resource)
@@ -662,13 +663,13 @@ class TestOTELResourceDetector(unittest.TestCase):
 
         self.assertEqual(
             aggregated_resource.attributes[PROCESS_EXECUTABLE_NAME],
-            sys.executable,
+            "uvicorn",
         )
         self.assertEqual(
             aggregated_resource.attributes[PROCESS_EXECUTABLE_PATH],
-            os.path.dirname(sys.executable),
+            "/usr/bin/uvicorn",
         )
-        self.assertEqual(aggregated_resource.attributes[PROCESS_COMMAND], sys.orig_argv[0])
+        self.assertEqual(aggregated_resource.attributes[PROCESS_COMMAND], "uvicorn")
         self.assertNotIn(
             PROCESS_COMMAND_LINE,
             aggregated_resource.attributes,
@@ -767,6 +768,20 @@ class TestOTELResourceDetector(unittest.TestCase):
         self.assertEqual(
             aggregated_resource.attributes[PROCESS_COMMAND_ARGS],
             ("/usr/bin/python", "-m", "myapp"),
+        )
+
+    @patch("sys.executable", None)
+    def test_process_detector_handles_missing_executable(self):
+        initial_resource = Resource({"foo": "bar"})
+        aggregated_resource = get_aggregated_resources([ProcessResourceDetector()], initial_resource)
+
+        self.assertEqual(
+            aggregated_resource.attributes[PROCESS_EXECUTABLE_NAME],
+            "",
+        )
+        self.assertEqual(
+            aggregated_resource.attributes[PROCESS_EXECUTABLE_PATH],
+            "",
         )
 
     def test_resource_detector_entry_points_default(self):


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Per registry [1]:
- process.executable.name should be the base name of the executable
- process.executable.path should be the full path of the executable

Now for name we send the full path and for path only the parent directory.

[1] https://opentelemetry.io/docs/specs/semconv/registry/attributes/process/

Spotted this when looking at #5459

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
