### PR TITLE
tox: move versioning of shared dev packages to dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 pylint==3.3.4
+griffe==1.7.3
 httpretty==1.1.4
 mocket==3.14.1
 pyright==1.1.405

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 pylint==3.3.4
 griffe==1.7.3
 httpretty==1.1.4
+inline-snapshot==0.34.2
 mocket==3.14.1
 pyright==1.1.405
 sphinx==8.1.3

--- a/tox.ini
+++ b/tox.ini
@@ -342,9 +342,10 @@ commands =
 
 [testenv:tracecontext]
 deps =
+  -c dev-requirements.txt
   # needed for tracecontext
   aiohttp~=3.6
-  pytest==9.0.3
+  pytest
   # needed for example trace integration
   flask~=2.3
   requests~=2.7

--- a/tox.ini
+++ b/tox.ini
@@ -427,8 +427,9 @@ commands =
 [testenv:public-symbols-check]
 recreate = True
 deps =
-  GitPython==3.1.58
-  griffe==1.7.3
+  -c dev-requirements.txt
+  GitPython
+  griffe
   toml
 commands =
   ; griffe check before to fail fast if there are any issues

--- a/tox.ini
+++ b/tox.ini
@@ -366,14 +366,15 @@ commands =
 
 [testenv:docker-tests-{otlpexporter,opencensus}]
 deps =
-  pytest==9.0.3
+  -c dev-requirements.txt
+  pytest
   ; core packages
   -e {toxinidir}/opentelemetry-api
   -e {toxinidir}/opentelemetry-semantic-conventions
   -e {toxinidir}/opentelemetry-sdk
   -e {toxinidir}/tests/opentelemetry-test-utils
   ; OTLP packages
-  otlpexporter: inline-snapshot==0.34.2
+  otlpexporter: inline-snapshot
   otlpexporter: -e {toxinidir}/opentelemetry-proto
   otlpexporter: -e {toxinidir}/exporter/opentelemetry-exporter-otlp-proto-common
   otlpexporter: -e {toxinidir}/exporter/opentelemetry-exporter-otlp-common


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Use dev-requirements.txt as a constraint so we don't need to duplicate the version in tox.ini. Not all tox environments deps are converted, these are the ones that are already listed in dev-requirements.txt or it's trivial to add them there.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Contrib Repo Change?

<!--
Answer the following question based on these examples of changes that would require a Contrib Repo Change:
- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`
- The method interfaces of `test/util` have changed
- Scripts in `scripts/` that were copied over to the Contrib repo have changed
- Configuration files that were copied over to the Contrib repo have changed (when consistency between repositories is applicable) such as in
    - `pyproject.toml`
    - `isort.cfg`
    - `.flake8`
- When a new `.github/CODEOWNER` is added
- Major changes to project information, such as in:
    - `README.md`
    - `CONTRIBUTING.md`
-->

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
