### PR TITLE
fix(docs): add scm_web links to metrics views README

### DIFF
--- a/docs/examples/metrics/views/README.rst
+++ b/docs/examples/metrics/views/README.rst
@@ -3,11 +3,11 @@ View common scenarios
 
 These examples show how to customize the metrics that are output by the SDK using Views. There are multiple examples:
 
-* change_aggregation.py: Shows how to configure to change the default aggregation for an instrument.
-* change_name.py: Shows how to change the name of a metric.
-* limit_num_of_attrs.py: Shows how to limit the number of attributes that are output for a metric.
-* drop_metrics_from_instrument.py: Shows how to drop measurements from an instrument.
-* change_reservoir_factory.py: Shows how to use your own ``ExemplarReservoir``
+* :scm_web:`change_aggregation.py <docs/examples/metrics/views/change_aggregation.py>`: Shows how to configure to change the default aggregation for an instrument.
+* :scm_web:`change_name.py <docs/examples/metrics/views/change_name.py>`: Shows how to change the name of a metric.
+* :scm_web:`limit_num_of_attrs.py <docs/examples/metrics/views/limit_num_of_attrs.py>`: Shows how to limit the number of attributes that are output for a metric.
+* :scm_web:`drop_metrics_from_instrument.py <docs/examples/metrics/views/drop_metrics_from_instrument.py>`: Shows how to drop measurements from an instrument.
+* :scm_web:`change_reservoir_factory.py <docs/examples/metrics/views/change_reservoir_factory.py>`: Shows how to use your own ``ExemplarReservoir``
 
 The source files of these examples are available :scm_web:`here <docs/examples/metrics/views/>`.
 


### PR DESCRIPTION
## What
Add `:scm_web:` directives to Python example files in `docs/examples/metrics/views/README.rst` so they link directly to their source files on GitHub, matching the pattern used in `docs/examples/django/README.rst`.

## Why
Without these links, users reading the rendered documentation have no easy way to navigate to the example source code.

## Test plan
- Verified the file renders correctly with the new `:scm_web:` directives
- No functional code change

Fixes #5427