### PR TITLE
fix(metrics): pass timeout_millis to exporter.shutdown in PeriodicExportingMetricReader

### DIFF
--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py
@@ -538,7 +538,7 @@ class PeriodicExportingMetricReader(MetricReader):
         self._shutdown_event.set()
         if self._daemon_thread:
             self._daemon_thread.join(timeout=(deadline_ns - time_ns()) / 10**9)
-        self._exporter.shutdown(timeout=(deadline_ns - time_ns()) / 10**6)
+        self._exporter.shutdown(timeout_millis=(deadline_ns - time_ns()) / 10**6)
 
     def force_flush(self, timeout_millis: float = 10_000) -> bool:
         super().force_flush(timeout_millis=timeout_millis)

--- a/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
+++ b/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
@@ -395,3 +395,24 @@ class TestPeriodicExportingMetricReader(ConcurrencyTestBase):
         self.assertTrue(name.startswith("periodic_metric_reader/"))
 
         mp.shutdown()
+
+    def test_shutdown_timeout_passed_to_exporter(self):
+        """Verify that PeriodicExportingMetricReader.shutdown forwards remaining
+        budget as timeout_millis to exporter.shutdown (issue #5574)."""
+        class TimeoutCapturingExporter(FakeMetricsExporter):
+            def __init__(self):
+                super().__init__()
+                self.received_timeout_millis = None
+
+            def shutdown(self, timeout_millis: float = 30_000, **kwargs) -> None:
+                self.received_timeout_millis = timeout_millis
+                self._shutdown = True
+
+        exporter = TimeoutCapturingExporter()
+        pmr = PeriodicExportingMetricReader(exporter, export_interval_millis=60000)
+        pmr.shutdown(timeout_millis=5000)
+
+        self.assertIsNotNone(exporter.received_timeout_millis)
+        # Should be <= 5000 and > 0, not default 30000
+        self.assertLessEqual(exporter.received_timeout_millis, 5000)
+        self.assertGreater(exporter.received_timeout_millis, 0)


### PR DESCRIPTION
## Summary

Fixes #5574

PeriodicExportingMetricReader.shutdown calculated the remaining caller timeout budget after joining the ticker thread, but passed it to self._exporter.shutdown using keyword argument 	imeout=.

Since MetricExporter.shutdown is declared as:
`python
def shutdown(self, timeout_millis: float = 30_000, **kwargs) -> None:
`
the passed 	imeout was absorbed into **kwargs and ignored, causing every metric exporter to fall back to its default 30-second timeout regardless of the caller's budget.

## Changes

- In opentelemetry/sdk/metrics/_internal/export/__init__.py, changed self._exporter.shutdown(timeout=...) to self._exporter.shutdown(timeout_millis=...).
- In 	est_periodic_exporting_metric_reader.py, added unit test 	est_shutdown_timeout_passed_to_exporter verifying that custom timeout budgets are correctly forwarded to exporter.shutdown(timeout_millis=...).
