### PR TITLE
ci: resolve contrib repo SHA once for hermetic CI

### DIFF
--- a/.changelog/5625.changed
+++ b/.changelog/5625.changed
@@ -1,0 +1,1 @@
+`ci`: resolve the contrib repo commit SHA once per CI run instead of recomputing a branch-name reference in each workflow, avoiding non-hermetic mismatches between jobs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  misc:
-    uses: ./.github/workflows/misc.yml
-  lint:
-    uses: ./.github/workflows/lint.yml
-  tests:
-    uses: ./.github/workflows/test.yml
-  contrib:
-    uses: open-telemetry/opentelemetry-python-contrib/.github/workflows/core_contrib_test.yml@main
-    with:
-      CORE_REPO_SHA: ${{ github.sha }}
-      CONTRIB_REPO_SHA: ${{ github.event_name == 'pull_request' && (
+  resolve-contrib-sha:
+    name: Resolve contrib repo SHA
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    env:
+      # Set the ref to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
+      # For PRs you can change the inner fallback ('main')
+      # For pushes you change the outer fallback ('main')
+      # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
+      CONTRIB_REPO_REF: ${{ github.event_name == 'pull_request' && (
           contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
           contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
           'main'
         ) || 'main' }}
+    steps:
+      - name: Resolve ${{ env.CONTRIB_REPO_REF }} to a commit SHA
+        id: resolve
+        run: |
+          SHA="$(git ls-remote https://github.com/open-telemetry/opentelemetry-python-contrib "refs/heads/${CONTRIB_REPO_REF}" | cut -f1)"
+          if [ -z "$SHA" ]; then
+            echo "::error::Could not resolve contrib branch '${CONTRIB_REPO_REF}' to a commit SHA"
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+  misc:
+    needs: resolve-contrib-sha
+    uses: ./.github/workflows/misc.yml
+    with:
+      contrib-repo-sha: ${{ needs.resolve-contrib-sha.outputs.sha }}
+  lint:
+    uses: ./.github/workflows/lint.yml
+  tests:
+    needs: resolve-contrib-sha
+    uses: ./.github/workflows/test.yml
+    with:
+      contrib-repo-sha: ${{ needs.resolve-contrib-sha.outputs.sha }}
+  contrib:
+    needs: resolve-contrib-sha
+    uses: open-telemetry/opentelemetry-python-contrib/.github/workflows/core_contrib_test.yml@main
+    with:
+      CORE_REPO_SHA: ${{ github.sha }}
+      CONTRIB_REPO_SHA: ${{ needs.resolve-contrib-sha.outputs.sha }}
 
   check:
     if: always()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,16 +10,6 @@ permissions:
   contents: read
 
 env:
-  CORE_REPO_SHA: main
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
-  CONTRIB_REPO_SHA: ${{ github.event_name == 'pull_request' && (
-       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
-       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -5,21 +5,17 @@ name: Misc
 
 on:
   workflow_call:
+    inputs:
+      contrib-repo-sha:
+        description: Commit SHA in the contrib repo to check out for jobs that need it.
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 env:
-  CORE_REPO_SHA: main
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
-  CONTRIB_REPO_SHA: ${{ github.event_name == 'pull_request' && (
-       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
-       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}
+  CONTRIB_REPO_SHA: ${{ inputs.contrib-repo-sha }}
   PIP_EXISTS_ACTION: w
   CONTRIB_REPO_UTIL_HTTP: ${{ github.workspace }}/opentelemetry-python-contrib/util/opentelemetry-util-http
   CONTRIB_REPO_INSTRUMENTATION: ${{ github.workspace }}/opentelemetry-python-contrib/opentelemetry-instrumentation

--- a/.github/workflows/templates/ci.yml.j2
+++ b/.github/workflows/templates/ci.yml.j2
@@ -18,21 +18,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  misc:
-    uses: ./.github/workflows/misc.yml
-  lint:
-    uses: ./.github/workflows/lint.yml
-  tests:
-    uses: ./.github/workflows/test.yml
-  contrib:
-    uses: open-telemetry/opentelemetry-python-contrib/.github/workflows/core_contrib_test.yml@main
-    with:
-      CORE_REPO_SHA: ${% raw %}{{ github.sha }}{% endraw %}
-      CONTRIB_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
+  resolve-contrib-sha:
+    name: Resolve contrib repo SHA
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sha: ${% raw %}{{ steps.resolve.outputs.sha }}{% endraw %}
+    env:
+      # Set the ref to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
+      # For PRs you can change the inner fallback ('main')
+      # For pushes you change the outer fallback ('main')
+      # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
+      CONTRIB_REPO_REF: {% raw %}${{ github.event_name == 'pull_request' && (
           contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
           contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
           'main'
         ) || 'main' }}{% endraw %}
+    steps:
+      - name: Resolve ${% raw %}{{ env.CONTRIB_REPO_REF }}{% endraw %} to a commit SHA
+        id: resolve
+        run: |
+          SHA="$(git ls-remote https://github.com/open-telemetry/opentelemetry-python-contrib "refs/heads/${CONTRIB_REPO_REF}" | cut -f1)"
+          if [ -z "$SHA" ]; then
+            echo "::error::Could not resolve contrib branch '${CONTRIB_REPO_REF}' to a commit SHA"
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+  misc:
+    needs: resolve-contrib-sha
+    uses: ./.github/workflows/misc.yml
+    with:
+      contrib-repo-sha: ${% raw %}{{ needs.resolve-contrib-sha.outputs.sha }}{% endraw %}
+  lint:
+    uses: ./.github/workflows/lint.yml
+  tests:
+    needs: resolve-contrib-sha
+    uses: ./.github/workflows/test.yml
+    with:
+      contrib-repo-sha: ${% raw %}{{ needs.resolve-contrib-sha.outputs.sha }}{% endraw %}
+  contrib:
+    needs: resolve-contrib-sha
+    uses: open-telemetry/opentelemetry-python-contrib/.github/workflows/core_contrib_test.yml@main
+    with:
+      CORE_REPO_SHA: ${% raw %}{{ github.sha }}{% endraw %}
+      CONTRIB_REPO_SHA: ${% raw %}{{ needs.resolve-contrib-sha.outputs.sha }}{% endraw %}
 
   check:
     if: always()

--- a/.github/workflows/templates/lint.yml.j2
+++ b/.github/workflows/templates/lint.yml.j2
@@ -10,16 +10,6 @@ permissions:
   contents: read
 
 env:
-  CORE_REPO_SHA: main
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
-  CONTRIB_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
-       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
-       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}{% endraw %}
   PIP_EXISTS_ACTION: w
 
 jobs:

--- a/.github/workflows/templates/misc.yml.j2
+++ b/.github/workflows/templates/misc.yml.j2
@@ -5,21 +5,17 @@ name: Misc
 
 on:
   workflow_call:
+    inputs:
+      contrib-repo-sha:
+        description: Commit SHA in the contrib repo to check out for jobs that need it.
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 env:
-  CORE_REPO_SHA: main
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
-  CONTRIB_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
-       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
-       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}{% endraw %}
+  CONTRIB_REPO_SHA: {% raw %}${{ inputs.contrib-repo-sha }}{% endraw %}
   PIP_EXISTS_ACTION: w
   CONTRIB_REPO_UTIL_HTTP: ${% raw %}{{ github.workspace }}{% endraw %}/opentelemetry-python-contrib/util/opentelemetry-util-http
   CONTRIB_REPO_INSTRUMENTATION: ${% raw %}{{ github.workspace }}{% endraw %}/opentelemetry-python-contrib/opentelemetry-instrumentation

--- a/.github/workflows/templates/test.yml.j2
+++ b/.github/workflows/templates/test.yml.j2
@@ -5,21 +5,17 @@ name: Test
 
 on:
   workflow_call:
+    inputs:
+      contrib-repo-sha:
+        description: Commit SHA in the contrib repo to check out for jobs that need it.
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 env:
-  CORE_REPO_SHA: main
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
-  CONTRIB_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
-       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
-       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}{% endraw %}
+  CONTRIB_REPO_SHA: {% raw %}${{ inputs.contrib-repo-sha }}{% endraw %}
   WEAVER_VERSION: "v0.25.1"
   PIP_EXISTS_ACTION: w
   CONTRIB_REPO_UTIL_HTTP: ${% raw %}{{ github.workspace }}{% endraw %}/opentelemetry-python-contrib/util/opentelemetry-util-http

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,21 +5,17 @@ name: Test
 
 on:
   workflow_call:
+    inputs:
+      contrib-repo-sha:
+        description: Commit SHA in the contrib repo to check out for jobs that need it.
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 env:
-  CORE_REPO_SHA: main
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the contrib repo.
-  CONTRIB_REPO_SHA: ${{ github.event_name == 'pull_request' && (
-       contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
-       contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}
+  CONTRIB_REPO_SHA: ${{ inputs.contrib-repo-sha }}
   WEAVER_VERSION: "v0.25.1"
   PIP_EXISTS_ACTION: w
   CONTRIB_REPO_UTIL_HTTP: ${{ github.workspace }}/opentelemetry-python-contrib/util/opentelemetry-util-http


### PR DESCRIPTION
## Summary

Fixes #4305.

`CONTRIB_REPO_SHA` was independently re-derived from a branch-name expression in four places (`ci.yml`, `misc.yml`, `test.yml`, `lint.yml`), always resolving to a **branch name**, not a pinned commit:

```
CONTRIB_REPO_SHA: ${{ github.event_name == 'pull_request' && (
    contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
    contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
    'main'
  ) || 'main' }}
```

Since each job re-evaluates this independently, jobs in the same CI run (or a re-run hours later) could end up checking out different contrib commits if contrib's target branch moved in between — not hermetic, and a likely contributor to flakiness like #4853.

This PR resolves the contrib branch to a concrete commit SHA **once**, in a new `resolve-contrib-sha` job in `ci.yml` (via `git ls-remote`), and passes that SHA down to `misc`, `tests`, and `contrib` via `workflow_call` inputs instead of each workflow recomputing its own branch-name expression.

While in there, I also removed `CORE_REPO_SHA: main` from `misc.yml`/`lint.yml`/`test.yml` — it was declared in each workflow's `env:` block but never actually referenced anywhere in `.github/`. The one meaningful use of `CORE_REPO_SHA` (passed to contrib's `core_contrib_test.yml` reusable workflow) was already correctly pinned to `github.sha`, so this only removes dead code. `lint.yml` also never used `CONTRIB_REPO_SHA` at all, so that's dropped there too.

## Changes

- `.github/workflows/templates/ci.yml.j2`: add `resolve-contrib-sha` job; wire its output into `misc`, `tests`, and `contrib` jobs via `needs`/`with`
- `.github/workflows/templates/misc.yml.j2` / `test.yml.j2`: accept `contrib-repo-sha` as a `workflow_call` input instead of recomputing it; drop unused `CORE_REPO_SHA`
- `.github/workflows/templates/lint.yml.j2`: drop unused `CORE_REPO_SHA` / `CONTRIB_REPO_SHA` (neither is referenced anywhere in this workflow)
- `.github/workflows/{ci,misc,lint,test}.yml`: regenerated via `tox -e generate-workflows` (no manual edits)

## Test plan

- [x] `tox -e generate-workflows` regenerates the four `.yml` files with no diff beyond what the template changes produce (confirms templates and generated output stay in sync, matching the repo's own `generate-workflows` CI check)
- [x] All four regenerated workflow files parse as valid YAML
- [ ] CI on this PR exercises the new `resolve-contrib-sha` job and downstream `misc`/`tests`/`contrib` jobs end-to-end

Note: this doesn't fully resolve #4853 (release-branch instrumentation mismatch) on its own — that likely needs a follow-up decision on what should happen when a release-branch PR's contrib ref doesn't have a matching instrumentation set. Left a note on that issue tracking it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKP2UVjDuXMFBeNLGs6QqE