### PR TITLE
fix(api): use percent encoding for W3C baggage propagator (fixes #5566)

### DIFF
--- a/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
@@ -4,7 +4,7 @@
 from collections.abc import Iterable, Iterator, Mapping
 from logging import getLogger
 from re import split
-from urllib.parse import quote_plus, unquote_plus
+from urllib.parse import quote, unquote
 
 from opentelemetry.baggage import _is_valid_pair, get_all, set_baggage
 from opentelemetry.context import get_current
@@ -115,8 +115,8 @@ class W3CBaggagePropagator(textmap.TextMapPropagator):
                 _logger.warning("Invalid baggage entry: `%s`", entry)
                 continue
 
-            name = unquote_plus(name).strip()
-            value = unquote_plus(value).strip()
+            name = unquote(name).strip()
+            value = unquote(value).strip()
 
             context = set_baggage(
                 name,
@@ -164,7 +164,7 @@ def _encode_baggage_pairs(
 ) -> Iterator[str]:
     """Yield URL-encoded 'key=value' pairs from baggage entries."""
     for key, value in baggage_entries.items():
-        yield quote_plus(str(key)) + "=" + quote_plus(str(value))
+        yield quote(str(key), safe="") + "=" + quote(str(value), safe="")
 
 
 def _extract_first_element(

--- a/opentelemetry-api/tests/propagators/test_w3cbaggagepropagator.py
+++ b/opentelemetry-api/tests/propagators/test_w3cbaggagepropagator.py
@@ -6,7 +6,7 @@
 from logging import WARNING
 from unittest import TestCase
 from unittest.mock import Mock, patch
-from urllib.parse import quote_plus
+from urllib.parse import quote
 
 from opentelemetry.baggage import get_all, set_baggage
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
@@ -139,6 +139,14 @@ class TestW3CBaggagePropagator(TestCase):
             self._extract("key%23key=value%23value"),
             {"key#key": "value#value"},
         )
+        self.assertEqual(
+            self._extract("key=a+b"),
+            {"key": "a+b"},
+        )
+        self.assertEqual(
+            self._extract("key=a%20b"),
+            {"key": "a b"},
+        )
 
     def test_header_max_entries_skip_invalid_entry(self):
         # 181 entries where index 2 is too long: skipping it leaves exactly 180 valid entries
@@ -186,7 +194,7 @@ class TestW3CBaggagePropagator(TestCase):
         self.assertEqual(None, output)
 
     def test_inject_space_entries(self):
-        self.assertEqual("key=val+ue", self._inject({"key": "val ue"}))
+        self.assertEqual("key=val%20ue", self._inject({"key": "val ue"}))
 
     def test_inject(self):
         values = {
@@ -232,12 +240,16 @@ class TestW3CBaggagePropagator(TestCase):
 
     def test_encode_baggage_pairs(self):
         def _format_baggage(entries):
-            return ",".join(quote_plus(str(k)) + "=" + quote_plus(str(v)) for k, v in entries.items())
+            return ",".join(quote(str(k), safe="") + "=" + quote(str(v), safe="") for k, v in entries.items())
 
-        self.assertEqual(_format_baggage({"key key": "value value"}), "key+key=value+value")
+        self.assertEqual(_format_baggage({"key key": "value value"}), "key%20key=value%20value")
         self.assertEqual(
             _format_baggage({"key/key": "value/value"}),
             "key%2Fkey=value%2Fvalue",
+        )
+        self.assertEqual(
+            _format_baggage({"key+key": "value+value"}),
+            "key%2Bkey=value%2Bvalue",
         )
 
     def test_inject_too_many_entries(self):
@@ -320,6 +332,6 @@ class TestW3CBaggagePropagator(TestCase):
 
         context = self.propagator.extract(carrier)
 
-        self.assertEqual(carrier, {"baggage": "transaction=string+with+spaces"})
+        self.assertEqual(carrier, {"baggage": "transaction=string%20with%20spaces"})
 
         self.assertEqual(context, {"abc": {"transaction": "string with spaces"}})


### PR DESCRIPTION
Fixes #5566

### Problem
`W3CBaggagePropagator` used `urllib.parse.quote_plus` / `unquote_plus` (form encoding) to encode and decode baggage values. This is wrong for two reasons:

1. **`+` in incoming values is silently corrupted**: `unquote_plus` decodes `+` as a space, so a compliant peer sending `key=a+b` is decoded as `{"key": "a b"}`.
2. **Spaces in outgoing values are encoded as `+` instead of `%20`**: `quote_plus` encodes a space as `+`, but the W3C Baggage spec requires `%20` since `+` (`%2B`) is a valid literal baggage character.

The W3C Baggage grammar defines `baggage-octet` as `%x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E`, so `+` is a reserved literal that must be percent-encoded when used as a baggage value. This bug causes silent, irreversible data corruption at service boundaries in polyglot deployments (Python ↔ Java/Go/JS).

### Solution
- Replaced `quote_plus` → `quote(..., safe="")` in `_encode_baggage_pairs` so spaces become `%20` and `+` becomes `%2B`.
- Replaced `unquote_plus` → `unquote` in `extract()` so a literal `+` in incoming values is preserved and `%20` is decoded to a space.
- Updated the existing `test_inject_space_entries`, `test_encode_baggage_pairs`, and `test_inject_extract` tests to assert correct `%20` encoding.
- Added regression tests asserting that `key=a+b` extracts as `{"key": "a+b"}` and `key=a%20b` extracts as `{"key": "a b"}`.
