### PR TITLE
fix(sdk): catch and log unhandled exceptions in MultiSpanProcessor

### DIFF
--- a/.changelog/5626.fixed
+++ b/.changelog/5626.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: catch and log unhandled exceptions in MultiSpanProcessor

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -177,21 +177,33 @@ class SynchronousMultiSpanProcessor(SpanProcessor):
         parent_context: context_api.Context | None = None,
     ) -> None:
         for sp in self._span_processors:
-            sp.on_start(span, parent_context=parent_context)
+            try:
+                sp.on_start(span, parent_context=parent_context)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("Exception while calling SpanProcessor.on_start.")
 
     def _on_ending(self, span: "Span") -> None:
         for sp in self._span_processors:
             # pylint: disable=protected-access
-            sp._on_ending(span)
+            try:
+                sp._on_ending(span)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("Exception while calling SpanProcessor._on_ending.")
 
     def on_end(self, span: "ReadableSpan") -> None:
         for sp in self._span_processors:
-            sp.on_end(span)
+            try:
+                sp.on_end(span)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("Exception while calling SpanProcessor.on_end.")
 
     def shutdown(self) -> None:
         """Sequentially shuts down all underlying span processors."""
         for sp in self._span_processors:
-            sp.shutdown()
+            try:
+                sp.shutdown()
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("Exception while calling SpanProcessor.shutdown.")
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         """Sequentially calls force_flush on all underlying
@@ -214,7 +226,11 @@ class SynchronousMultiSpanProcessor(SpanProcessor):
             if current_time_ns >= deadline_ns:
                 return False
 
-            if sp.force_flush((deadline_ns - current_time_ns) // 1000000) is False:
+            try:
+                if sp.force_flush((deadline_ns - current_time_ns) // 1000000) is False:
+                    all_flushed = False
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("Exception while calling SpanProcessor.force_flush.")
                 all_flushed = False
 
         return all_flushed
@@ -269,10 +285,16 @@ class ConcurrentMultiSpanProcessor(SpanProcessor):
     ):
         futures = []
         for sp in self._span_processors:
-            future = self._executor.submit(func(sp), *args, **kwargs)
-            futures.append(future)
+            try:
+                future = self._executor.submit(func(sp), *args, **kwargs)
+                futures.append(future)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("Exception while submitting task to SpanProcessor executor.")
         for future in futures:
-            future.result()
+            try:
+                future.result()
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("Exception while executing SpanProcessor task.")
 
     def on_start(
         self,
@@ -305,19 +327,27 @@ class ConcurrentMultiSpanProcessor(SpanProcessor):
         """
         futures = []
         for sp in self._span_processors:
-            future = self._executor.submit(sp.force_flush, timeout_millis)
-            futures.append(future)
+            try:
+                future = self._executor.submit(sp.force_flush, timeout_millis)
+                futures.append(future)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("Exception while submitting task to SpanProcessor executor.")
 
         timeout_sec = timeout_millis / 1e3
         done_futures, not_done_futures = concurrent.futures.wait(futures, timeout_sec)
         if not_done_futures:
             return False
 
+        all_flushed = True
         for future in done_futures:
-            if future.result() is False:
-                return False
+            try:
+                if future.result() is False:
+                    all_flushed = False
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("Exception while executing SpanProcessor force_flush.")
+                all_flushed = False
 
-        return True
+        return all_flushed
 
 
 class EventBase(abc.ABC):

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py
@@ -325,6 +325,7 @@ class ConcurrentMultiSpanProcessor(SpanProcessor):
             True if all span processors flushed their spans within the given
             timeout, False otherwise.
         """
+        all_flushed = True
         futures = []
         for sp in self._span_processors:
             try:
@@ -332,13 +333,13 @@ class ConcurrentMultiSpanProcessor(SpanProcessor):
                 futures.append(future)
             except Exception:  # pylint: disable=broad-exception-caught
                 logger.exception("Exception while submitting task to SpanProcessor executor.")
+                all_flushed = False
 
         timeout_sec = timeout_millis / 1e3
         done_futures, not_done_futures = concurrent.futures.wait(futures, timeout_sec)
         if not_done_futures:
             return False
 
-        all_flushed = True
         for future in done_futures:
             try:
                 if future.result() is False:

--- a/opentelemetry-sdk/tests/trace/test_span_processor.py
+++ b/opentelemetry-sdk/tests/trace/test_span_processor.py
@@ -321,6 +321,89 @@ class MultiSpanProcessorTestBase(abc.ABC):
         for mock_processor in mocks:
             mock_processor.shutdown.assert_called_once_with()
 
+    def test_on_end_exception_does_not_raise(self):
+        multi_processor = self.create_multi_span_processor()
+        raising_proc = mock.Mock(spec=trace.SpanProcessor)
+        raising_proc.on_end.side_effect = RuntimeError("processor failed")
+        normal_proc = mock.Mock(spec=trace.SpanProcessor)
+
+        multi_processor.add_span_processor(raising_proc)
+        multi_processor.add_span_processor(normal_proc)
+
+        span = self.create_default_span()
+        multi_processor.on_end(span)
+
+        raising_proc.on_end.assert_called_once_with(span)
+        normal_proc.on_end.assert_called_once_with(span)
+        multi_processor.shutdown()
+
+    def test_on_start_exception_does_not_raise(self):
+        multi_processor = self.create_multi_span_processor()
+        raising_proc = mock.Mock(spec=trace.SpanProcessor)
+        raising_proc.on_start.side_effect = RuntimeError("processor failed")
+        normal_proc = mock.Mock(spec=trace.SpanProcessor)
+
+        multi_processor.add_span_processor(raising_proc)
+        multi_processor.add_span_processor(normal_proc)
+
+        span = self.create_default_span()
+        multi_processor.on_start(span)
+
+        raising_proc.on_start.assert_called_once_with(span, parent_context=None)
+        normal_proc.on_start.assert_called_once_with(span, parent_context=None)
+        multi_processor.shutdown()
+
+    def test_on_ending_exception_does_not_raise(self):
+        multi_processor = self.create_multi_span_processor()
+        raising_proc = mock.Mock(spec=trace.SpanProcessor)
+        # pylint: disable=protected-access
+        raising_proc._on_ending.side_effect = RuntimeError("processor failed")
+        normal_proc = mock.Mock(spec=trace.SpanProcessor)
+
+        multi_processor.add_span_processor(raising_proc)
+        multi_processor.add_span_processor(normal_proc)
+
+        span = self.create_default_span()
+        # pylint: disable=protected-access
+        multi_processor._on_ending(span)
+
+        # pylint: disable=protected-access
+        raising_proc._on_ending.assert_called_once_with(span)
+        normal_proc._on_ending.assert_called_once_with(span)
+        multi_processor.shutdown()
+
+    def test_shutdown_exception_does_not_raise(self):
+        multi_processor = self.create_multi_span_processor()
+        raising_proc = mock.Mock(spec=trace.SpanProcessor)
+        raising_proc.shutdown.side_effect = RuntimeError("processor failed")
+        normal_proc = mock.Mock(spec=trace.SpanProcessor)
+
+        multi_processor.add_span_processor(raising_proc)
+        multi_processor.add_span_processor(normal_proc)
+
+        multi_processor.shutdown()
+
+        raising_proc.shutdown.assert_called_once_with()
+        normal_proc.shutdown.assert_called_once_with()
+
+    def test_on_end_exception_does_not_replace_application_exception(self):
+        tracer_provider = trace.TracerProvider()
+        tracer = tracer_provider.get_tracer(__name__)
+
+        multi_processor = self.create_multi_span_processor()
+        raising_proc = mock.Mock(spec=trace.SpanProcessor)
+        raising_proc.on_end.side_effect = RuntimeError("processor failed")
+        multi_processor.add_span_processor(raising_proc)
+
+        tracer_provider.add_span_processor(multi_processor)
+
+        with self.assertRaises(ValueError) as ctx:
+            with tracer.start_as_current_span("app_span"):
+                raise ValueError("application failed")
+
+        self.assertEqual(str(ctx.exception), "application failed")
+        multi_processor.shutdown()
+
     def test_force_flush(self):
         multi_processor = self.create_multi_span_processor()
 

--- a/opentelemetry-sdk/tests/trace/test_span_processor.py
+++ b/opentelemetry-sdk/tests/trace/test_span_processor.py
@@ -404,6 +404,23 @@ class MultiSpanProcessorTestBase(abc.ABC):
         self.assertEqual(str(ctx.exception), "application failed")
         multi_processor.shutdown()
 
+    def test_force_flush_exception_does_not_raise_and_returns_false(self):
+        multi_processor = self.create_multi_span_processor()
+        raising_proc = mock.Mock(spec=trace.SpanProcessor)
+        raising_proc.force_flush.side_effect = RuntimeError("processor failed")
+        normal_proc = mock.Mock(spec=trace.SpanProcessor)
+        normal_proc.force_flush.return_value = True
+
+        multi_processor.add_span_processor(raising_proc)
+        multi_processor.add_span_processor(normal_proc)
+
+        flushed = multi_processor.force_flush(1000)
+
+        self.assertFalse(flushed)
+        raising_proc.force_flush.assert_called_once()
+        normal_proc.force_flush.assert_called_once()
+        multi_processor.shutdown()
+
     def test_force_flush(self):
         multi_processor = self.create_multi_span_processor()
 
@@ -640,3 +657,24 @@ class TestConcurrentMultiSpanProcessor(MultiSpanProcessorTestBase, unittest.Test
         with tracer.start_as_current_span("main process after fork span"):
             pass
         assert exporter.get_finished_spans()[-1].name == "main process after fork span"
+
+    def test_executor_submit_exception_does_not_raise(self):
+        multi_processor = trace.ConcurrentMultiSpanProcessor(2)
+        # Shut down the executor so that subsequent submit calls raise RuntimeError
+        # pylint: disable=protected-access
+        multi_processor._executor.shutdown(wait=True)
+
+        mock_processor = mock.Mock(spec=trace.SpanProcessor)
+        multi_processor.add_span_processor(mock_processor)
+
+        span = self.create_default_span()
+        # Verify that all callbacks handle executor submission failures gracefully
+        multi_processor.on_start(span)
+        # pylint: disable=protected-access
+        multi_processor._on_ending(span)
+        multi_processor.on_end(span)
+        multi_processor.shutdown()
+
+        # force_flush must return False when submission fails and not raise
+        flushed = multi_processor.force_flush(100)
+        self.assertFalse(flushed)


### PR DESCRIPTION
# Description

Fixes #5624

Per the OpenTelemetry specification:
- [OnEnd(Span)](https://opentelemetry.io/docs/specs/otel/trace/sdk/#onendspan): "This method MUST be called synchronously within the `Span.End()` API, therefore it should not block or throw an exception."
- [OnStart(Span, Context)](https://opentelemetry.io/docs/specs/otel/trace/sdk/#onstart): "This method MUST be called synchronously within the `Tracer.StartSpan` API, therefore it should not block or throw an exception."
- [Error handling](https://opentelemetry.io/docs/specs/otel/error-handling/): "OpenTelemetry implementations MUST NOT throw unhandled exceptions at runtime. API methods that accept external callbacks MUST handle all errors."

Previously, `SynchronousMultiSpanProcessor` and `ConcurrentMultiSpanProcessor` did not catch exceptions raised by underlying `SpanProcessor` instances during `on_start`, `_on_ending`, `on_end`, `shutdown`, and `force_flush`.

When a span processor raised in `on_end` during context manager exit (`Span.__exit__`), the exception escaped and replaced or suppressed the application's actual exception. Furthermore, a failure in an earlier processor in the list prevented subsequent processors from being called.

This change wraps calls to underlying processors in `try...except Exception:` blocks and logs failures via `logger.exception(...)`, ensuring that:
1. Application exceptions are never replaced or suppressed by processor failures.
2. All registered span processors are invoked even if one throws.
3. Thread pool executor submission failures (such as during interpreter shutdown) are handled gracefully.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Added `test_on_end_exception_does_not_raise` to `MultiSpanProcessorTestBase` (runs against both Synchronous and Concurrent processors).
- Added `test_on_start_exception_does_not_raise` to `MultiSpanProcessorTestBase`.
- Added `test_on_ending_exception_does_not_raise` to `MultiSpanProcessorTestBase`.
- Added `test_shutdown_exception_does_not_raise` to `MultiSpanProcessorTestBase`.
- Added `test_on_end_exception_does_not_replace_application_exception` verifying that application exceptions inside `with tracer.start_as_current_span(...)` are properly propagated and never replaced.
- Verified all 35 tests in `opentelemetry-sdk/tests/trace/test_span_processor.py` pass.
- Verified `ruff check` passes with 0 errors.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated