### PR TITLE
fix: otel-weaver flaky tests

### DIFF
--- a/.github/workflows/templates/test.yml.j2
+++ b/.github/workflows/templates/test.yml.j2
@@ -20,7 +20,7 @@ env:
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
        'main'
     ) || 'main' }}{% endraw %}
-  WEAVER_VERSION: "v0.22.1"
+  WEAVER_VERSION: "v0.25.1"
   PIP_EXISTS_ACTION: w
   CONTRIB_REPO_UTIL_HTTP: ${% raw %}{{ github.workspace }}{% endraw %}/opentelemetry-python-contrib/util/opentelemetry-util-http
   CONTRIB_REPO_INSTRUMENTATION: ${% raw %}{{ github.workspace }}{% endraw %}/opentelemetry-python-contrib/opentelemetry-instrumentation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ env:
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
        'main'
     ) || 'main' }}
-  WEAVER_VERSION: "v0.22.1"
+  WEAVER_VERSION: "v0.25.1"
   PIP_EXISTS_ACTION: w
   CONTRIB_REPO_UTIL_HTTP: ${{ github.workspace }}/opentelemetry-python-contrib/util/opentelemetry-util-http
   CONTRIB_REPO_INSTRUMENTATION: ${{ github.workspace }}/opentelemetry-python-contrib/opentelemetry-instrumentation


### PR DESCRIPTION
I've noticed that `opentelemetry-test-utils` test suite is a bit flaky because of some weaver test failures:

https://github.com/open-telemetry/opentelemetry-python/actions/runs/32396057250/job/96513062384 

https://github.com/open-telemetry/opentelemetry-python/actions/runs/32351289717/job/96370826884

https://github.com/open-telemetry/opentelemetry-python/actions/runs/31783373109/job/94713791733

My understanding is because of https://github.com/open-telemetry/weaver/issues/1626. I was able to reproduce the flaky test locally by running `uvx --with tox-uv tox -e py314-test-opentelemetry-test-utils -- -ra -k 'test_weaver_live_check'` multiple times using weaver `0.22.1`. I installed weaver `0.25.1` and was not able to reproduce the issue anymore. 