### PR TITLE
Fix metrics collection timeout so slow observable callbacks raise MetricsTimeoutError

### DIFF
--- a/.changelog/5616.fixed
+++ b/.changelog/5616.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: fix `timeout_millis` in metrics collection so slow observable callbacks raise `MetricsTimeoutError`

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
@@ -111,7 +111,9 @@ class SynchronousMeasurementConsumer(MeasurementConsumer):
                     metric_reader_storage.consume_measurement(measurement, should_sample_exemplar)
 
                 if time_ns() >= deadline_ns:
-                    raise MetricsTimeoutError("Timed out while executing callback")
+                    raise MetricsTimeoutError(
+                        f"Timed out while executing callback for instrument {async_instrument.name}"
+                    )
 
             result = self._reader_storages[metric_reader].collect()
 

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/measurement_consumer.py
@@ -98,11 +98,10 @@ class SynchronousMeasurementConsumer(MeasurementConsumer):
                 if remaining_time < default_timeout_ns:
                     callback_options = CallbackOptions(timeout_millis=remaining_time / 1e6)
 
-                measurements = async_instrument.callback(callback_options)
-                if time_ns() >= deadline_ns:
-                    raise MetricsTimeoutError("Timed out while executing callback")
-
-                for measurement in measurements:
+                # callback() is a generator function: the user callback
+                # only runs while the loop below iterates it, so the
+                # deadline can only be observed after iteration completes.
+                for measurement in async_instrument.callback(callback_options):
                     should_sample_exemplar = self._sdk_config.exemplar_filter.should_sample(
                         measurement.value,
                         measurement.time_unix_nano,
@@ -110,6 +109,9 @@ class SynchronousMeasurementConsumer(MeasurementConsumer):
                         measurement.context,
                     )
                     metric_reader_storage.consume_measurement(measurement, should_sample_exemplar)
+
+                if time_ns() >= deadline_ns:
+                    raise MetricsTimeoutError("Timed out while executing callback")
 
             result = self._reader_storages[metric_reader].collect()
 

--- a/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
+++ b/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
@@ -120,13 +120,13 @@ class TestSynchronousMeasurementConsumer(TestCase):
             metric_readers=[reader_mock],
         )
 
-        def slow_callback(*args, **kwargs):
+        def sleep_0_05(*args, **kwargs):
             # A generator, like the real _Asynchronous.callback: calling it
             # returns immediately and the body only runs during iteration.
-            sleep(1)
+            sleep(0.05)
             yield Mock()
 
-        consumer.register_asynchronous_instrument(Mock(**{"callback.side_effect": slow_callback}))
+        consumer.register_asynchronous_instrument(Mock(**{"callback.side_effect": sleep_0_05}))
 
         with self.assertRaises(Exception) as error:
             consumer.collect(reader_mock, timeout_millis=10)

--- a/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
+++ b/opentelemetry-sdk/tests/metrics/test_measurement_consumer.py
@@ -120,10 +120,13 @@ class TestSynchronousMeasurementConsumer(TestCase):
             metric_readers=[reader_mock],
         )
 
-        def sleep_1(*args, **kwargs):
+        def slow_callback(*args, **kwargs):
+            # A generator, like the real _Asynchronous.callback: calling it
+            # returns immediately and the body only runs during iteration.
             sleep(1)
+            yield Mock()
 
-        consumer.register_asynchronous_instrument(Mock(**{"callback.side_effect": sleep_1}))
+        consumer.register_asynchronous_instrument(Mock(**{"callback.side_effect": slow_callback}))
 
         with self.assertRaises(Exception) as error:
             consumer.collect(reader_mock, timeout_millis=10)


### PR DESCRIPTION
# Description

`_Asynchronous.callback` is a generator function, so calling it returns immediately without executing any user callback code. The deadline check in `SynchronousMeasurementConsumer.collect` ran right after that call, before the loop that actually drives the callbacks, so it always observed ~0 elapsed time and `timeout_millis` could never raise `MetricsTimeoutError`.

Move the deadline check after the measurement iteration, where the elapsed time is actually observable. A single slow callback now raises `MetricsTimeoutError` once it finishes, and remaining instruments are not invoked after the deadline passes. The existing `test_collect_timeout` only passed because its `Mock` callback slept at call time; it now uses a generator to match the real instrument's lazy behavior (it fails without the fix).

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Updated `test_collect_timeout` to use a generator callback like the real `_Asynchronous.callback`; it fails without the fix and passes with it.
- [x] `pytest opentelemetry-sdk/tests/metrics/test_measurement_consumer.py` (9 passed)

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
