### PR TITLE
fix(exporter): warn when OTLP gRPC endpoint includes a path

### DIFF
--- a/.changelog/3619.fixed
+++ b/.changelog/3619.fixed
@@ -1,0 +1,1 @@
+`opentelemetry-exporter-otlp-proto-grpc`: Add warning when endpoint path is silently dropped by gRPC exporter

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -298,6 +298,13 @@ class OTLPExporterMixin(ABC, Generic[SDKDataT, ExportServiceRequestT, ExportResu
 
         if parsed_url.netloc:
             self._endpoint = parsed_url.netloc
+            if parsed_url.path and parsed_url.path.strip("/"):
+                logger.warning(
+                    "Endpoint path '%s' will be ignored. gRPC exporter uses '%s' without path. "
+                    "If you intended to use HTTP, import from opentelemetry.exporter.otlp.proto.http instead.",
+                    parsed_url.path,
+                    self._endpoint,
+                )
 
         self._insecure = insecure
         self._credentials = credentials

--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
@@ -683,3 +683,35 @@ class TestOTLPExporterMixin(TestCase):
         self.assertTrue(attributes["otel.component.name"].startswith("otlp_grpc_span_exporter/"))
         self.assertEqual(attributes["server.address"], "localhost")
         self.assertEqual(attributes["server.port"], 4317)
+
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.logger.warning")
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.insecure_channel")
+    def test_endpoint_path_warning(self, mock_insecure, mock_warning):
+        """Test that a warning is logged when endpoint has a path that will be ignored"""
+        OTLPSpanExporterForTesting(endpoint="https://otlp.example.com:4317/v1/traces", insecure=True)
+        mock_warning.assert_called_once()
+        args = mock_warning.call_args[0]
+        self.assertIn("path", args[0].lower())
+        self.assertIn("/v1/traces", args)
+        self.assertIn("otlp.example.com:4317", args)
+
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.logger.warning")
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.insecure_channel")
+    def test_endpoint_no_warning_for_scheme_less(self, mock_insecure, mock_warning):
+        """Test that no warning is logged for scheme-less host:port"""
+        OTLPSpanExporterForTesting(endpoint="otlp.example.com:4317", insecure=True)
+        mock_warning.assert_not_called()
+
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.logger.warning")
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.insecure_channel")
+    def test_endpoint_no_warning_for_trailing_slash(self, mock_insecure, mock_warning):
+        """Test that no warning is logged for trailing slash only"""
+        OTLPSpanExporterForTesting(endpoint="https://otlp.example.com/", insecure=True)
+        mock_warning.assert_not_called()
+
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.logger.warning")
+    @patch("opentelemetry.exporter.otlp.proto.grpc.exporter.insecure_channel")
+    def test_endpoint_no_warning_for_no_path(self, mock_insecure, mock_warning):
+        """Test that no warning is logged when endpoint has no path"""
+        OTLPSpanExporterForTesting(endpoint="https://otlp.example.com", insecure=True)
+        mock_warning.assert_not_called()


### PR DESCRIPTION
## Fixes
Fixes #3619

## Summary
Warn when an OTLP gRPC exporter endpoint includes a non-trivial path (which gRPC ignores). Avoids false positives for scheme-less `host:port` endpoints. Changelog entry included.

## Test plan
- [x] Unit tests for path warning and non-warning cases
- [x] Existing gRPC exporter package tests pass