### PR TITLE
fix(sdk): set histogram min and max to None when record_min_max is False (fixes #5570)

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py
@@ -522,8 +522,8 @@ class _ExplicitBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                         sum=sum_,
                         bucket_counts=tuple(value),
                         explicit_bounds=self._boundaries,
-                        min=min_,
-                        max=max_,
+                        min=min_ if self._record_min_max else None,
+                        max=max_ if self._record_min_max else None,
                     )
 
                 if value is None:
@@ -552,8 +552,8 @@ class _ExplicitBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                     sum=self._previous_sum,
                     bucket_counts=tuple(self._previous_value),
                     explicit_bounds=self._boundaries,
-                    min=self._previous_min,
-                    max=self._previous_max,
+                    min=self._previous_min if self._record_min_max else None,
+                    max=self._previous_max if self._record_min_max else None,
                 )
 
             return None
@@ -808,8 +808,8 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                         ),
                         # FIXME: Find the right value for flags
                         flags=0,
-                        min=min_,
-                        max=max_,
+                        min=min_ if self._record_min_max else None,
+                        max=max_ if self._record_min_max else None,
                     )
 
                 # Here collection_temporality is CUMULATIVE.
@@ -950,8 +950,8 @@ class _ExponentialBucketHistogramAggregation(_Aggregation[HistogramPoint]):
                     ),
                     # FIXME: Find the right value for flags
                     flags=0,
-                    min=self._previous_min,
-                    max=self._previous_max,
+                    min=self._previous_min if self._record_min_max else None,
+                    max=self._previous_max if self._record_min_max else None,
                 )
 
             return None

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/point.py
@@ -44,8 +44,8 @@ class HistogramDataPoint:
     sum: int | float
     bucket_counts: Sequence[int]
     explicit_bounds: Sequence[float]
-    min: float
-    max: float
+    min: float | None = None
+    max: float | None = None
     exemplars: Sequence[Exemplar] = field(default_factory=list)
 
     def to_json(self, indent: int | None = 4) -> str:
@@ -75,8 +75,8 @@ class ExponentialHistogramDataPoint:
     positive: Buckets
     negative: Buckets
     flags: int
-    min: float
-    max: float
+    min: float | None = None
+    max: float | None = None
     exemplars: Sequence[Exemplar] = field(default_factory=list)
 
     def to_json(self, indent: int | None = 4) -> str:

--- a/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
+++ b/opentelemetry-sdk/tests/metrics/exponential_histogram/test_exponential_bucket_histogram_aggregation.py
@@ -137,7 +137,7 @@ class TestExponentialBucketHistogramAggregation(TestCase):
                 exponential_histogram_aggregation = _ExponentialBucketHistogramAggregation(
                     Mock(),
                     _default_reservoir_factory(_ExponentialBucketHistogramAggregation),
-                    AggregationTemporality.CUMULATIVE,
+                    AggregationTemporality.DELTA,
                     0,
                     record_min_max=record_min_max,
                 )
@@ -147,6 +147,15 @@ class TestExponentialBucketHistogramAggregation(TestCase):
 
                 self.assertEqual(exponential_histogram_aggregation._min, expected_min)
                 self.assertEqual(exponential_histogram_aggregation._max, expected_max)
+                point = exponential_histogram_aggregation.collect(
+                    AggregationTemporality.CUMULATIVE, 1
+                )
+                if record_min_max:
+                    self.assertEqual(point.min, expected_min)
+                    self.assertEqual(point.max, expected_max)
+                else:
+                    self.assertIsNone(point.min)
+                    self.assertIsNone(point.max)
 
     def assertInEpsilon(self, first, second, epsilon):
         self.assertLessEqual(first, (second * (1 + epsilon)))

--- a/opentelemetry-sdk/tests/metrics/test_aggregation.py
+++ b/opentelemetry-sdk/tests/metrics/test_aggregation.py
@@ -325,7 +325,7 @@ class TestExplicitBucketHistogramAggregation(TestCase):
 
         explicit_bucket_histogram_aggregation = _ExplicitBucketHistogramAggregation(
             Mock(),
-            AggregationTemporality.CUMULATIVE,
+            AggregationTemporality.DELTA,
             0,
             _default_reservoir_factory(_ExplicitBucketHistogramAggregation),
             record_min_max=False,
@@ -339,6 +339,11 @@ class TestExplicitBucketHistogramAggregation(TestCase):
 
         self.assertEqual(explicit_bucket_histogram_aggregation._min, inf)
         self.assertEqual(explicit_bucket_histogram_aggregation._max, -inf)
+        point = explicit_bucket_histogram_aggregation.collect(
+            AggregationTemporality.CUMULATIVE, 1
+        )
+        self.assertIsNone(point.min)
+        self.assertIsNone(point.max)
 
     def test_collect(self):
         """


### PR DESCRIPTION
Fixes #5570

### Problem
When `record_min_max=False` was configured on an `ExplicitBucketHistogramAggregation` or `ExponentialBucketHistogramAggregation`, `_min` and `_max` were initialized to `inf` and `-inf`. In `collect()`, these sentinel values were passed unconditionally to `HistogramDataPoint` / `ExponentialHistogramDataPoint` instead of checking `self._record_min_max`.

This caused:
1. Exported histogram data points to report `min=inf` and `max=-inf` (violating `min <= max` and emitting invalid JSON `Infinity`/`-Infinity` in `to_json()`).
2. OTLP protobuf encoders to mark `min` and `max` optional double fields as present with infinite values.

### Solution
- Updated `HistogramDataPoint` and `ExponentialHistogramDataPoint` dataclass definitions so `min` and `max` are typed `float | None = None`.
- In `_ExplicitBucketHistogramAggregation.collect()` and `_ExponentialBucketHistogramAggregation.collect()`, pass `min_ if self._record_min_max else None` (and `previous_min if self._record_min_max else None` for cumulative collections).
- Added test assertions in `test_aggregation.py` and `test_exponential_bucket_histogram_aggregation.py` verifying `collect()` returns `min=None` and `max=None` when `record_min_max=False`.
