### PR TITLE
Fix crashes from unguarded str()/repr() on invalid attribute keys/values

### DIFF
--- a/.changelog/0.fixed
+++ b/.changelog/0.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-api`/`opentelemetry-sdk`: guard unguarded `str()`/`repr()` calls used when stringifying invalid span attribute keys/values, log exception messages, and baggage entries, so an object whose `__str__`/`__repr__` itself raises no longer crashes the calling application

--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -76,12 +76,18 @@ def _clean_attribute_value(
             # Spec says to convert unknown types to strings if possible (here and below too).
             if not isinstance(key, str):
                 _logger.warning(
-                    "Invalid type `%s` for attribute key `%s`, must be a str. Key's `__str__/__repr__` method will be called if it exists, otherwise the key/value pair will be dropped.",
+                    "Invalid type `%s` for attribute key, must be a str. Key's `__str__/__repr__` method will be called if it exists, otherwise the key/value pair will be dropped.",
                     type(key),
-                    key,
                 )
                 if _is_non_custom_str(key):
-                    key = str(key)
+                    try:
+                        key = str(key)
+                    except Exception:
+                        _logger.warning(
+                            "Failed to stringify attribute key of type `%s`. Dropping key from attributes.",
+                            type(key),
+                        )
+                        continue
                 else:
                     continue
             cleaned_mapping[key] = _clean_attribute_value(val, max_string_value_length)
@@ -94,7 +100,14 @@ def _clean_attribute_value(
         type(value),
     )
     if _is_non_custom_str(value):
-        return str(value)
+        try:
+            return str(value)
+        except Exception:
+            _logger.warning(
+                "Failed to stringify attribute value of type `%s`. Replacing with None.",
+                type(value),
+            )
+            return None
     return None
 
 

--- a/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
@@ -164,7 +164,17 @@ def _encode_baggage_pairs(
 ) -> Iterator[str]:
     """Yield URL-encoded 'key=value' pairs from baggage entries."""
     for key, value in baggage_entries.items():
-        yield quote_plus(str(key)) + "=" + quote_plus(str(value))
+        try:
+            encoded_key = quote_plus(str(key))
+            encoded_value = quote_plus(str(value))
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.warning(
+                "Failed to stringify baggage key/value of type `%s`/`%s`. Dropping entry.",
+                type(key),
+                type(value),
+            )
+            continue
+        yield encoded_key + "=" + encoded_value
 
 
 def _extract_first_element(

--- a/opentelemetry-api/tests/attributes/test_attributes.py
+++ b/opentelemetry-api/tests/attributes/test_attributes.py
@@ -20,6 +20,14 @@ class _NoStrNoReprObject:
         pass
 
 
+class _RaisingReprObject:
+    """An object whose __repr__ itself raises -- simulates a broken
+    third-party object being passed as an attribute value/key."""
+
+    def __repr__(self):
+        raise RuntimeError("boom from __repr__")
+
+
 class TestBoundedAttributes(unittest.TestCase):
     # pylint: disable=consider-using-dict-items
     base = {
@@ -220,6 +228,31 @@ class TestBoundedAttributes(unittest.TestCase):
             self.assertEqual(bdict.get("reentrant.key"), "set_by_handler")
         finally:
             otel_logger.removeHandler(handler)
+
+    def test_clean_attribute_value_raising_repr_does_not_crash(self):
+        """A value whose __repr__/__str__ itself raises must not crash the
+        caller -- the docstring promises the value is replaced with None
+        on stringification failure, and _clean_attribute_value must
+        deliver on that promise instead of propagating the exception."""
+        with self.assertLogs("opentelemetry", level="WARNING"):
+            self.assertIsNone(_clean_attribute_value(_RaisingReprObject(), None))
+
+    def test_bounded_attributes_raising_repr_value_does_not_crash(self):
+        """End-to-end: setting an attribute whose value's __repr__ raises
+        must not crash the caller; the attribute becomes None instead."""
+        bdict = BoundedAttributes(immutable=False)
+        with self.assertLogs("opentelemetry", level="WARNING"):
+            bdict["bad"] = _RaisingReprObject()
+        self.assertIsNone(bdict["bad"])
+
+    def test_bounded_attributes_raising_repr_key_does_not_crash(self):
+        """End-to-end: a mapping value with a key whose __repr__ raises
+        must not crash the caller; the offending key is dropped, other
+        keys are preserved."""
+        bdict = BoundedAttributes(immutable=False)
+        with self.assertLogs("opentelemetry", level="WARNING"):
+            bdict["outer"] = {_RaisingReprObject(): "value", "good_key": "good_value"}
+        self.assertEqual(bdict["outer"], {"good_key": "good_value"})
 
     def test_wsgi_request_conversion_to_string(self):
         """Test that WSGI request objects are converted to strings when _clean_attribute_value is called."""

--- a/opentelemetry-api/tests/propagators/test_w3cbaggagepropagator.py
+++ b/opentelemetry-api/tests/propagators/test_w3cbaggagepropagator.py
@@ -216,6 +216,23 @@ class TestW3CBaggagePropagator(TestCase):
         self.assertIn("key2=123", output)
         self.assertIn("key3=123.567", output)
 
+    def test_inject_raising_str_value_does_not_crash(self):
+        """A baggage value whose __str__ itself raises must not crash
+        inject() -- the offending entry should be dropped while other
+        valid entries are still injected."""
+
+        class BadValue:
+            def __str__(self):
+                raise RuntimeError("boom from baggage value __str__")
+
+        values = {
+            "good_key": "good_value",
+            "bad_key": BadValue(),
+        }
+        output = self._inject(values)
+        self.assertIn("good_key=good_value", output)
+        self.assertNotIn("bad_key", output)
+
     @patch("opentelemetry.baggage.propagation.get_all")
     def test_fields(self, mock_baggage):
         mock_baggage.return_value = {"key": "value"}

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -572,7 +572,14 @@ class LoggingHandler(logging.Handler):
             if exctype is not None:
                 attributes[exception_attributes.EXCEPTION_TYPE] = exctype.__name__
             if value is not None and value.args:
-                attributes[exception_attributes.EXCEPTION_MESSAGE] = str(value.args[0])
+                try:
+                    attributes[exception_attributes.EXCEPTION_MESSAGE] = str(value.args[0])
+                except Exception:  # pylint: disable=broad-exception-caught
+                    _logger.warning(
+                        "Failed to stringify exception message of type `%s`.",
+                        type(value.args[0]),
+                    )
+                    attributes[exception_attributes.EXCEPTION_MESSAGE] = "<unprintable exception message>"
             if tb is not None:
                 # https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/#stacktrace-representation
                 attributes[exception_attributes.EXCEPTION_STACKTRACE] = "".join(

--- a/opentelemetry-sdk/tests/logs/test_handler.py
+++ b/opentelemetry-sdk/tests/logs/test_handler.py
@@ -280,6 +280,41 @@ class TestLoggingHandler(unittest.TestCase):
 
         logger.removeHandler(handler)
 
+    def test_log_record_exception_with_raising_arg_does_not_crash(self):
+        """Exception logging (e.g. logger.exception(...)) must not crash
+        when the raised exception's first arg has a __str__ that itself
+        raises -- the exception message attribute should fall back to a
+        placeholder instead of propagating the failure into the caller's
+        logging call."""
+        processor, logger, handler = set_up_test_logging(logging.ERROR)
+
+        class BadArg:
+            def __str__(self):
+                raise RuntimeError("BadArg.__str__ blew up")
+
+        class BadException(Exception):
+            pass
+
+        try:
+            raise BadException(BadArg())
+        except BadException:
+            with self.assertLogs(level=logging.ERROR):
+                logger.exception("something failed")
+
+        record = processor.get_log_record(0)
+
+        self.assertIsNotNone(record)
+        self.assertEqual(
+            record.log_record.attributes[exception_attributes.EXCEPTION_TYPE],
+            BadException.__name__,
+        )
+        self.assertEqual(
+            record.log_record.attributes[exception_attributes.EXCEPTION_MESSAGE],
+            "<unprintable exception message>",
+        )
+
+        logger.removeHandler(handler)
+
     def test_log_record_trace_correlation(self):
         processor, logger, handler = set_up_test_logging(logging.WARNING)
 


### PR DESCRIPTION
# Description

Three separate call sites use "best-effort stringify" as a fallback for
attribute keys/values, log exception messages, and baggage entries, but
none of them guard the `str()` call itself:

- `opentelemetry-api/src/opentelemetry/attributes/__init__.py`:
  `_clean_attribute_value`'s docstring says an unstringifiable value "is
  replaced with None", but `str(key)`/`str(value)` were unguarded, so an
  object whose `__str__`/`__repr__` itself raises crashed
  `span.set_attribute(...)` instead.

- `opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py`:
  `LoggingHandler._get_attributes` called `str(value.args[0])` unguarded
  when translating a stdlib `LogRecord`'s `exc_info`, crashing the common
  `logger.exception(...)` pattern whenever the raised exception's first
  arg has a raising `__str__`.

- `opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py`:
  `_encode_baggage_pairs` called `str(key)`/`str(value)` unguarded,
  crashing `W3CBaggagePropagator.inject()` the same way.

All three now catch the stringification failure, log a warning, and
degrade gracefully (drop the offending key/value or entry) instead of
propagating the exception into the caller's application code — which
observability/telemetry code should never do.

Fixes #5597

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added 5 regression tests across the three affected test files:
- `test_clean_attribute_value_raising_repr_does_not_crash`,
  `test_bounded_attributes_raising_repr_value_does_not_crash`,
  `test_bounded_attributes_raising_repr_key_does_not_crash`
  (`opentelemetry-api/tests/attributes/test_attributes.py`)
- `test_log_record_exception_with_raising_arg_does_not_crash`
  (`opentelemetry-sdk/tests/logs/test_handler.py`)
- `test_inject_raising_str_value_does_not_crash`
  (`opentelemetry-api/tests/propagators/test_w3cbaggagepropagator.py`)

Verified all 5 tests are load-bearing: reverted the three production
fixes locally, confirmed each test fails with the exact original crash
traceback, restored the fixes, confirmed all pass.

Ran the full `opentelemetry-api` (277 tests) and `opentelemetry-sdk`
(836 tests) suites — all passing except one pre-existing, unrelated
failure (`test_shutdown`, a Windows-local subprocess/module-resolution
issue, confirmed to fail identically on a clean `main` checkout).

Ran `ruff check`, `ruff format --check`, `tox -e public-symbols-check`
(no public API surface changed), and `tox -e spellcheck` — all clean.

- [x] Test A: `test_clean_attribute_value_raising_repr_does_not_crash`

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
