### PR TITLE
fix: guard str() calls with try/except to prevent crashes

### DIFF
--- a/opentelemetry-api/src/opentelemetry/attributes/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/attributes/__init__.py
@@ -94,7 +94,10 @@ def _clean_attribute_value(
         type(value),
     )
     if _is_non_custom_str(value):
-        return str(value)
+        try:
+            return str(value)
+        except Exception:  # pylint: disable=broad-except
+            pass
     return None
 
 

--- a/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
@@ -164,7 +164,11 @@ def _encode_baggage_pairs(
 ) -> Iterator[str]:
     """Yield URL-encoded 'key=value' pairs from baggage entries."""
     for key, value in baggage_entries.items():
-        yield quote_plus(str(key)) + "=" + quote_plus(str(value))
+        try:
+            encoded_value = quote_plus(str(value))
+        except Exception:  # pylint: disable=broad-except
+            encoded_value = quote_plus(f"<exception {type(value).__name__}>")
+        yield quote_plus(str(key)) + "=" + encoded_value
 
 
 def _extract_first_element(

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py
@@ -572,7 +572,10 @@ class LoggingHandler(logging.Handler):
             if exctype is not None:
                 attributes[exception_attributes.EXCEPTION_TYPE] = exctype.__name__
             if value is not None and value.args:
-                attributes[exception_attributes.EXCEPTION_MESSAGE] = str(value.args[0])
+                try:
+                    attributes[exception_attributes.EXCEPTION_MESSAGE] = str(value.args[0])
+                except Exception:  # pylint: disable=broad-except
+                    attributes[exception_attributes.EXCEPTION_MESSAGE] = "<exception str() failed>"
             if tb is not None:
                 # https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/#stacktrace-representation
                 attributes[exception_attributes.EXCEPTION_STACKTRACE] = "".join(


### PR DESCRIPTION
## Summary

Fixes #5597

Objects with broken `__str__` methods can cause crashes when OpenTelemetry tries to convert them to strings for logging/attributes.

## Problem

When an object has a broken `__str__` method (raises an exception), OpenTelemetry crashes instead of gracefully handling it.

## Solution

Wrap all user-provided object's `str()` calls in try/except blocks:

1. `_clean_attribute_value` in opentelemetry-api/src/opentelemetry/attributes/__init__.py: wrap `str(value)`
2. `LoggingHandler._get_attributes` in opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py: wrap `str(value.args[0])`  
3. `_encode_baggage_pairs` in opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py: wrap `str(value)`

Assisted-by: Claude Opus 4.6