### PR TITLE
DOC(exporter-otlp-proto-http): clarify endpoint= kwarg requires full signal path

### DIFF
--- a/.changelog/5633.changed
+++ b/.changelog/5633.changed
@@ -1,0 +1,1 @@
+`opentelemetry-exporter-otlp-proto-http`: clarify that the `endpoint=` kwarg requires the full signal path

--- a/exporter/opentelemetry-exporter-otlp-json-http/src/opentelemetry/exporter/otlp/json/http/_log_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-json-http/src/opentelemetry/exporter/otlp/json/http/_log_exporter.py
@@ -81,6 +81,13 @@ class OTLPLogExporter(LogRecordExporter):
         *,
         _transport: BaseHTTPTransport | None = None,
     ) -> None:
+        """OTLP HTTP JSON log exporter.
+
+        Args:
+            endpoint: Full URL of the OTLP/HTTP signal endpoint, including the signal
+                path. Example: ``http://collector:4318/v1/logs``. For a base URL without a
+                signal path, set the ``OTEL_EXPORTER_OTLP_ENDPOINT`` environment variable.
+        """
         transport = _transport or _build_transport(
             certificate_file,
             client_key_file,

--- a/exporter/opentelemetry-exporter-otlp-json-http/src/opentelemetry/exporter/otlp/json/http/metric_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-json-http/src/opentelemetry/exporter/otlp/json/http/metric_exporter.py
@@ -95,6 +95,13 @@ class OTLPMetricExporter(MetricExporter):
         *,
         _transport: BaseHTTPTransport | None = None,
     ) -> None:
+        """OTLP HTTP JSON metric exporter.
+
+        Args:
+            endpoint: Full URL of the OTLP/HTTP signal endpoint, including the signal
+                path. Example: ``http://collector:4318/v1/metrics``. For a base URL without a
+                signal path, set the ``OTEL_EXPORTER_OTLP_ENDPOINT`` environment variable.
+        """
         MetricExporter.__init__(
             self,
             preferred_temporality=_get_temporality(preferred_temporality),

--- a/exporter/opentelemetry-exporter-otlp-json-http/src/opentelemetry/exporter/otlp/json/http/trace_exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-json-http/src/opentelemetry/exporter/otlp/json/http/trace_exporter.py
@@ -76,6 +76,13 @@ class OTLPSpanExporter(SpanExporter):
         *,
         _transport: BaseHTTPTransport | None = None,
     ) -> None:
+        """OTLP HTTP JSON span exporter.
+
+        Args:
+            endpoint: Full URL of the OTLP/HTTP signal endpoint, including the signal
+                path. Example: ``http://collector:4318/v1/traces``. For a base URL without a
+                signal path, set the ``OTEL_EXPORTER_OTLP_ENDPOINT`` environment variable.
+        """
         transport = _transport or _build_transport(
             certificate_file,
             client_key_file,

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py
@@ -120,7 +120,9 @@ class OTLPLogExporter(LogRecordExporter):
         """OTLP HTTP log exporter.
 
         Args:
-            endpoint: Target URL to which the exporter is going to send logs.
+            endpoint: Full URL of the OTLP/HTTP signal endpoint, including the signal
+                path. Example: ``http://collector:4318/v1/logs``. For a base URL without a
+                signal path, set the ``OTEL_EXPORTER_OTLP_ENDPOINT`` environment variable.
             certificate_file: Path to the CA certificate file for TLS.
             client_key_file: Path to the client key file for mTLS.
             client_certificate_file: Path to the client certificate file for mTLS.

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py
@@ -164,7 +164,9 @@ class OTLPMetricExporter(MetricExporter):
         """OTLP HTTP metrics exporter
 
         Args:
-            endpoint: Target URL to which the exporter is going to send metrics
+            endpoint: Full URL of the OTLP/HTTP signal endpoint, including the signal
+                path. Example: ``http://collector:4318/v1/metrics``. For a base URL without a
+                signal path, set the ``OTEL_EXPORTER_OTLP_ENDPOINT`` environment variable.
             certificate_file: Path to the certificate file to use for any TLS
             client_key_file: Path to the client key file to use for any TLS
             client_certificate_file: Path to the client certificate file to use for any TLS

--- a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py
@@ -116,7 +116,9 @@ class OTLPSpanExporter(SpanExporter):
         """OTLP HTTP span exporter.
 
         Args:
-            endpoint: Target URL to which the exporter is going to send spans.
+            endpoint: Full URL of the OTLP/HTTP signal endpoint, including the signal
+                path. Example: ``http://collector:4318/v1/traces``. For a base URL without a
+                signal path, set the ``OTEL_EXPORTER_OTLP_ENDPOINT`` environment variable.
             certificate_file: Path to the CA certificate file for TLS.
             client_key_file: Path to the client key file for mTLS.
             client_certificate_file: Path to the client certificate file for mTLS.


### PR DESCRIPTION
Closes #5628.

The `endpoint=` kwarg is used verbatim, but the env-var path appends
the signal path in `_resolve_endpoint`. The previous docstring
("Target URL to which the exporter is going to send ...") didn't
distinguish the two, so users passing a base URL got a permanent 404
at the collector with no hint why.

State the full signal path requirement on the kwarg and point at
`OTEL_EXPORTER_OTLP_ENDPOINT` for the base-URL case. Behavior unchanged.

Scope: the three HTTP exporters (trace, metric, log). The gRPC
exporters route by service, not path, so they were left alone.