### PR TITLE
Fail any test that leaks a PeriodicExportingMetricReader ticker thread, and fix the four that do

### DIFF
--- a/.changelog/5641.fixed
+++ b/.changelog/5641.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: fail any test that leaves a `PeriodicExportingMetricReader` ticker thread running, and shut down the four readers that were leaking one into the rest of the test session

--- a/opentelemetry-sdk/tests/conftest.py
+++ b/opentelemetry-sdk/tests/conftest.py
@@ -2,11 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import random
+from collections.abc import Iterator
 from os import environ
+from threading import Thread
+from threading import enumerate as enumerate_threads
+from time import monotonic, sleep
 
 import pytest
 
 from opentelemetry.environment_variables import OTEL_PYTHON_CONTEXT
+
+# PeriodicExportingMetricReader names its ticker thread this. The name is
+# hardcoded, so every instance shares it.
+METRIC_READER_THREAD_NAME = "OtelPeriodicExportingMetricReader"
+
+# shutdown() joins the ticker with a timeout, so a thread that is on its way
+# out can still be alive for a moment after the test body returns. Wait this
+# long before calling it a leak. Only a test that actually leaks pays the cost.
+_LEAK_GRACE_PERIOD_SECONDS = 2.0
+_LEAK_POLL_INTERVAL_SECONDS = 0.05
 
 
 def pytest_sessionstart(session):
@@ -23,3 +37,39 @@ def pytest_sessionfinish(session):
 def random_seed():
     # We use random numbers a lot in sampling tests, make sure they are always the same.
     random.seed(0)
+
+
+def live_metric_reader_threads() -> set[Thread]:
+    return {thread for thread in enumerate_threads() if thread.name == METRIC_READER_THREAD_NAME}
+
+
+@pytest.fixture(autouse=True)
+def no_leaked_metric_reader_threads(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Fail a test that leaves a PeriodicExportingMetricReader ticker thread running.
+
+    The ticker is a daemon thread, so nothing reaps it between tests. A leaked
+    one keeps waking up and calling collect() for the rest of the session,
+    inside unrelated tests. That has produced cross-test failures before, see
+    issue #5157.
+
+    Only threads that appear during this test are reported, so one leak fails
+    the test that caused it rather than every test that runs after it.
+    """
+    before = live_metric_reader_threads()
+
+    yield
+
+    leaked = live_metric_reader_threads() - before
+    deadline = monotonic() + _LEAK_GRACE_PERIOD_SECONDS
+    while leaked and monotonic() < deadline:
+        sleep(_LEAK_POLL_INTERVAL_SECONDS)
+        leaked = live_metric_reader_threads() - before
+
+    if leaked:
+        pytest.fail(
+            f"{request.node.nodeid} left {len(leaked)} {METRIC_READER_THREAD_NAME} "
+            "thread(s) running. A leaked ticker thread calls collect() during "
+            "later tests and can fail them (see issue #5157). Shut the reader "
+            "down, or its MeterProvider, from a finally block or addCleanup so "
+            "it happens even when the test fails."
+        )

--- a/opentelemetry-sdk/tests/metrics/integration_test/test_exporter_concurrency.py
+++ b/opentelemetry-sdk/tests/metrics/integration_test/test_exporter_concurrency.py
@@ -79,6 +79,7 @@ class TestExporterConcurrency(ConcurrencyTestBase):
             export_interval_millis=100_000,
         )
         meter_provider = MeterProvider(metric_readers=[reader])
+        self.addCleanup(meter_provider.shutdown)
 
         counter_cb_counter = 0
 

--- a/opentelemetry-sdk/tests/metrics/test_metrics.py
+++ b/opentelemetry-sdk/tests/metrics/test_metrics.py
@@ -101,7 +101,9 @@ class TestMeterProvider(ConcurrencyTestBase, TestCase):
         mock_exporter._preferred_temporality = None
         mock_exporter._preferred_aggregation = None
         metric_reader_0 = PeriodicExportingMetricReader(mock_exporter)
+        self.addCleanup(metric_reader_0.shutdown)
         metric_reader_1 = PeriodicExportingMetricReader(mock_exporter)
+        self.addCleanup(metric_reader_1.shutdown)
 
         with self.assertNotRaises(Exception):
             MeterProvider(metric_readers=(metric_reader_0,))

--- a/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
+++ b/opentelemetry-sdk/tests/metrics/test_periodic_exporting_metric_reader.py
@@ -245,6 +245,7 @@ class TestPeriodicExportingMetricReader(ConcurrencyTestBase):
             },
         )
         pmr = PeriodicExportingMetricReader(exporter)
+        self.addCleanup(pmr.shutdown)
         for key, value in pmr._instrument_class_temporality.items():
             if key is not _Counter:
                 self.assertEqual(value, AggregationTemporality.CUMULATIVE)
@@ -258,6 +259,7 @@ class TestPeriodicExportingMetricReader(ConcurrencyTestBase):
             },
         )
         pmr = PeriodicExportingMetricReader(exporter)
+        self.addCleanup(pmr.shutdown)
         for key, value in pmr._instrument_class_aggregation.items():
             if key is not _Counter:
                 self.assertTrue(isinstance(value, DefaultAggregation))


### PR DESCRIPTION
# Description

Fixes #5640

`PeriodicExportingMetricReader` starts a **daemon** ticker thread in its constructor, and nothing reaps a daemon thread between tests. A reader that is never shut down leaves that thread waking on its own clock for the rest of the session, calling `collect()` inside unrelated tests. With the default 60 second interval its first tick lands long after the guilty test has passed, so the guilty test is green and the damage shows up somewhere else, naming the victim rather than the cause.

There was no check for this. This PR adds one, and fixes the four leaks that exist today so it can land on a clean suite.

### Commits

Each commit touches exactly one file.

1. **`test_exporter_not_called_concurrently`** registers a reader on a `MeterProvider` and never shuts either down. This is the most consequential of the four: the provider holds an observable counter, so every later tick runs the callback and feeds a measurement back into the storage.
2. **`test_register_metric_readers`** builds two readers to check that one cannot be registered on two providers, and shuts down neither. Two leaked threads.
3. **The two exporter preference tests** each build a reader purely to read its preference mapping. These readers are never registered on a provider, so their ticks return early at the `self._collect is None` guard and cannot corrupt another test's state, but each still burns a thread and logs a warning every interval into whatever test is running.
4. **The detector**, an autouse fixture in `opentelemetry-sdk/tests/conftest.py`.

All four fixes use `addCleanup` so the shutdown happens even when the test body fails.

### How the detector works

It snapshots the live threads named `OtelPeriodicExportingMetricReader` before the test and fails if a **new** one is still alive afterwards.

Diffing against a before-snapshot is the important part. It attributes a leak to the test that caused it, and it stops one leak from cascading into a failure in every test that runs after it.

There is a short grace period before it gives up, because `shutdown()` joins the ticker with a timeout and a thread on its way out can still be alive when the test body returns. Only a test that actually leaks pays that cost.

### Testing

- `pytest opentelemetry-sdk/tests` before the fixes, with the detector in place: **4 errors**, naming exactly the four tests above.
- `pytest opentelemetry-sdk/tests` after: **888 passed**, 47 subtests passed, 0 errors.
- `ruff format --check` and `ruff check` clean on all four changed files with the pinned `ruff==0.16.1`.

I also checked that the detector fires and does not cascade, using a scratch module with two tests: one that builds a reader and drops it, one that builds a reader and shuts it down. Result was `2 passed, 1 error`, the error naming only the leaking test. The well-behaved test ran afterwards and passed, confirming the before-snapshot prevents the cascade.

### Scope and overlap

Test-only. No production code touched.

Commit 3 overlaps with #5622, which fixes the same two preference tests with `try/finally` rather than `addCleanup`. Happy to drop that commit if #5622 lands first, though the detector needs those two fixed one way or the other to stay green.

### Relationship to #5157

I want to be careful not to overclaim. I have **not** proven that any of these four leaks produced the traceback in #5157; the CI logs from that run have expired, and the surviving excerpt does not pin it down. What this gives is a mechanical guard, so that if it recurs the leaking test fails by name instead of the symptom surfacing three files later.

The other half of #5157, the tests asserting on process-global mock state, is #5638 and #5639.
