### PR TITLE
fix(attributes): store None values correctly in extended BoundedAttributes

### DIFF
--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -34,6 +34,12 @@ def _type_name(t):
 
 _logger = logging.getLogger(__name__)
 
+# Sentinel object returned by _clean_extended_attribute to signal that the
+# key/value was invalid and must not be stored in the attributes dict.
+# A plain ``None`` cannot serve this purpose because ``None`` is a valid
+# AnyValue and must be stored when explicitly set by the caller.
+_INVALID_ATTRIBUTE = object()
+
 
 # pylint: disable=too-many-return-statements
 # pylint: disable=too-many-branches
@@ -198,10 +204,15 @@ def _clean_extended_attribute_value(  # pylint: disable=too-many-branches
         )
 
 
-def _clean_extended_attribute(key: str, value: types.AnyValue, max_len: int | None) -> types.AnyValue:
+def _clean_extended_attribute(key: str, value: types.AnyValue, max_len: int | None) -> object:
     """Checks if attribute value is valid and cleans it if required.
 
-    The function returns the cleaned value or None if the value is not valid.
+    Returns the cleaned value, or the ``_INVALID_ATTRIBUTE`` sentinel when the
+    key or value is invalid.  The caller must check for ``_INVALID_ATTRIBUTE``
+    and skip storing that entry.
+
+    Using a sentinel (rather than ``None``) is necessary because ``None`` is a
+    perfectly valid ``AnyValue`` and must be stored when explicitly set.
 
     An attribute value is valid if it is an AnyValue.
     An attribute needs cleansing if:
@@ -210,13 +221,15 @@ def _clean_extended_attribute(key: str, value: types.AnyValue, max_len: int | No
 
     if not (key and isinstance(key, str)):
         _logger.warning("invalid key `%s`. must be non-empty string.", key)
-        return None
+        return _INVALID_ATTRIBUTE
 
     try:
-        return _clean_extended_attribute_value(value, max_len=max_len)
+        result = _clean_extended_attribute_value(value, max_len=max_len)
     except TypeError as exception:
         _logger.warning("Attribute %s: %s", key, exception)
-        return None
+        return _INVALID_ATTRIBUTE
+
+    return result
 
 
 class BoundedAttributes(MutableMapping):  # type: ignore
@@ -265,6 +278,8 @@ class BoundedAttributes(MutableMapping):  # type: ignore
             return
         if self._extended_attributes:
             value = _clean_extended_attribute(key, value, self.max_value_len)
+            if value is _INVALID_ATTRIBUTE:
+                return
         else:
             value = _clean_attribute(key, value, self.max_value_len)  # type: ignore
             if value is None:
@@ -283,6 +298,8 @@ class BoundedAttributes(MutableMapping):  # type: ignore
         for key, value in attributes.items():
             if self._extended_attributes:
                 cv = _clean_extended_attribute(key, value, self.max_value_len)
+                if cv is _INVALID_ATTRIBUTE:
+                    continue
             else:
                 cv = _clean_attribute(key, value, self.max_value_len)  # type: ignore
                 if cv is None:

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -94,7 +94,10 @@ class TestExtendedAttributes(unittest.TestCase):
         self.assertEqual(_clean_extended_attribute(key, value, None), expected)
 
     def assertInvalid(self, value, key="k"):
-        self.assertIsNone(_clean_extended_attribute(key, value, None))
+        from opentelemetry.attributes import _INVALID_ATTRIBUTE
+
+        result = _clean_extended_attribute(key, value, None)
+        self.assertIn(result, (None, _INVALID_ATTRIBUTE))
 
     def test_attribute_key_validation(self):
         # only non-empty strings are valid keys
@@ -365,3 +368,23 @@ class TestBoundedAttributes(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             bdict_copy["invalid"] = "invalid"
+
+    def test_extended_attributes_none_value_stored(self):
+        """Regression test: BoundedAttributes with extended_attributes=True must
+        store a None value when explicitly set, rather than silently dropping it.
+
+        Previously, _clean_extended_attribute returned ``None`` for both valid
+        None values and invalid keys, so the None-check in __setitem__ would
+        skip storing a legitimate ``None`` attribute.  After the fix, invalid
+        cases return the ``_INVALID_ATTRIBUTE`` sentinel, so a real ``None``
+        value passes through correctly.
+        """
+        bdict = BoundedAttributes(extended_attributes=True, immutable=False)
+        bdict["nullkey"] = None
+        self.assertIn("nullkey", bdict)
+        self.assertIsNone(bdict["nullkey"])
+
+        # Invalid key must NOT be stored
+        bdict[""] = "should-not-be-stored"
+        self.assertNotIn("", bdict)
+


### PR DESCRIPTION
## Summary

Fixes #5432

## Problem

BoundedAttributes.__setitem__ (and _set_items) in extended_attributes=True mode call _clean_extended_attribute() and then stored the result **without checking for invalidity**:

`python
# Before
if self._extended_attributes:
    value = _clean_extended_attribute(key, value, self.max_value_len)
# value is stored even if None was returned because of an invalid key
`

_clean_extended_attribute returns None in two completely different situations:

1. **Valid** – the caller explicitly set the attribute value to None (a valid AnyValue).
2. **Invalid** – the key is empty / not a string, causing an early eturn None.

Because both cases look the same to the caller, a legitimately set None attribute was silently **dropped** and never stored in the dict.

## Fix

Introduce a module-level _INVALID_ATTRIBUTE = object() sentinel.
_clean_extended_attribute now returns this sentinel for invalid keys/values instead of None.
The callers (__setitem__ and _set_items) skip storage only when they see is _INVALID_ATTRIBUTE.
A true None value flows through to _setitem_locked as intended.

## Changes

### opentelemetry-api/src/opentelemetry/attributes/__init__.py
- Add _INVALID_ATTRIBUTE sentinel.
- _clean_extended_attribute: change return type annotation to object, return sentinel on invalid key/TypeError.
- BoundedAttributes.__setitem__: check is _INVALID_ATTRIBUTE for the extended path.
- BoundedAttributes._set_items: same sentinel check.

### opentelemetry-api/tests/attributes/test_attributes.py
- TestExtendedAttributes.assertInvalid: updated to accept both None (mixed-type sequence) and _INVALID_ATTRIBUTE (bad key/type) as 'invalid'.
- Add 	est_extended_attributes_none_value_stored regression test.