### PR TITLE
fix(sdk): handle bytes-valued Resource attributes in __hash__ and to_json

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py
@@ -62,7 +62,7 @@ import sys
 import threading
 import uuid
 from collections.abc import Mapping, Sequence
-from json import dumps
+from json import JSONEncoder, dumps
 from os import environ
 from types import ModuleType
 from typing import cast
@@ -92,6 +92,29 @@ except ImportError:
 LabelValue = AnyValue
 Attributes = Mapping[str, LabelValue]
 logger = logging.getLogger(__name__)
+
+
+class _ResourceJsonEncoder(JSONEncoder):
+    """JSON encoder that handles attribute value types not natively supported
+    by :mod:`json`, specifically :class:`bytes` which is a valid
+    ``AnyValue`` type in the OpenTelemetry data model but is not
+    JSON-serializable by default.
+
+    ``bytes`` values are encoded as their hexadecimal string representation
+    so that hashing and serialisation remain deterministic and stable.
+    """
+
+    def default(self, o: object) -> object:
+        if isinstance(o, bytes):
+            return o.hex()
+        return super().default(o)
+
+
+def _dumps_resource(obj: object, **kwargs: object) -> str:
+    """Like :func:`json.dumps` but using :class:`_ResourceJsonEncoder`."""
+    return dumps(obj, cls=_ResourceJsonEncoder, **kwargs)
+
+
 CLOUD_PROVIDER = ResourceAttributes.CLOUD_PROVIDER
 CLOUD_ACCOUNT_ID = ResourceAttributes.CLOUD_ACCOUNT_ID
 CLOUD_REGION = ResourceAttributes.CLOUD_REGION
@@ -253,10 +276,12 @@ class Resource:
         return self._attributes == other._attributes and self._schema_url == other._schema_url
 
     def __hash__(self) -> int:
-        return hash(f"{dumps(self._attributes.copy(), sort_keys=True)}|{self._schema_url}")
+        return hash(
+            f"{_dumps_resource(self._attributes.copy(), sort_keys=True)}|{self._schema_url}"
+        )
 
     def to_json(self, indent: int | None = 4) -> str:
-        return dumps(
+        return _dumps_resource(
             {
                 "attributes": dict(self.attributes),
                 "schema_url": self._schema_url,

--- a/opentelemetry-sdk/tests/resources/test_resources.py
+++ b/opentelemetry-sdk/tests/resources/test_resources.py
@@ -275,6 +275,26 @@ class TestResources(unittest.TestCase):
         )
         self.assertEqual(len(resource.attributes), 2)
 
+    def test_bytes_valued_resource_attribute(self):
+        """bytes is a valid AnyValue type; Resource.__hash__ and to_json must
+        not raise TypeError for bytes-valued attributes (issue #5576)."""
+        resource = Resource({"service.name": "svc", "build.id": b"\x01\x02\x03"})
+        # hashing must not raise
+        h = hash(resource)
+        self.assertIsInstance(h, int)
+        # to_json must not raise
+        json_str = resource.to_json()
+        self.assertIn("build.id", json_str)
+        # two identical resources must hash the same
+        resource2 = Resource({"service.name": "svc", "build.id": b"\x01\x02\x03"})
+        self.assertEqual(hash(resource), hash(resource2))
+        # different bytes must produce different hashes
+        resource3 = Resource({"service.name": "svc", "build.id": b"\xff"})
+        self.assertNotEqual(hash(resource), hash(resource3))
+        # usable as a dict key (covers the OTLP encoder use-case)
+        d = {resource: "value"}
+        self.assertEqual(d[resource], "value")
+
     def test_aggregated_resources_no_detectors(self):
         aggregated_resources = get_aggregated_resources([])
         self.assertEqual(


### PR DESCRIPTION
## Summary

Fixes #5576

Resource.__hash__ and Resource.to_json() used json.dumps() on self._attributes, which raises TypeError: Object of type bytes is not JSON serializable whenever a resource contains a ytes-valued attribute.

ytes is a valid AnyValue type in the OpenTelemetry data model (encoding to OTLP ytes_value). When a resource carries a bytes attribute (such as binary build IDs, checksums, compact container hashes), every OTLP encoder fails during grouping or dictionary lookup. Furthermore, BatchSpanProcessor._export catches broad exceptions and drops batches, turning this into silent 100% telemetry loss.

## Changes

- Introduced _ResourceJsonEncoder in opentelemetry/sdk/resources/__init__.py which serializes ytes as their hexadecimal string (o.hex()), providing deterministic and stable hashing.
- Updated Resource.__hash__ and Resource.to_json to serialize via _dumps_resource using _ResourceJsonEncoder.
- Added regression test 	est_bytes_valued_resource_attribute in 	est_resources.py verifying hash(), 	o_json(), deterministic matching, and dictionary key usage with ytes attributes.
