### PR TITLE
Ignore reader preferred aggregations incompatible with async instruments

### DIFF
--- a/.changelog/5554.fixed
+++ b/.changelog/5554.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: fix `MetricReader` `preferred_aggregation` silently producing no data points when it maps an asynchronous instrument to a histogram aggregation

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
@@ -37,6 +37,8 @@ from opentelemetry.sdk.environment_variables._internal import (
 from opentelemetry.sdk.metrics._internal.aggregation import (
     AggregationTemporality,
     DefaultAggregation,
+    ExplicitBucketHistogramAggregation,
+    ExponentialBucketHistogramAggregation,
 )
 from opentelemetry.sdk.metrics._internal.exceptions import MetricsTimeoutError
 from opentelemetry.sdk.metrics._internal.instrument import (
@@ -64,6 +66,19 @@ from opentelemetry.util._once import Once
 from ._metric_reader_metrics import create_metric_reader_metrics
 
 _logger = getLogger(__name__)
+
+# Histogram aggregations only implement the DELTA instrument temporality path,
+# so asynchronous instruments (always CUMULATIVE) would silently produce no
+# data points. `MetricReaderStorage` applies the same check to views.
+_ASYNCHRONOUS_INSTRUMENT_CLASSES = (
+    ObservableCounter,
+    ObservableUpDownCounter,
+    ObservableGauge,
+)
+_ASYNCHRONOUS_INCOMPATIBLE_AGGREGATIONS = (
+    ExplicitBucketHistogramAggregation,
+    ExponentialBucketHistogramAggregation,
+)
 
 
 class MetricExportResult(Enum):
@@ -270,6 +285,16 @@ class MetricReader(ABC):
 
         if preferred_aggregation is not None:
             for typ, aggregation in preferred_aggregation.items():
+                if typ in _ASYNCHRONOUS_INSTRUMENT_CLASSES and isinstance(
+                    aggregation, _ASYNCHRONOUS_INCOMPATIBLE_AGGREGATIONS
+                ):
+                    _logger.warning(
+                        "Instrument class %s and aggregation %s will produce semantic errors when matched, "
+                        "the preferred aggregation has not been applied.",
+                        typ.__name__,
+                        type(aggregation).__name__,
+                    )
+                    continue
                 if typ is Counter:
                     self._instrument_class_aggregation[_Counter] = aggregation
                 elif typ is UpDownCounter:

--- a/opentelemetry-sdk/tests/metrics/test_metric_reader.py
+++ b/opentelemetry-sdk/tests/metrics/test_metric_reader.py
@@ -7,7 +7,13 @@ from collections.abc import Iterable
 from unittest import TestCase
 from unittest.mock import patch
 
-from opentelemetry.sdk.metrics import Counter, Histogram, ObservableGauge
+from opentelemetry.sdk.metrics import (
+    Counter,
+    Histogram,
+    ObservableCounter,
+    ObservableGauge,
+    ObservableUpDownCounter,
+)
 from opentelemetry.sdk.metrics import _Gauge as _SDKGauge
 from opentelemetry.sdk.metrics._internal.instrument import (
     _Counter,
@@ -26,6 +32,8 @@ from opentelemetry.sdk.metrics.export import (
 from opentelemetry.sdk.metrics.view import (
     Aggregation,
     DefaultAggregation,
+    ExplicitBucketHistogramAggregation,
+    ExponentialBucketHistogramAggregation,
     LastValueAggregation,
 )
 
@@ -124,6 +132,38 @@ class TestMetricReader(TestCase):
         self.assertIsInstance(
             dummy_metric_reader._instrument_class_aggregation[_Counter],
             LastValueAggregation,
+        )
+
+    def test_configure_aggregation_asynchronous_histogram_incompatibility(self):
+        for instrument_class, internal_class in (
+            (ObservableCounter, _ObservableCounter),
+            (ObservableUpDownCounter, _ObservableUpDownCounter),
+            (ObservableGauge, _ObservableGauge),
+        ):
+            for aggregation in (
+                ExplicitBucketHistogramAggregation(),
+                ExponentialBucketHistogramAggregation(),
+            ):
+                with self.subTest(
+                    instrument=instrument_class.__name__,
+                    aggregation=type(aggregation).__name__,
+                ):
+                    with self.assertLogs(level="WARNING") as log:
+                        dummy_metric_reader = DummyMetricReader(preferred_aggregation={instrument_class: aggregation})
+                    self.assertIn("will produce semantic errors when matched", log.output[0])
+                    # The incompatible aggregation is ignored, so the instrument
+                    # keeps producing data through its default aggregation.
+                    self.assertIsInstance(
+                        dummy_metric_reader._instrument_class_aggregation[internal_class],
+                        DefaultAggregation,
+                    )
+
+    def test_configure_aggregation_synchronous_histogram_allowed(self):
+        aggregation = ExplicitBucketHistogramAggregation()
+        dummy_metric_reader = DummyMetricReader(preferred_aggregation={Counter: aggregation})
+        self.assertIs(
+            dummy_metric_reader._instrument_class_aggregation[_Counter],
+            aggregation,
         )
 
     # pylint: disable=no-self-use


### PR DESCRIPTION
## No existing issue — found by reading the code.
`MetricReaderStorage` warns and skips a `View` that configures a histogram
aggregation for an asynchronous instrument. The same aggregation set through
`MetricReader(preferred_aggregation=...)` skips that check and silently produces
no data at all: histogram aggregations only implement the DELTA instrument
temporality path, so asynchronous instruments (always CUMULATIVE) return `None`
from every `collect()`.

```python
from opentelemetry.metrics import Observation
from opentelemetry.sdk.metrics import MeterProvider, ObservableCounter
from opentelemetry.sdk.metrics.export import InMemoryMetricReader
from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation

reader = InMemoryMetricReader(
    preferred_aggregation={ObservableCounter: ExplicitBucketHistogramAggregation()}
)
meter = MeterProvider(metric_readers=[reader]).get_meter("repro")
meter.create_observable_counter("my_counter", callbacks=[lambda options: [Observation(7)]])

print(reader.get_metrics_data())  # None, and nothing logged
```

Both histogram aggregations and all three asynchronous instrument classes are
affected. Synchronous instruments are not, so the OTLP exporter's
`OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION` handling (which maps
`Histogram`) is unchanged.

This warns and keeps the instrument's default aggregation, matching what the
`View` path already does. 

Related: #5461 fixes the matching gap on the `View` path. Different file and
function, so the two can be reviewed independently.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- New `test_configure_aggregation_asynchronous_histogram_incompatibility`
  (3 async instrument classes × both histogram aggregations) and
  `test_configure_aggregation_synchronous_histogram_allowed`.
- `opentelemetry-sdk/tests/metrics/` — 309 passed, 1 skipped.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated