### PR TITLE
opentelemetry-sdk: handle RuntimeError during LoggingHandler.flush

### DIFF
--- a/.changelog/5596.fixed
+++ b/.changelog/5596.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: catch `RuntimeError` in `LoggingHandler.flush()` when Python interpreter is shutting down.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -661,8 +661,11 @@ class LoggingHandler(logging.Handler):
         ):
             # This is done in a separate thread to avoid a potential deadlock, for
             # details see https://github.com/open-telemetry/opentelemetry-python/pull/4636.
-            thread = threading.Thread(target=self._logger_provider.force_flush)  # type: ignore[reportAttributeAccessIssue]
-            thread.start()
+            try:
+                thread = threading.Thread(target=self._logger_provider.force_flush)  # type: ignore[reportAttributeAccessIssue]
+                thread.start()
+            except RuntimeError:
+                pass
 
 
 @dataclass

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -654,13 +654,18 @@ class LoggingHandler(logging.Handler):
 
     def flush(self) -> None:
         """
-        Flushes the logging output. Skip flushing if logging_provider has no force_flush method.
+        Flushes the logging output. Skip flushing if logger_provider has no force_flush method.
+
+        Flushing is delegated to a separate thread to avoid potential deadlocks.
+        RuntimeError exceptions raised when starting the thread during interpreter shutdown
+        are safely ignored.
         """
         if hasattr(self._logger_provider, "force_flush") and callable(
             self._logger_provider.force_flush  # type: ignore[reportAttributeAccessIssue]
         ):
             # This is done in a separate thread to avoid a potential deadlock, for
             # details see https://github.com/open-telemetry/opentelemetry-python/pull/4636.
+            # Catch RuntimeError if thread cannot be started during interpreter shutdown (see #4752).
             try:
                 thread = threading.Thread(target=self._logger_provider.force_flush)  # type: ignore[reportAttributeAccessIssue]
                 thread.start()

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -99,6 +99,46 @@ class TestLoggingHandler(unittest.TestCase):
 
         logger.removeHandler(handler)
 
+    def test_log_flush(self):
+        logger_provider_mock = Mock()
+        logger_provider_mock.force_flush = Mock()
+
+        logger = logging.getLogger("foo")
+        handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider_mock)
+        logger.addHandler(handler)
+
+        with patch("opentelemetry.sdk._logs._internal.threading.Thread") as thread_mock:
+            logger.handlers[0].flush()
+            thread_mock.assert_called_once_with(target=logger_provider_mock.force_flush)
+            thread_mock.return_value.start.assert_called_once()
+
+        logger.removeHandler(handler)
+
+    def test_log_flush_thread_start_runtime_error_ignored(self):
+        logger_provider_mock = Mock()
+        logger_provider_mock.force_flush = Mock()
+
+        logger = logging.getLogger("foo")
+        handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider_mock)
+        logger.addHandler(handler)
+
+        with patch("opentelemetry.sdk._logs._internal.threading.Thread") as thread_mock:
+            thread_mock.return_value.start.side_effect = RuntimeError("can't create new thread at interpreter shutdown")
+            logger.handlers[0].flush()
+
+        logger.removeHandler(handler)
+
+    def test_log_flush_when_logger_provider_none(self):
+        logger = logging.getLogger("foo")
+        handler = LoggingHandler(level=logging.NOTSET, logger_provider=None)
+        logger.addHandler(handler)
+
+        with patch("opentelemetry.sdk._logs._internal.threading.Thread") as thread_mock:
+            logger.handlers[0].flush()
+            thread_mock.assert_not_called()
+
+        logger.removeHandler(handler)
+
     def test_log_record_no_span_context(self):
         processor, logger, handler = set_up_test_logging(logging.WARNING)
 


### PR DESCRIPTION
…utdown

Catch RuntimeError in LoggingHandler.flush() when starting the background force_flush thread fails during interpreter shutdown.

Fixes #4752

Assisted-by: Antigravity

# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
