### PR TITLE
fix: benchmarks ci

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
     - name: Run tox
-      run: uvx --with tox-uv tox -e benchmark-opentelemetry-sdk -- -k opentelemetry-sdk/benchmarks --benchmark-json=opentelemetry-sdk/output.json
+      run: uvx --with tox-uv tox -e benchmark-opentelemetry-sdk -- --benchmark-json=opentelemetry-sdk/output.json
     - name: Report on SDK benchmark results
       uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
       with:


### PR DESCRIPTION
# Description

Failed CI: https://github.com/open-telemetry/opentelemetry-python/actions/runs/31789198500/job/94732007084 

pytest >8.x changed how tests are collected. 
https://docs.pytest.org/en/9.0.x/changelog.html#collection-changes

The issue is with the `-k`. We don't need the -k here; we already set the directory in tox.