### PR TITLE
Make processor queue capacity metrics observable

### DIFF
--- a/.changelog/5618.fixed
+++ b/.changelog/5618.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: report processor queue capacity with observable instruments

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/_processor_metrics.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/_processor_metrics.py
@@ -14,12 +14,12 @@ from opentelemetry.semconv._incubating.attributes.otel_attributes import (
     OtelComponentTypeValues,
 )
 from opentelemetry.semconv._incubating.metrics.otel_metrics import (
+    OTEL_SDK_PROCESSOR_LOG_QUEUE_CAPACITY,
     OTEL_SDK_PROCESSOR_LOG_QUEUE_SIZE,
+    OTEL_SDK_PROCESSOR_SPAN_QUEUE_CAPACITY,
     OTEL_SDK_PROCESSOR_SPAN_QUEUE_SIZE,
     create_otel_sdk_processor_log_processed,
-    create_otel_sdk_processor_log_queue_capacity,
     create_otel_sdk_processor_span_processed,
-    create_otel_sdk_processor_span_queue_capacity,
 )
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 
@@ -78,16 +78,32 @@ class ProcessorMetrics:
 
         if signal == "traces":
             create_processed = create_otel_sdk_processor_span_processed
-            create_queue_capacity = create_otel_sdk_processor_span_queue_capacity
+            queue_capacity_name = OTEL_SDK_PROCESSOR_SPAN_QUEUE_CAPACITY
+            queue_capacity_description = (
+                "The maximum number of spans the queue of a given instance of an SDK span processor can hold."
+            )
+            queue_capacity_unit = "{span}"
         else:
             create_processed = create_otel_sdk_processor_log_processed
-            create_queue_capacity = create_otel_sdk_processor_log_queue_capacity
+            queue_capacity_name = OTEL_SDK_PROCESSOR_LOG_QUEUE_CAPACITY
+            queue_capacity_description = "The maximum number of log records the queue of a given instance of an SDK Log Record processor can hold."
+            queue_capacity_unit = "{log_record}"
 
         self._processed = create_processed(meter)
 
         if capacity is not None:
-            self._queue_capacity = create_queue_capacity(meter)
-            self._queue_capacity.add(capacity, self._standard_attrs)
+
+            def record_queue_capacity(
+                _options: CallbackOptions,
+            ) -> tuple[Observation]:
+                return (Observation(capacity, self._standard_attrs),)
+
+            self._queue_capacity = self._meter.create_observable_up_down_counter(
+                queue_capacity_name,
+                callbacks=(record_queue_capacity,),
+                description=queue_capacity_description,
+                unit=queue_capacity_unit,
+            )
 
     def register_queue_size(self, get_queue_size: Callable[[], int]) -> None:
         def record_queue_size(

--- a/opentelemetry-sdk/tests/shared_internal/test_processor_metrics.py
+++ b/opentelemetry-sdk/tests/shared_internal/test_processor_metrics.py
@@ -1,0 +1,55 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+
+from opentelemetry.metrics._internal import _ProxyMeterProvider
+from opentelemetry.sdk._shared_internal._processor_metrics import (
+    ProcessorMetrics,
+)
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.semconv._incubating.attributes.otel_attributes import (
+    OtelComponentTypeValues,
+)
+
+
+class TestProcessorMetrics(TestCase):
+    def test_queue_capacity_with_late_meter_provider(self):
+        cases = (
+            (
+                "traces",
+                OtelComponentTypeValues.BATCHING_SPAN_PROCESSOR,
+                "otel.sdk.processor.span.queue.capacity",
+            ),
+            (
+                "logs",
+                OtelComponentTypeValues.BATCHING_LOG_PROCESSOR,
+                "otel.sdk.processor.log.queue.capacity",
+            ),
+        )
+
+        for signal, component_type, metric_name in cases:
+            with self.subTest(signal=signal):
+                proxy_meter_provider = _ProxyMeterProvider()
+                ProcessorMetrics(
+                    signal,
+                    component_type,
+                    proxy_meter_provider,
+                    capacity=2048,
+                )
+
+                metric_reader = InMemoryMetricReader()
+                meter_provider = MeterProvider(metric_readers=[metric_reader])
+                proxy_meter_provider.on_set_meter_provider(meter_provider)
+
+                for _ in range(2):
+                    metric_data = metric_reader.get_metrics_data()
+                    metrics = metric_data.resource_metrics[0].scope_metrics[0].metrics
+                    queue_capacity = next(metric for metric in metrics if metric.name == metric_name)
+                    self.assertEqual(
+                        queue_capacity.data.data_points[0].value,
+                        2048,
+                    )
+
+                meter_provider.shutdown()


### PR DESCRIPTION
## Description

Report span and log processor queue capacity with observable up-down counters instead of recording the capacity once with synchronous counters.

A processor can be constructed before the SDK installs the real meter provider. In that case, the one-time synchronous measurement is made against a proxy instrument and is not replayed when the provider is installed, so queue capacity is never exported. Observing the fixed capacity during collection avoids that initialization-order dependency and remains compliant with the metrics semantic conventions.

Adds regression coverage for processors created before the real meter provider is installed.