### PR TITLE
fix(sdk): add validation for export_timeout_millis <= 0 in BatchSpanP…

### DIFF
--- a/.changelog/5648.fixed
+++ b/.changelog/5648.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-sdk`: add validation for export_timeout_millis <= 0 in BatchSpanProcessor

--- a/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py
@@ -283,7 +283,12 @@ class BatchLogRecordProcessor(LogRecordProcessor):
         if export_timeout_millis is None:
             export_timeout_millis = BatchLogRecordProcessor._default_export_timeout_millis()
 
-        BatchLogRecordProcessor._validate_arguments(max_queue_size, schedule_delay_millis, max_export_batch_size)
+        BatchLogRecordProcessor._validate_arguments(
+            max_queue_size,
+            schedule_delay_millis,
+            max_export_batch_size,
+            export_timeout_millis,
+        )
         # Initializes BatchProcessor
         self._batch_processor = BatchProcessor(
             exporter,
@@ -378,7 +383,12 @@ class BatchLogRecordProcessor(LogRecordProcessor):
             return _DEFAULT_EXPORT_TIMEOUT_MILLIS
 
     @staticmethod
-    def _validate_arguments(max_queue_size, schedule_delay_millis, max_export_batch_size):
+    def _validate_arguments(
+        max_queue_size,
+        schedule_delay_millis,
+        max_export_batch_size,
+        export_timeout_millis=None,
+    ):
         if max_queue_size <= 0:
             raise ValueError("max_queue_size must be a positive integer.")
 
@@ -390,3 +400,6 @@ class BatchLogRecordProcessor(LogRecordProcessor):
 
         if max_export_batch_size > max_queue_size:
             raise ValueError("max_export_batch_size must be less than or equal to max_queue_size.")
+
+        if export_timeout_millis is not None and export_timeout_millis <= 0:
+            raise ValueError("export_timeout_millis must be positive.")

--- a/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
+++ b/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/__init__.py
@@ -180,7 +180,12 @@ class BatchSpanProcessor(SpanProcessor):
         if export_timeout_millis is None:
             export_timeout_millis = BatchSpanProcessor._default_export_timeout_millis()
 
-        BatchSpanProcessor._validate_arguments(max_queue_size, schedule_delay_millis, max_export_batch_size)
+        BatchSpanProcessor._validate_arguments(
+            max_queue_size,
+            schedule_delay_millis,
+            max_export_batch_size,
+            export_timeout_millis,
+        )
 
         self._batch_processor = BatchProcessor(
             span_exporter,
@@ -274,7 +279,12 @@ class BatchSpanProcessor(SpanProcessor):
             return _DEFAULT_EXPORT_TIMEOUT_MILLIS
 
     @staticmethod
-    def _validate_arguments(max_queue_size, schedule_delay_millis, max_export_batch_size):
+    def _validate_arguments(
+        max_queue_size,
+        schedule_delay_millis,
+        max_export_batch_size,
+        export_timeout_millis=None,
+    ):
         if max_queue_size <= 0:
             raise ValueError("max_queue_size must be a positive integer.")
 
@@ -286,6 +296,9 @@ class BatchSpanProcessor(SpanProcessor):
 
         if max_export_batch_size > max_queue_size:
             raise ValueError("max_export_batch_size must be less than or equal to max_queue_size.")
+
+        if export_timeout_millis is not None and export_timeout_millis <= 0:
+            raise ValueError("export_timeout_millis must be positive.")
 
 
 class ConsoleSpanExporter(SpanExporter):

--- a/opentelemetry-sdk/tests/logs/test_export.py
+++ b/opentelemetry-sdk/tests/logs/test_export.py
@@ -419,6 +419,16 @@ class TestSimpleLogRecordProcessor(unittest.TestCase):
 # before the end of the test, otherwise the worker thread will continue
 # to run after the end of the test.
 class TestBatchLogRecordProcessor(unittest.TestCase):
+    def test_invalid_export_timeout_millis(self):
+        with self.assertRaises(ValueError):
+            BatchLogRecordProcessor(
+                InMemoryLogRecordExporter(), export_timeout_millis=0
+            )
+        with self.assertRaises(ValueError):
+            BatchLogRecordProcessor(
+                InMemoryLogRecordExporter(), export_timeout_millis=-500
+            )
+
     def test_emit_call_log_record(self):
         exporter = InMemoryLogRecordExporter()
         log_record_processor = Mock(wraps=BatchLogRecordProcessor(exporter))

--- a/opentelemetry-sdk/tests/trace/export/test_export.py
+++ b/opentelemetry-sdk/tests/trace/export/test_export.py
@@ -241,6 +241,16 @@ class TestBatchSpanProcessor(unittest.TestCase):
         self.assertEqual(batch_span_processor._batch_processor._export_timeout_millis, 4)
         batch_span_processor.shutdown()
 
+    def test_invalid_export_timeout_millis(self):
+        with self.assertRaises(ValueError):
+            export.BatchSpanProcessor(
+                MySpanExporter(destination=[]), export_timeout_millis=0
+            )
+        with self.assertRaises(ValueError):
+            export.BatchSpanProcessor(
+                MySpanExporter(destination=[]), export_timeout_millis=-500
+            )
+
     def test_args_env_var_defaults(self):
         batch_span_processor = export.BatchSpanProcessor(MySpanExporter(destination=[]))
 


### PR DESCRIPTION
# Description

Fixes #5648

Currently, `BatchSpanProcessor` validates `max_queue_size`, `schedule_delay_millis`, and `max_export_batch_size` during initialization to ensure they are positive integers. However, `export_timeout_millis` was omitted from argument validation, allowing non-positive or negative values (`0` or negative integers) to be passed without error.

This PR adds validation for `export_timeout_millis` in `BatchSpanProcessor._validate_arguments()`, raising a `ValueError` if `export_timeout_millis <= 0`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit tests in `opentelemetry-sdk/tests/trace/export/test_export.py` (`test_invalid_export_timeout_millis`)

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated