### PR TITLE
Warn on conflicting metric identities between views matching the same instrument

### DIFF
--- a/.changelog/5630.fixed
+++ b/.changelog/5630.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: warn when views matching the same instrument produce conflicting metric identities; drop-aggregation views are no longer reported as conflicting

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/_view_instrument_match.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/_view_instrument_match.py
@@ -15,6 +15,7 @@ from opentelemetry.sdk.metrics._internal.aggregation import (
     AggregationTemporality,
     DefaultAggregation,
     _Aggregation,
+    _DropAggregation,
     _SumAggregation,
 )
 from opentelemetry.sdk.metrics._internal.instrument import _Instrument
@@ -97,6 +98,10 @@ class _ViewInstrumentMatch:
 
     def conflicts(self, other: "_ViewInstrumentMatch") -> bool:
         # pylint: disable=protected-access
+
+        # Dropped streams are never exported, so they cannot conflict.
+        if isinstance(self._aggregation, _DropAggregation) or isinstance(other._aggregation, _DropAggregation):
+            return False
 
         result = (
             self._name == other._name

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/metric_reader_storage.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/metric_reader_storage.py
@@ -224,7 +224,14 @@ class MetricReaderStorage:
                 instrument_class_aggregation=(self._instrument_class_aggregation),
             )
 
-            for existing_view_instrument_matches in self._instrument_view_instrument_matches.values():
+            # view_instrument_matches is included because matches for this
+            # instrument are only added to the dict after every view has been
+            # processed; without it, conflicts between views matching the same
+            # instrument would go unreported.
+            for existing_view_instrument_matches in (
+                *self._instrument_view_instrument_matches.values(),
+                view_instrument_matches,
+            ):
                 for existing_view_instrument_match in existing_view_instrument_matches:
                     if existing_view_instrument_match.conflicts(new_view_instrument_match):
                         _logger.warning(

--- a/opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py
+++ b/opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py
@@ -71,7 +71,8 @@ class TestMetricReaderStorage(ConcurrencyTestBase):
 
         # instrument1 matches view1 and view2, so should create two
         # ViewInstrumentMatch objects
-        storage.consume_measurement(Measurement(1, time_ns(), instrument1, Context()))
+        with self.assertLogs(level=WARNING):
+            storage.consume_measurement(Measurement(1, time_ns(), instrument1, Context()))
         self.assertEqual(
             len(MockViewInstrumentMatch.call_args_list),
             2,
@@ -117,7 +118,8 @@ class TestMetricReaderStorage(ConcurrencyTestBase):
         # Measurements from an instrument should be passed on to each
         # ViewInstrumentMatch objects created for that instrument
         measurement = Measurement(1, time_ns(), instrument1, Context())
-        storage.consume_measurement(measurement)
+        with self.assertLogs(level=WARNING):
+            storage.consume_measurement(measurement)
         view_instrument_match1.consume_measurement.assert_called_once_with(measurement, True)
         view_instrument_match2.consume_measurement.assert_called_once_with(measurement, True)
         view_instrument_match3.consume_measurement.assert_not_called()
@@ -721,3 +723,97 @@ class TestMetricReaderStorage(ConcurrencyTestBase):
             "will cause conflicting metrics",
             log.records[0].message,
         )
+
+    def test_view_instrument_match_conflict_9(self):
+        # There is a conflict between two views matching the same instrument
+        # and producing the same metric stream identity.
+
+        observable_counter = _ObservableCounter(
+            "observable_counter",
+            Mock(),
+            [Mock()],
+            unit="unit",
+            description="description",
+        )
+        metric_reader_storage = MetricReaderStorage(
+            SdkConfiguration(
+                exemplar_filter=Mock(),
+                resource=Mock(),
+                views=(
+                    View(
+                        instrument_name="observable_counter",
+                        attribute_keys={"a"},
+                    ),
+                    View(
+                        instrument_name="observable_counter",
+                        attribute_keys={"b"},
+                    ),
+                ),
+            ),
+            MagicMock(**{"__getitem__.return_value": AggregationTemporality.CUMULATIVE}),
+            MagicMock(**{"__getitem__.return_value": DefaultAggregation()}),
+        )
+
+        with self.assertLogs(level=WARNING) as log:
+            metric_reader_storage.consume_measurement(Measurement(1, time_ns(), observable_counter, Context()))
+
+        self.assertIn(
+            "will cause conflicting metrics",
+            log.records[0].message,
+        )
+
+    def test_view_instrument_match_conflict_10(self):
+        # There is no conflict between two views matching the same instrument
+        # because they produce different metric stream names.
+
+        observable_counter = _ObservableCounter(
+            "observable_counter",
+            Mock(),
+            [Mock()],
+            unit="unit",
+            description="description",
+        )
+        metric_reader_storage = MetricReaderStorage(
+            SdkConfiguration(
+                exemplar_filter=Mock(),
+                resource=Mock(),
+                views=(
+                    View(instrument_name="observable_counter", name="foo"),
+                    View(instrument_name="observable_counter", name="bar"),
+                ),
+            ),
+            MagicMock(**{"__getitem__.return_value": AggregationTemporality.CUMULATIVE}),
+            MagicMock(**{"__getitem__.return_value": DefaultAggregation()}),
+        )
+
+        with self.assertRaises(AssertionError):
+            with self.assertLogs(level=WARNING):
+                metric_reader_storage.consume_measurement(Measurement(1, time_ns(), observable_counter, Context()))
+
+    def test_view_instrument_match_conflict_11(self):
+        # There is no conflict between two drop views matching the same
+        # instrument because dropped streams are never exported.
+
+        observable_counter = _ObservableCounter(
+            "observable_counter",
+            Mock(),
+            [Mock()],
+            unit="unit",
+            description="description",
+        )
+        metric_reader_storage = MetricReaderStorage(
+            SdkConfiguration(
+                exemplar_filter=Mock(),
+                resource=Mock(),
+                views=(
+                    View(instrument_name="observable_*", aggregation=DropAggregation()),
+                    View(instrument_name="*", aggregation=DropAggregation()),
+                ),
+            ),
+            MagicMock(**{"__getitem__.return_value": AggregationTemporality.CUMULATIVE}),
+            MagicMock(**{"__getitem__.return_value": DefaultAggregation()}),
+        )
+
+        with self.assertRaises(AssertionError):
+            with self.assertLogs(level=WARNING):
+                metric_reader_storage.consume_measurement(Measurement(1, time_ns(), observable_counter, Context()))


### PR DESCRIPTION
# Description

Fixes #5627

`MetricReaderStorage._handle_view_instrument_match` warns when a new
`_ViewInstrumentMatch` conflicts with an existing one ("Views ... will cause
conflicting metrics identities"), but the check only scans
`self._instrument_view_instrument_matches.values()` — the matches of
*previously registered* instruments. The list being built for the *current*
instrument is written to that dict only after every view has been processed,
so two views matching the **same** instrument with identical stream identities
were never compared: both streams were exported under the same name in one
payload and nothing was logged.

```python
reader = InMemoryMetricReader()
mp = MeterProvider(
    metric_readers=[reader],
    views=[
        View(instrument_name="requests", attribute_keys={"path"}),
        View(instrument_name="requests", attribute_keys={"method"}),
    ],
)
mp.get_meter("m").create_counter("requests").add(1, {"path": "/a", "method": "GET"})

md = reader.get_metrics_data()
print([m.name for m in md.resource_metrics[0].scope_metrics[0].metrics])
# ['requests', 'requests'] — duplicate identity, no warning
```

The spec requires the warning
([sdk.md#view](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view)):

> If applying the View results in conflicting metric identities the
> implementation SHOULD apply the View and emit a warning.

The same conflict split across two instruments (`View(instrument_name="c1",
name="foo")` + `View(instrument_name="c2", name="foo")`) already warned, so
only the same-instrument path was affected.

This PR includes the in-progress match list in the conflict scan. It also
excludes drop-aggregation matches from `conflicts()`: dropped streams are never
exported (`collect()` skips `_DropAggregation`), so layered drop views such as
`View("http.client.*", aggregation=DropAggregation())` +
`View("*", aggregation=DropAggregation())` must not trigger the warning.

Out of scope, tracked in #5629: the `_DEFAULT_VIEW` fallback path still
appends its match without a conflict check, so a view-renamed stream colliding
with a default-view stream is only reported in one registration order.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- New `test_view_instrument_match_conflict_9`: two views on the same
  instrument with identical identity → warning (fails without the fix with
  `no logs of level WARNING`).
- New `test_view_instrument_match_conflict_10`: two views on the same
  instrument with different names → no warning.
- New `test_view_instrument_match_conflict_11`: two overlapping drop views on
  the same instrument → no warning.
- `test_creates_view_instrument_matches` and
  `test_forwards_calls_to_view_instrument_match` now assert the warning that
  their mocked `conflicts()` (a truthy `Mock`) triggers on the first
  measurement, matching how they already handled the cross-instrument case.
- `opentelemetry-sdk/tests/metrics/` — 334 passed, 1 skipped.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
