### PR TITLE
fix(sdk): raise error when named view specifies no instrument name (#2815)

### DIFF
--- a/.changelog/5631.fixed
+++ b/.changelog/5631.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: raise an error when a named `View` is defined without specifying `instrument_name`.

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/view.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/view.py
@@ -68,6 +68,8 @@ class View:
 
         name: This is a metric stream customizing attribute: the name of the
             metric stream. If `None`, the name of the instrument will be used.
+            When `name` is specified, `instrument_name` must also be specified
+            and cannot contain wildcard characters.
 
         description: This is a metric stream customizing attribute: the
             description of the metric stream. If `None`, the description of the instrument will
@@ -119,9 +121,15 @@ class View:
             # pylint: disable=broad-exception-raised
             raise Exception(f"Some instrument selection criteria must be provided for View {name}")
 
-        if name is not None and instrument_name is not None and ("*" in instrument_name or "?" in instrument_name):
-            # pylint: disable=broad-exception-raised
-            raise Exception(f"View {name} declared with wildcard characters in instrument_name")
+        if name is not None:
+            if instrument_name is None:
+                # pylint: disable=broad-exception-raised
+                raise Exception(
+                    f"View {name} specifies a name but no instrument_name, which may select multiple instruments"
+                )
+            if "*" in instrument_name or "?" in instrument_name:
+                # pylint: disable=broad-exception-raised
+                raise Exception(f"View {name} declared with wildcard characters in instrument_name")
 
         # _name, _description, _aggregation, _exemplar_reservoir_factory and
         # _attribute_keys will be accessed when instantiating a _ViewInstrumentMatch.

--- a/opentelemetry-sdk/tests/metrics/test_view.py
+++ b/opentelemetry-sdk/tests/metrics/test_view.py
@@ -6,6 +6,7 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
+from opentelemetry.sdk.metrics import Counter, MeterProvider
 from opentelemetry.sdk.metrics.view import View
 
 
@@ -107,3 +108,114 @@ class TestView(TestCase):
     def test_view_name(self):
         with self.assertRaises(Exception):
             View(name="name", instrument_name="instrument_name*")
+
+    def test_view_name_wildcard(self):
+        with self.assertRaisesRegex(
+            Exception,
+            r"View name declared with wildcard characters in instrument_name",
+        ):
+            View(name="name", instrument_name="instrument_name*")
+
+        with self.assertRaisesRegex(
+            Exception,
+            r"View name declared with wildcard characters in instrument_name",
+        ):
+            View(name="name", instrument_name="*")
+
+        with self.assertRaisesRegex(
+            Exception,
+            r"View name declared with wildcard characters in instrument_name",
+        ):
+            View(name="name", instrument_name="instrument?name")
+
+    def test_view_name_without_instrument_name(self):
+        with self.assertRaisesRegex(
+            Exception,
+            r"View custom_name specifies a name but no instrument_name, which may select multiple instruments",
+        ):
+            View(name="custom_name", instrument_type=Mock)
+
+        with self.assertRaisesRegex(
+            Exception,
+            r"View custom_name specifies a name but no instrument_name, which may select multiple instruments",
+        ):
+            View(name="custom_name", meter_name="some_meter")
+
+        with self.assertRaisesRegex(
+            Exception,
+            r"View custom_name specifies a name but no instrument_name, which may select multiple instruments",
+        ):
+            View(name="custom_name", instrument_unit="ms")
+
+        with self.assertRaisesRegex(
+            Exception,
+            r"View custom_name specifies a name but no instrument_name, which may select multiple instruments",
+        ):
+            View(name="custom_name", meter_version="1.0.0")
+
+        with self.assertRaisesRegex(
+            Exception,
+            r"View custom_name specifies a name but no instrument_name, which may select multiple instruments",
+        ):
+            View(name="custom_name", meter_schema_url="https://opentelemetry.io/schemas/1.4.0")
+
+        with self.assertRaisesRegex(
+            Exception,
+            r"View name specifies a name but no instrument_name, which may select multiple instruments",
+        ):
+            View(name="name", instrument_type=Counter)
+
+        with self.assertRaisesRegex(
+            Exception,
+            r"View custom_name specifies a name but no instrument_name, which may select multiple instruments",
+        ):
+            View(
+                name="custom_name",
+                instrument_type=Counter,
+                meter_name="some_meter",
+                instrument_unit="ms",
+            )
+
+        with self.assertRaisesRegex(
+            Exception,
+            r"View name specifies a name but no instrument_name, which may select multiple instruments",
+        ):
+            MeterProvider(views=[View(name="name", instrument_type=Counter)])
+
+    def test_unnamed_view_without_instrument_name(self):
+        view = View(instrument_type=Counter)
+        self.assertIsNone(view._name)
+        self.assertIs(view._instrument_type, Counter)
+        self.assertIsNone(view._instrument_name)
+
+        meter_provider = MeterProvider(views=[view])
+        self.assertIsNotNone(meter_provider)
+
+    def test_view_name_with_concrete_instrument_name(self):
+        mock_instrument = Mock()
+        mock_instrument.configure_mock(name="my_counter")
+
+        view = View(name="custom_name", instrument_name="my_counter")
+        self.assertEqual(view._name, "custom_name")
+        self.assertEqual(view._instrument_name, "my_counter")
+        self.assertTrue(view._match(mock_instrument))
+
+        other_instrument = Mock()
+        other_instrument.configure_mock(name="other_counter")
+        self.assertFalse(view._match(other_instrument))
+
+        view_with_type = View(
+            name="custom_name",
+            instrument_name="my_counter",
+            instrument_type=Mock,
+        )
+        self.assertTrue(view_with_type._match(mock_instrument))
+
+        view_with_counter = View(
+            name="custom_name",
+            instrument_name="my_counter",
+            instrument_type=Counter,
+        )
+        self.assertEqual(view_with_counter._name, "custom_name")
+        self.assertEqual(view_with_counter._instrument_name, "my_counter")
+        self.assertIs(view_with_counter._instrument_type, Counter)


### PR DESCRIPTION
# Description

According to the [OpenTelemetry Metrics SDK Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view):
> In order to avoid conflicts, views which specify a name SHOULD have an instrument selector that selects at most one instrument. For the registration mechanism described above, where selection is provided via configuration, the SDK SHOULD NOT allow Views with a specified name to be declared with instrument selectors that may select more than one instrument (e.g. wild card instrument name) in the same Meter.

Previously, `View` validation checked for wildcard characters in `instrument_name` only when `instrument_name is not None`. However, omitting `instrument_name` while specifying `name` (e.g. `View(name="custom_name", instrument_type=Counter)`) implicitly selects all instruments matching that type or meter criteria, which may select multiple instruments in the same Meter.

This PR adds a check in `View.__init__` that raises an `Exception` when `name` is specified but `instrument_name` is omitted (`None`), ensuring consistency with the specification and wildcard validation.

Fixes #2815

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Added unit tests in `opentelemetry-sdk/tests/metrics/test_view.py`:
  - `test_view_name_wildcard`: asserts wildcard characters (`*`, `?`) in named views continue to raise `Exception`.
  - `test_view_name_without_instrument_name`: asserts defining a named View without `instrument_name` (e.g., with `instrument_type`, `meter_name`, `instrument_unit`, `meter_version`, `meter_schema_url`) raises `Exception`.
  - `test_view_name_with_concrete_instrument_name`: asserts that named views with concrete `instrument_name` work as expected.
- Verified test suite:
  - `pytest opentelemetry-sdk/tests/metrics/test_view.py opentelemetry-sdk/tests/metrics/test_view_instrument_match.py opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py` (47/47 passing).
  - `ruff check` and `ruff format --check` passed cleanly.

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
