### PR TITLE
docs: add links to metrics view examples

### DIFF
--- a/docs/examples/metrics/views/README.rst
+++ b/docs/examples/metrics/views/README.rst
@@ -3,11 +3,12 @@ View common scenarios
 
 These examples show how to customize the metrics that are output by the SDK using Views. There are multiple examples:
 
-* change_aggregation.py: Shows how to configure to change the default aggregation for an instrument.
-* change_name.py: Shows how to change the name of a metric.
-* limit_num_of_attrs.py: Shows how to limit the number of attributes that are output for a metric.
-* drop_metrics_from_instrument.py: Shows how to drop measurements from an instrument.
-* change_reservoir_factory.py: Shows how to use your own ``ExemplarReservoir``
+* :scm_web:`change_aggregation.py <docs/examples/metrics/views/change_aggregation.py>`: Shows how to configure to change the default aggregation for an instrument.
+* :scm_web:`change_name.py <docs/examples/metrics/views/change_name.py>`: Shows how to change the name of a metric.
+* :scm_web:`limit_num_of_attrs.py <docs/examples/metrics/views/limit_num_of_attrs.py>`: Shows how to limit the number of attributes that are output for a metric.
+* :scm_web:`drop_metrics_from_instrument.py <docs/examples/metrics/views/drop_metrics_from_instrument.py>`: Shows how to drop measurements from an instrument.
+* :scm_web:`change_reservoir_factory.py <docs/examples/metrics/views/change_reservoir_factory.py>`: Shows how to use your own ``ExemplarReservoir``
+
 
 The source files of these examples are available :scm_web:`here <docs/examples/metrics/views/>`.
 


### PR DESCRIPTION
## Description

Updated the Metrics Views README to add links to the example Python files.

Refs #5427 

### Changes

* Added a link to `change_aggregation.py`
* Added a link to `change_name.py`
* Added a link to `limit_num_of_attrs.py`
* Added a link to `drop_metrics_from_instrument.py`
* Added a link to `change_reservoir_factory.py`

This makes the examples easier to navigate from the README.

## Testing

No code changes were made. This is a documentation-only change.
