### PR TITLE
fix(sdk): preserve type discrimination for bool, int, float and mapping in _hash_attributes (fixes #5572)

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/_view_instrument_match.py
@@ -6,7 +6,7 @@ from logging import getLogger
 from threading import Lock
 from time import time_ns
 from types import NoneType
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from typing_extensions import assert_never
 
@@ -25,24 +25,40 @@ from opentelemetry.util.types import AnyValue, Attributes
 
 _logger = getLogger(__name__)
 
-_HashedAttributes = str | bool | int | float | bytes | None | tuple["_HashedAttributes", ...]
+_HashedAttributes = (
+    str
+    | bytes
+    | None
+    | tuple[type, bool | int | float]
+    | tuple[type, tuple["_HashedAttributes", ...]]
+    | tuple[type, tuple[tuple[Any, "_HashedAttributes"], ...]]
+)
 
 
 # pylint: disable=inconsistent-return-statements
 def _hash_attributes(value: Attributes | AnyValue) -> _HashedAttributes:
     # Attributes have been cleaned and validated when Measurement was instantiated,
     # so value is guaranteed to match one of the branches below at runtime.
-    if isinstance(value, (NoneType, str, int, float, bool, bytes)):
+    if isinstance(value, (NoneType, str, bytes)):
         return value
+    if isinstance(value, bool):
+        return (bool, value)
+    if isinstance(value, int):
+        return (int, value)
+    if isinstance(value, float):
+        return (float, value)
     if isinstance(value, Sequence):
-        return tuple(_hash_attributes(v) for v in value)
+        return (list, tuple(_hash_attributes(v) for v in value))
     if isinstance(value, Mapping):
-        return tuple(
-            (k, _hash_attributes(value[k]))
-            for k in sorted(
-                value,
-                key=lambda item: item if isinstance(item, str) else str(item),
-            )
+        return (
+            dict,
+            tuple(
+                (k, _hash_attributes(value[k]))
+                for k in sorted(
+                    value,
+                    key=lambda item: item if isinstance(item, str) else str(item),
+                )
+            ),
         )
     if TYPE_CHECKING:
         assert_never(value)

--- a/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
+++ b/opentelemetry-sdk/tests/metrics/test_view_instrument_match.py
@@ -564,6 +564,34 @@ class Test_ViewInstrumentMatch(TestCase):  # pylint: disable=invalid-name
             _hash_attributes(attrs_list),
         )
 
+    def test_hash_attributes_discriminates_scalar_types(self):
+        self.assertNotEqual(
+            _hash_attributes({"k": True}),
+            _hash_attributes({"k": 1}),
+        )
+        self.assertNotEqual(
+            _hash_attributes({"k": True}),
+            _hash_attributes({"k": 1.0}),
+        )
+        self.assertNotEqual(
+            _hash_attributes({"k": 1}),
+            _hash_attributes({"k": 1.0}),
+        )
+        self.assertNotEqual(
+            _hash_attributes({"k": False}),
+            _hash_attributes({"k": 0}),
+        )
+        self.assertNotEqual(
+            _hash_attributes({"k": False}),
+            _hash_attributes({"k": 0.0}),
+        )
+
+    def test_hash_attributes_sequence_vs_mapping_distinct(self):
+        self.assertNotEqual(
+            _hash_attributes({"a": 1}),
+            _hash_attributes([("a", 1)]),
+        )
+
     def test_consume_measurement_with_non_string_keys(self):
         instrument1 = _Counter(
             name="instrument1",


### PR DESCRIPTION
Fixes #5572

### Problem
In Python, boolean and numeric values compare equal (`True == 1 == 1.0` and `False == 0 == 0.0`) and share the same hash value. Previously, `_hash_attributes` returned scalar attribute values untagged. Consequently, attribute sets differing only in scalar type (such as `{"k": True}`, `{"k": 1}`, `{"k": 1.0}`) produced identical aggregation keys and collapsed into a single metric time series, causing data corruption and misreported attribute types.

Additionally, a sequence of pairs and a dict mapping could produce identical tuples under `_hash_attributes`.

### Solution
- Tag scalar types `bool`, `int`, and `float` as `(bool, value)`, `(int, value)`, `(float, value)` in `_hash_attributes` so they do not collide as dictionary aggregation keys.
- Tag sequences with `list` and mappings with `dict` to prevent collision between sequence and mapping structures while preserving tuple/list equivalence within sequence attributes.
- Added unit tests in `test_view_instrument_match.py` verifying that scalar types `bool`, `int`, `float`, and sequences vs mappings generate distinct hash keys.
