### PR TITLE
Fix exception.escaped always False via start_as_current_span

### DIFF
--- a/.changelog/0.fixed
+++ b/.changelog/0.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-api`: set `escaped=True` when auto-recording an exception raised inside a `start_as_current_span` block, matching the behavior of the raw `Span` context manager

--- a/opentelemetry-api/src/opentelemetry/trace/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/trace/__init__.py
@@ -610,7 +610,7 @@ def use_span(
         if isinstance(span, Span) and span.is_recording():
             # Record the exception as an event
             if record_exception:
-                span.record_exception(exc)
+                span.record_exception(exc, escaped=True)
 
             # Set status in case exception was raised
             if set_status_on_exception:

--- a/opentelemetry-api/tests/trace/test_globals.py
+++ b/opentelemetry-api/tests/trace/test_globals.py
@@ -13,6 +13,7 @@ from opentelemetry.trace.status import Status, StatusCode
 class SpanTest(trace.NonRecordingSpan):
     has_ended = False
     recorded_exception = None
+    recorded_exception_escaped = None
     recorded_status = Status(status_code=StatusCode.UNSET)
 
     def set_status(self, status, description=None):
@@ -29,6 +30,7 @@ class SpanTest(trace.NonRecordingSpan):
 
     def record_exception(self, exception, attributes=None, timestamp=None, escaped=False):
         self.recorded_exception = exception
+        self.recorded_exception_escaped = escaped
 
 
 class TestGlobals(TraceGlobalsTest, unittest.TestCase):
@@ -128,6 +130,9 @@ class TestUseTracer(unittest.TestCase):
                 raise exception
 
         self.assertEqual(test_span.recorded_exception, exception)
+        # The exception propagates out of the `with` block, so it is, by
+        # definition, escaping the span's scope.
+        self.assertTrue(test_span.recorded_exception_escaped)
 
     def test_use_span_set_status(self):
         class TestUseSpanException(Exception):

--- a/opentelemetry-sdk/tests/trace/test_trace.py
+++ b/opentelemetry-sdk/tests/trace/test_trace.py
@@ -1409,6 +1409,7 @@ class TestSpan(unittest.TestCase):
     raise RuntimeError("example error")
 RuntimeError: example error"""
             self.assertIn(stacktrace, event.attributes["exception.stacktrace"])
+            self.assertEqual("True", event.attributes["exception.escaped"])
 
         try:
             with self.tracer.start_as_current_span("span", record_exception=False) as span:
@@ -1417,6 +1418,34 @@ RuntimeError: example error"""
             pass
         finally:
             self.assertEqual(len(span.events), 0)
+
+    def test_record_exception_escaped_consistent_across_span_apis(self):
+        # An exception that propagates out of the `with` block is,
+        # by definition, escaping the span's scope in both APIs below.
+        # start_as_current_span (the common, documented API) and the
+        # raw start_span context manager must agree on this.
+        span_from_current = None
+        try:
+            with self.tracer.start_as_current_span("span") as span_from_current:
+                raise RuntimeError("example error")
+        except RuntimeError:
+            pass
+
+        span_from_raw = None
+        try:
+            with self.tracer.start_span("span") as span_from_raw:
+                raise RuntimeError("example error")
+        except RuntimeError:
+            pass
+
+        self.assertEqual(
+            "True",
+            span_from_current.events[0].attributes["exception.escaped"],
+        )
+        self.assertEqual(
+            "True",
+            span_from_raw.events[0].attributes["exception.escaped"],
+        )
 
     def test_record_exception_out_of_scope(self):
         span = trace._Span("name", mock.Mock(spec=trace_api.SpanContext))


### PR DESCRIPTION
# Description

`use_span()` (the internal implementation behind `Tracer.start_as_current_span`,
the most commonly used span-creation API) called `record_exception()` without
passing `escaped=True` when an exception propagates out of the `with` block,
even though the exception is, in fact, escaping the span's scope.

This was inconsistent with the SDK's own `Span.__exit__`, reachable only via
the less common `with tracer.start_span(...)` pattern, which already sets
`escaped=True` for the identical scenario.

Since `start_as_current_span` is the primary documented span API, this meant
the vast majority of auto-recorded exceptions in the ecosystem were tagged
`exception.escaped=False` regardless of whether they actually escaped,
undermining the field's usefulness for distinguishing real failures from
caught-and-handled exceptions in trace data.

Fixes # (no existing issue — found independently; will link if one is opened first)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Added `test_record_exception_escaped_consistent_across_span_apis` in
  `opentelemetry-sdk/tests/trace/test_trace.py`, which raises the same
  exception through both `start_as_current_span` and `start_span` and
  asserts `exception.escaped == "True"` for both, locking in that the two
  APIs now agree.
- Added an `exception.escaped` assertion to the existing
  `test_record_exception_context_manager` test in the same file.
- Extended `SpanTest.record_exception` in
  `opentelemetry-api/tests/trace/test_globals.py` to capture the `escaped`
  argument, and added an assertion to `test_use_span_exception` confirming
  `escaped=True` is now passed at the API level.
- Verified the fix is load-bearing: reverted the one-line change locally,
  confirmed the new tests fail (`AssertionError: False is not true`),
  then restored it and confirmed all tests pass.
- Ran the full `opentelemetry-api` and `opentelemetry-sdk` test suites
  locally (`tox -e py311-opentelemetry-api`, `tox -e py311-opentelemetry-sdk`)
  — all passing except one pre-existing, unrelated failure
  (`test_shutdown`, a Windows-local subprocess/module-resolution issue,
  confirmed to fail identically on a clean `main` checkout).
- Ran `ruff check`, `ruff format --check`, `tox -e public-symbols-check`
  (no public API surface changed), and `tox -e spellcheck` — all clean.

- [x] Test A: `test_record_exception_escaped_consistent_across_span_apis`

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
