### PR TITLE
Publish checksums.txt alongside release artifacts

### DIFF
--- a/.changelog/5600.added
+++ b/.changelog/5600.added
@@ -1,0 +1,1 @@
+Publish a sha256 `checksums.txt` alongside GitHub release artifacts, matching the layout used by other OpenTelemetry language repos.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,10 @@ jobs:
       - name: Build wheels
         run: ./scripts/build.sh
 
+      - name: Generate checksums
+        run: |
+          (cd dist && sha256sum * > ../checksums.txt)
+
       - name: Install twine
         run: |
           pip install twine
@@ -133,4 +137,5 @@ jobs:
                             --title "Version ${STABLE_VERSION}/${UNSTABLE_VERSION}" \
                             --notes-file /tmp/release-notes.txt \
                             --discussion-category announcements \
-                            v$STABLE_VERSION
+                            v$STABLE_VERSION \
+                            checksums.txt


### PR DESCRIPTION
## Summary
- Generates a sha256 `checksums.txt` for the wheels and sdists built by `scripts/build.sh` during the release workflow
- Attaches `checksums.txt` to the GitHub release, matching the layout used by opentelemetry-dotnet-instrumentation and [opentelemetry-java-instrumentation#19914](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19914)

Downstream consumers building on top of this repo's release artifacts can verify integrity with a simple hash comparison, without needing to re-derive hashes from PyPI.