### PR TITLE
docs: link individual .py files in metrics reader/views READMEs

### DIFF
--- a/docs/examples/metrics/reader/README.rst
+++ b/docs/examples/metrics/reader/README.rst
@@ -3,10 +3,10 @@ MetricReader configuration scenarios
 
 These examples show how to customize the metrics that are output by the SDK using configuration on metric readers. There are multiple examples:
 
-* preferred_aggregation.py: Shows how to configure the preferred aggregation for metric instrument types.
-* preferred_temporality.py: Shows how to configure the preferred temporality for metric instrument types.
-* preferred_exemplarfilter.py: Shows how to configure the exemplar filter.
-* synchronous_gauge_read.py: Shows how to use `PeriodicExportingMetricReader` in a synchronous manner to explicitly control the collection of metrics.
+* :scm_web:`preferred_aggregation.py <docs/examples/metrics/reader/preferred_aggregation.py>`: Shows how to configure the preferred aggregation for metric instrument types.
+* :scm_web:`preferred_temporality.py <docs/examples/metrics/reader/preferred_temporality.py>`: Shows how to configure the preferred temporality for metric instrument types.
+* :scm_web:`preferred_exemplarfilter.py <docs/examples/metrics/reader/preferred_exemplarfilter.py>`: Shows how to configure the exemplar filter.
+* :scm_web:`synchronous_gauge_read.py <docs/examples/metrics/reader/synchronous_gauge_read.py>`: Shows how to use `PeriodicExportingMetricReader` in a synchronous manner to explicitly control the collection of metrics.
 
 The source files of these examples are available :scm_web:`here <docs/examples/metrics/reader/>`.
 

--- a/docs/examples/metrics/views/README.rst
+++ b/docs/examples/metrics/views/README.rst
@@ -3,11 +3,11 @@ View common scenarios
 
 These examples show how to customize the metrics that are output by the SDK using Views. There are multiple examples:
 
-* change_aggregation.py: Shows how to configure to change the default aggregation for an instrument.
-* change_name.py: Shows how to change the name of a metric.
-* limit_num_of_attrs.py: Shows how to limit the number of attributes that are output for a metric.
-* drop_metrics_from_instrument.py: Shows how to drop measurements from an instrument.
-* change_reservoir_factory.py: Shows how to use your own ``ExemplarReservoir``
+* :scm_web:`change_aggregation.py <docs/examples/metrics/views/change_aggregation.py>`: Shows how to configure to change the default aggregation for an instrument.
+* :scm_web:`change_name.py <docs/examples/metrics/views/change_name.py>`: Shows how to change the name of a metric.
+* :scm_web:`limit_num_of_attrs.py <docs/examples/metrics/views/limit_num_of_attrs.py>`: Shows how to limit the number of attributes that are output for a metric.
+* :scm_web:`drop_metrics_from_instrument.py <docs/examples/metrics/views/drop_metrics_from_instrument.py>`: Shows how to drop measurements from an instrument.
+* :scm_web:`change_reservoir_factory.py <docs/examples/metrics/views/change_reservoir_factory.py>`: Shows how to use your own ``ExemplarReservoir``
 
 The source files of these examples are available :scm_web:`here <docs/examples/metrics/views/>`.
 


### PR DESCRIPTION
Links individual Python example filenames in bullet lists to their GitHub source files using the :scm_web: role, completing the work from issue #5427.

- docs/examples/metrics/reader/README.rst: links preferred_aggregation.py, preferred_temporality.py, preferred_exemplarfilter.py, synchronous_gauge_read.py
- docs/examples/metrics/views/README.rst: links change_aggregation.py, change_name.py, limit_num_of_attrs.py, drop_metrics_from_instrument.py, change_reservoir_factory.py

Refs open-telemetry/opentelemetry-python#5427