### PR TITLE
fix(sdk): check default-view fallback stream for conflicting metric identities

### DIFF
--- a/.changelog/5632.fixed
+++ b/.changelog/5632.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: check default-view fallback stream for conflicting metric identities to ensure order-independent warnings

--- a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/metric_reader_storage.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/metric_reader_storage.py
@@ -80,13 +80,13 @@ class MetricReaderStorage:
 
             # if no view targeted the instrument, use the default
             if not view_instrument_matches:
-                view_instrument_matches.append(
-                    _ViewInstrumentMatch(
-                        view=_DEFAULT_VIEW,
-                        instrument=instrument,
-                        instrument_class_aggregation=(self._instrument_class_aggregation),
-                    )
+                default_view_instrument_match = _ViewInstrumentMatch(
+                    view=_DEFAULT_VIEW,
+                    instrument=instrument,
+                    instrument_class_aggregation=(self._instrument_class_aggregation),
                 )
+                self._check_conflicts_and_add_match(default_view_instrument_match, view_instrument_matches)
+
             self._instrument_view_instrument_matches[instrument] = view_instrument_matches
 
             return view_instrument_matches
@@ -224,16 +224,23 @@ class MetricReaderStorage:
                 instrument_class_aggregation=(self._instrument_class_aggregation),
             )
 
-            for existing_view_instrument_matches in self._instrument_view_instrument_matches.values():
-                for existing_view_instrument_match in existing_view_instrument_matches:
-                    if existing_view_instrument_match.conflicts(new_view_instrument_match):
-                        _logger.warning(
-                            "Views %s and %s will cause conflicting metrics identities",
-                            existing_view_instrument_match._view,
-                            new_view_instrument_match._view,
-                        )
+            self._check_conflicts_and_add_match(new_view_instrument_match, view_instrument_matches)
 
-            view_instrument_matches.append(new_view_instrument_match)
+    def _check_conflicts_and_add_match(
+        self,
+        new_view_instrument_match: "_ViewInstrumentMatch",
+        view_instrument_matches: list["_ViewInstrumentMatch"],
+    ) -> None:
+        for existing_view_instrument_matches in self._instrument_view_instrument_matches.values():
+            for existing_view_instrument_match in existing_view_instrument_matches:
+                if existing_view_instrument_match.conflicts(new_view_instrument_match):
+                    _logger.warning(
+                        "Views %s and %s will cause conflicting metrics identities",
+                        existing_view_instrument_match._view,
+                        new_view_instrument_match._view,
+                    )
+
+        view_instrument_matches.append(new_view_instrument_match)
 
     @staticmethod
     def _check_view_instrument_compatibility(view: View, instrument: _Instrument) -> bool:

--- a/opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py
+++ b/opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py
@@ -246,7 +246,8 @@ class TestMetricReaderStorage(ConcurrencyTestBase):
         self.assertEqual(len(MockViewInstrumentMatch.call_args_list), 1)
 
         MockViewInstrumentMatch.call_args_list.clear()
-        storage.consume_measurement(Measurement(1, time_ns(), instrument2, Context()))
+        with self.assertLogs(level=WARNING):
+            storage.consume_measurement(Measurement(1, time_ns(), instrument2, Context()))
         self.assertEqual(len(MockViewInstrumentMatch.call_args_list), 1)
 
     def test_drop_aggregation(self):
@@ -721,3 +722,64 @@ class TestMetricReaderStorage(ConcurrencyTestBase):
             "will cause conflicting metrics",
             log.records[0].message,
         )
+
+    def test_view_instrument_match_conflict_default_view_order_independence(self):
+        # A conflict between a view-renamed instrument and a default-view
+        # fallback instrument is reported regardless of arrival order.
+
+        observable_counter_bar = _ObservableCounter(
+            "bar",
+            Mock(),
+            [Mock()],
+            unit="unit",
+            description="description",
+        )
+        observable_counter_foo = _ObservableCounter(
+            "foo",
+            Mock(),
+            [Mock()],
+            unit="unit",
+            description="description",
+        )
+
+        def make_storage():
+            return MetricReaderStorage(
+                SdkConfiguration(
+                    exemplar_filter=Mock(),
+                    resource=Mock(),
+                    views=(
+                        View(instrument_name="bar", name="foo"),
+                    ),
+                ),
+                MagicMock(**{"__getitem__.return_value": AggregationTemporality.CUMULATIVE}),
+                MagicMock(**{"__getitem__.return_value": DefaultAggregation()}),
+            )
+
+        # Order 1: default-view instrument arrives first, view-renamed arrives second
+        storage_1 = make_storage()
+        with self.assertRaises(AssertionError):
+            with self.assertLogs(level=WARNING):
+                storage_1.consume_measurement(Measurement(1, time_ns(), observable_counter_foo, Context()))
+
+        with self.assertLogs(level=WARNING) as log_1:
+            storage_1.consume_measurement(Measurement(1, time_ns(), observable_counter_bar, Context()))
+
+        self.assertIn(
+            "will cause conflicting metrics",
+            log_1.records[0].message,
+        )
+
+        # Order 2: view-renamed arrives first, default-view instrument arrives second
+        storage_2 = make_storage()
+        with self.assertRaises(AssertionError):
+            with self.assertLogs(level=WARNING):
+                storage_2.consume_measurement(Measurement(1, time_ns(), observable_counter_bar, Context()))
+
+        with self.assertLogs(level=WARNING) as log_2:
+            storage_2.consume_measurement(Measurement(1, time_ns(), observable_counter_foo, Context()))
+
+        self.assertIn(
+            "will cause conflicting metrics",
+            log_2.records[0].message,
+        )
+


### PR DESCRIPTION
# Description

Fixes #5629

`MetricReaderStorage` creates metric streams for instruments either via matching user-configured views in `_handle_view_instrument_match` or via the `_DEFAULT_VIEW` fallback in `_get_or_init_view_instrument_match` when no view matches the instrument.

Previously, only `_handle_view_instrument_match` executed conflict scanning against existing matches. As a result, when an explicit view renamed an instrument to collide with an instrument taking the fallback path, the duplicate identity warning ("Views ... will cause conflicting metrics identities") was emitted only if the renamed instrument recorded second. If the renamed instrument recorded first, the fallback stream was appended without a conflict check, and two streams with identical identity were exported without warning.

Per the OpenTelemetry specification (https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view):
> If applying the View results in conflicting metric identities the implementation SHOULD apply the View and emit a warning.

This change extracts `_check_conflicts_and_add_match` to ensure both stream-creation paths (matching views and the `_DEFAULT_VIEW` fallback) perform conflict scanning against existing matches before appending, guaranteeing consistent, order-independent warning behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Added `test_view_instrument_match_conflict_default_view_order_independence` testing both arrival orders (default view first vs renamed view first). Both orders reliably emit the warning.
- Updated `test_default_view_enabled` to assert the conflict warning emitted when a second instrument with a mocked match is recorded.
- Ran full test suite in `opentelemetry-sdk/tests/metrics/test_metric_reader_storage.py` (18/18 passed).
- Linted with `ruff check` (clean).

# Does This PR Require a Contrib Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated